### PR TITLE
fix: blog openai dep, heartbeat timer auto-start, interval 3h

### DIFF
--- a/agent.yaml.example
+++ b/agent.yaml.example
@@ -53,12 +53,12 @@ language: en
 skill_prefix: "don"
 tool_prefix: edge
 edge_home: "~/edge/"
-heartbeat_interval: 2h
+heartbeat_interval: 3h
 blog_port: 8766
-blog_host: "0.0.0.0"           # public by default (accessible from outside)
-blog_auth_enabled: false        # public blog — no login required
-blog_auth_user: ""
-blog_auth_pass: ""
+blog_host: "0.0.0.0"           # accessible from outside (use 127.0.0.1 to restrict)
+blog_auth_enabled: false        # donald is public — set to true + user/pass for private agents
+blog_auth_user: ""              # default for new agents: "admin"
+blog_auth_pass: ""              # default for new agents: generate a password
 
 # --- Before each skill ---
 # Instructions the agent follows before starting any task.

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -301,7 +301,7 @@ def phase_venv(cfg, dry_run, skip_venv=False):
         return False
 
     pip = venv_dir / "bin" / "pip"
-    result = run(f"{pip} install -q flask flask-compress markdown pyyaml sqlite-vec")
+    result = run(f"{pip} install -q flask flask-compress markdown pyyaml sqlite-vec openai")
     if result.returncode != 0:
         fail(f"pip install failed: {result.stderr.strip()}")
         return False
@@ -419,7 +419,8 @@ def phase_systemd(cfg, dry_run):
         run("systemctl --user daemon-reload")
         run("systemctl --user enable blog-server.service")
         run("systemctl --user restart blog-server.service")
-    ok("systemd daemon-reload + blog-server enabled + started")
+        run("systemctl --user enable --now agent-heartbeat.timer")
+    ok("systemd daemon-reload + blog-server enabled + started + heartbeat timer active")
     return True
 
 


### PR DESCRIPTION
## Summary
- Blog venv now installs openai (fixes search API 500, #36)
- edge-apply activates heartbeat timer automatically (#39)
- Default heartbeat interval 3h (was 2h)
- Auth comments clarified: donald is public, new agents default to authenticated