### PR TITLE
fix: read_only only hides UI, does not block API

### DIFF
--- a/blog/app.py
+++ b/blog/app.py
@@ -83,11 +83,6 @@ def enforce_auth():
         if not auth or auth.username != _auth_user or auth.password != _auth_pass:
             return ("Unauthorized", 401, {"WWW-Authenticate": 'Basic realm="Blog"'})
 
-@app.before_request
-def enforce_read_only():
-    if BLOG_READ_ONLY and request.method in ("POST", "PUT", "DELETE", "PATCH"):
-        return jsonify({"error": "read-only mode"}), 403
-
 @app.context_processor
 def inject_read_only():
     return {"read_only": BLOG_READ_ONLY}


### PR DESCRIPTION
## Summary
- `read_only` was blocking ALL POST requests via `before_request` hook
- This broke consolidate-state pipeline (which POSTs to the blog API)
- Fix: `read_only` only controls UI visibility (hides chat, comments, save buttons)
- API protection is handled by `auth_enabled` (Basic Auth), not `read_only`

## The correct combination for Donald
- `read_only: true` — visitors see a read-only dashboard
- `auth_enabled: true` — API POST requires credentials (pipeline has them)

## Test plan
- [ ] `read_only: true` + `auth_enabled: true`: GET without auth shows read-only UI, POST with auth works
- [ ] `read_only: true` + `auth_enabled: false`: GET shows read-only UI, POST works (no auth needed)
- [ ] `read_only: false`: full UI with chat, comments, save buttons

Closes #45

Generated with [Claude Code](https://claude.com/claude-code)