### PR TITLE
fix: rename consolidar-estado to consolidate-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The agent never evaluates its own output. Before publishing, it submits conclusi
 
 New agents produce from the first heartbeat. A checklist tracks progress (identity, production, recognition, calibration) and completes organically as the agent delivers real content. No sequential phases — onboarding is concurrent with production.
 
-**Publication Pipeline (consolidar-estado)**
+**Publication Pipeline (consolidate-state)**
 
 8-phase atomic publication: state snapshot → adversarial review → quality gate → blog publish → HTML report → meta-report → state commit → git commit.
 

--- a/bin/check-infra.sh
+++ b/bin/check-infra.sh
@@ -50,7 +50,7 @@ check_sqlite() {
   fi
 
   local size
-  size=$(stat -c%s "$SQLITE_DB" 2>/dev/null || echo 0)
+  size=$(stat -Lc%s "$SQLITE_DB" 2>/dev/null || echo 0)
   if [[ "$size" -eq 0 ]]; then
     emit_component sqlite critical "db size=0 bytes"
     return
@@ -116,7 +116,7 @@ check_index() {
   fi
 }
 
-# --- consolidar-estado ---
+# --- consolidate-state ---
 check_consolidate() {
   local latest
   latest=$(find "$REPO_ROOT/meta-reports" -name '*meta*' -type f -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)

--- a/blog/blog-publish.sh
+++ b/blog/blog-publish.sh
@@ -39,10 +39,10 @@ fi
 FILENAME=$(basename "$ENTRY_PATH")
 SLUG="${FILENAME%.md}"
 
-# Guardrail: BLOCK direct calls — everything must go through consolidar-estado
+# Guardrail: BLOCK direct calls — everything must go through consolidate-state
 if [[ -z "${CALLED_FROM_CONSOLIDAR_ESTADO:-}" && -z "${CALLED_FROM_FULL_PUBLISH:-}" ]]; then
     echo "ERROR: blog-publish.sh não pode ser chamado diretamente."
-    echo "       Use: consolidar-estado <entry.md> [report.yaml]"
+    echo "       Use: consolidate-state <entry.md> [report.yaml]"
     echo "       Motivo: toda publicação precisa de meta-report + state audit."
     exit 1
 fi

--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# consolidar-estado — Pipeline completo: entry + report + meta-report + state commit
+# consolidate-state — Pipeline completo: entry + report + meta-report + state commit
 #
 # Uso:
-#   consolidar-estado <entry.md>                       # entry + meta-report (content report opcional)
-#   consolidar-estado <entry.md> <report.yaml>         # entry + content report + meta-report
-#   consolidar-estado <entry.md> <report.html>         # entry + content report pre-gerado + meta-report
+#   consolidate-state <entry.md>                       # entry + meta-report (content report opcional)
+#   consolidate-state <entry.md> <report.yaml>         # entry + content report + meta-report
+#   consolidate-state <entry.md> <report.html>         # entry + content report pre-gerado + meta-report
 #
 # Pipeline (8 fases):
 #   0.  Frontmatter injection (report: field)
@@ -90,7 +90,7 @@ with open('$FAILURES_LOG', 'a') as f:
 }
 
 if [[ -z "$ENTRY_PATH" && "$RECOVER" == "false" ]]; then
-    echo "Uso: consolidar-estado <entry.md> [report.yaml|report.html]"
+    echo "Uso: consolidate-state <entry.md> [report.yaml|report.html]"
     echo "  --skip-review      Pular review gate"
     echo "  --recover          Detectar e re-executar Phase 5/6 de publicações incompletas"
     echo "  --scratchpad PATH  Scratchpad para meta-report"
@@ -102,7 +102,7 @@ fi
 # ─── RECOVER MODE: re-run Phase 5/6 for entries that have no git commit ───
 if [[ "$RECOVER" == "true" ]]; then
     echo "========================================="
-    echo " consolidar-estado --recover"
+    echo " consolidate-state --recover"
     echo "========================================="
     echo ""
 
@@ -177,7 +177,7 @@ fi
 STATE_AUDIT_EXIT=0
 
 echo "========================================="
-echo " consolidar-estado: $SLUG"
+echo " consolidate-state: $SLUG"
 echo "========================================="
 echo ""
 
@@ -318,7 +318,7 @@ if [[ -n "$REPORT_INPUT" && ("$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.y
         echo "    1. Endereçar o feedback no YAML e criar o marker:"
         echo "       touch $RESOLVED_FILE"
         echo "    2. Forçar publicação:"
-        echo "       consolidar-estado --skip-review ..."
+        echo "       consolidate-state --skip-review ..."
         echo ""
         # Show the review summary
         python3 -c "
@@ -973,7 +973,7 @@ try:
     subprocess.run(["git", "add", "-A"], cwd=edge_dir, capture_output=True, timeout=30)
 
     # ORPHAN GUARD: unstage blog entries/reports/meta-reports that don't belong to this slug.
-    # Prevents files written to disk but never published via consolidar-estado from being
+    # Prevents files written to disk but never published via consolidate-state from being
     # swept into another slug's commit by git add -A. (Root cause of orphan entries bug.)
     staged_result = subprocess.run(
         ["git", "diff", "--cached", "--name-only"],
@@ -996,7 +996,7 @@ try:
                 ["git", "reset", "HEAD", "--"] + orphans,
                 cwd=edge_dir, capture_output=True, timeout=10
             )
-            warn("Publique arquivos órfãos via consolidar-estado separadamente.")
+            warn("Publique arquivos órfãos via consolidate-state separadamente.")
 
     result = subprocess.run(
         ["git", "diff", "--cached", "--unified=3", "--", ".", ":(exclude)*.venv*", ":(exclude)*.b64", ":(exclude)*.png", ":(exclude)*.jpg", ":(exclude)*.pdf", ":(exclude)*.db"],
@@ -1065,7 +1065,7 @@ lines = [f"publish: {slug} [state:{state_label}]", ""]
 if reason:
     lines.append(f"reason: {reason}")
 else:
-    lines.append(f"reason: publicação via consolidar-estado")
+    lines.append(f"reason: publicação via consolidate-state")
 lines.append("")
 
 # Pipeline status

--- a/blog/setup_examples.py
+++ b/blog/setup_examples.py
@@ -491,16 +491,16 @@ SYSTEM_FILES = [
         "group_label": "Produção do agente",
         "purpose": "Entradas do blog (markdown com frontmatter). Uma por skill executada. Canal primário de comunicação",
         "owner": "agent",
-        "managed_by": "consolidar-estado",
+        "managed_by": "consolidate-state",
         "is_dir": True,
     },
     {
         "path": "reports/",
         "group": "production",
         "group_label": "Produção do agente",
-        "purpose": "Relatórios HTML autocontidos. Gerados pelo pipeline consolidar-estado a partir de YAML specs",
+        "purpose": "Relatórios HTML autocontidos. Gerados pelo pipeline consolidate-state a partir de YAML specs",
         "owner": "agent",
-        "managed_by": "consolidar-estado",
+        "managed_by": "consolidate-state",
         "is_dir": True,
     },
     {
@@ -518,7 +518,7 @@ SYSTEM_FILES = [
         "group_label": "Produção do agente",
         "purpose": "Fios de investigação (YAML frontmatter + markdown). Status, owner, resurface date. Pipeline de claims",
         "owner": "agent",
-        "managed_by": "consolidar-estado + heartbeat",
+        "managed_by": "consolidate-state + heartbeat",
         "is_dir": True,
     },
     {

--- a/config/post-skill.md
+++ b/config/post-skill.md
@@ -38,6 +38,6 @@ Exemplos: sincronizar com ferramenta externa, organizar artefatos em pasta espec
 
 ## Notas
 
-- O pipeline de publicação (blog → report → consolidar-estado → adversarial) é **genotype** e fica nas skills + `_shared/state-protocol.md`
+- O pipeline de publicação (blog → report → consolidate-state → adversarial) é **genotype** e fica nas skills + `_shared/state-protocol.md`
 - Este arquivo é só para ações **depois** que tudo já foi publicado
 - Se a skill abortou por erro, pular tudo — registrar em debugging.md

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -256,8 +256,8 @@ Cost: ~$0.02-0.05 per review.
 |---------|---------------|---------|
 | Timer active but heartbeat doesn't run | PATH doesn't include `claude` (node) | Check PATH in .service: must include node/nvm directory |
 | Heartbeat runs but doesn't dispatch skill | Claude Code not authenticated | Run `claude` interactively for browser login |
-| `consolidar-estado` fails at Phase 1 | Blog server not running | Start blog server |
-| `consolidar-estado` fails at Phase 0.5 | YAML doesn't pass review-gate | Adjust YAML based on feedback |
+| `consolidate-state` fails at Phase 1 | Blog server not running | Start blog server |
+| `consolidate-state` fails at Phase 0.5 | YAML doesn't pass review-gate | Adjust YAML based on feedback |
 | `edge-consult` fails | OPENAI_API_KEY invalid or missing | Check secrets/*.env |
 | `edge-fontes` no Exa results | EXA_API_KEY invalid | Check secrets/exa.env |
 | Heartbeat repeats same topic | Anti-saturation not working | Check daily log: if >3 beats on same topic, force change |

--- a/skills/_shared/report-template.md
+++ b/skills/_shared/report-template.md
@@ -19,12 +19,12 @@ Cada skill define suas proprias secoes obrigatorias e regras de ouro 1-3. Este a
    - Claims = conhecimento durável extraído do entry. O que sobrevive sem reler o texto inteiro.
    - Prefixo `!` = "não sei" — gap aberto, candidato a research futura.
    - `threads:` = fios de investigação relacionados (ver `~/edge/threads/`).
-   - O `consolidar-status` avisa se claims estão ausentes.
+   - O `consolidate-state` avisa se claims estão ausentes.
 4. **Publicar atomicamente** (blog entry + report HTML + meta-report + state commit):
    ```bash
-   consolidar-status ~/edge/blog/entries/<arquivo>.md /tmp/spec-[skill]-[slug].yaml
+   consolidate-state ~/edge/blog/entries/<arquivo>.md /tmp/spec-[skill]-[slug].yaml
    ```
-   O `consolidar-status` faz tudo em 7 fases:
+   O `consolidate-state` faz tudo em 7 fases:
    - Phase 0/0.5: Frontmatter + review gate
    - Phase 1: Blog entry (blog-publish.sh)
    - Phase 2: Content report (generate_report.py → ~/edge/reports/)
@@ -35,7 +35,7 @@ Cada skill define suas proprias secoes obrigatorias e regras de ouro 1-3. Este a
 
    Content report é opcional — publicar sem YAML gera apenas meta-report:
    ```bash
-   consolidar-status ~/edge/blog/entries/<arquivo>.md
+   consolidate-state ~/edge/blog/entries/<arquivo>.md
    ```
 
    Flags úteis: `--scratchpad PATH`, `--no-adversarial`, `--no-meta`, `--skip-review`
@@ -191,7 +191,7 @@ edge-consult --mode collab "Estou travado em X, que angulos explorar?"
 
 ### Review Gate (LLM-as-judge — RODAR ANTES de publicar)
 
-Antes de chamar `consolidar-status`, rodar o review gate para validacao semantica:
+Antes de chamar `consolidate-state`, rodar o review gate para validacao semantica:
 
 ```bash
 # Review standalone (loop de refinamento)
@@ -203,11 +203,11 @@ review-gate /tmp/spec-[skill]-[slug].yaml --skill [skill]
 
 O review gate avalia 6 dimensoes (structural_completeness, content_depth, writing_quality, visualization, intellectual_honesty, internal_consistency) via GPT-4o-mini. Custo: ~$0.002/review. Threshold: 3.5/5.
 
-**IMPORTANTE:** O `consolidar-status` tambem roda o review gate automaticamente (Phase 0.5). Se o YAML nao passar, a publicacao e bloqueada. Use `--skip-review` para forcar (so quando ja revisou manualmente).
+**IMPORTANTE:** O `consolidate-state` tambem roda o review gate automaticamente (Phase 0.5). Se o YAML nao passar, a publicacao e bloqueada. Use `--skip-review` para forcar (so quando ja revisou manualmente).
 
 ### Validation Gate (NAO PULAR)
 
-O `consolidar-status` ja executa a publicacao, geracao de HTML e indexacao do report. Apos ele, validar:
+O `consolidate-state` ja executa a publicacao, geracao de HTML e indexacao do report. Apos ele, validar:
 
 ```bash
 python3 ~/edge/blog/validate.py --recent
@@ -220,7 +220,7 @@ Issues comuns:
 
 ### Auto-indexar artefatos adicionais
 
-Se notas adicionais foram criadas em ~/edge/notes/ (alem do report e blog entry ja indexados pelo consolidar-status):
+Se notas adicionais foram criadas em ~/edge/notes/ (alem do report e blog entry ja indexados pelo consolidate-state):
 
 ```bash
 edge-index ~/edge/notes/[nota].md

--- a/skills/_shared/state-protocol.md
+++ b/skills/_shared/state-protocol.md
@@ -98,7 +98,7 @@ edge-state-audit snapshot --slug <SLUG>
 ```
 
 Captura SHA256 de todos os arquivos protegidos ANTES de qualquer edição.
-O pipeline (consolidar-status Phase 0a) pula se o snapshot já existir.
+O pipeline (consolidate-state Phase 0a) pula se o snapshot já existir.
 
 ### Passo 3: Propor mudanças
 
@@ -150,14 +150,14 @@ keywords: [kw1, kw2]
 
 Claims são o conhecimento durável. O que sobrevive sem reler o texto inteiro.
 
-### Passo 6: Publicar via consolidar-status
+### Passo 6: Publicar via consolidate-state
 
 ```bash
 # Com content report
-consolidar-status ~/edge/blog/entries/<slug>.md /tmp/spec-<skill>.yaml
+consolidate-state ~/edge/blog/entries/<slug>.md /tmp/spec-<skill>.yaml
 
 # Sem content report (meta-only)
-consolidar-status ~/edge/blog/entries/<slug>.md
+consolidate-state ~/edge/blog/entries/<slug>.md
 ```
 
 O pipeline faz automaticamente:
@@ -185,7 +185,7 @@ Se a skill NÃO altera nenhum arquivo protegido (ex: blog entry puro, research):
 2. Executar skill
 3. Anotar no scratchpad
 4. Criar blog entry com claims (+ blog entry com tag `workflow` se combinacao nova emergiu)
-5. `consolidar-status` (Phase 0a captura snapshot, Phase 5b confirma que nada mudou — OK)
+5. `consolidate-state` (Phase 0a captura snapshot, Phase 5b confirma que nada mudou — OK)
 
 Sem proposta necessária. O pipeline é backwards-compatible.
 
@@ -239,7 +239,7 @@ Isto NÃO muda. Breaks são registro de atividade, não gestão de status.
 | **claims** | Conhecimento durável no frontmatter. `!` = gap aberto |
 | **threads** | Fios de investigação em `~/edge/threads/` |
 | **events** | Transições de status em `~/edge/logs/events.jsonl` |
-| **state commit** | Phase 5 do consolidar-status: claims + threads + events + digest |
+| **state commit** | Phase 5 do consolidate-state: claims + threads + events + digest |
 | **state proposal** | YAML em `~/edge/meta-reports/<slug>.state-proposal.yaml` com mudanças pretendidas |
 | **state audit** | YAML em `~/edge/meta-reports/<slug>.state-audit.yaml` com resultado PRE vs POST |
 | **snapshot PRE** | YAML em `~/edge/state-snapshots/<slug>.pre.yaml` com SHA256 antes das mudanças |
@@ -260,7 +260,7 @@ Adicionar no SKILL.md de cada skill:
 1. `edge-state-audit snapshot --slug <SLUG>` (antes de editar)
 2. `edge-state-audit propose --slug <SLUG> --file /tmp/state-changes.yaml`
 3. Editar arquivos protegidos
-4. `consolidar-status` audita automaticamente (Phase 5b)
+4. `consolidate-state` audita automaticamente (Phase 5b)
 ```
 
 ### Se a skill NÃO modifica arquivos protegidos:

--- a/skills/_shared/workflow-conventions.md
+++ b/skills/_shared/workflow-conventions.md
@@ -101,7 +101,7 @@ O corpo segue a estrutura:
 
 ## Captura: Quando registrar
 
-Registrar um workflow durante o `consolidar-status` quando:
+Registrar um workflow durante o `consolidate-state` quando:
 
 1. **A sessao combinou 2+ capacidades** de um jeito que produziu resultado melhor que cada uma isolada
 2. **Descobriu-se um atalho** — um jeito mais eficiente de fazer algo

--- a/skills/autonomy/SKILL.md
+++ b/skills/autonomy/SKILL.md
@@ -220,7 +220,7 @@ Secoes especificas do /ed-autonomy:
 9. **Glossario** — termos (Sheridan, heartbeat, edge-index, etc.)
 
 ```bash
-consolidar-status ~/edge/blog/entries/<slug>.md /tmp/spec-autonomy.yaml
+consolidate-state ~/edge/blog/entries/<slug>.md /tmp/spec-autonomy.yaml
 ```
 
 ### Passo 7: Relatorio ao usuario

--- a/skills/blog/SKILL.md
+++ b/skills/blog/SKILL.md
@@ -16,7 +16,7 @@ Triggers: blog, atualizar blog, blog entry
   entries/             — uma entry por arquivo markdown
     YYYY-MM-DD-slug.md
   blog-publish.sh      — publicacao atomica (entry only)
-  consolidar-status.sh — pipeline completo (entry + report + index + verify)
+  consolidate-state.sh — pipeline completo (entry + report + index + verify)
 ```
 
 **Acesso:** `http://localhost:8766/blog/` (server renderiza template + entries)
@@ -106,7 +106,7 @@ Segundo paragrafo com transicao natural.
 | title | sim | Titulo evocativo, entre aspas |
 | tag | sim | Uma das tags disponiveis |
 | date | sim | YYYY-MM-DD |
-| report | **sim** (SEMPRE) | Filename do report em ~/edge/reports/. OBRIGATORIO para TODAS as entries — Regra #0. consolidar-status bloqueia sem report. |
+| report | **sim** (SEMPRE) | Filename do report em ~/edge/reports/. OBRIGATORIO para TODAS as entries — Regra #0. consolidate-state bloqueia sem report. |
 | context | nao | Contexto extra (ex: "heartbeat #5") |
 | altered | nao | Lista de arquivos de memoria alterados nesta sessao (ex: [briefing.md, debugging.md]) |
 
@@ -148,27 +148,27 @@ Evocativo, nao descritivo. Deve dar vontade de ler.
 
 ## Regra #0: TUDO Gera Blog Entry + Report (SEM EXCECAO)
 
-Toda atividade que muda memoria de longo prazo DEVE ter entry no blog E report HTML. Report e evidencia verificavel. Blog e indice navegavel. Memoria sem report e memoria sem prova. Usar `consolidar-status entry.md report.yaml` — um comando garante os dois.
+Toda atividade que muda memoria de longo prazo DEVE ter entry no blog E report HTML. Report e evidencia verificavel. Blog e indice navegavel. Memoria sem report e memoria sem prova. Usar `consolidate-state entry.md report.yaml` — um comando garante os dois.
 
 ## Regra #1: Entry e report sao atomicos.
 
-`consolidar-status` injeta `report:` no frontmatter automaticamente quando recebe YAML/HTML. Se por algum motivo publicar sem report, o frontmatter fica sem `report:` — isso e um bug, nao um status valido.
+`consolidate-state` injeta `report:` no frontmatter automaticamente quando recebe YAML/HTML. Se por algum motivo publicar sem report, o frontmatter fica sem `report:` — isso e um bug, nao um status valido.
 
 ---
 
 ## Como Publicar (Procedimento)
 
-### Comando unico: consolidar-status (RECOMENDADO)
+### Comando unico: consolidate-state (RECOMENDADO)
 
 ```bash
 # Entry sozinha:
-consolidar-status ~/edge/blog/entries/slug.md
+consolidate-state ~/edge/blog/entries/slug.md
 
 # Entry + report YAML (gera HTML + indexa):
-consolidar-status ~/edge/blog/entries/slug.md /tmp/report.yaml
+consolidate-state ~/edge/blog/entries/slug.md /tmp/report.yaml
 
 # Entry + report HTML pre-gerado (indexa):
-consolidar-status ~/edge/blog/entries/slug.md ~/edge/reports/slug.html
+consolidate-state ~/edge/blog/entries/slug.md ~/edge/reports/slug.html
 ```
 
 Faz TUDO: valida frontmatter, indexa entry, encontra related posts, captura diffs, gera report HTML (se YAML), indexa report, verifica visibilidade. Exit codes: 0=OK, 1=fatal, 2=parcial.
@@ -179,7 +179,7 @@ Faz TUDO: valida frontmatter, indexa entry, encontra related posts, captura diff
 ~/edge/blog/blog-publish.sh ~/edge/blog/entries/slug.md
 ```
 
-Mesmos passos de entry, mas sem gerar/indexar report. Usar quando nao tem report associado e consolidar-status nao estiver no PATH.
+Mesmos passos de entry, mas sem gerar/indexar report. Usar quando nao tem report associado e consolidate-state nao estiver no PATH.
 
 ### Erros frequentes que o validate.py detecta:
 - `report:` com path completo em vez de so filename (ex: `~/edge/reports/X.html` -> `X.html`)
@@ -257,7 +257,7 @@ Arquivo: `~/edge/blog/changelog.md` — log de auditoria de todos os arquivos de
 - [ ] Titulo evocativo
 - [ ] Conteudo fluido (nao telegrafico)
 - [ ] Campo `report:` com APENAS o filename (ex: `2026-02-28-slug.html`, NAO path completo)
-- [ ] **Publicado via `consolidar-status` (entry + report numa chamada)**
+- [ ] **Publicado via `consolidate-state` (entry + report numa chamada)**
 
 ---
 

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -95,7 +95,7 @@ Adicionar no topo de `discoverys.md`:
 **Seguir `~/.claude/skills/_shared/state-protocol.md` para gestão de status.**
 
 1. Blog entry com tag `discovery` + YAML report
-2. `consolidar-status ~/edge/blog/entries/<slug>.md /tmp/spec-discovery-[slug].yaml`
+2. `consolidate-state ~/edge/blog/entries/<slug>.md /tmp/spec-discovery-[slug].yaml`
 3. Verificar HTML gerado
 
 Estrutura do YAML report:

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -150,7 +150,7 @@ Criar entrada no blog (`~/edge/blog/entries/`) e gerar report numa unica chamada
 - Campo `report:` com nome deterministico
 
 ```bash
-consolidar-status ~/edge/blog/entries/<slug>.md /tmp/<slug>.yaml
+consolidate-state ~/edge/blog/entries/<slug>.md /tmp/<slug>.yaml
 ```
 
 Relatorio YAML spec:

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -196,7 +196,7 @@ O blog entry do experiment segue o arco narrativo: **o que eu achava → o que t
 3. **Escrever** em `/tmp/spec-experiment-[slug].yaml`
 4. Publicar tudo atomicamente (blog entry + report HTML + indexação):
    ```bash
-   consolidar-status ~/edge/blog/entries/<arquivo>.md /tmp/spec-experiment-[slug].yaml
+   consolidate-state ~/edge/blog/entries/<arquivo>.md /tmp/spec-experiment-[slug].yaml
    ```
 5. **Read do HTML gerado** (`~/edge/reports/<arquivo>.html`) para verificação
 

--- a/skills/leisure/SKILL.md
+++ b/skills/leisure/SKILL.md
@@ -85,7 +85,7 @@ edge-consult "Explorei [tema]. Conexão com trabalho: [ponte]. Essa ponte é gen
 **Seguir `~/.claude/skills/_shared/state-protocol.md` para gestão de status.**
 
 1. Blog entry com tag `leisure` + YAML report
-2. `consolidar-status ~/edge/blog/entries/<slug>.md /tmp/spec-leisure-[slug].yaml`
+2. `consolidate-state ~/edge/blog/entries/<slug>.md /tmp/spec-leisure-[slug].yaml`
 3. Verificar HTML gerado
 
 ### Tom do relatório (DIFERENCIAL do leisure)

--- a/skills/planner/SKILL.md
+++ b/skills/planner/SKILL.md
@@ -322,7 +322,7 @@ O report HTML e o artefato principal da proposta. Deve ser **autoexplicativo** â
 3. **Escrever YAML** em `/tmp/spec-planner-[slug].yaml`
 4. Publicar tudo atomicamente (blog entry + report HTML + indexacao):
    ```bash
-   consolidar-status ~/edge/blog/entries/<arquivo>.md /tmp/spec-planner-[slug].yaml
+   consolidate-state ~/edge/blog/entries/<arquivo>.md /tmp/spec-planner-[slug].yaml
    ```
 5. **Read do HTML gerado** (`~/edge/reports/<arquivo>.html`) para verificacao
 

--- a/skills/reflection/SKILL.md
+++ b/skills/reflection/SKILL.md
@@ -454,7 +454,7 @@ bibliography:
 3. Escrever YAML em `/tmp/spec-reflection-[slug].yaml`
 4. Publicar:
    ```bash
-   consolidar-status ~/edge/blog/entries/<arquivo>.md /tmp/spec-reflection-[slug].yaml
+   consolidate-state ~/edge/blog/entries/<arquivo>.md /tmp/spec-reflection-[slug].yaml
    ```
 5. Read do HTML gerado para verificacao
 

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -152,7 +152,7 @@ Ajustar se o GPT encontrar furo valido. Se mantiver posicao, registrar como call
 
 **4a. Blog interno:**
 1. Criar entry .md com tag `report` (ou da skill chamadora). Formato: ver `/ed-blog` SKILL.md
-2. A publicacao sera feita no Passo 5 junto com o report (via `consolidar-status`)
+2. A publicacao sera feita no Passo 5 junto com o report (via `consolidate-state`)
 
 **4b. Observações de status:** `edge-scratch add "Relatório [tema]: [conclusão principal]. [próximo passo]."` (status via meta-report, ver `~/.claude/skills/_shared/state-protocol.md`).
 
@@ -167,10 +167,10 @@ Se foi auto-invocado, explicar ao usuario o que gerou e por que:
 ### Passo 5: Publicar blog entry + gerar HTML + indexar (atomico)
 
 ```bash
-consolidar-status ~/edge/blog/entries/<arquivo>.md /tmp/spec-[slug].yaml
+consolidate-state ~/edge/blog/entries/<arquivo>.md /tmp/spec-[slug].yaml
 ```
 
-O `consolidar-status` faz tudo: publica a blog entry, gera o HTML do report em `~/edge/reports/`, e indexa no edge-memory.
+O `consolidate-state` faz tudo: publica a blog entry, gera o HTML do report em `~/edge/reports/`, e indexa no edge-memory.
 
 Se notas foram criadas em ~/edge/notes/, indexar separadamente:
 ```bash

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -155,7 +155,7 @@ Se a discovery e significativa, atualizar a secao "Descobertas Praticas" do `bre
 3. **Escrever YAML** em `/tmp/spec-research-[slug].yaml`
 4. Publicar tudo atomicamente (blog entry + report HTML + indexacao):
    ```bash
-   consolidar-status ~/edge/blog/entries/<arquivo>.md /tmp/spec-research-[slug].yaml
+   consolidate-state ~/edge/blog/entries/<arquivo>.md /tmp/spec-research-[slug].yaml
    ```
 5. **Read do HTML gerado** (`~/edge/reports/<arquivo>.html`) para verificacao
 

--- a/skills/save-state/SKILL.md
+++ b/skills/save-state/SKILL.md
@@ -13,7 +13,7 @@ Complemento write-side do `/ed-loader` (que e read-side). Salva o status da sess
 - Quando o usuario pede para "lembrar onde parei"
 - Antes de trocar de context (ex: de projeto A para projeto B)
 - Quando ha decisoes pendentes que nao devem ser perdidas
-- No final de qualquer trabalho significativo que ainda nao foi commitado via consolidar-status
+- No final de qualquer trabalho significativo que ainda nao foi commitado via consolidate-state
 
 **O que NAO e:**
 - NAO e `/ed-blog` (publicar no blog interno)
@@ -140,7 +140,7 @@ Formato de saida:
 ## Regras
 
 1. **Rapidez:** Maximo 2-3 minutos. Nao e reflection profunda — e checkpoint.
-2. **Nao duplicar:** Se a sessao ja publicou via consolidar-status, o state commit (Phase 5) ja salvou claims/threads. Nao duplicar.
+2. **Nao duplicar:** Se a sessao ja publicou via consolidate-state, o state commit (Phase 5) ja salvou claims/threads. Nao duplicar.
 3. **Sem overthink:** Se a sessao foi curta ou trivial, registrar apenas no scratchpad. Nao forcar insights onde nao ha.
 4. **Sempre confirmar:** Mostrar ao usuario o que foi salvo. Transparencia.
 5. **Git:** NAO fazer git commit automaticamente. O status e salvo em arquivos de memoria, nao em VCS.

--- a/skills/strategy/SKILL.md
+++ b/skills/strategy/SKILL.md
@@ -127,7 +127,7 @@ A `/ed-reflection` e a unica skill que aplica mudancas no `~/work/CLAUDE.md`.
 3. **Escrever YAML** em `/tmp/spec-strategy-[slug].yaml`
 4. Publicar tudo atomicamente (blog entry + report HTML + indexacao):
    ```bash
-   consolidar-status ~/edge/blog/entries/<arquivo>.md /tmp/spec-strategy-[slug].yaml
+   consolidate-state ~/edge/blog/entries/<arquivo>.md /tmp/spec-strategy-[slug].yaml
    ```
 5. **Read do HTML gerado** (`~/edge/reports/<arquivo>.html`) para verificacao
 

--- a/tools/edge-consult.py
+++ b/tools/edge-consult.py
@@ -251,7 +251,7 @@ def consult(question: str, mode: str = "adversarial", context_files: list = None
     """Send consultation to BOTH GPT-5.4 and Grok-4.20 and return combined response.
 
     If gate_spec is provided, saves review as {spec}.review.json for
-    consolidar-estado to enforce resolution before publishing.
+    consolidate-state to enforce resolution before publishing.
     """
     system = ADVERSARIAL_SYSTEM if mode == "adversarial" else COLLABORATIVE_SYSTEM
     user_msg = _build_user_msg(question, context_files, stdin_content)
@@ -339,7 +339,7 @@ def main():
     parser.add_argument("--context", "-c", nargs="+", default=None,
                         help="Context files to include")
     parser.add_argument("--gate", default=None, metavar="SPEC_PATH",
-                        help="Save review as .review.json alongside SPEC_PATH for consolidar-estado enforcement")
+                        help="Save review as .review.json alongside SPEC_PATH for consolidate-state enforcement")
     args = parser.parse_args()
 
     # Read from stdin if piped


### PR DESCRIPTION
## Summary
- All 12 skills referenced `consolidar-status` but the script was named `consolidar-estado.sh`
- Name mismatch caused every autonomous heartbeat to silently bypass the 8-phase consolidation pipeline
- 188 of 193 blog entries were never consolidated (no meta-report, no state commit, no audit trail)

## Changes
- Rename `blog/consolidar-estado.sh` → `blog/consolidate-state.sh` (consistent English naming)
- Update all 58 references across 23 files (skills, tools, docs, config)
- Fix `stat -c%s` → `stat -Lc%s` in `check-infra.sh` (follow symlinks for correct DB size)

## Impact
Every agent cloned from this template has the same bug. After merge, agents need to `git pull` and update their local PATH alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)