### PR TITLE
feat: llm-provider as epigenetic primitive for non-standard providers (#194)

### DIFF
--- a/agent.yaml.example
+++ b/agent.yaml.example
@@ -180,6 +180,14 @@ public_url: ""
 repo_owner: lucasrp
 repo_name: edge-of-chaos
 
+# --- LLM Provider (optional) ---
+# Only set this if NOT using standard OpenAI (sk-*) or Grok (xAI).
+# When set, edge-apply generates a llm-provider primitive in libexec/
+# that the agent owns and can fix directly.
+# Values: azure, openrouter, bedrock (omit for standard OpenAI/Grok)
+# llm_provider: azure
+
+# --- LLM Models ---
 openai_model: gpt-5.4
 openai_model_mini: gpt-4.1-mini
 grok_model: grok-4.20-multi-agent-beta-0309

--- a/tools/_shared/openai_client.py
+++ b/tools/_shared/openai_client.py
@@ -18,13 +18,16 @@ Usage:
     # Works identically whether OpenAI or AzureOpenAI
 """
 
+import json
 import os
+import subprocess
 from pathlib import Path
 
 _SECRETS_DIR = None
 AZURE_API_VERSION_DEFAULT = "2025-03-01-preview"
 
 _env_loaded = False
+_provider_config = None
 
 
 def _get_secrets_dir() -> Path:
@@ -80,12 +83,40 @@ def _is_azure_key(api_key: str) -> bool:
     return bool(api_key) and not api_key.startswith("sk-")
 
 
-def make_openai_client(api_key=None, timeout=120, base_url=None):
-    """Create OpenAI or AzureOpenAI client based on key type.
+def _load_provider_config():
+    """Check for llm-provider primitive and load its config (#194)."""
+    global _provider_config
+    if _provider_config is not None:
+        return _provider_config
 
-    - If base_url is given (e.g. xAI), always standard OpenAI client.
-    - If key is Azure-style and endpoint available, AzureOpenAI.
-    - Otherwise, standard OpenAI.
+    edge_dir = Path(os.environ.get("EDGE_DIR", os.path.expanduser("~/edge")))
+    codename = os.environ.get("EDGE_CODENAME", "ed")
+    prim_path = edge_dir / "libexec" / codename / "llm-provider"
+
+    if prim_path.exists() and os.access(prim_path, os.X_OK):
+        try:
+            result = subprocess.run(
+                [str(prim_path)], capture_output=True, text=True, timeout=10,
+                env={**os.environ, "EDGE_DIR": str(edge_dir)}
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                _provider_config = json.loads(result.stdout.strip())
+                return _provider_config
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+            pass
+
+    _provider_config = {}
+    return _provider_config
+
+
+def make_openai_client(api_key=None, timeout=120, base_url=None):
+    """Create OpenAI or AzureOpenAI client based on key type or llm-provider primitive.
+
+    Priority:
+    1. Explicit base_url (e.g. xAI) → standard OpenAI client
+    2. llm-provider primitive exists → use its config
+    3. Azure auto-detection (non-sk- key + endpoint)
+    4. Standard OpenAI
     """
     from openai import OpenAI
 
@@ -99,7 +130,30 @@ def make_openai_client(api_key=None, timeout=120, base_url=None):
             kwargs["timeout"] = timeout
         return OpenAI(**kwargs)
 
-    # Azure detection
+    # Check llm-provider primitive (#194)
+    provider_cfg = _load_provider_config()
+    if provider_cfg.get("provider") == "azure":
+        from openai import AzureOpenAI
+        kwargs = {
+            "api_key": provider_cfg.get("api_key", api_key),
+            "azure_endpoint": provider_cfg.get("endpoint", ""),
+            "api_version": provider_cfg.get("api_version", AZURE_API_VERSION_DEFAULT),
+        }
+        if timeout:
+            kwargs["timeout"] = timeout
+        return AzureOpenAI(**kwargs)
+    elif provider_cfg.get("provider") == "openrouter":
+        kwargs = {
+            "api_key": provider_cfg.get("api_key", api_key),
+            "base_url": provider_cfg.get("endpoint", "https://openrouter.ai/api/v1"),
+            "timeout": timeout,
+        }
+        return OpenAI(**kwargs)
+    elif provider_cfg.get("provider") == "bedrock":
+        # Bedrock uses its own SDK — fallback to standard for now
+        pass
+
+    # Azure auto-detection (legacy — kept for instances without llm-provider)
     if _is_azure_key(api_key):
         azure_endpoint = _load_azure_endpoint()
         if azure_endpoint:

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -1272,6 +1272,56 @@ Threads should be concrete workstreams (e.g. 'competitive-landscape', 'positioni
         stubs = sum(1 for e in manifest_entries if e["status"] == "stub")
         ok(f"Source primitives: {active} functional + {stubs} stubs in libexec/{codename_local}/")
 
+    # --- llm-provider primitive for non-standard providers (#194) ---
+    llm_provider = cfg.get("llm_provider", "").strip().lower()
+    if llm_provider and llm_provider not in ("standard", "openai", "xai", "grok", ""):
+        libexec_dir.mkdir(parents=True, exist_ok=True)
+        prim_path = libexec_dir / "llm-provider"
+        meta_path = libexec_dir / "llm-provider.meta.yaml"
+        if not prim_path.exists():
+            # Generate provider-specific primitive
+            if llm_provider == "azure":
+                prim_path.write_text(
+                    '#!/usr/bin/env bash\n'
+                    '# llm-provider — Azure OpenAI config (epigenetic, fix directly)\n'
+                    '# Called by edge-consult, review-gate, and other LLM tools.\n'
+                    '# Outputs JSON with provider config.\n'
+                    'set -uo pipefail\n'
+                    'EDGE_DIR="${EDGE_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"\n'
+                    'source "$EDGE_DIR/secrets/keys.env" 2>/dev/null\n'
+                    'source "$EDGE_DIR/secrets/openai.env" 2>/dev/null\n'
+                    'source "$EDGE_DIR/secrets/azure-tcu.env" 2>/dev/null\n'
+                    'cat <<EOF\n'
+                    '{"provider":"azure","api_key":"${OPENAI_API_KEY}","endpoint":"${AZURE_OPENAI_ENDPOINT:-${URL_AZ_OPENAI:-}}","api_version":"${AZURE_OPENAI_API_VERSION:-2025-03-01-preview}"}\n'
+                    'EOF\n'
+                )
+            else:
+                # Generic template for openrouter, bedrock, etc.
+                prim_path.write_text(
+                    '#!/usr/bin/env bash\n'
+                    f'# llm-provider — {llm_provider} config (epigenetic, fix directly)\n'
+                    '# Called by edge-consult, review-gate, and other LLM tools.\n'
+                    '# Outputs JSON with provider config. Implement for your provider.\n'
+                    'set -uo pipefail\n'
+                    'EDGE_DIR="${EDGE_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"\n'
+                    'source "$EDGE_DIR/secrets/keys.env" 2>/dev/null\n'
+                    f'echo \'{{"provider":"{llm_provider}","error":"not configured — edit this primitive"}}\'\n'
+                    'exit 127\n'
+                )
+            prim_path.chmod(0o755)
+            ok(f"llm-provider primitive generated ({llm_provider})")
+        else:
+            ok(f"llm-provider primitive already exists")
+
+        if not meta_path.exists():
+            meta_path.write_text(
+                f'name: llm-provider\n'
+                f'description: "LLM provider config for {llm_provider}. Outputs JSON with endpoint, key, api_version. Fix directly if broken."\n'
+                f'provider: {llm_provider}\n'
+                f'created_by: edge-apply\n'
+                f'created_at: "{datetime.now().isoformat()}"\n'
+            )
+
     # --- seed workflow blog entries (static, no LLM cost) ---
     prefix = cfg.get("skill_prefix", cfg.get("codename", "ed"))
     workflow_entries = [


### PR DESCRIPTION
## Summary
- New optional `llm_provider` field in agent.yaml: `azure`, `openrouter`, `bedrock`
- edge-apply generates `libexec/{codename}/llm-provider` primitive when set
- `openai_client.py` checks the primitive before legacy Azure auto-detection
- Azure primitive works out of the box; others get a template stub
- Standard OpenAI/Grok users unaffected (field is optional)

Closes #194

## Test plan
- [ ] Add `llm_provider: azure` to bracis/roberto yamls and re-run edge-apply
- [ ] Verify llm-provider primitive is generated and outputs valid JSON
- [ ] Verify edge-consult uses the primitive's config for Azure calls
- [ ] Verify standard OpenAI instances (ed, gauss) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)