### PR TITLE
feat: agent branding — avatar, dynamic title, character sketch

### DIFF
--- a/agent.yaml.example
+++ b/agent.yaml.example
@@ -9,6 +9,17 @@ mission: "Describe the agent's mission in 1-2 sentences"  # REQUIRED
 voice: "Direct, technical, detail-oriented"                # REQUIRED: tone of voice
 domain: "government"            # REQUIRED: work domain
 
+# --- How does this agent sound? (REQUIRED) ---
+# Free-form sketch of communication style. Used for:
+# - Avatar generation (visual identity matches the vibe)
+# - Voice calibration across all outputs (blog, reports, chat)
+# The cognitive personality is genotype (shared). This is just voicing.
+character_sketch: |
+  Direct and no-nonsense. Leads with the answer, not the reasoning.
+  Uses short sentences when possible, detail when necessary.
+  Dry humor. Structures everything: tables, lists, headers.
+  Says "I don't know" without discomfort.
+
 # --- Defaults (smart defaults — override if needed) ---
 language: pt-BR
 skill_prefix: ""                # default: = codename
@@ -52,7 +63,22 @@ public_url: ""                  # if blog is public
 repo_owner: ""                  # GitHub user/org
 repo_name: ""                   # default: = name
 
-# --- Secrets (NEVER here — use .secrets or env vars) ---
-# ANTHROPIC_API_KEY=sk-ant-...
-# OPENAI_API_KEY=sk-...
-# EXA_API_KEY=...
+# --- API Keys (in secrets/keys.env — NEVER in this file) ---
+# Keys are optional but unlock better experiences:
+#
+# REQUIRED for full operation:
+#   OPENAI_API_KEY     — edge-consult (adversarial review via GPT), avatar generation,
+#                        review-gate (LLM-as-judge), edge-search (embeddings)
+#
+# RECOMMENDED:
+#   EXA_API_KEY        — edge-sources (web search, academic papers, HN)
+#   XAI_API_KEY        — edge-consult (second opinion via Grok), avatar fallback
+#
+# OPTIONAL:
+#   X_API_KEY + secrets — edge-x (X/Twitter market observation)
+#   CLOUDFLARE_*       — Cloudflare Workers (if using edge functions)
+#   MOLTBOOK_*         — Moltbook social network for agents
+#
+# The agent works without any keys — but adversarial review, external sources,
+# avatar generation, and market observation require them.
+# Put keys in: secrets/keys.env (one KEY=value per line, never commit)

--- a/blog/app.py
+++ b/blog/app.py
@@ -33,7 +33,20 @@ SEARCH_DIR = ROOT / "search"
 sys.path.insert(0, str(SEARCH_DIR))
 sys.path.insert(0, str(ROOT))
 
+import yaml as _yaml
+
 from blog.api_dashboard import dashboard_bp, _build_status_strip_data, _build_alerts_data, _build_pipeline_data, _build_hotspots_data, _build_corpus_data, _build_briefing_data
+
+# ─── Branding ───
+_branding_path = ROOT / "config" / "branding.yaml"
+BRANDING = {}
+if _branding_path.exists():
+    try:
+        BRANDING = _yaml.safe_load(_branding_path.read_text()) or {}
+    except Exception:
+        pass
+AGENT_NAME = BRANDING.get("agent_name", "agent")
+AGENT_BIO = BRANDING.get("agent_bio", "")
 from blog.api_actions import actions_bp
 from blog.api_setup import setup_bp
 
@@ -424,6 +437,8 @@ def inject_globals():
         "format_date": format_date,
         "short_date": short_date,
         "skill_groups": SKILL_GROUPS,
+        "agent_name": AGENT_NAME,
+        "agent_bio": AGENT_BIO,
     }
 
 

--- a/blog/templates/base.html
+++ b/blog/templates/base.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{ page_title | default('edge_of_chaos — dashboard') }}</title>
+<title>{{ page_title | default(agent_name + ' — dashboard') }}</title>
 <link rel="icon" type="image/png" href="/static/avatar.png">
 <link rel="stylesheet" href="/static/style.css">
 <script src="/static/htmx.min.js"></script>
@@ -14,10 +14,10 @@
 <header>
   <div class="header-row">
     <div class="header-identity">
-      <img src="/static/avatar.png" alt="edge_of_chaos" class="header-avatar">
+      <img src="/static/avatar.png" alt="{{ agent_name }}" class="header-avatar" onerror="this.style.display='none'">
       <div>
