### PR TITLE
fix: health check no longer penalizes fresh installs

### DIFF
--- a/bin/check-quality.sh
+++ b/bin/check-quality.sh
@@ -155,12 +155,22 @@ check_providers
 generate_backfill
 
 # Determine status
-local_status="ok"
-if [[ "$adversarial_rate" -lt 50 ]] || [[ "$fontes_rate" -lt 30 ]]; then
-  local_status="degraded"
-fi
-if [[ "$adversarial_rate" -lt 15 ]] || [[ "$fontes_rate" -lt 10 ]] || [[ "$review_gate_active" == "false" ]]; then
-  local_status="fail"
+# If no entries/meta-reports exist yet, quality is not applicable (ok)
+if [[ "$total_meta_7d" -eq 0 ]] && [[ "$total_q2q3_7d" -eq 0 ]]; then
+  local_status="unknown"
+else
+  local_status="ok"
+  if [[ "$total_meta_7d" -gt 0 ]]; then
+    if [[ "$adversarial_rate" -lt 50 ]]; then local_status="degraded"; fi
+    if [[ "$adversarial_rate" -lt 15 ]]; then local_status="fail"; fi
+  fi
+  if [[ "$total_q2q3_7d" -gt 0 ]]; then
+    if [[ "$fontes_rate" -lt 30 ]] && [[ "$local_status" != "fail" ]]; then local_status="degraded"; fi
+    if [[ "$fontes_rate" -lt 10 ]]; then local_status="fail"; fi
+  fi
+  if [[ "$total_meta_7d" -gt 0 ]] && [[ "$review_gate_active" == "false" ]]; then
+    local_status="fail"
+  fi
 fi
 
 detail="adversarial=${adversarial_rate}% (${meta_with_adversarial}/${total_meta_7d})"

--- a/bin/survival-lib.sh
+++ b/bin/survival-lib.sh
@@ -33,16 +33,15 @@ compute_score() {
 
   for comp in "${!weights[@]}"; do
     local w="${weights[$comp]}"
-    max=$((max + w))
     local raw_file="$RAW_DIR/${comp}.json"
     if [[ -f "$raw_file" ]]; then
       local st
       st=$(jq -r '.status' "$raw_file" 2>/dev/null)
       case "$st" in
-        ok)       total=$((total + w)) ;;
-        degraded) total=$((total + w / 2)) ;;
-        unknown)  total=$((total + w / 4)) ;;
-        fail)     ;;
+        ok)       max=$((max + w)); total=$((total + w)) ;;
+        degraded) max=$((max + w)); total=$((total + w / 2)) ;;
+        unknown)  ;;  # exclude from score — no data yet, not a failure
+        fail)     max=$((max + w)) ;;
         *)        ;;
       esac
     fi


### PR DESCRIPTION
## Summary
- `compute_score` now excludes `unknown` components from max instead of scoring at 25%
- `check-quality` treats 0/0 entries/meta-reports as `unknown` instead of `fail`
- Fresh install with working infra scores ~85+ instead of ~28

## Context
Donald's first heartbeat after clean install showed score 28 (critical) despite all infra being functional. The distortion came from quality gates penalizing empty state (no entries, no meta-reports, no adversarial reviews) as failures.

Fixes #8