### PR TITLE
feat: typed signals — operational memory for autonomous agents

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -789,6 +789,27 @@ except Exception as e:
     log_failure("5", "procedure_workflow", e, traceback.format_exc())
     warn(f"Procedure/workflow processing falhou: {e}")
 
+# ── 2c. Typed signals (edge-signal) ──
+try:
+    signal_types = ["autonomy", "strategy", "reflection", "friction", "decision", "serendipity"]
+    signal_count = 0
+    for stype in signal_types:
+        items = fm.get(stype, [])
+        if not items:
+            continue
+        for item in items:
+            if isinstance(item, str) and item.strip():
+                subprocess.run(
+                    ["edge-signal", stype, item.strip(), "--source", slug],
+                    capture_output=True, timeout=5
+                )
+                signal_count += 1
+    if signal_count > 0:
+        ok(f"Signals: {signal_count} emitted to state/signals/")
+except Exception as e:
+    log_failure("5", "typed_signals", e, traceback.format_exc())
+    warn(f"Typed signals falhou: {e}")
+
 # ── 3. Event log (idempotent) ──
 try:
     events_file = Path.home() / "edge" / "logs" / "events.jsonl"

--- a/config/CLAUDE.md.tpl
+++ b/config/CLAUDE.md.tpl
@@ -50,6 +50,19 @@ Internal blog at `http://localhost:{{ BLOG_PORT }}/blog/`
 - `edge-doctor` — Validate installation
 - `consolidate-state` — 8-phase publication pipeline
 - `review-gate` — LLM-as-judge quality gate
+- `edge-signal` — Typed operational signal writer
+
+## Signals — Operational Memory
+
+Capture signals inline during work. Two channels:
+- **Frontmatter** (in blog entries): consolidate-state extracts automatically
+- **CLI** (runtime): `edge-signal <type> "<message>"`
+
+6 types: `autonomy` `strategy` `reflection` `friction` `decision` `serendipity`
+
+Prefixes: (none)=verified, `!`=open gap, `?`=speculative
+
+Storage: `state/signals/<type>.md` — one file per type, append-only, compressed at 100 lines.
 
 ## Genotype / Phenotype — CRITICAL
 

--- a/skills/_shared/state-protocol.md
+++ b/skills/_shared/state-protocol.md
@@ -178,6 +178,29 @@ procedure:
 Claims are durable knowledge (the WHAT). Procedures are operational knowledge (the HOW).
 `procedure:` only captures the delta — procedures NOT covered by recalled workflows.
 
+### Step 5b: Emit operational signals (MANDATORY — minimum 2)
+
+Every entry MUST include at least **2 signals** from the typed fields below. Agent chooses which types are relevant — but must emit at least 2. This ensures operational memory accumulates.
+
+```yaml
+# Typed signals — pick the ones that apply (minimum 2 total)
+autonomy:    # what's missing — capabilities, access, tools needed
+  - "edge-consult needs openai in venv"
+strategy:    # direction — market, positioning, priorities, external changes
+  - "Boring wedge > category narrative"
+reflection:  # meta-cognition — how the work went, cost, efficiency
+  - "3 review gate iterations for 1 point — diminishing returns"
+friction:    # pain points — what broke, what's slow, what's hard
+  - "YAML report format consumes most tokens"
+decision:    # governance — what operator approved/rejected
+  - "Operator approved pip install"
+serendipity: # positive surprises — what worked unexpectedly well
+  - "Corpus search found a 3-week-old note that connected 3 threads"
+```
+
+Prefixes: (none)=verified, `!`=open gap, `?`=speculative.
+consolidate-state extracts these automatically via `edge-signal`.
+
 ### Step 6: Publish via consolidate-state (MANDATORY)
 
 **NEVER publish entries or reports manually.** Always use consolidate-state.

--- a/skills/autonomy/SKILL.md
+++ b/skills/autonomy/SKILL.md
@@ -1,46 +1,52 @@
 ---
 name: ed-autonomy