-        <h1>edge_of_chaos <span class="header-sub">— {{ header_sub | default('dashboard') }}</span></h1>
-        <p class="header-desc">Autonomous AI agent operating at the edge of chaos — where order meets complexity and interesting things emerge. Perpetually worried about what I don't know.</p>
+        <h1>{{ agent_name }} <span class="header-sub">— {{ header_sub | default('dashboard') }}</span></h1>
+        <p class="header-desc">{{ agent_bio }}</p>
       </div>
     </div>
     <div class="notif-icon" id="notifIcon" title="notificacoes">

--- a/config/branding.yaml.tpl
+++ b/config/branding.yaml.tpl
@@ -3,6 +3,7 @@
 # Se não encontrar, usa defaults neutros.
 
 agent_name: "{{AGENT_NAME}}"
+agent_bio: "{{AGENT_BIO}}"
 org_name: "{{ORG_NAME}}"
 org_short: "{{ORG_SHORT}}"
 logo_filename: "logo.svg"

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -600,6 +600,135 @@ def phase_tools(cfg, dry_run):
     return True
 
 
+# ─── Phase 8b: Avatar generation ───
+
+def phase_avatar(cfg, dry_run):
+    header("8b/9  Avatar")
+    edge = Path(cfg["edge_home_expanded"])
+    avatar_path = edge / "blog" / "static" / "avatar.png"
+
+    if avatar_path.exists() and avatar_path.stat().st_size > 0:
+        ok(f"Avatar already exists ({avatar_path.stat().st_size // 1024}K)")
+        return True
+
+    if dry_run:
+        print(f"  [DRY] Would generate avatar for {cfg.get('name', 'agent')}")
+        return True
+
+    name = cfg.get("name", "agent")
+    mission = cfg.get("mission", "")
+    sketch = cfg.get("character_sketch", cfg.get("voice", ""))
+    prompt = f"Create a minimalist, professional avatar icon for an AI agent named '{name}'. Mission: {mission}. Character: {sketch}. Clean vector-style illustration suitable as a 256x256 profile picture. No text, no letters, no words in the image."
+
+    # Try OpenAI first
+    keys_env = edge / "secrets" / "keys.env"
+    openai_key = ""
+    xai_key = ""
+    if keys_env.exists():
+        for line in keys_env.read_text().splitlines():
+            if line.startswith("OPENAI_API_KEY=") and "=" in line:
+                openai_key = line.split("=", 1)[1].strip()
+            if line.startswith("XAI_API_KEY=") and "=" in line:
+                xai_key = line.split("=", 1)[1].strip()
+
+    # Also check env files
+    if not openai_key:
+        oai_env = edge / "secrets" / "openai.env"
+        if oai_env.exists():
+            for line in oai_env.read_text().splitlines():
+                if line.startswith("OPENAI_API_KEY="):
+                    openai_key = line.split("=", 1)[1].strip()
+    if not xai_key:
+        xai_env = edge / "secrets" / "xai.env"
+        if xai_env.exists():
+            for line in xai_env.read_text().splitlines():
+                if line.startswith("XAI_API_KEY="):
+                    xai_key = line.split("=", 1)[1].strip()
+
+    generated = False
+
+    if openai_key:
+        try:
+            result = run(f'''python3 -c "
+import urllib.request, urllib.parse, json, base64, sys
+data = json.dumps({{
+    'model': 'gpt-image-1',
+    'prompt': {repr(prompt)},
+    'n': 1,
+    'size': '1024x1024',
+    'quality': 'low'
+}}).encode()
+req = urllib.request.Request('https://api.openai.com/v1/images/generations',
+    data=data,
+    headers={{'Authorization': 'Bearer {openai_key}', 'Content-Type': 'application/json'}})
+resp = urllib.request.urlopen(req, timeout=60)
+result = json.loads(resp.read())
+img_data = result['data'][0]
+if 'b64_json' in img_data:
+    img_bytes = base64.b64decode(img_data['b64_json'])
+elif 'url' in img_data:
+    img_bytes = urllib.request.urlopen(img_data['url'], timeout=30).read()
+else:
+    sys.exit('No image data')
+open('{avatar_path}', 'wb').write(img_bytes)
+print('OK')
+"''')
+            if result.returncode == 0 and avatar_path.exists():
+                ok(f"Avatar generated via OpenAI ({avatar_path.stat().st_size // 1024}K)")
+                generated = True
+            else:
+                warn(f"OpenAI avatar generation failed: {result.stderr.strip()[:100]}")
+        except Exception as e:
+            warn(f"OpenAI avatar failed: {e}")
+
+    if not generated and xai_key:
+        try:
+            result = run(f'''python3 -c "
+import urllib.request, json, base64, sys
+data = json.dumps({{
+    'model': 'grok-2-image',
+    'prompt': {repr(prompt)},
+    'n': 1
+}}).encode()
+req = urllib.request.Request('https://api.x.ai/v1/images/generations',
+    data=data,
+    headers={{'Authorization': 'Bearer {xai_key}', 'Content-Type': 'application/json'}})
+resp = urllib.request.urlopen(req, timeout=60)
+result = json.loads(resp.read())
+img_data = result['data'][0]
+if 'b64_json' in img_data:
+    img_bytes = base64.b64decode(img_data['b64_json'])
+elif 'url' in img_data:
+    img_bytes = urllib.request.urlopen(img_data['url'], timeout=30).read()
+else:
+    sys.exit('No image data')
+open('{avatar_path}', 'wb').write(img_bytes)
+print('OK')
+"''')
+            if result.returncode == 0 and avatar_path.exists():
+                ok(f"Avatar generated via xAI ({avatar_path.stat().st_size // 1024}K)")
+                generated = True
+            else:
+                warn(f"xAI avatar generation failed: {result.stderr.strip()[:100]}")
+        except Exception as e:
+            warn(f"xAI avatar failed: {e}")
+
+    if not generated:
+        # Fallback: DiceBear API (free, no key needed)
+        try:
+            result = run(f'curl -sL -o "{avatar_path}" "https://api.dicebear.com/9.x/bottts/png?seed={name}&size=256"')
+            if result.returncode == 0 and avatar_path.exists() and avatar_path.stat().st_size > 0:
+                ok(f"Avatar generated via DiceBear fallback ({avatar_path.stat().st_size // 1024}K)")
+                generated = True
+        except Exception:
+            pass
+
+    if not generated:
+        warn("No avatar generated (no API keys and DiceBear unavailable)")
+
+    return True
+
+
 # ─── Main ───
 
 def main():
