### PR TITLE
feat: add blog_read_only mode for public-facing blogs

### DIFF
--- a/blog/app.py
+++ b/blog/app.py
@@ -65,6 +65,22 @@ app.register_blueprint(setup_bp)
 
 PAGE_SIZE = 20
 
+# ─── Read-only mode ───
+# When enabled, all POST/PUT/DELETE requests return 403.
+# GET/HEAD/OPTIONS pass through. For public-facing blogs.
+_read_only_env = os.environ.get("BLOG_READ_ONLY", "").lower()
+_read_only_branding = str(BRANDING.get("blog", {}).get("read_only", False)).lower()
+BLOG_READ_ONLY = (_read_only_env or _read_only_branding) in ("true", "1", "yes")
+
+@app.before_request
+def enforce_read_only():
+    if BLOG_READ_ONLY and request.method in ("POST", "PUT", "DELETE", "PATCH"):
+        return jsonify({"error": "read-only mode"}), 403
+
+@app.context_processor
+def inject_read_only():
+    return {"read_only": BLOG_READ_ONLY}
+
 # ─── Tag normalization ───
 TAG_MAP = {
     "leisure": "lazer", "reflection": "reflexao", "research": "pesquisa",

--- a/blog/templates/base.html
+++ b/blog/templates/base.html
@@ -32,9 +32,9 @@
 <div class="view-tabs">
   <a class="view-tab {{ 'active' if tab == 'feed' }}" href="/blog/?tab=feed">feed</a>
   <a class="view-tab {{ 'active' if tab == 'workflows' }}" href="/blog/?tab=workflows">workflows</a>
-  <a class="view-tab {{ 'active' if tab == 'chat' }}" href="/blog/?tab=chat">chat</a>
-  <a class="view-tab {{ 'active' if tab == 'dashboard' }}" href="/dashboard">ops</a>
-  <a class="view-tab {{ 'active' if tab == 'setup' }}" href="/setup">setup</a>
+  {% if not read_only %}<a class="view-tab {{ 'active' if tab == 'chat' }}" href="/blog/?tab=chat">chat</a>{% endif %}
+  {% if not read_only %}<a class="view-tab {{ 'active' if tab == 'dashboard' }}" href="/dashboard">ops</a>{% endif %}
+  {% if not read_only %}<a class="view-tab {{ 'active' if tab == 'setup' }}" href="/setup">setup</a>{% endif %}
   <a class="view-tab {{ 'active' if tab == 'knowledge' }}" href="/knowledge">knowledge</a>
 </div>
 

--- a/blog/templates/partials/entry_card.html
+++ b/blog/templates/partials/entry_card.html
@@ -73,6 +73,7 @@
   {% endif %}
 
   {# Actions bar #}
+  {% if not read_only %}
   <div class="entry-actions">
     <button class="act-btn act-save{{ ' on' if saved }}" onclick="toggleSave(this)">salvar</button>
     <button class="act-btn act-comment{{ ' has-comments' if comments }}" onclick="toggleThread(this)">
@@ -95,4 +96,5 @@
       <button class="comment-send" onclick="submitComment(this)">enviar</button>
     </div>
   </div>
+  {% endif %}
 </article>

--- a/config/branding.yaml.tpl
+++ b/config/branding.yaml.tpl
@@ -25,6 +25,7 @@ blog:
   auth_enabled: {{BLOG_AUTH_ENABLED}}
   auth_user: "{{BLOG_AUTH_USER}}"
   auth_pass: "{{BLOG_AUTH_PASS}}"
+  read_only: {{BLOG_READ_ONLY}}
 
 # Paths
 edge_dir: ""  # empty = auto-detect from script location

--- a/config/paths.sh
+++ b/config/paths.sh
@@ -14,6 +14,7 @@ if [ -f "$BRANDING_FILE" ]; then
   BLOG_AUTH_ENABLED=$(grep '^  auth_enabled:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}')
   BLOG_AUTH_USER=$(grep '^  auth_user:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
   BLOG_AUTH_PASS=$(grep '^  auth_pass:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
+  BLOG_READ_ONLY=$(grep '^  read_only:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}')
   MEMORY_PROJECT_DIR=$(grep '^memory_project_dir:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
   SKILL_PREFIX=$(grep '^skill_prefix:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
 else
@@ -21,6 +22,7 @@ else
   BLOG_AUTH_ENABLED=false
   BLOG_AUTH_USER=""
   BLOG_AUTH_PASS=""
+  BLOG_READ_ONLY=false
   MEMORY_PROJECT_DIR=""
   SKILL_PREFIX="agent"
 fi
@@ -46,8 +48,11 @@ else
   PROJECT_DIR="$HOME/.claude/projects/${_first_proj}"
 fi
 
+# Defaults for read-only
+BLOG_READ_ONLY=${BLOG_READ_ONLY:-false}
+
 # Export key variables for embedded Python heredocs
-export EDGE_DIR MEMORY_BASE MEMORY_PROJECT_DIR BLOG_URL PROJECT_DIR
+export EDGE_DIR MEMORY_BASE MEMORY_PROJECT_DIR BLOG_URL PROJECT_DIR BLOG_READ_ONLY
 
 # --- Derived paths ---
 BLOG_DIR="$EDGE_DIR/blog"

--- a/tools/edge-render
+++ b/tools/edge-render
@@ -68,6 +68,7 @@ def load_agent_yaml(path: Path) -> dict:
     cfg.setdefault("blog_auth_enabled", True)
     cfg.setdefault("blog_auth_user", "admin")
     cfg.setdefault("blog_auth_pass", "change-me")
+    cfg.setdefault("blog_read_only", False)
     cfg.setdefault("onboarding_mode", True)
     cfg.setdefault("bio", cfg["mission"])
     cfg.setdefault("character_sketch", cfg.get("voice", "Direct, technical."))
@@ -143,6 +144,7 @@ def build_placeholder_map(cfg: dict) -> dict:
         "BLOG_AUTH_ENABLED": str(cfg["blog_auth_enabled"]).lower(),
         "BLOG_AUTH_USER": cfg["blog_auth_user"],
         "BLOG_AUTH_PASS": cfg["blog_auth_pass"],
+        "BLOG_READ_ONLY": str(cfg["blog_read_only"]).lower(),
         # Heartbeat
         "HEARTBEAT_INTERVAL": cfg["heartbeat_interval"],
         "HEARTBEAT_SECONDS": str(cfg["heartbeat_seconds"]),


### PR DESCRIPTION
## Summary
- Adds `blog_read_only` config option to agent.yaml / branding.yaml
- When enabled: POST/PUT/DELETE return 403, write UI elements hidden
- For agents like Donald whose blog should be publicly readable but not writable

## Changes
- `blog/app.py`: `@before_request` hook blocks writes, `@context_processor` injects `read_only` to templates
- `blog/templates/base.html`: hides chat/ops/setup tabs when read-only
- `blog/templates/partials/entry_card.html`: hides comment form and save button
- `config/branding.yaml.tpl`: new `read_only` field under `blog:`
- `config/paths.sh`: loads `BLOG_READ_ONLY` from branding.yaml
- `tools/edge-render`: maps `blog_read_only` from agent.yaml to template var

## Test plan
- [ ] Set `BLOG_READ_ONLY=true` and verify POST to `/api/chat` returns 403
- [ ] Verify GET to `/blog/` works normally
- [ ] Verify chat/ops/setup tabs are hidden
- [ ] Verify comment forms are hidden on entry cards
- [ ] Verify `blog_read_only: false` (default) preserves current behavior

Closes #45

Generated with [Claude Code](https://claude.com/claude-code)