### PR TITLE
[genotype] Enforce entire consolidate-state pipeline — no silent optional gates

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -49,18 +49,36 @@ POSITIONAL=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h)
-            echo "Usage: consolidate-state <entry.md> [report.yaml|report.html]"
+            echo "Usage: consolidate-state <entry.md> <report.yaml|report.html>"
+            echo ""
+            echo "Note: <report> is MANDATORY (Rule #0, issue #189). To publish without"
+            echo "a report, set ALLOW_NO_REPORT_REASON=\"<reason>\" — opt-out is logged."
             echo ""
             echo "Flags:"
-            echo "  --skip-review      Skip review gate (LLM-as-judge)"
+            echo "  --skip-review      Skip review gate (requires SKIP_REVIEW_REASON)"
             echo "  --review-only      Run only the review gate, without publishing"
             echo "  --recover          Detect and re-run Phase 5/6 for incomplete publications"
             echo "  --scratchpad PATH  Scratchpad for meta-report (default: /tmp/edge-scratch-active.md)"
             echo "  --no-adversarial   Skip edge-consult in meta-report"
-            echo "  --no-meta          Skip meta-report (Phase 4)"
-            echo "  --force            Bypass workflow citation check (procedure without workflows_used)"
+            echo "  --no-meta          Skip meta-report Phase 4 (requires NO_META_REASON)"
+            echo "  --force            Bypass workflow citation check (requires FORCE_REASON)"
             echo "  --reason TEXT      Custom commit message reason"
             echo "  --help, -h         Show this help"
+            echo ""
+            echo "Bypass env vars (issue #189 — every escape hatch requires a reason):"
+            echo "  ALLOW_NO_REPORT_REASON     — publish without <report.yaml|html>"
+            echo "  NO_META_REASON             — required if --no-meta is used"
+            echo "  SKIP_REVIEW_REASON         — required if --skip-review is used"
+            echo "  FORCE_REASON               — required if --force is used"
+            echo "  ALLOW_UNCRYSTALLIZED_REASON — required to bypass Phase 3.35 crystallization gate"
+            echo ""
+            echo "Exit codes:"
+            echo "  0  success"
+            echo "  1  fatal error (most blocks)"
+            echo "  2  partial success"
+            echo "  3  adversarial review pending / review-gate below threshold"
+            echo "  4  missing required enforcement / reason (Rule #0)"
+            echo "  5  state audit detected unproposed/divergent change"
             exit 0
             ;;
         --skip-review) SKIP_REVIEW=true; shift ;;
@@ -86,6 +104,50 @@ NC='\033[0m'
 ok()   { echo -e "  ${GREEN}OK${NC}: $1"; }
 warn() { echo -e "  ${YELLOW}WARN${NC}: $1"; }
 fail() { echo -e "  ${RED}FAIL${NC}: $1"; }
+
+# ─── Rule #0 Enforcement (issue #189) ───
+# Documented invariants compiled into checks. Every escape hatch from a
+# documented bypass requires an env var with a justification string, logged
+# to state/signals/friction.md. Exit code 4 = missing required reason.
+#
+# Bypasses governed:
+#   - no REPORT_INPUT (Phase 2 + Phase 0.5 collateral) → ALLOW_NO_REPORT_REASON
+#   - --no-meta (Phase 4)                              → NO_META_REASON
+#   - --skip-review (Phase 0.5)                        → SKIP_REVIEW_REASON
+#   - --force (Phase 3.3)                              → FORCE_REASON
+#
+# Phase 3.35 crystallization gate has its own block downstream.
+
+require_reason() {
+    local label="$1"
+    local var_name="$2"
+    local var_value="${!var_name:-}"
+    if [[ -z "$var_value" ]]; then
+        fail "$label requires $var_name=\"<justification>\" env var"
+        fail "See genotype issue #189 for the enforcement policy."
+        exit 4
+    fi
+    if command -v edge-signal &>/dev/null; then
+        edge-signal friction "$label opt-out: $var_value" --source consolidate-state 2>/dev/null || true
+    fi
+    warn "$label opt-out logged: $var_value"
+}
+
+# Phase 2 (+ Phase 0.5 collateral): report YAML/HTML mandatory
+if [[ -z "$REPORT_INPUT" ]]; then
+    if [[ -z "${ALLOW_NO_REPORT_REASON:-}" ]]; then
+        fail "Rule #0: report YAML/HTML is MANDATORY for all entries."
+        fail "Pass spec as 2nd arg, OR set ALLOW_NO_REPORT_REASON=\"<justification>\""
+        fail "See genotype issue #189."
+        exit 4
+    fi
+    require_reason "Rule #0 (no report)" "ALLOW_NO_REPORT_REASON"
+fi
+
+# Flag-based bypass paths require reasons
+[[ "$NO_META"     == "true" ]] && require_reason "--no-meta"     "NO_META_REASON"
+[[ "$SKIP_REVIEW" == "true" ]] && require_reason "--skip-review" "SKIP_REVIEW_REASON"
+[[ "$FORCE"       == "true" ]] && require_reason "--force"       "FORCE_REASON"
 
 # Log pipeline failure to JSONL (bash phases)
 FAILURES_LOG="$LOGS_DIR/pipeline-failures.jsonl"
