### PR TITLE
fix: make Phase 0.3 adversarial review active for all publication flows

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -9,7 +9,7 @@
 # Pipeline (8 fases):
 #   0.  Frontmatter injection (report: field)
 #   0b. Note link injection (note: field, if matching note exists)
-#   0.3 Adversarial review enforcement (edge-consult --gate)
+#   0.3 Adversarial review enforcement (active: runs edge-consult; passive: blocks on .review.json)
 #   0.5 Review gate (LLM-as-judge, content report only)
 #   1.  Blog entry (blog-publish.sh)
 #   2.  Content report (generate_report.py, optional)
@@ -316,20 +316,49 @@ else
 fi
 
 # ─── PHASE 0.3: Adversarial Review Enforcement ───
-# If edge-consult was run with --gate against this YAML spec,
-# a .review.json exists. Block publication until .resolved marker is created.
-if [[ -n "$REPORT_INPUT" && ("$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.yml) && "$SKIP_REVIEW" == "false" ]]; then
-    REVIEW_JSON_FILE="${REPORT_INPUT%.yaml}.review.json"
-    [[ "$REPORT_INPUT" == *.yml ]] && REVIEW_JSON_FILE="${REPORT_INPUT%.yml}.review.json"
-    RESOLVED_FILE="${REVIEW_JSON_FILE%.review.json}.resolved"
+# Active: runs edge-consult if no prior review exists for the content.
+# Passive: blocks if .review.json exists without .resolved marker.
+# Covers ALL flows: YAML, HTML, and entry-only.
+if [[ "$SKIP_REVIEW" == "false" ]]; then
+    # Determine review target: report if provided, otherwise entry
+    if [[ -n "$REPORT_INPUT" ]]; then
+        REVIEW_TARGET="$REPORT_INPUT"
+    else
+        REVIEW_TARGET="$ENTRY_PATH"
+    fi
 
+    # Derive review/resolved file paths (replace extension with .review.json)
+    REVIEW_JSON_FILE="${REVIEW_TARGET%.*}.review.json"
+    RESOLVED_FILE="${REVIEW_TARGET%.*}.resolved"
+
+    # Active gate: run edge-consult if no review exists yet
+    if [[ ! -f "$REVIEW_JSON_FILE" ]]; then
+        if command -v edge-consult &>/dev/null; then
+            echo "── Phase 0.3: Adversarial Review ──"
+            echo "  Running edge-consult against $(basename "$REVIEW_TARGET")..."
+            if edge-consult "Review this content critically. Flag any shallow analysis, unsupported claims, missing evidence, or logical gaps." \
+                --context "$REVIEW_TARGET" \
+                --gate "$REVIEW_TARGET" \
+                --mode adversarial 2>&1; then
+                echo ""
+            else
+                warn "edge-consult failed (exit $?) — continuing without adversarial review"
+                echo ""
+            fi
+        else
+            warn "edge-consult not found in PATH — skipping adversarial review"
+            echo ""
+        fi
+    fi
+
+    # Passive gate: block if review exists without resolution
     if [[ -f "$REVIEW_JSON_FILE" && ! -f "$RESOLVED_FILE" ]]; then
         echo "── Phase 0.3: Adversarial Review ──"
         fail "Adversarial review pending: $(basename "$REVIEW_JSON_FILE")"
         echo ""
         echo "  edge-consult generated feedback that has not been addressed."
         echo "  Options:"
-        echo "    1. Address the feedback in YAML and create the marker:"
+        echo "    1. Address the feedback and create the marker:"
         echo "       touch $RESOLVED_FILE"
         echo "    2. Force publication:"
         echo "       consolidate-state --skip-review ..."

--- a/memory/rules-core.md
+++ b/memory/rules-core.md
@@ -16,6 +16,7 @@ Specific topics go in `memory/topics/`. Core should not exceed 15 rules.
 - When generating a report or blog entry: **verify that key insights enter memory/topics/**. Without distillation = write-only.
 - When publishing an entry: **include claims, threads, keywords, report link**. An entry without metadata is invisible in the corpus.
 - When producing an artifact: **blog ALWAYS**. Primary communication channel with the user.
+- When publishing a report or entry via consolidar-estado: **ALWAYS run `edge-consult --context <content> --mode adversarial` BEFORE invoking consolidar-estado**. If the review identifies gaps, correct them before publishing. The pipeline now enforces this (Phase 0.3 active gate), but running the review first avoids the block-resolve cycle. Use `--skip-review` ONLY when explicitly instructed by the user — never to save time.
 
 ## Recognition
 


### PR DESCRIPTION
## Summary

- **Phase 0.3 now actively runs `edge-consult`** before publishing, instead of passively checking for a pre-existing `.review.json`
- **Covers all flows**: entry-only, pre-generated HTML, and YAML specs (previously only YAML was covered)
- **Behavioral rule added** to `rules-core.md` as defense-in-depth: agents must run `edge-consult` before `consolidar-estado`

## Context

On 2026-04-08, a report was published via Slack/Drive without adversarial review. Post-hoc `edge-consult` found 6 critical issues. Root cause: Phase 0.3 was passive (only checked for `.review.json`) and only covered YAML flows — entry-only and HTML flows bypassed the gate entirely.

Ref: `~/roberto/issues/2026-04-08-adversarial-review-bypass.md`

## Changes

| File | Change |
|------|--------|
| `blog/consolidate-state.sh` | Phase 0.3 determines review target (report or entry), runs `edge-consult --gate` actively, then applies passive block |
| `memory/rules-core.md` | Added behavioral enforcement rule for pre-publish adversarial review |

## Test plan

- [ ] Run `consolidate-state entry.md` (entry-only) — should trigger edge-consult
- [ ] Run `consolidate-state entry.md report.html` (HTML) — should trigger edge-consult
- [ ] Run `consolidate-state entry.md spec.yaml` (YAML) — should trigger edge-consult
- [ ] Run `consolidate-state --skip-review entry.md` — should skip review
- [ ] Verify `.review.json` is created and blocks until `.resolved`

🤖 Generated with [Claude Code](https://claude.com/claude-code)