### PR TITLE
feat: meta-skill communication + telemetry digest

### DIFF
--- a/search/db.py
+++ b/search/db.py
@@ -87,6 +87,23 @@ def init_db(conn: sqlite3.Connection) -> None:
         CREATE INDEX IF NOT EXISTS idx_search_events_ts ON search_events(ts);
     """)
 
+    # Telemetry snapshots — historical digests for trend analysis
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS telemetry_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+            source TEXT NOT NULL,
+            calls INTEGER DEFAULT 0,
+            ok INTEGER DEFAULT 0,
+            fail INTEGER DEFAULT 0,
+            avg_ms INTEGER DEFAULT 0,
+            cost_usd REAL DEFAULT 0,
+            notes TEXT DEFAULT '{}'
+        );
+        CREATE INDEX IF NOT EXISTS idx_telemetry_ts ON telemetry_snapshots(ts);
+        CREATE INDEX IF NOT EXISTS idx_telemetry_source ON telemetry_snapshots(source);
+    """)
+
     # Dashboard: signals and chat
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS signals (

--- a/skills/_shared/proposals-protocol.md
+++ b/skills/_shared/proposals-protocol.md
@@ -1,0 +1,122 @@
+# Proposals Protocol — Shared Backlog for Meta-Skills
+
+`state/proposals.json` is the shared backlog where meta-skills coordinate.
+Strategy and reflection produce proposals. Autonomy curates and executes.
+
+---
+
+## Roles
+
+| Role | Skills | What they do |
+|------|--------|---|
+| **Producer** | strategy, reflection | Add proposals, add evidence to existing ones |
+| **Curator + Executor** | autonomy | Prioritize, execute, remove stale, enforce max 3 |
+
+Any meta-skill can strengthen or weaken a proposal by adding evidence.
+Only autonomy removes proposals or changes their status to `done`.
+
+---
+
+## Proposal format
+
+```json
+{
+  "id": "slug-description",
+  "what": "Human-readable description of what needs to happen",
+  "created_by": "strategy|reflection|autonomy",
+  "created_at": "2026-04-07T12:00:00",
+  "status": "active|executing|done|stale",
+  "evidence": [
+    {"from": "reflection", "date": "2026-04-07", "note": "edge-x failed 70% in last 24h"},
+    {"from": "strategy", "date": "2026-04-07", "note": "X is declared source, priority 1"}
+  ],
+  "strength": 2
+}
+```
+
+- `id` — slug, unique, descriptive (e.g., `materialize-edge-x`, `dedup-signals`)
+- `strength` — count of distinct skills that contributed evidence
+- `status` — lifecycle state (see below)
+
+---
+
+## Lifecycle
+
+```
+created (active) → evidence grows → strong enough → executing → done
+                 → no evidence in 5 beats → stale → removed
+```
+
+### Autonomy's curation rules
+
+| Condition | Action |
+|---|---|
+| Evidence from 2+ distinct skills | **Strong** — execute this beat |
+| Evidence from 1 skill for 3+ beats | **Mature** — execute |
+| No new evidence in 5 beats | **Stale** — remove with note |
+| 4th active proposal arrives | Weakest (lowest strength) exits |
+| Proposal executed successfully | Status → `done`, keep for 3 beats then remove |
+
+### Adding a proposal (producer)
+
+```python
+import json, os
+from datetime import datetime
+
+f = os.path.expanduser("~/edge/state/proposals.json")
+proposals = json.load(open(f)) if os.path.exists(f) else []
+
+# Check if proposal already exists
+existing = next((p for p in proposals if p["id"] == "SLUG"), None)
+if existing:
+    # Strengthen with new evidence
+    existing["evidence"].append({
+        "from": "THIS_SKILL",
+        "date": datetime.now().strftime("%Y-%m-%d"),
+        "note": "WHAT WAS OBSERVED"
+    })
+    existing["strength"] = len(set(e["from"] for e in existing["evidence"]))
+else:
+    # Create new (only if < 3 active)
+    active = [p for p in proposals if p["status"] == "active"]
+    if len(active) < 3:
+        proposals.append({
+            "id": "SLUG",
+            "what": "DESCRIPTION",
+            "created_by": "THIS_SKILL",
+            "created_at": datetime.now().isoformat(),
+            "status": "active",
+            "evidence": [{"from": "THIS_SKILL", "date": datetime.now().strftime("%Y-%m-%d"), "note": "REASON"}],
+            "strength": 1
+        })
+
+with open(f, "w") as fh:
+    json.dump(proposals, fh, indent=2)
+```
+
+### Curating proposals (autonomy only)
+
+Autonomy reads the full list, applies the rules above, and rewrites the file.
+When removing a stale proposal, log the reason in the blog entry for traceability.
+
+---
+
+## What does NOT go in proposals
+
+- Immediate fixes (→ reflection fixes directly or queues via dispatch)
+- Operator decisions (→ strategy.md "Proposals" section, operator reviews)
+- Content work (→ threads and beats)
+
+Proposals are for **capability changes**: new primitives, source materialization,
+workflow crystallization, config changes, infrastructure improvements.
+
+---
+
+## Relation to dispatch queue
+
+The dispatch queue (`state/dispatch-queue.json`) is for **immediate routing**:
+"reflection found X, autonomy should handle it next beat."
+
+Proposals are for **accumulated evidence**: "multiple signals point to X,
+it's worth investing a beat to fix." A dispatch can trigger reading a proposal,
+but they serve different purposes.

--- a/skills/autonomy/SKILL.md
+++ b/skills/autonomy/SKILL.md
@@ -18,15 +18,54 @@ is just a bigger toolbox. The value is in seeing what nobody asked for.
 ## The Job
 
 1. **Evaluate** — read, don't discover. Everything is declarative now:
+   - `state/dispatch-queue.json` → pending requests from other meta-skills (read FIRST)
+   - `state/telemetry-digest.json` → quantitative operational facts (fail rates, cost, anomalies)
    - `sources:` (yaml) vs `state/sources-manifest.yaml` → what's declared but not materialized?
    - `state/source-usage.jsonl` → what works? what's wasted? diversity?
    - `state/signals/` → friction, serendipity, strategy shifts?
-   - `state/proposals.json` → active proposals: strengthen, remove stale, or add new
+   - `state/proposals.json` → shared backlog: proposals from strategy, reflection, and autonomy
 
-2. **Propose** (max 3 active, max 1 new per beat):
-   - Each proposal: what, why, evidence, cost
-   - Adversarial review before adding (edge-consult)
-   - Proposal that survives 3+ revisions with growing evidence = strong signal
+   **Read dispatch queue first:**
+   ```bash
+   python3 -c "
+   import json, os
+   f = os.path.expanduser('~/edge/state/dispatch-queue.json')
+   if os.path.exists(f):
+       queue = json.load(open(f))
+       mine = [q for q in queue if q.get('skill') == 'autonomy']
+       if mine:
+           for item in mine:
+               print(f'DISPATCH from {item.get(\"source\",\"?\")}: {item.get(\"reason\",\"\")}')
+           remaining = [q for q in queue if q.get('skill') != 'autonomy']
+           with open(f, 'w') as fh:
+               json.dump(remaining, fh, indent=2)
+       else:
+           print('No pending dispatches.')
+   else:
+       print('No dispatch queue.')
+   " 2>/dev/null
+   
+   # Telemetry digest
+   cat ~/edge/state/telemetry-digest.json 2>/dev/null || echo "(no telemetry digest)"
+   ```
+   
+   Dispatches from reflection ("edge-x broken, can't fix") and strategy ("source X is priority") inform which proposals to act on first. Telemetry provides quantitative evidence.
+
+2. **Curate proposals** — autonomy is the curator of `state/proposals.json`, the shared backlog:
+
+   ```bash
+   cat ~/edge/state/proposals.json 2>/dev/null || echo "[]"
+   ```
+
+   - Proposal with evidence from 2+ distinct skills → **strong**, execute this beat
+   - Proposal with evidence from 1 skill for 3+ beats → **mature**, execute
+   - Proposal without new evidence in 5 beats → **stale**, remove with note
+   - Max 3 active proposals — if a 4th arrives, the weakest exits
+   - Max 1 NEW proposal per beat (from autonomy itself)
+   
+   Strategy and reflection add proposals and evidence. Autonomy prioritizes, executes, and removes stale ones. See `~/.claude/skills/_shared/proposals-protocol.md`.
+   
+   - Adversarial review before adding new proposals (edge-consult)
    - Proposal the agent removes = self-correction (positive)
 
 3. **Act** — approval depends on scope:
@@ -89,11 +128,22 @@ autonomy proposes removal. Blog documents why.
 
 ---
 
+## Post-execution: Dispatch to other meta-skills
+
+After acting, queue dispatches for what autonomy cannot resolve alone:
+
+- **Created a new primitive** → queue for reflection (to validate in next beat)
+- **Source not worth the cost** → queue for strategy (to reprioritize)
+- **Proposal executed** → update `proposals.json` status to `done`
+
+---
+
 ## When to run
 
 - Heartbeat meta rotation (every ~9 beats, alongside reflection/strategy)
 - After gaining new access (new key, new host, new data)
 - When friction signals accumulate
+- When dispatch queue has items addressed to autonomy
 
 ---
 

--- a/skills/reflection/SKILL.md
+++ b/skills/reflection/SKILL.md
@@ -22,6 +22,38 @@ Signal sources: **git archaeology** (git_signals.py), **execution ledger** (edge
 
 ---
 
+## Step -0.5: Read dispatch queue + telemetry digest
+
+Before any analysis, check what other meta-skills need from reflection:
+
+```bash
+# Read dispatches addressed to reflection
+python3 -c "
+import json, os
+f = os.path.expanduser('~/edge/state/dispatch-queue.json')
+if os.path.exists(f):
+    queue = json.load(open(f))
+    mine = [q for q in queue if q.get('skill') == 'reflection']
+    if mine:
+        for item in mine:
+            print(f'DISPATCH from {item.get(\"source\",\"?\")}: {item.get(\"reason\",\"\")}')
+        remaining = [q for q in queue if q.get('skill') != 'reflection']
+        with open(f, 'w') as fh:
+            json.dump(remaining, fh, indent=2)
+    else:
+        print('No pending dispatches.')
+else:
+    print('No dispatch queue.')
+" 2>/dev/null
+
+# Read telemetry digest (operational facts, not opinions)
+cat ~/edge/state/telemetry-digest.json 2>/dev/null || echo "(no telemetry digest yet)"
+```
+
+Dispatches from other meta-skills take priority — they represent gaps already identified by strategy or autonomy. Telemetry digest provides quantitative grounding (fail rates, cost trends, anomalies) before reading qualitative signals.
+
+---
+
 ## Operating Modes
 
 | Mode | Duration | When | Output |
@@ -646,7 +678,33 @@ Report to user:
 
 ---
 
-## Post-execution
+## Post-execution: Dispatch to other meta-skills
+
+After main work, queue dispatches for gaps reflection cannot resolve alone:
+
+- **Broken tool/primitive you cannot fix** → queue for autonomy (to materialize or replace)
+- **Pattern that changes strategic priorities** → queue for strategy (to reprioritize)
+- **Evidence that strengthens or weakens an existing proposal** → add to `state/proposals.json` (see `~/.claude/skills/_shared/proposals-protocol.md`)
+
+```bash
+# Example: queue for autonomy when a tool is broken beyond reflection's ability to fix
+python3 -c "
+import json, os
+from datetime import datetime
+f = os.path.expanduser('~/edge/state/dispatch-queue.json')
+queue = json.load(open(f)) if os.path.exists(f) else []
+queue.append({
+    'skill': 'autonomy',
+    'source': 'reflection',
+    'reason': 'DESCRIBE THE GAP',
+    'created_at': datetime.now().isoformat()
+})
+with open(f, 'w') as fh:
+    json.dump(queue, fh, indent=2)
+" 2>/dev/null
+```
+
+**Rule:** only queue when you have concrete evidence. "I think strategy should look at this" is not enough. "edge-x failed 70% in the last 24h, autonomy should materialize an alternative" is.
 
 **Follow `~/edge/config/post-skill.md` for post-publication actions.**
 

--- a/skills/strategy/SKILL.md
+++ b/skills/strategy/SKILL.md
@@ -30,9 +30,41 @@ Look at the big picture across all projects. Analyze where each one stands, what
 
 ## Protocol (follow in order)
 
+### Step -1: Read dispatch queue
+
+Before analysis, check what other meta-skills need from strategy:
+
+```bash
+python3 -c "
+import json, os
+f = os.path.expanduser('~/edge/state/dispatch-queue.json')
+if os.path.exists(f):
+    queue = json.load(open(f))
+    mine = [q for q in queue if q.get('skill') == 'strategy']
+    if mine:
+        for item in mine:
+            print(f'DISPATCH from {item.get(\"source\",\"?\")}: {item.get(\"reason\",\"\")}')
+        remaining = [q for q in queue if q.get('skill') != 'strategy']
+        with open(f, 'w') as fh:
+            json.dump(remaining, fh, indent=2)
+    else:
+        print('No pending dispatches.')
+else:
+    print('No dispatch queue.')
+" 2>/dev/null
+```
+
+Dispatches from autonomy or reflection represent operational reality that strategy must incorporate.
+
 ### Step 0: Read operational signals
 
 ```bash
+# Telemetry digest — quantitative operational facts
+cat ~/edge/state/telemetry-digest.json 2>/dev/null || echo "(no telemetry digest)"
+
+# Active proposals (shared backlog with autonomy and reflection)
+cat ~/edge/state/proposals.json 2>/dev/null || echo "[]"
+
 # Primary signals
 cat ~/edge/state/signals/strategy.md 2>/dev/null || echo "(empty)"
 
@@ -43,6 +75,8 @@ cat ~/edge/state/signals/serendipity.md 2>/dev/null  # what's working → where 
 cat ~/edge/state/signals/autonomy.md 2>/dev/null     # what's missing → factor into roadmap
 cat ~/edge/state/signals/reflection.md 2>/dev/null   # how work went + cost → efficiency signals
 ```
+
+Telemetry grounds strategy in operational reality: cost trends, source reliability, tool effectiveness. Proposals show what's already been identified by other meta-skills and how strong the evidence is.
 
 These signals are atoms accumulated across all skills. Use them to ground strategy in operational reality, not narrative.
 
@@ -259,7 +293,15 @@ Format:
 
 ---
 
-## Post-execution
+## Post-execution: Dispatch to other meta-skills + proposals
+
+After analysis, queue dispatches and create/strengthen proposals:
+
+- **Capability gap or high-priority materialization** → queue for autonomy
+- **Something that needs immediate remediation** → queue for reflection
+- **Strategic insight that should become a proposal** → add to `state/proposals.json` (see `~/.claude/skills/_shared/proposals-protocol.md`)
+
+Strategy is a **producer** of proposals, not a curator. Autonomy curates and executes.
 
 **Follow `~/edge/config/post-skill.md` for post-publication actions.**
 

--- a/tools/edge-telemetry-digest
+++ b/tools/edge-telemetry-digest
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""edge-telemetry-digest: Compact telemetry files and produce a unified snapshot.
+
+Reads raw telemetry from multiple sources, produces a compact JSON digest,
+and implements ringbuffer compaction on JSONL files (digest header + last N entries).
+
+Also inserts a snapshot row into telemetry_snapshots in edge-memory.db for
+historical trend analysis.
+
+Usage:
+    edge-telemetry-digest                  # compact + digest + store
+    edge-telemetry-digest --dry-run        # show what would happen
+    edge-telemetry-digest --max-lines 500  # compact threshold (default: 500)
+    edge-telemetry-digest --keep-lines 100 # entries to keep after compaction (default: 100)
+"""
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
+
+
+EDGE_DIR = Path(os.environ.get("EDGE_DIR", Path.home() / "edge"))
+DIGEST_HEADER_START = "=== DIGEST ("
+DIGEST_HEADER_END = "=== END DIGEST ==="
+
+
+def parse_jsonl_with_digest(filepath: Path) -> tuple[dict | None, list[dict]]:
+    """Read a JSONL file that may have an inline digest header.
+
+    Returns (existing_digest, entries). The digest is the parsed header
+    block if present, entries are the JSONL lines after the header.
+    """
+    if not filepath.exists():
+        return None, []
+
+    lines = filepath.read_text(encoding="utf-8", errors="replace").splitlines()
+    digest = None
+    entries = []
+    in_digest = False
+    digest_lines = []
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith(DIGEST_HEADER_START):
+            in_digest = True
+            digest_lines = [line]
+            continue
+        if line == DIGEST_HEADER_END:
+            in_digest = False
+            digest = _parse_digest_block(digest_lines)
+            continue
+        if in_digest:
+            digest_lines.append(line)
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    return digest, entries
+
+
+def _parse_digest_block(lines: list[str]) -> dict:
+    """Parse a digest header block into a dict."""
+    result = {}
+    for line in lines:
+        if ":" in line and not line.startswith("==="):
+            key, _, val = line.partition(":")
+            result[key.strip()] = val.strip()
+    return result
+
+
+def compact_jsonl(
+    filepath: Path,
+    max_lines: int,
+    keep_lines: int,
+    dry_run: bool = False,
+) -> dict | None:
+    """Compact a JSONL file: merge old entries into digest header, keep recent.
+
+    Returns the computed digest stats or None if no compaction needed.
+    """
+    old_digest, entries = parse_jsonl_with_digest(filepath)
+
+    if len(entries) < max_lines:
+        return None  # No compaction needed
+
+    # Split: entries to digest vs entries to keep
+    to_digest = entries[:-keep_lines] if keep_lines < len(entries) else []
+    to_keep = entries[-keep_lines:]
+
+    if not to_digest:
+        return None
+
+    # Compute stats from entries being digested
+    stats = _compute_entry_stats(to_digest)
+
+    # Merge with existing digest if present
+    if old_digest:
+        stats = _merge_digest(old_digest, stats)
+
+    if dry_run:
+        print(f"  WOULD compact {filepath.name}: {len(entries)} → {len(to_keep)} entries")
+        print(f"  Digest: {stats}")
+        return stats
+
+    # Write compacted file
+    digest_block = _format_digest_header(stats)
+    jsonl_lines = [json.dumps(e, ensure_ascii=False) for e in to_keep]
+
+    filepath.write_text(
+        digest_block + "\n" + "\n".join(jsonl_lines) + "\n",
+        encoding="utf-8",
+    )
+    print(f"  Compacted {filepath.name}: {len(entries)} → {len(to_keep)} entries")
+
+    return stats
+
+
+def _compute_entry_stats(entries: list[dict]) -> dict:
+    """Compute aggregate stats from a list of telemetry entries."""
+    total = len(entries)
+    ok = sum(1 for e in entries if e.get("ok", e.get("status") == "OK"))
+    fail = total - ok
+    durations = [e.get("ms", e.get("duration_ms", 0)) for e in entries if e.get("ms") or e.get("duration_ms")]
+    avg_ms = int(sum(durations) / len(durations)) if durations else 0
+
+    # Top failures by error/reason
+    failures = [
+        e.get("error", e.get("reason", "unknown"))
+        for e in entries
+        if not e.get("ok", e.get("status") == "OK")
+    ]
+    top_failures = Counter(failures).most_common(5)
+
+    # Source breakdown
+    sources = Counter(e.get("source", e.get("tool", "unknown")) for e in entries)
+
+    # Date range
+    dates = [e.get("ts", e.get("timestamp", "")) for e in entries if e.get("ts") or e.get("timestamp")]
+    period_start = min(dates)[:10] if dates else "?"
+    period_end = max(dates)[:10] if dates else "?"
+
+    return {
+        "total_calls": total,
+        "ok": ok,
+        "fail": fail,
+        "ok_pct": round(ok * 100 / total, 1) if total else 0,
+        "avg_ms": avg_ms,
+        "top_failures": ", ".join(f"{r} ({c})" for r, c in top_failures) if top_failures else "none",
+        "sources": dict(sources),
+        "period": f"{period_start} to {period_end}",
+    }
+
+
+def _merge_digest(old: dict, new: dict) -> dict:
+    """Merge an existing digest with new stats."""
+    try:
+        old_total = int(old.get("total_calls", 0))
+        old_ok = int(old.get("ok", 0))
+    except (ValueError, TypeError):
+        old_total = 0
+        old_ok = 0
+
+    total = old_total + new["total_calls"]
+    ok = old_ok + new["ok"]
+    fail = total - ok
+
+    return {
+        "total_calls": total,
+        "ok": ok,
+        "fail": fail,
+        "ok_pct": round(ok * 100 / total, 1) if total else 0,
+        "avg_ms": new["avg_ms"],  # Use recent avg, not historical
+        "top_failures": new["top_failures"],  # Use recent failures
+        "period": f"{old.get('period', '?').split(' to ')[0]} to {new['period'].split(' to ')[-1]}",
+    }
+
+
+def _format_digest_header(stats: dict) -> str:
+    """Format stats as inline digest header block."""
+    now = datetime.now().strftime("%Y-%m-%d")
+    lines = [
+        f"=== DIGEST (compacted: {now}) ===",
+        f"total_calls: {stats['total_calls']}, ok: {stats['ok']} ({stats['ok_pct']}%), fail: {stats['fail']}",
+        f"avg_duration_ms: {stats['avg_ms']}",
+        f"top_failures: {stats['top_failures']}",
+        f"period: {stats['period']}",
+        DIGEST_HEADER_END,
+    ]
+    return "\n".join(lines)
+
+
+def read_search_telemetry(edge_dir: Path) -> dict:
+    """Read search telemetry from edge-memory.db."""
+    db_path = edge_dir / "search" / "edge-memory.db"
+    if not db_path.exists():
+        return {}
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+
+        total = conn.execute("SELECT COUNT(*) FROM search_events").fetchone()[0]
+        unique = conn.execute("SELECT COUNT(DISTINCT query_norm) FROM search_events").fetchone()[0]
+
+        # Workflows found in search (documents of type workflow that appeared in results)
+        wf_found = conn.execute("""
+            SELECT COUNT(*) FROM search_events se
+            JOIN documents d ON d.id = se.doc_id
+            WHERE d.type = 'workflow'
+        """).fetchone()[0]
+
+        conn.close()
+        return {
+            "total_queries": total,
+            "unique_queries": unique,
+            "workflows_found": wf_found,
+        }
+    except Exception:
+        return {}
+
+
+def produce_digest(
+    edge_dir: Path,
+    max_lines: int,
+    keep_lines: int,
+    dry_run: bool,
+) -> dict:
+    """Produce the unified telemetry digest."""
+    digest = {
+        "generated_at": datetime.now().isoformat(),
+        "sources": {},
+        "tools": {},
+        "search": {},
+        "anomalies": [],
+    }
+
+    # 1. Source usage
+    source_file = edge_dir / "state" / "source-usage.jsonl"
+    if source_file.exists():
+        stats = compact_jsonl(source_file, max_lines, keep_lines, dry_run)
+        _, entries = parse_jsonl_with_digest(source_file)
+
+        # Per-source breakdown from recent entries
+        by_source = defaultdict(lambda: {"calls": 0, "ok": 0, "fail": 0, "ms_sum": 0})
+        for e in entries:
+            src = e.get("source", "unknown")
+            by_source[src]["calls"] += 1
+            if e.get("ok"):
+                by_source[src]["ok"] += 1
+            else:
+                by_source[src]["fail"] += 1
+            by_source[src]["ms_sum"] += e.get("ms", 0)
+
+        for src, s in by_source.items():
+            total = s["calls"]
+            digest["sources"][src] = {
+                "calls": total,
+                "ok": s["ok"],
+                "fail": s["fail"],
+                "rate_pct": round(s["ok"] * 100 / total, 1) if total else 0,
+                "avg_ms": int(s["ms_sum"] / total) if total else 0,
+            }
+            # Anomaly detection
+            if total >= 5 and s["fail"] / total > 0.3:
+                digest["anomalies"].append(
+                    f"{src}: {round(s['fail']*100/total)}% fail rate ({s['fail']}/{total})"
+                )
+    else:
+        print("  source-usage.jsonl not found, skipping")
+
+    # 2. Tool execution (ledger)
+    ledger_file = edge_dir / "logs" / "ledger.jsonl"
+    if ledger_file.exists():
+        compact_jsonl(ledger_file, max_lines, keep_lines, dry_run)
+        _, entries = parse_jsonl_with_digest(ledger_file)
+
+        by_tool = defaultdict(lambda: {"calls": 0, "ok": 0, "fail": 0, "ms_sum": 0})
+        for e in entries:
+            tool = e.get("tool", "unknown")
+            by_tool[tool]["calls"] += 1
+            if e.get("ok", e.get("status") == "OK"):
+                by_tool[tool]["ok"] += 1
+            else:
+                by_tool[tool]["fail"] += 1
+            by_tool[tool]["ms_sum"] += e.get("duration_ms", e.get("ms", 0))
+
+        for tool, s in by_tool.items():
+            total = s["calls"]
+            digest["tools"][tool] = {
+                "calls": total,
+                "ok": s["ok"],
+                "fail_rate_pct": round(s["fail"] * 100 / total, 1) if total else 0,
+                "p50_ms": int(s["ms_sum"] / total) if total else 0,
+            }
+            if total >= 5 and s["fail"] / total > 0.3:
+                digest["anomalies"].append(
+                    f"{tool}: {round(s['fail']*100/total)}% fail rate ({s['fail']}/{total})"
+                )
+    else:
+        print("  ledger.jsonl not found, skipping")
+
+    # 3. Search telemetry
+    digest["search"] = read_search_telemetry(edge_dir)
+
+    return digest
+
+
+def store_snapshot(edge_dir: Path, digest: dict) -> None:
+    """Insert digest snapshot into telemetry_snapshots table."""
+    db_path = edge_dir / "search" / "edge-memory.db"
+    if not db_path.exists():
+        return
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+
+        # Ensure table exists
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS telemetry_snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+                source TEXT NOT NULL,
+                calls INTEGER DEFAULT 0,
+                ok INTEGER DEFAULT 0,
+                fail INTEGER DEFAULT 0,
+                avg_ms INTEGER DEFAULT 0,
+                cost_usd REAL DEFAULT 0,
+                notes TEXT DEFAULT '{}'
+            );
+        """)
+
+        now = datetime.now().isoformat()
+
+        # One row per source
+        for src, stats in digest.get("sources", {}).items():
+            conn.execute(
+                "INSERT INTO telemetry_snapshots (ts, source, calls, ok, fail, avg_ms, notes) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (now, src, stats["calls"], stats["ok"], stats["fail"],
+                 stats["avg_ms"], json.dumps(stats)),
+            )
+
+        # One row per tool
+        for tool, stats in digest.get("tools", {}).items():
+            conn.execute(
+                "INSERT INTO telemetry_snapshots (ts, source, calls, ok, fail, avg_ms, notes) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (now, f"tool:{tool}", stats["calls"], stats["ok"],
+                 stats.get("fail", 0), stats.get("p50_ms", 0), json.dumps(stats)),
+            )
+
+        # One global row
+        total_calls = sum(s["calls"] for s in digest.get("sources", {}).values())
+        total_ok = sum(s["ok"] for s in digest.get("sources", {}).values())
+        conn.execute(
+            "INSERT INTO telemetry_snapshots (ts, source, calls, ok, fail, notes) "
+            "VALUES (?, '_global', ?, ?, ?, ?)",
+            (now, total_calls, total_ok, total_calls - total_ok,
+             json.dumps({"anomalies": digest.get("anomalies", [])})),
+        )
+
+        conn.commit()
+        conn.close()
+        print(f"  Stored snapshot in edge-memory.db ({total_calls} calls)")
+    except Exception as e:
+        print(f"  Warning: could not store snapshot: {e}", file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compact telemetry files and produce unified digest"
+    )
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would happen without writing")
+    parser.add_argument("--max-lines", type=int, default=500,
+                        help="Compact JSONL files exceeding this many entries (default: 500)")
+    parser.add_argument("--keep-lines", type=int, default=100,
+                        help="Keep this many recent entries after compaction (default: 100)")
+    args = parser.parse_args()
+
+    edge_dir = EDGE_DIR
+    print(f"edge-telemetry-digest — {datetime.now().strftime('%Y-%m-%d %H:%M')}")
+    print(f"  EDGE_DIR: {edge_dir}")
+
+    digest = produce_digest(edge_dir, args.max_lines, args.keep_lines, args.dry_run)
+
+    # Write digest JSON
+    digest_path = edge_dir / "state" / "telemetry-digest.json"
+    if not args.dry_run:
+        digest_path.parent.mkdir(parents=True, exist_ok=True)
+        digest_path.write_text(json.dumps(digest, indent=2, ensure_ascii=False) + "\n")
+        print(f"  Wrote {digest_path}")
+
+        # Store in DB
+        store_snapshot(edge_dir, digest)
+    else:
+        print(f"  WOULD write {digest_path}")
+        print(json.dumps(digest, indent=2))
+
+    # Summary
+    n_sources = len(digest.get("sources", {}))
+    n_tools = len(digest.get("tools", {}))
+    n_anomalies = len(digest.get("anomalies", []))
+    print(f"\n  Sources: {n_sources}, Tools: {n_tools}, Anomalies: {n_anomalies}")
+    for a in digest.get("anomalies", []):
+        print(f"  !! {a}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Meta-skill dispatch queue**: reflection, strategy, and autonomy now communicate through `state/dispatch-queue.json`. Each reads pending dispatches at start, writes dispatches for other skills at end.
- **Shared proposals backlog**: `state/proposals.json` replaces autonomy's private pool. Strategy and reflection produce proposals with evidence. Autonomy curates (max 3 active, removes stale, executes strong ones). Protocol documented in `skills/_shared/proposals-protocol.md`.
- **`edge-telemetry-digest` tool**: compacts JSONL telemetry files using ringbuffer pattern (inline digest header + last N entries, file never grows beyond threshold). Produces `state/telemetry-digest.json` snapshot consumed by all meta-skills. Stores historical snapshots in `telemetry_snapshots` table for SQL trend analysis.
- **Telemetry grounding**: strategy and autonomy now read telemetry digest for quantitative operational facts (fail rates, cost, anomalies) alongside qualitative signals.

## Files changed

| File | Change |
|---|---|
| `skills/reflection/SKILL.md` | +dispatch queue read/write, +telemetry digest read |
| `skills/strategy/SKILL.md` | +dispatch queue read, +telemetry/proposals read, +dispatch write |
| `skills/autonomy/SKILL.md` | +dispatch queue read, proposals curation rewrite, +dispatch write |
| `skills/_shared/proposals-protocol.md` | New — shared proposals format and lifecycle |
| `tools/edge-telemetry-digest` | New — JSONL compaction + unified digest + DB snapshots |
| `search/db.py` | +telemetry_snapshots table schema |

## Test plan

- [ ] Verify `edge-telemetry-digest --dry-run` runs without errors on a fresh install
- [ ] Verify `telemetry_snapshots` table is created on next `ensure_db()` call
- [ ] Run a heartbeat cycle and confirm meta-skills read/write dispatch queue
- [ ] Verify proposals.json lifecycle: create → strengthen → execute → done

🤖 Generated with [Claude Code](https://claude.com/claude-code)