@@ -735,7 +797,22 @@ except Exception as e:
 case "$CRYST_CHECK" in
     MISSING:*)
         N="${CRYST_CHECK#MISSING:}"
-        warn "Curation has $N uncrystallized candidates — run 'edge-crystallize' to create workflow-draft entries"
+        # Phase 3.35 hard block (issue #189): curation entries with uncrystallized
+        # candidates must crystallize before publishing OR opt out with a reason.
+        if [[ -z "${ALLOW_UNCRYSTALLIZED_REASON:-}" ]]; then
+            fail "Curation has $N uncrystallized candidates"
+            fail "Run 'edge-crystallize' to create workflow-draft entries"
+            fail "Or set ALLOW_UNCRYSTALLIZED_REASON=\"<justification>\" to bypass"
+            fail "See genotype issue #189."
+            if command -v edge-signal &>/dev/null; then
+                edge-signal friction "Phase 3.35 BLOCKED: $N uncrystallized candidates" --source consolidate-state 2>/dev/null || true
+            fi
+            exit 4
+        fi
+        warn "Publishing with $N uncrystallized candidates (opt-out): $ALLOW_UNCRYSTALLIZED_REASON"
+        if command -v edge-signal &>/dev/null; then
+            edge-signal friction "Phase 3.35 opt-out ($N uncrystallized): $ALLOW_UNCRYSTALLIZED_REASON" --source consolidate-state 2>/dev/null || true
+        fi
         ;;
     OK) ;;
     *) ;;


### PR DESCRIPTION
Closes #189.

## What

Compile every documented invariant in `consolidate-state.sh` into a structural check. Every existing bypass path now requires an explicit env var with a justification string, logged to `state/signals/friction.md`.

## Why

`blog/SKILL.md` Rule #0: *"report field is MANDATORY for ALL entries — consolidate-state blocks without report"*. This rule lived in prose but not in code. Production data showed the consequence:

- **gauss 2026-04-09**: 9 of 11 beats published `.md` entries with no HTML report. Self-reported by gauss as *"preguiça de pipeline — o .md publica mais rápido sem montar o YAML, e eu fui tomando o atalho."*
- **ed last 20 entries**: 5/20 with HTML reports (25%). Strategy 100%, autonomy 0%, workflow 0/8.
- **Downstream impact** documented in pandoc-block report: João lost the LaTeX/PDF reading path for the entire 9-beat batch because Phase 2 silently skipped, leaving pandoc with nothing to consume even after the dependency was installed.

## Changes (single commit)

| Phase | Bypass closed | Env var required for opt-out |
|---|---|---|
| **2** | `REPORT_INPUT` was optional | `ALLOW_NO_REPORT_REASON` |
| **0.5** | (auto via collateral) `--skip-review` | `SKIP_REVIEW_REASON` |
| **3.3** | `--force` | `FORCE_REASON` |
| **3.35** | warn-only crystallization gate → hard block | `ALLOW_UNCRYSTALLIZED_REASON` |
| **4** | `--no-meta` | `NO_META_REASON` |

**Exit code 4** added: *"missing required enforcement / reason"*. Conventions preserved (0/1/2/3/5 unchanged).

The `require_reason()` helper centralizes the pattern for the four flag-based bypasses. The positional `REPORT_INPUT` case is handled inline because its prompt message differs.

`--help` updated to document new env vars + exit codes.

## Local test results (ed)

- ✅ TEST 1: missing report → exit 4, mentions `ALLOW_NO_REPORT_REASON`
- ✅ TEST 2: `--no-meta` without reason → exit 4, mentions `NO_META_REASON`
- ✅ TEST 3: `--skip-review` without reason → exit 4
- ✅ TEST 4: `--force` without reason → exit 4
- ✅ TEST 5: `ALLOW_NO_REPORT_REASON="testing"` → bypass logged to friction signal, pipeline continues past Rule #0 gate (then blocks at Phase 0.2 source check, which is correct — separate enforcement layer doing its job)
- ✅ Friction signal entry verified: `[2026-04-10 01:22 | consolidate-state] Rule #0 (no report) opt-out: testing enforcement`

## Skipped from analysis

I originally proposed a Phase 5b *"no proposal → block"* fix. After re-reading the code, `edge-state-audit` already hard-blocks on `exit ≥ 4` (divergent change detected). Phase 5b's `warn "No change proposal"` line is informational only — already structurally correct.

## Prior art

- #158 — same pattern shape (`consolidate-state` failing on missing `workflows_used:` when procedure is present). This PR extends the same approach to the rest of the pipeline.

## Blast radius

When this lands and propagates fleet-wide, **every skill that today produces blog-only entries (no YAML spec) will exit 4 on its next call.** This is the point — silent failure becomes loud failure. Skills that genuinely need to publish without a report can opt out with `ALLOW_NO_REPORT_REASON=...`, but every opt-out is logged and auditable.

Expected fallout: a brief storm of exit-4s on first heartbeat, then skills either start generating YAML specs (the right fix) or operators add explicit opt-outs with justification.

## Propagation plan (after merge)

1. ed (local) — `git pull` + smoke test
2. gauss (the instance with confirmed bypasses) — verify enforcement fires
3. drucker, roberto, bracis — same flow, one at a time

## Conflict note

PR #188 was closed at operator request to clear the way. No other open PRs touch `blog/consolidate-state.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)