### PR TITLE
fix: enforce pre/post-skill execution with proof files

### DIFF
--- a/skills/_shared/required-context.md
+++ b/skills/_shared/required-context.md
@@ -9,9 +9,51 @@ Without it, the agent operates without identity, rules, or strategy — producin
 
 ## Step -1: Required context (BEFORE everything)
 
-1. Read: `memory/rules-core.md`, `memory/personality.md`, `memory/metodo.md`, `memory/debugging.md`
-2. Read: `config/pre-skill.md`, `config/post-skill.md`, `config/strategy.md`
-3. Execute the Boot Ritual defined in `pre-skill.md` procedure section
+**This step is NOT optional. Do NOT summarize it, skip it, or "understand the intent" without executing. Every sub-step must produce visible tool output.**
+
+1. **Read** (use the Read tool on each file — do not skip any):
+   - `memory/rules-core.md`
+   - `memory/personality.md`
+   - `memory/metodo.md`
+   - `memory/debugging.md`
+   - `config/pre-skill.md`
+   - `config/post-skill.md`
+   - `config/strategy.md`
+
+2. **Execute the Boot Ritual** defined in the "Procedure" section of `pre-skill.md`.
+   Each numbered step in the procedure MUST be executed individually,
+   producing visible output (command results, API responses, messages read).
+   Do NOT paraphrase or summarize the steps — run them.
+
+3. **PUBLISH PRE-SKILL REPORT** — After executing ALL boot ritual steps,
+   write a file to `logs/pre-skill-<date>.md` with the following format:
+
+   ```markdown
+   # Pre-skill report — <YYYY-MM-DD HH:MM>
+
+   ## Boot ritual execution
+
+   ### Step 1: <step name from pre-skill.md>
+   **Executed:** yes/no
+   **Output:** <actual result — commits found, messages read, files changed, etc.>
+
+   ### Step 2: <step name>
+   **Executed:** yes/no
+   **Output:** <actual result>
+
+   ... (one section per step in the boot ritual)
+
+   ## Priority overrides
+   <any high-priority requests found that change the beat plan, or "None">
+
+   ## Verdict
+   All steps executed: yes/no
+   Ready to proceed: yes/no
+   ```
+
+   **This file is the PROOF that pre-skill ran. Without it, the beat is invalid.**
+   If any step shows "Executed: no", go back and execute it before writing the verdict.
+
 4. Only then proceed to Step 0.
 
 **Note:** Source primitives are available as MCP tools (registered via `.mcp.json`). No need to manually read `state/sources-manifest.yaml` — the primitives appear alongside native tools.
@@ -36,27 +78,38 @@ The heartbeat is especially vulnerable because it runs autonomously with no user
 
 ## Step Final: Post-skill execution (AFTER work completes)
 
+**This step is NOT optional. It runs after EVERY skill, even if the skill failed. Do NOT end the session without executing post-skill.**
+
 After the skill's main work is done and before closing the session:
 
-1. Re-read `config/post-skill.md`
-2. Execute EVERY procedure defined there, one by one
+1. **Re-read** `config/post-skill.md` (use the Read tool — do not rely on memory)
+2. **Execute EVERY procedure** defined there, one by one, producing
+   visible output for each (tool calls, API responses, messages sent).
 3. **CRITICAL: each procedure is independent. A failure in one MUST NOT
    stop the others.** Execute all of them, every time, regardless of
-   prior failures. Log the outcome of each to `logs/post-skill.log`:
-   ```
-   [TIMESTAMP] procedure: [name] | status: [OK/FAIL/SKIP] | reason: [detail]
-   ```
+   prior failures.
 4. If a tool is missing (pandoc, latexmk), log it and move on — do not
    attempt to install packages mid-skill. **Dependency remediation
-   happens during reflection, not mid-beat** — reflection reads
-   post-skill.log, detects repeated SKIPs, and self-provisions
-   missing tools into the agent's venv (see reflection HN-1c)
+   happens during reflection, not mid-beat.**
 5. If a primitive exists for the task (e.g. `libexec/<codename>/overleaf-sync`),
    use it instead of raw commands
 6. notify.sh is ALWAYS the last call, even if everything else failed —
    the operator needs to know what happened
 
-**A post-skill that stops at the first failure is a bug, not caution.**
+7. **PUBLISH POST-SKILL REPORT** — Append to `logs/post-skill.log`:
+
+   ```
+   ── <YYYY-MM-DD HH:MM> ──
+   1. [procedure name] → [OK/FAIL/SKIP] — [what happened: message sent, file published, etc.]
+   2. [procedure name] → [OK/FAIL/SKIP] — [what happened]
+   ...
+   ```
+
+   **This log is the PROOF that post-skill ran. A session that ends
+   without appending to this log is incomplete.**
+
+**A post-skill that stops at the first failure is a bug, not caution.
+A session that ends without the post-skill log entry is invalid.**
 
 ---
 


### PR DESCRIPTION
## Summary

- Agents must now write `logs/pre-skill-<date>.md` proving each boot ritual step was executed with actual output
- Agents must append to `logs/post-skill.log` proving each post-skill procedure ran
- Without these proof files, the beat is explicitly invalid

## Context

Roberto heartbeat (2026-04-08) skipped entire pre/post-skill: no Slack check, no git pull, no Drive check, no Slack post. The skill says "follow required-context.md" which says "execute boot ritual" — 4 levels of indirection, zero verification. Agent jumped straight to research.

Closes #143

## Test plan

- [ ] Run heartbeat — verify `logs/pre-skill-<date>.md` is created with step-by-step output
- [ ] Verify `logs/post-skill.log` has entry after beat completes
- [ ] Run a skill directly — same verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)