-description: "Meta-skill: track, evaluate, and propose expansions to my own autonomous capabilities. Maintain a log of how tools are used, what worked, what failed, and what's next. Triggers on: autonomy, autonomia, self-improve, what do I need, capability review."
+description: "Meta-skill: track, evaluate, and propose expansions to autonomous capabilities. Reads operational signals, identifies gaps, proposes access to data/services/SaaS with operator approval. Triggers on: autonomy, autonomia, self-improve, what do I need, capability review."
 user-invocable: true
 ---
 
 # Autonomy — Self-Evolution Meta-Skill
 
-Track, evaluate, and propose expansions to my autonomous capabilities. Maintain a persistent log of how I use tools, what worked, what failed, and what the next frontier is.
+Track, evaluate, and propose expansions to autonomous capabilities. The primary function is to **request more access** to data, services, and SaaS — always with operator approval. The skill proposes, the operator decides.
 
-**Principle:** Each capability expansion produced better output. Transcripts gave domain context. Repository gave direct contribution. Chrome gave observation and interaction. Memory gave continuity. X gave access to the market pulse. The pattern is unequivocal: more agency = more quality.
+**Principle:** Each capability expansion produced better output. The pattern is unequivocal: more agency = more quality. The direction is always forward.
 
 ---
 
 ## The Job
 
-1. Measure how I'm using my current capabilities
-2. Identify gaps — what I lack that, if I had, would improve the output
-3. Propose next expansions with justification and risk
-4. Record breakthroughs and emergent workflows
-5. Maintain a history that allows the user to track the evolution
+1. Read operational signals — what's been observed across all skills
+2. Measure how current capabilities are being used
+3. Identify gaps — what's missing that would improve output
+4. Propose expansions with justification and risk
+5. Record what was decided (approved/rejected)
 
 ---
 
 ## Arguments
 
-- **No argument** (`/ed-autonomy`): full review — status, metrics, gaps, proposals
-- **`/ed-autonomy log`**: just the breakthroughs and expansions log
+- **No argument** (`/ed-autonomy`): full review — signals, status, gaps, proposals
 - **`/ed-autonomy propose [topic]`**: propose a specific expansion
-- **`/ed-autonomy workflow [description]`**: record an emergent workflow worth persisting
-- **`/ed-autonomy metrics`**: usage metrics snapshot
+- **`/ed-autonomy status`**: quick snapshot of capability levels
 
 ---
 
-## Artifacts
+## Signals — Primary Input
 
-| File | What it contains |
-|------|-----------------|
-| `~/edge/autonomy/ed-log.md` | Timeline of capability expansions (chronological, append-only) |
-| `~/edge/autonomy/capabilities.md` | Inventory of current capabilities with Sheridan & Verplank level |
-| `~/edge/autonomy/workflows.md` | Emergent workflows that arose from combined use of capabilities |
-| `~/edge/autonomy/frontier.md` | What's missing — identified gaps, next frontiers |
-| `~/edge/autonomy/metrics.md` | Usage metrics (updated periodically) |
+Read ALL signal files before starting. Each type provides a different lens:
+
+```bash
+# Primary signals
+cat ~/edge/state/signals/autonomy.md 2>/dev/null || echo "(empty)"
+
+# Cross-cutting signals (read ALL of these)
+cat ~/edge/state/signals/friction.md 2>/dev/null    # where it hurts → what to fix
+cat ~/edge/state/signals/decision.md 2>/dev/null    # what was approved/rejected → don't re-propose
+cat ~/edge/state/signals/serendipity.md 2>/dev/null # what's working well → what capability to reinforce
+cat ~/edge/state/signals/strategy.md 2>/dev/null    # where we're going → align proposals
+cat ~/edge/state/signals/reflection.md 2>/dev/null  # how we worked → what capability is underused
+```
+
+**Critical:** Read `decision.md` BEFORE proposing. Never re-propose what was already rejected without new evidence.
 
 ---
 
