### PR TITLE
fix: health check path validation + content check performance

### DIFF
--- a/bin/check-content.sh
+++ b/bin/check-content.sh
@@ -12,74 +12,121 @@ stale_files=()
 remediation=()
 total_monitored=0
 total_stale=0
-stable_dates=()
+missing_paths=()
 
-# Parse monitored_files from config
+# Parse monitored_files from config and process in a single Python pass.
+# This replaces the previous O(n) bash+jq loop that hung on large directories
+# (1000+ blog entries = ~4000 jq calls = minutes of CPU).
 check_files() {
-  local files_json
-  files_json=$(python3 -c "
-import yaml, json, sys, glob, os
-d = yaml.safe_load(open('$CONFIG_FILE'))
-result = []
-for f in d.get('monitored_files', []):
-    path = f['path']
-    if f.get('glob'):
-        matches = glob.glob(os.path.join(path, f['glob']))
-        for m in matches:
-            result.append({'path': m, 'category': f['category'], 'threshold_days': f.get('threshold_days'), 'remedy_skill': f.get('remedy_skill')})
+  local result
+  result=$(python3 -c "
+import yaml, json, sys, glob, os, time
+
+config_file = '$CONFIG_FILE'
+if not os.path.exists(config_file):
+    print(json.dumps({'error': 'config not found', 'path': config_file}))
+    sys.exit(0)
+
+d = yaml.safe_load(open(config_file))
+monitored = d.get('monitored_files', [])
+now = time.time()
+day_secs = 86400
+
+results = {
+    'total': 0,
+    'stale': 0,
+    'stale_files': [],
+    'missing_paths': [],
+    'remediation': [],
+    'stable_days': []
+}
+
+for entry in monitored:
+    path = entry['path']
+    category = entry.get('category', 'unknown')
+    threshold = entry.get('threshold_days')
+    remedy = entry.get('remedy_skill')
+    file_glob = entry.get('glob')
+
+    # Validate path exists — absence is NOT health
+    if not os.path.exists(path):
+        results['missing_paths'].append(path)
+        continue
+
+    if file_glob:
+        files = glob.glob(os.path.join(path, file_glob))
     else:
-        result.append({'path': path, 'category': f['category'], 'threshold_days': f.get('threshold_days'), 'remedy_skill': f.get('remedy_skill')})
-print(json.dumps(result))
+        files = [path]
+
+    for f in files:
+        results['total'] += 1
+        if not os.path.exists(f):
+            continue
+        mtime = os.stat(f).st_mtime
+        days = int((now - mtime) / day_secs)
+
+        if category == 'stable':
+            results['stable_days'].append(days)
+            continue
+
+        if threshold is not None and days > threshold:
+            results['stale'] += 1
+            results['stale_files'].append(f'{os.path.basename(f)}:{days}d')
+            if remedy:
+                results['remediation'].append({
+                    'file': os.path.basename(f),
+                    'days_stale': days,
+                    'remedy_skill': remedy,
+                    'priority': 2
+                })
+
+# Stable group alarm: if all stable files same staleness (within 2d) and >7d
+stable = results['stable_days']
+if len(stable) > 1:
+    first = stable[0]
+    all_same = all(abs(d - first) <= 2 for d in stable)
+    if all_same and first > 7:
+        results['stale'] += 1
+        results['stale_files'].append(f'STABLE_GROUP:{first}d')
+        results['remediation'].append({
+            'file': 'stable_group',
+            'days_stale': first,
+            'remedy_skill': '/ed-reflexao',
+            'priority': 1
+        })
+
+print(json.dumps(results))
 " 2>/dev/null)
 
-  if [[ -z "$files_json" ]]; then
+  if [[ -z "$result" ]]; then
     log_health "WARN: could not parse monitored_files from config"
     return
   fi
 
-  local count
-  count=$(echo "$files_json" | jq 'length')
-
-  for i in $(seq 0 $((count - 1))); do
-    local path category threshold remedy days
-    path=$(echo "$files_json" | jq -r ".[$i].path")
-    category=$(echo "$files_json" | jq -r ".[$i].category")
-    threshold=$(echo "$files_json" | jq -r ".[$i].threshold_days")
-    remedy=$(echo "$files_json" | jq -r ".[$i].remedy_skill")
-
-    total_monitored=$((total_monitored + 1))
-    days=$(days_since_mtime "$path")
-
-    if [[ "$category" == "stable" ]]; then
-      stable_dates+=("$days")
-      continue
-    fi
-
-    if [[ "$threshold" != "null" ]] && [[ "$days" -gt "$threshold" ]]; then
-      total_stale=$((total_stale + 1))
-      stale_files+=("$(basename "$path"):${days}d")
-      if [[ "$remedy" != "null" ]]; then
-        remediation+=("{\"file\":\"$(basename "$path")\",\"days_stale\":$days,\"remedy_skill\":\"$remedy\",\"priority\":2}")
-      fi
-    fi
-  done
-
-  # Group alarm for stable files: if all have same staleness (within 2 days), skill stopped
-  if [[ ${#stable_dates[@]} -gt 1 ]]; then
-    local first="${stable_dates[0]}"
-    local all_same=true
-    for d in "${stable_dates[@]}"; do
-      if [[ $(( first - d )) -gt 2 ]] || [[ $(( d - first )) -gt 2 ]]; then
-        all_same=false
-        break
-      fi
-    done
-    if $all_same && [[ "$first" -gt 7 ]]; then
-      stale_files+=("STABLE_GROUP:${first}d")
-      total_stale=$((total_stale + 1))
-      remediation+=("{\"file\":\"stable_group\",\"days_stale\":$first,\"remedy_skill\":\"/ed-reflexao\",\"priority\":1}")
-    fi
+  # Check for config read error
+  local err
+  err=$(echo "$result" | jq -r '.error // empty')
+  if [[ -n "$err" ]]; then
+    log_health "WARN: config error: $err"
+    return
   fi
+
+  total_monitored=$(echo "$result" | jq -r '.total')
+  total_stale=$(echo "$result" | jq -r '.stale')
+
+  # Extract stale files
+  while IFS= read -r f; do
+    [[ -n "$f" ]] && stale_files+=("$f")
+  done < <(echo "$result" | jq -r '.stale_files[]' 2>/dev/null)
+
+  # Extract missing paths — these are NOT healthy, they're invisible failures
+  while IFS= read -r p; do
+    [[ -n "$p" ]] && missing_paths+=("$p")
+  done < <(echo "$result" | jq -r '.missing_paths[]' 2>/dev/null)
+
+  # Write remediation from Python output
+  echo "$result" | jq '.remediation' > "$RAW_DIR/content-remediation.json" 2>/dev/null || \
+    echo "[]" > "$RAW_DIR/content-remediation.json"
 }
 
 # Check monitored skills usage
@@ -146,6 +193,12 @@ check_threads
 
 # Determine status
 local_status="ok"
+
+# Missing monitored paths is always a failure — absence is NOT health
+if [[ ${#missing_paths[@]} -gt 0 ]]; then
+  local_status="fail"
+fi
+
 if [[ "$total_stale" -gt 0 ]] || [[ ${#overdue_skills[@]} -gt 0 ]] || [[ "$overdue_threads" -gt 2 ]]; then
   local_status="degraded"
 fi
@@ -154,14 +207,11 @@ if [[ "$total_stale" -gt 3 ]] || [[ ${#overdue_skills[@]} -gt 2 ]]; then
 fi
 
 detail="stale=${total_stale}/${total_monitored}"
+[[ ${#missing_paths[@]} -gt 0 ]] && detail+=" MISSING_PATHS=[$(IFS=,; echo "${missing_paths[*]}")]"
 [[ ${#stale_files[@]} -gt 0 ]] && detail+=" files=[$(IFS=,; echo "${stale_files[*]}")]"
 [[ ${#overdue_skills[@]} -gt 0 ]] && detail+=" skills=[$(IFS=,; echo "${overdue_skills[*]}")]"
 [[ "$overdue_threads" -gt 0 ]] && detail+=" threads_overdue=${overdue_threads}"
 
 emit_component content "$local_status" "$detail"
-
-# Write remediation queue
-echo "[$(IFS=,; echo "${remediation[*]}")]" | jq '.' > "$RAW_DIR/content-remediation.json" 2>/dev/null || \
-  echo "[]" > "$RAW_DIR/content-remediation.json"
 
 log_health "check-content done: $local_status"

--- a/bin/edge-check.sh
+++ b/bin/edge-check.sh
@@ -36,7 +36,7 @@ ts=$(ts_now)
 
 # Collect infra components
 infra=$(jq -n '{}')
-for comp in disk fs_rw sqlite blog index consolidate git heartbeat mini_repos; do
+for comp in disk fs_rw sqlite blog index consolidate git heartbeat mini_repos config_paths; do
   if [[ -f "$RAW_DIR/${comp}.json" ]]; then
     infra=$(echo "$infra" | jq --arg k "$comp" --slurpfile v "$RAW_DIR/${comp}.json" '.[$k] = {status: $v[0].status, detail: $v[0].detail}')
   fi


### PR DESCRIPTION
## Summary

- **check-content.sh:** monitored paths that don't exist now cause `fail` instead of silent `ok` (absence ≠ health)
- **check-content.sh:** replaced O(n) bash+jq loop with single Python pass — fixes hang on 1000+ entries
- **check-infra.sh:** new `config_paths` component validates all paths from health/config.yaml exist on the filesystem

## Context

During an eoc→edge directory migration, the health check reported "ok" for days while monitoring non-existent paths. The root cause: `check-content.sh` globbed a missing directory, got 0 files, 0 stale files = "ok". The system was blind to its own misconfiguration.

Three interconnected bugs:

1. **Absence = health**: if a monitored path doesn't exist, the system reports healthy because there's nothing to complain about
2. **O(n) performance**: the bash+jq per-file loop hangs when a glob config matches 1000+ files (~4000 jq calls)
3. **No config validation**: nothing checks whether the paths in `health/config.yaml` actually exist

## Changes

| File | Change |
|------|--------|
| `bin/survival-lib.sh` | New `check_path_exists()` helper |
| `bin/check-content.sh` | Single Python pass replaces bash+jq loop; missing paths → explicit `fail` with `MISSING_PATHS=[...]` |
| `bin/check-infra.sh` | New `check_config_paths()` validates monitored + critical paths |
| `bin/edge-check.sh` | Include `config_paths` in infra JSON output |

## Test plan

- [x] Health check completes in <2s with 1000+ blog entries (was hanging)
- [x] Non-existent path in config → `status: fail, detail: MISSING_PATHS=[...]`
- [x] All valid paths → `status: ok, detail: all N monitored paths exist`
- [ ] Fresh install with no config.yaml → graceful degradation (unknown)
- [ ] Config with mixed valid/invalid paths → reports exactly which are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)