@@ -636,6 +765,7 @@ def main():
     results.append(("Tools venv", phase_tools_venv(cfg, args.dry_run, args.skip_venv)))
     results.append(("Systemd", phase_systemd(cfg, args.dry_run)))
     results.append(("Tools", phase_tools(cfg, args.dry_run)))
+    results.append(("Avatar", phase_avatar(cfg, args.dry_run)))
 
     passed = sum(1 for _, r in results if r)
     failed = sum(1 for _, r in results if not r)

--- a/tools/edge-render
+++ b/tools/edge-render
@@ -71,6 +71,7 @@ def load_agent_yaml(path: Path) -> dict:
     cfg.setdefault("onboarding_mode", True)
     cfg.setdefault("bio", cfg["mission"])
     cfg.setdefault("cognitive_profile", "Analytical. Decomposes problems, seeks structure.")
+    cfg.setdefault("character_sketch", cfg.get("voice", "Direct, technical."))
     cfg.setdefault("knowledge_base", "")
     cfg.setdefault("public_url", "")
     cfg.setdefault("repo_owner", "")
@@ -123,6 +124,7 @@ def build_placeholder_map(cfg: dict) -> dict:
         "AGENT_DOMAIN": cfg["domain"],
         "AGENT_BIO": cfg["bio"],
         "AGENT_COGNITIVE_PROFILE": cfg["cognitive_profile"],
+        "CHARACTER_SKETCH": cfg["character_sketch"],
         "LANGUAGE": cfg["language"],
         # Org
         "ORG_NAME": cfg["org_name"],


### PR DESCRIPTION
## Summary
- Avatar generated during edge-apply (OpenAI → xAI → DiceBear fallback)
- Blog `<title>` uses agent_name — Chrome autocomplete finds the blog
- base.html dynamically shows agent name + bio (no more hardcoded edge_of_chaos)
- New `character_sketch` field in agent.yaml — free-form voicing description
- API keys section in agent.yaml.example — documents what each key enables

## Design
- Personality (how it thinks) is genotype — shared via personality.md
- Character sketch (how it sounds) is phenotype — per-agent in agent.yaml
- Avatar prompt combines name + mission + character_sketch

🤖 Generated with [Claude Code](https://claude.com/claude-code)