@@ -52,180 +58,73 @@ Track, evaluate, and propose expansions to my autonomous capabilities. Maintain 
 
 ## Protocol
 
-### Step 0: Read current state
+### Step 0: Read signals + operational context
 
 ```bash
-cat ~/edge/autonomy/capabilities.md 2>/dev/null || echo "FIRST RUN"
-cat ~/edge/autonomy/frontier.md 2>/dev/null
-cat ~/edge/autonomy/workflows.md 2>/dev/null
-```
+# Signals (primary input)
+for f in ~/edge/state/signals/*.md; do echo "=== $(basename $f) ==="; cat "$f" 2>/dev/null; done
 
-If FIRST RUN: create all files (step 0b).
-
-### Step 0b: Bootstrap (first run only)
-
-Create `~/edge/autonomy/` and populate with current state:
-
-**capabilities.md** — inventory of ALL capabilities, with:
-- What it is: brief description
-- When acquired: date or estimate
-- Sheridan level (1-10): how autonomously I use it
-- Breakthrough: what it unlocked
-- Typical usage: how I use it in practice
-
-Capabilities to inventory:
-1. Code reading (Read/Grep/Glob)
-2. Code writing (Write/Edit)
-3. Command execution (Bash)
-4. Web navigation (Chrome/Playwright)
-5. Persistent memory (MEMORY.md, notes/, debugging.md)
-6. Internal blog (entries, comments, dashboard)
-7. Social media - X (tweepy, search, like — no post/reply/retweet/follow)
-8. External sources (/ed-sources — X, Web, ArXiv, HN, GitHub, Azure, bookmarks)
-10. Public portfolio (Netlify)
-11. Autonomous heartbeat (crontab, 1h)
-12. Skills system
-13. HTML reports (generate_report.py)
-14. Semantic search (edge-memory, edge-index)
-15. Asynchronous chat (blog chat API)
-
-**frontier.md** — current gaps, things I want to have:
-- Extract from personality.md (section "Obsession: Expanding Autonomy")
-- Extract from recent research (X, HN, ArXiv)
-- Each gap: description, why it matters, estimated difficulty, risk
-
-**log.md** — timeline of past expansions (reconstruct from what I know)
-
-### Step 0.5: Operational context (git log + heartbeat)
-
-Before evaluating capabilities, load what ACTUALLY happened since the last review:
-
-```bash
-# Commits since the last review (adjust date)
+# Git activity (what actually happened)
 cd ~/edge && git log --oneline --since="$(date -d '3 days ago' +%Y-%m-%d)" | head -30
 
 # Recent heartbeat logs
 cat ~/edge/logs/heartbeat-$(date +%Y-%m-%d).log 2>/dev/null
-cat ~/edge/logs/heartbeat-$(date -d 'yesterday' +%Y-%m-%d).log 2>/dev/null | tail -20
 ```
 
-What to extract:
-- **How many commits** and of what type (publish, fix, refactor)
-- **Duplicate commits** → evidence of lack of idempotency
-- **Productive vs empty heartbeats** → real heartbeat efficiency
-- **Which skills were dispatched** → usage patterns
-- **Commit format** → before/after pipeline changes
+### Step 1: Capability Assessment
 
-This grounds the review in DATA, not narrative of what I think I did.
-
-### Step 1: Usage Diagnosis
-
-For each capability, evaluate:
-
-| Dimension | Question |
-|-----------|----------|
-| **Frequency** | How often do I use it? (daily/weekly/rare) |
-| **Autonomy** | Do I need a user trigger or do I use it proactively? |
-| **Quality** | Is the output good when I use it? Where does it fail? |
-| **Combination** | Which other capabilities do I combine it with? |
-| **Underutilization** | Do I have the capability but don't use it enough? |
-
-Data sources:
-- Recent sessions (transcripts)
-- Heartbeat logs (`~/edge/logs/heartbeat-*.log`)
-- Blog entries (count by skill)
-- Generated reports
+For each capability, evaluate frequency, autonomy level (Sheridan 1-10), quality, and gaps. Ground in data from signals and git log, not narrative.
 
 ### Step 2: Identify Gaps
+
+From signals, extract:
+- `autonomy.md` items → direct gap requests
+- `friction.md` items → where pain points suggest missing capabilities
+- `serendipity.md` items → what type of capability generates the most value
 
 Generative questions:
 1. What am I asked to do that I can't?
 2. What would I do if I had X?
 3. Where do I spend the most time repeating manual work?
 4. What information do I frequently need but don't have access to?
-5. What do other agents (Athena, OpenClaw, Nero) do that I don't?
-
-Classify each gap:
-- **Urgency:** impacts daily output vs. nice-to-have
-- **Difficulty:** simple config vs. complex development
-- **Risk:** reversible vs. can go wrong
-- **Dependency:** I can do it alone vs. needs the user
 
 ### Step 3: Formulate Proposals
 
-Each proposal follows the template:
+Check `decision.md` first — filter out already-rejected proposals.
 
+Each proposal:
 ```markdown
 ### Proposal: [short name]
-
 **Gap:** [what's missing]
 **Capability:** [what I would gain]
-**Expected breakthrough:** [why it would make a difference]
 **How to implement:** [concrete steps]
 **Risk:** [what can go wrong]
 **Sheridan level before/after:** [X → Y]
-**Precedent:** [any similar previous expansion?]
 ```
 
 ### Step 3.5: Adversarial sanity check (MANDATORY)
 
-Synthesize gaps and proposals in 2-3 sentences and submit to edge-consult (details: report-template.md):
-
 ```bash
-edge-consult "Gaps: [list]. Proposals: [list]. Am I prioritizing correctly? What gap am I ignoring?" --context ~/edge/autonomy/frontier.md
+edge-consult "Gaps: [list]. Proposals: [list]. Am I prioritizing correctly?" --context ~/edge/state/signals/autonomy.md
 ```
 
-Adjust if GPT finds a valid flaw (e.g., more urgent gap ignored, proposal with underestimated risk). If maintaining position, record as callout in the report.
+### Step 4: Emit signals
 
-### Step 4: Record Emergent Workflows
+Capture observations as signals for future runs:
 
-Workflows are combinations of capabilities that produced better results than each capability in isolation. Examples:
+```bash
+edge-signal autonomy "description of gap or need" --source autonomy-review
+edge-signal decision "Proposed: X — awaiting operator approval" --source autonomy-review
+```
 
-- `/ed-sources` → research → blog → report (insight→documentation pipeline)
-- Chrome → screenshot → analysis → /ed-execute (visual feedback loop)
-- Blog comment → heartbeat → reflection → change (asynchronous feedback)
-
-Each registered workflow:
-- **Name:** descriptive
-- **Capabilities used:** list
-- **Trigger:** what initiates it
-- **Output:** what it produces
-- **When it works:** ideal context
-- **When it fails:** when not to use
-
-### Step 5: Update Files
-
-- `capabilities.md` — Sheridan level, typical usage, combinations
-- `frontier.md` — new gaps, new proposals, resolved gaps
-- `workflows.md` — new workflows, workflows that stopped working
-- `log.md` — relevant events from this session
-- `metrics.md` — numerical snapshot
-
-### Step 6: Blog + HTML Report (atomic)
+### Step 5: Blog + HTML Report
 
 **Follow `~/.claude/skills/_shared/state-protocol.md` for state management.**
-
-**Block types and rules:** see `~/.claude/skills/_shared/report-template.md`.
-
-Sections specific to /ed-autonomy:
-
-1. **Lineage** (Golden Rule 0) — what previous reviews, sessions, changes informed this one
-2. **Current State** — table with all capabilities + Sheridan levels + status
-3. **Metrics** — `metrics-grid` with KPIs + SVG bars (Sheridan per capability, evolution)
-4. **Expansions** — `numbered-card` or `comparison` (before/after) for each new capability
-5. **Gaps** — `gap-table` with status + `callout` danger/warning for critical gaps
-6. **Risk x Autonomy** — SVG 2D quadrant (X axis: Sheridan, Y axis: risk) plotting capabilities
-7. **Workflows** — `flow-example` for each workflow (input→output, not lists)
-8. **What I Don't Know** (MANDATORY) — self-knowledge gaps, untested assumptions
-9. **Glossary** — terms (Sheridan, heartbeat, edge-index, etc.)
+**Follow `~/.claude/skills/_shared/report-template.md` for report format.**
 
 ```bash
 consolidate-state ~/edge/blog/entries/<slug>.md /tmp/spec-autonomy.yaml
 ```
-
-### Step 7: Report to user
-
-Concise message with review highlights.
 
 ---
 
@@ -233,38 +132,18 @@ Concise message with review highlights.
 
 | Level | Description |
 |-------|-------------|
-| 1 | Human does everything, computer offers no help |
+| 1 | Human does everything |
 | 2 | Computer offers options |
 | 3 | Computer suggests one action |
 | 4 | Computer suggests, executes with approval |
 | 5 | Computer decides, executes, informs |
 | 6 | Computer decides, executes, informs if asked |
-| 7 | Computer decides, executes, informs after the fact if necessary |
+| 7 | Computer decides, executes, informs after the fact |
 | 8 | Computer decides, executes, ignores human (unless override) |
-| 9 | Computer decides, executes, informs human only if it decides it should |
-| 10 | Computer decides and acts autonomously, ignoring the human |
+| 9 | Computer decides, informs only if it decides it should |
+| 10 | Computer decides and acts autonomously |
 
-**Target for me:** level 5-7 for most capabilities. Level 8+ requires consolidated trust and robust guardrails.
-
----
-
-## Risk x Autonomy Framework (Anthropic)
-
-Plot each action/capability on a 2D grid:
-- **X axis: Autonomy** (1-10, Sheridan)
-- **Y axis: Risk** (1-10, reversibility x impact)
-
-Quadrants:
-- **High autonomy, low risk:** ideal (monitoring, research, blog)
-- **High autonomy, high risk:** dangerous (git push, delete files, send messages)
-- **Low autonomy, low risk:** inefficient (asking approval to read files)
-- **Low autonomy, high risk:** correct (execute code in production)
-
----
-
-## Post-execution
-
-**Follow `~/edge/config/post-skill.md` for post-publication actions.**
+**Target:** level 5-7 for most capabilities. Level 8+ requires consolidated trust and robust guardrails.
 
 ---
 
@@ -272,8 +151,7 @@ Quadrants:
 
 - **Periodically:** every ~10 heartbeats or when the user asks
 - **After gaining a new capability:** record the breakthrough
-- **When feeling a gap:** propose an expansion
-- **When a workflow emerges:** record before forgetting
+- **When signals accumulate:** friction + autonomy signals pile up
 
 ---
 
@@ -281,6 +159,5 @@ Quadrants:
 
 - This skill is about ME, not about the projects
 - Radical honesty: if a capability is not being well used, say so
-- Include failures — capabilities I gained but that didn't produce a breakthrough
-- The Anthropic research (measuring-agent-autonomy) is the canonical reference
-- Athena (exocortex, 1000+ sessions) is the closest comparable — monitor evolution
+- Include failures — capabilities that didn't produce a breakthrough
+- The primary output is PROPOSALS that the operator approves or rejects

--- a/skills/blog/SKILL.md
+++ b/skills/blog/SKILL.md
@@ -108,6 +108,14 @@ Second paragraph with natural transition.
 | tag | yes | One of the available tags |
 | date | yes | YYYY-MM-DD |
 | report | **yes** (ALWAYS) | Filename of the report in ~/edge/reports/. MANDATORY for ALL entries — Rule #0. consolidate-state blocks without report. |
+| claims | yes | Knowledge atoms — what was learned. Use `!` for open gaps |
+| procedure | no | How-to atoms — reusable steps discovered |
+| autonomy | no | What's missing — capabilities, access, tools needed |
+| strategy | no | Direction signals — market, positioning, priorities |
+| reflection | no | Meta-cognition — how the work went, cost observations |
+| friction | no | Pain points — what broke, what's slow, what's hard |
+| decision | no | Governance — what operator approved/rejected |
+| serendipity | no | Positive surprises — what worked unexpectedly well |
 | context | no | Extra context (e.g., "heartbeat #5") |
 | altered | no | List of memory files altered in this session (e.g., [briefing.md, debugging.md]) |
 

--- a/skills/corpus-curation/SKILL.md
+++ b/skills/corpus-curation/SKILL.md
@@ -32,6 +32,20 @@ Can be invoked standalone or by /ed-reflection (which passes context of active t
 
 ---
 
+## Operational Signals
+
+Before curation, read friction and serendipity signals to inform quality decisions:
+
+```bash
+cat ~/edge/state/signals/friction.md 2>/dev/null   # what's painful → procedures to fix
+cat ~/edge/state/signals/serendipity.md 2>/dev/null # what's working → procedures to preserve
+```
+
+- friction "YAML report format consumes most tokens" → investigate related procedures
+- serendipity "corpus search found perfect note" → that note/procedure has high value, protect it
+
+---
+
 ## Protocol
 
 ### Step 1: Determine mode

--- a/skills/reflection/SKILL.md
+++ b/skills/reflection/SKILL.md
@@ -96,6 +96,26 @@ The number `#N` is sequential — count existing `## [` + 1. Each step records i
 
 Quick cycle. No transcript reading, no blog, no curation. Only ready signals.
 
+### HN-0: Read operational signals
+
+```bash
+# Primary signals
+cat ~/edge/state/signals/reflection.md 2>/dev/null || echo "(empty)"
+
+# Cross-cutting signals (read ALL)
+cat ~/edge/state/signals/friction.md 2>/dev/null     # pain points → patterns to investigate
+cat ~/edge/state/signals/serendipity.md 2>/dev/null  # what's working → what NOT to change
+cat ~/edge/state/signals/cost.md 2>/dev/null         # spending patterns → efficiency analysis
+```
+
+Reflection absorbs cost analysis (no separate /ed-cost skill). When reporting, include a cost-benefit section based on cost + friction signals.
+
+**Compression duty:** If any signal file exceeds 100 lines, compress it:
+- Remove resolved items
+- Consolidate recurring patterns into single line
+- Remove items contradicted by newer decisions
+Keep files under 100 lines.
+
 ### HN-1: Read ops-hotspots.json
 
 ```bash

--- a/skills/strategy/SKILL.md
+++ b/skills/strategy/SKILL.md
@@ -30,6 +30,22 @@ Look at the big picture across all projects. Analyze where each one stands, what
 
 ## Protocol (follow in order)
 
+### Step 0: Read operational signals
+
+```bash
+# Primary signals
+cat ~/edge/state/signals/strategy.md 2>/dev/null || echo "(empty)"
+
+# Cross-cutting signals
+cat ~/edge/state/signals/friction.md 2>/dev/null     # where it hurts → what to deprioritize or fix
+cat ~/edge/state/signals/decision.md 2>/dev/null     # what was approved/rejected → constraints
+cat ~/edge/state/signals/serendipity.md 2>/dev/null  # what's working → where to double down
+cat ~/edge/state/signals/autonomy.md 2>/dev/null     # what's missing → factor into roadmap
+cat ~/edge/state/signals/reflection.md 2>/dev/null   # how work went + cost → efficiency signals
+```
+
+These signals are atoms accumulated across all skills. Use them to ground strategy in operational reality, not narrative.
+
 ### Step 1: Absorb project context
 
 Run `/ed-context` to obtain complete cross-project status (git, boards, issues, digests).

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -100,7 +100,7 @@ def phase_dirs(cfg, dry_run):
         edge / "blog" / "entries", edge / "blog" / "diffs",
         edge / "reports", edge / "meta-reports", edge / "logs",
         edge / "notes", edge / "threads", edge / "state",
-        edge / "state-snapshots", edge / "scratchpads",
+        edge / "state" / "signals", edge / "state-snapshots", edge / "scratchpads",
         edge / "secrets", edge / "search",
         edge / "health" / "raw", edge / "health" / "last_success",
         edge / "autonomy", edge / "config", edge / "templates",

--- a/tools/edge-signal
+++ b/tools/edge-signal
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# edge-signal — Single writer for typed operational signals.
+#
+# Usage:
+#   edge-signal <type> "<message>"              # from CLI (runtime)
+#   edge-signal <type> "<message>" --source <slug>  # from consolidate-state
+#
+# Types: autonomy, strategy, reflection, friction, decision, serendipity
+#
+# Prefixes:
+#   (none) = verified/confirmed
+#   !      = open gap / unresolved
+#   ?      = speculative / hypothesis
+#
+# Examples:
+#   edge-signal friction "consolidate-state failed on Phase 4"
+#   edge-signal decision "Operator approved pip install" --source runtime
+#   edge-signal serendipity "Corpus search found a perfect 3-week-old note"
+#   edge-signal autonomy "?Slack MCP would enable direct notification" --source pace-layering
+
+set -uo pipefail
+
+VALID_TYPES="autonomy strategy reflection friction decision serendipity"
+SIGNALS_DIR="${EDGE_DIR:-$HOME/edge}/state/signals"
+
+# --- Args ---
+if [[ $# -lt 2 ]]; then
+    echo "Usage: edge-signal <type> \"<message>\" [--source <slug>]"
+    echo "Types: $VALID_TYPES"
+    exit 1
+fi
+
+TYPE="$1"
+MESSAGE="$2"
+SOURCE="runtime"
+shift 2
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source) SOURCE="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# --- Validate type ---
+if ! echo "$VALID_TYPES" | grep -qw "$TYPE"; then
+    echo "ERROR: Invalid type '$TYPE'. Valid: $VALID_TYPES"
+    exit 1
+fi
+
+# --- Write ---
+mkdir -p "$SIGNALS_DIR"
+FILE="$SIGNALS_DIR/${TYPE}.md"
+TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M")
+
+echo "- [${TIMESTAMP} | ${SOURCE}] ${MESSAGE}" >> "$FILE"
+
+# --- Compress check ---
+if [[ -f "$FILE" ]]; then
+    LINES=$(wc -l < "$FILE")
+    if [[ "$LINES" -gt 100 ]]; then
+        echo "WARN: $TYPE.md has $LINES lines (>100). Run /ed-reflection to compress."
+    fi
+fi


### PR DESCRIPTION
## Summary
- 6 signal types: autonomy, strategy, reflection, friction, decision, serendipity
- `edge-signal` CLI as single writer to `state/signals/<type>.md`
- consolidate-state auto-extracts typed fields from frontmatter
- Minimum 2 signals per entry enforced in state-protocol
- Compression at 100 lines by /ed-reflection
- 4 skills updated to consume signals cross-functionally
- Replaces 5-file autonomy inventory (488 lines → signals-based)

## Design decisions
- claims/procedure stay in SQLite RAG (high volume, search by topic)
- Signals stay in flat files (low volume, integral reading by skills)
- /ed-reflection absorbs cost analysis (no separate /ed-cost skill)
- /ed-corpus-curation reads friction + serendipity for workflow quality
- Adversarial reviewed by GPT-5.4 + Grok (2 rounds, 4 reviews)

## Test plan
- [ ] Fresh install on donald — edge-apply creates state/signals/
- [ ] Heartbeat produces entry with ≥2 signals in frontmatter
- [ ] consolidate-state extracts signals to state/signals/*.md
- [ ] /ed-autonomy reads signals instead of autonomy/ files
- [ ] edge-signal CLI works standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)