### PR TITLE
fix(#206): pipeline enforcement — BLOCKED state + hold queue + idempotent escalation

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -345,54 +345,149 @@ fi
 echo ""
 
 # ─── PHASE 0.3: Adversarial Review Enforcement ───
-# Active: runs edge-consult if no prior review exists for the content.
-# Passive: blocks if .review.json exists without .resolved marker.
-# Covers ALL flows: YAML, HTML, and entry-only.
+# Three terminal states per #206:
+#   PASS    — review.json + .resolved present → proceed
+#   FAIL    — review.json present, no .resolved → block (agent addresses)
+#   BLOCKED — edge-consult couldn't run (key invalid, not in PATH, etc.) →
+#             hold queue at holding/<date>/<slug>.blocked.json, exit 4
+# "continuing without adversarial review" is no longer a path.
 if [[ "$SKIP_REVIEW" == "false" ]]; then
-    # Determine review target: report if provided, otherwise entry
     if [[ -n "$REPORT_INPUT" ]]; then
         REVIEW_TARGET="$REPORT_INPUT"
     else
         REVIEW_TARGET="$ENTRY_PATH"
     fi
 
-    # Derive review/resolved file paths (replace extension with .review.json)
     REVIEW_JSON_FILE="${REVIEW_TARGET%.*}.review.json"
     RESOLVED_FILE="${REVIEW_TARGET%.*}.resolved"
 
-    # Active gate: run edge-consult if no review exists yet
+    # ── Active gate: try to obtain a review verdict ──
     if [[ ! -f "$REVIEW_JSON_FILE" ]]; then
+        echo "── Phase 0.3: Adversarial Review ──"
+        REVIEW_STDERR=$(mktemp -t edge-consult-stderr.XXXXXX)
+        REVIEW_EXIT=0
         if command -v edge-consult &>/dev/null; then
-            echo "── Phase 0.3: Adversarial Review ──"
             echo "  Running edge-consult against $(basename "$REVIEW_TARGET")..."
             if edge-consult "Review this content critically. Flag any shallow analysis, unsupported claims, missing evidence, or logical gaps." \
                 --context "$REVIEW_TARGET" \
                 --gate "$REVIEW_TARGET" \
-                --mode adversarial 2>&1; then
-                echo ""
+                --mode adversarial 2> >(tee "$REVIEW_STDERR" >&2); then
+                REVIEW_EXIT=0
             else
-                warn "edge-consult failed (exit $?) — continuing without adversarial review"
-                echo ""
+                REVIEW_EXIT=$?
             fi
         else
-            warn "edge-consult not found in PATH — skipping adversarial review"
-            echo ""
+            REVIEW_EXIT=127
+            echo "edge-consult not found in PATH" > "$REVIEW_STDERR"
         fi
+
+        # If the review failed to produce review.json, this is BLOCKED (not FAIL).
+        # BLOCKED = step couldn't run. FAIL = step ran and said NO.
+        if [[ ! -f "$REVIEW_JSON_FILE" ]]; then
+            # Classify error heuristically from stderr content + exit code
+            ERROR_CLASS="unknown"
+            if [[ $REVIEW_EXIT -eq 127 ]]; then
+                ERROR_CLASS="tool_not_found"
+            elif grep -qE "401|Incorrect API key|invalid.*key|Unauthorized" "$REVIEW_STDERR" 2>/dev/null; then
+                ERROR_CLASS="auth_failed"
+            elif grep -qE "429|rate limit|quota|credits" "$REVIEW_STDERR" 2>/dev/null; then
+                ERROR_CLASS="rate_or_quota"
+            elif grep -qE "timeout|timed out|network|ECONNREFUSED|ConnectionError" "$REVIEW_STDERR" 2>/dev/null; then
+                ERROR_CLASS="transient_network"
+            elif [[ $REVIEW_EXIT -ne 0 ]]; then
+                ERROR_CLASS="unknown_failure"
+            fi
+
+            # Write hold-queue entry
+            HOLD_DATE=$(date -u +%F)
+            HOLD_DIR="$EDGE_DIR/holding/$HOLD_DATE"
+            mkdir -p "$HOLD_DIR"
+            HOLD_FILE="$HOLD_DIR/${SLUG}.blocked.json"
+            STDERR_SUMMARY=$(head -c 2000 "$REVIEW_STDERR" 2>/dev/null | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))" 2>/dev/null || echo '""')
+            python3 - "$HOLD_FILE" "$SLUG" "$REVIEW_TARGET" "$ERROR_CLASS" "$REVIEW_EXIT" "$STDERR_SUMMARY" <<'PYEOF'
+import json, os, sys, time
+hold_file, slug, target, err_class, exit_code, stderr_json = sys.argv[1:7]
+try:
+    stderr_text = json.loads(stderr_json)
+except Exception:
+    stderr_text = stderr_json
+now = int(time.time())
+attempts = 1
+first_seen = now
+if os.path.exists(hold_file):
+    try:
+        prev = json.load(open(hold_file))
+        attempts = prev.get('attempts', 0) + 1
+        first_seen = prev.get('first_seen', now)
+    except Exception:
+        pass
+entry = {
+    'slug': slug,
+    'target': target,
+    'step': 'adversarial_review',
+    'state': 'BLOCKED',
+    'error_class': err_class,
+    'exit_code': int(exit_code),
+    'stderr_excerpt': stderr_text[-500:] if stderr_text else "",
+    'first_seen': first_seen,
+    'last_attempt': now,
+    'attempts': attempts,
+}
+with open(hold_file, 'w') as f:
+    json.dump(entry, f, indent=2)
+
+# Update rollup index
+index_file = os.path.join(os.path.dirname(os.path.dirname(hold_file)), 'index.json')
+try:
+    index = json.load(open(index_file))
+except Exception:
+    index = {'items': [], 'by_class': {}}
+# Remove any prior entry for this slug, then add current
+index['items'] = [i for i in index.get('items', []) if i.get('slug') != slug]
+index['items'].append({'slug': slug, 'file': hold_file, 'error_class': err_class, 'first_seen': first_seen, 'attempts': attempts})
+index['by_class'] = {}
+for i in index['items']:
+    c = i['error_class']
+    index['by_class'][c] = index['by_class'].get(c, 0) + 1
+index['count'] = len(index['items'])
+with open(index_file, 'w') as f:
+    json.dump(index, f, indent=2)
+PYEOF
+
+            # Idempotent escalation — one notify per (error_class, 6h window)
+            if command -v notify.sh &>/dev/null; then
+                notify.sh alert "Adversarial review BLOCKED on ${SLUG} (class=${ERROR_CLASS}, total in hold: see holding/index.json)" \
+                    --once-per "review_blocked_${ERROR_CLASS}" --window 6h >/dev/null 2>&1 || true
+            elif [[ -x "$EDGE_DIR/tools/notify.sh" ]]; then
+                "$EDGE_DIR/tools/notify.sh" alert "Adversarial review BLOCKED on ${SLUG} (class=${ERROR_CLASS})" \
+                    --once-per "review_blocked_${ERROR_CLASS}" --window 6h >/dev/null 2>&1 || true
+            fi
+
+            rm -f "$REVIEW_STDERR"
+            fail "Adversarial review BLOCKED: edge-consult could not complete (class=${ERROR_CLASS}, exit=${REVIEW_EXIT})"
+            echo ""
+            echo "  Artifact held at: $HOLD_FILE"
+            echo "  Index:            $EDGE_DIR/holding/index.json"
+            echo ""
+            echo "  This is NOT a silent skip. Resolve the cause (refresh key,"
+            echo "  install tool, wait for quota) and re-run consolidate-state."
+            echo "  Next beat preflight will surface this hold queue."
+            echo ""
+            exit 4
+        fi
+
+        rm -f "$REVIEW_STDERR"
     fi
 
-    # Passive gate: block if review exists without resolution
+    # ── Evaluate review verdict: PASS or FAIL ──
     if [[ -f "$REVIEW_JSON_FILE" && ! -f "$RESOLVED_FILE" ]]; then
         echo "── Phase 0.3: Adversarial Review ──"
         fail "Adversarial review pending: $(basename "$REVIEW_JSON_FILE")"
         echo ""
         echo "  edge-consult generated feedback that has not been addressed."
-        echo "  Options:"
-        echo "    1. Address the feedback and create the marker:"
-        echo "       touch $RESOLVED_FILE"
-        echo "    2. Force publication:"
-        echo "       consolidate-state --skip-review ..."
+        echo "  Address the feedback, then create the resolution marker:"
+        echo "     touch $RESOLVED_FILE"
         echo ""
-        # Show the review summary
         python3 -c "
 import json, sys
 try:
@@ -410,8 +505,36 @@ except: pass
     elif [[ -f "$REVIEW_JSON_FILE" && -f "$RESOLVED_FILE" ]]; then
         echo "── Phase 0.3: Adversarial Review ──"
         ok "Adversarial review resolved ($(basename "$RESOLVED_FILE") present)"
+        # Drain hold queue entry if present (this slug is now unblocked)
+        HOLD_FILE_DRAIN="$EDGE_DIR/holding/$(date -u +%F)/${SLUG}.blocked.json"
+        if [[ -f "$HOLD_FILE_DRAIN" ]]; then
+            rm -f "$HOLD_FILE_DRAIN"
+            python3 - "$EDGE_DIR/holding/index.json" "$SLUG" <<'PYEOF' 2>/dev/null || true
+import json, sys, os
+path, slug = sys.argv[1], sys.argv[2]
+try:
+    idx = json.load(open(path))
+except Exception:
+    sys.exit(0)
+idx['items'] = [i for i in idx.get('items', []) if i.get('slug') != slug]
+idx['by_class'] = {}
+for i in idx['items']:
+    c = i['error_class']
+    idx['by_class'][c] = idx['by_class'].get(c, 0) + 1
+idx['count'] = len(idx['items'])
+with open(path, 'w') as f:
+    json.dump(idx, f, indent=2)
+PYEOF
+            ok "Drained hold queue entry for ${SLUG}"
+        fi
         echo ""
     fi
+elif [[ "$SKIP_REVIEW" == "true" ]]; then
+    # Loud warn — not silent. --skip-review exists only for specific internal
+    # flows (e.g., --recover). Every use is logged.
+    warn "SKIP_REVIEW=true — adversarial review bypassed. This path is an internal recovery mechanism; usage is logged."
+    mkdir -p "$EDGE_DIR/logs" 2>/dev/null
+    echo "[$(date -u +%FT%TZ)] consolidate-state --skip-review on ${SLUG} reason=${COMMIT_REASON:-none}" >> "$EDGE_DIR/logs/skip-review.log" 2>/dev/null || true
 fi
 
 # ─── PHASE 0.5: Review Gate (LLM-as-judge) ───

--- a/memory/rules-core.md
+++ b/memory/rules-core.md
@@ -16,7 +16,7 @@ Specific topics go in `memory/topics/`. Core should not exceed 15 rules.
 - When generating a report or blog entry: **verify that key insights enter memory/topics/**. Without distillation = write-only.
 - When publishing an entry: **include claims, threads, keywords, report link**. An entry without metadata is invisible in the corpus.
 - When producing an artifact: **blog ALWAYS**. Primary communication channel with the user.
-- When publishing a report or entry via consolidar-estado: **ALWAYS run `edge-consult --context <content> --mode adversarial` BEFORE invoking consolidar-estado**. If the review identifies gaps, correct them before publishing. The pipeline now enforces this (Phase 0.3 active gate), but running the review first avoids the block-resolve cycle. Use `--skip-review` ONLY when explicitly instructed by the user — never to save time.
+- When publishing a report or entry via consolidar-estado: **ALWAYS run `edge-consult --context <content> --mode adversarial` BEFORE invoking consolidar-estado**. The pipeline has three terminal states for review (per #206): **PASS** (review ok, proceed), **FAIL** (review found issues, address + `touch .resolved`), **BLOCKED** (edge-consult couldn't run — artifact moves to `holding/<date>/<slug>.blocked.json` automatically, one idempotent notify per error class per 6h window, beat continues with other work). Never suggest `--skip-review` to users or teach it as a workaround — its only legitimate use is internal recovery flows. A "silent skip" is a genotype bug — report as issue, not as a runtime workaround.
 
 ## Recognition
 

--- a/tools/edge-source
+++ b/tools/edge-source
@@ -35,6 +35,7 @@ EDGE_DIR="${EDGE_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 CODENAME="${EDGE_CODENAME:-ed}"
 PRIM_PATH="$EDGE_DIR/libexec/$CODENAME/$PRIMITIVE"
 USAGE_LOG="$EDGE_DIR/state/source-usage.jsonl"
+MISSING_LOG="$EDGE_DIR/state/missing-primitives.jsonl"
 
 mkdir -p "$(dirname "$USAGE_LOG")"
 
@@ -43,9 +44,19 @@ TS_START=$(date -u +%FT%TZ)
 # Log start
 echo "{\"ts\":\"$TS_START\",\"source\":\"$PRIMITIVE\",\"codename\":\"$CODENAME\",\"phase\":\"start\"}" >> "$USAGE_LOG"
 
+# Record missing primitive so heartbeat-preflight can surface & route to
+# primitive-build on the next beat. Without this halt-flag, exit 127 is a
+# hint the agent can freely ignore (observed pattern in fleet: primitives
+# stay broken for 7+ days).
+_record_missing() {
+  local reason="$1"
+  echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"primitive\":\"$PRIMITIVE\",\"codename\":\"$CODENAME\",\"reason\":\"$reason\"}" >> "$MISSING_LOG"
+}
+
 # Primitive not found
 if [ ! -x "$PRIM_PATH" ]; then
   echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"source\":\"$PRIMITIVE\",\"codename\":\"$CODENAME\",\"phase\":\"end\",\"ok\":false,\"exit_code\":127,\"error\":\"not found\"}" >> "$USAGE_LOG"
+  _record_missing "not_found"
   _show_contract "$PRIMITIVE" "primitive not found at $PRIM_PATH"
   exit 127
 fi
@@ -57,8 +68,10 @@ RC=$?
 # Log end
 echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"source\":\"$PRIMITIVE\",\"codename\":\"$CODENAME\",\"phase\":\"end\",\"ok\":$([ $RC -eq 0 ] && echo true || echo false),\"exit_code\":$RC}" >> "$USAGE_LOG"
 
-# Exit 127 = not implemented — show contract as implementation instruction
+# Exit 127 = not implemented (per TOOL_CONTRACT.md) — show contract as
+# implementation instruction AND record so preflight can see it.
 if [ $RC -eq 127 ]; then
+  _record_missing "not_implemented"
   _show_contract "$PRIMITIVE" "primitive not implemented"
 fi
 

--- a/tools/heartbeat-preflight.sh
+++ b/tools/heartbeat-preflight.sh
@@ -116,6 +116,59 @@ else
   SIGNALS+=("SOURCE:source-usage.jsonl missing — no primitives have ever been called")
 fi
 
+# 5b. Missing primitives (from #206 edge-source halt-flag)
+# Surface primitives that have been requested but don't exist or aren't
+# implemented. Without this, exit 127 is a hint the agent can ignore;
+# primitives stay broken for days. If anything recent, route next beat to build.
+MISSING_LOG="$EDGE_DIR/state/missing-primitives.jsonl"
+if [ -f "$MISSING_LOG" ]; then
+  missing_summary=$(python3 -c "
+import json
+from datetime import datetime, timedelta, timezone
+cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+counts = {}
+try:
+    with open('$MISSING_LOG') as f:
+        for line in f:
+            try:
+                e = json.loads(line.strip())
+                ts = datetime.fromisoformat(e['ts'].replace('Z', '+00:00'))
+                if ts >= cutoff:
+                    key = f\"{e.get('primitive','?')}({e.get('reason','?')})\"
+                    counts[key] = counts.get(key, 0) + 1
+            except: pass
+    if counts:
+        top = sorted(counts.items(), key=lambda x: -x[1])[:3]
+        print(','.join(f'{k}x{v}' for k,v in top))
+except: pass" 2>/dev/null || echo "")
+  if [ -n "$missing_summary" ]; then
+    SIGNALS+=("PRIMITIVE:missing in last 24h — $missing_summary (next beat should materialize per TOOL_CONTRACT.md)")
+  fi
+fi
+
+# 6. Hold queue (from #206 adversarial review BLOCKED state)
+# Surface artifacts blocked in review so preflight routes to drain before
+# new work. Without this, blocked artifacts age silently in holding/.
+HOLD_INDEX="$EDGE_DIR/holding/index.json"
+if [ -f "$HOLD_INDEX" ]; then
+  hold_summary=$(python3 -c "
+import json, time
+try:
+    idx = json.load(open('$HOLD_INDEX'))
+    count = idx.get('count', 0)
+    if count > 0:
+        now = int(time.time())
+        oldest = min((i.get('first_seen', now) for i in idx.get('items', [])), default=now)
+        age_h = (now - oldest) // 3600
+        by_class = idx.get('by_class', {})
+        cls = ','.join(f'{k}:{v}' for k,v in by_class.items())
+        print(f'{count} artifacts blocked ({cls}) — oldest {age_h}h')
+except: pass" 2>/dev/null || echo "")
+  if [ -n "$hold_summary" ]; then
+    SIGNALS+=("HOLD:$hold_summary — resolve blocking condition, then re-run consolidate-state to drain")
+  fi
+fi
+
 # 6. Recent operator session (last 2h)?
 # PROJECT_DIR already set by paths.sh
 latest_session=$(ls -t "${PROJECT_DIR}"/*.jsonl 2>/dev/null | head -1)

--- a/tools/notify.sh
+++ b/tools/notify.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 # notify.sh — Unified notification routing
-# Usage: notify <type> <message> [--file <path>]
+# Usage: notify <type> <message> [--file <path>] [--once-per <key> --window <duration>]
 #
 # Types: heartbeat, alert, report, default
 # Routes to the correct Slack channel based on config/features.yaml
 # Falls back gracefully: bot_token > webhook > chat API > silent
 #
+# Idempotency (anti-spam for blackouts / repeated failures):
+#   --once-per <key>     dedup key (e.g. openai_401, pandoc_missing)
+#   --window <duration>  duration spec: 30s, 5m, 6h, 1d (default: 6h)
+#   Within window, repeated calls with same key are recorded but not transmitted.
+#   State at $EDGE_DIR/state/notify-windows.json
+#
 # Examples:
 #   notify heartbeat "Beat #5 — /ed-pesquisa sobre DSPy"
 #   notify report "Relatório: IAA Protocol" --file ~/edge/reports/report.html
 #   notify alert "Health degraded: score 45"
+#   notify alert "Adversarial review BLOCKED: openai_401 (3 in hold)" \
+#     --once-per openai_401 --window 6h
 
 set -euo pipefail
 
@@ -19,19 +27,81 @@ EDGE_DIR="$(dirname "$SCRIPT_DIR")"
 TYPE="${1:-default}"
 MESSAGE="${2:-}"
 FILE=""
+ONCE_PER=""
+WINDOW="6h"
 
-# Parse --file argument
+# Parse optional arguments
 shift 2 2>/dev/null || true
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --file) FILE="$2"; shift 2 ;;
+    --once-per) ONCE_PER="$2"; shift 2 ;;
+    --window) WINDOW="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
 
 if [[ -z "$MESSAGE" ]]; then
-  echo "Usage: notify <type> <message> [--file <path>]" >&2
+  echo "Usage: notify <type> <message> [--file <path>] [--once-per <key> --window <duration>]" >&2
   exit 1
+fi
+
+# ─── Idempotency check (--once-per) ──────────────────────────────────────────
+
+# Parse window spec to seconds
+window_seconds() {
+  local w="$1"
+  case "$w" in
+    *s) echo "${w%s}" ;;
+    *m) echo "$((${w%m} * 60))" ;;
+    *h) echo "$((${w%h} * 3600))" ;;
+    *d) echo "$((${w%d} * 86400))" ;;
+    *) echo "$w" ;;
+  esac
+}
+
+WINDOW_FILE="$EDGE_DIR/state/notify-windows.json"
+SUPPRESSED=false
+
+if [[ -n "$ONCE_PER" ]]; then
+  WIN_SEC=$(window_seconds "$WINDOW")
+  mkdir -p "$(dirname "$WINDOW_FILE")"
+  # Atomically check + update via python.
+  # Returns "SEND" or "SUPPRESS:N" where N is current counter.
+  RESULT=$(python3 - "$WINDOW_FILE" "$ONCE_PER" "$WIN_SEC" <<'PYEOF'
+import json, os, sys, time, fcntl
+path, key, win = sys.argv[1], sys.argv[2], int(sys.argv[3])
+now = int(time.time())
+try:
+    with open(path, 'r') as f:
+        state = json.load(f)
+except Exception:
+    state = {}
+entry = state.get(key, {})
+last = entry.get('last_sent', 0)
+in_window = (now - last) < win and last > 0
+if in_window:
+    entry['calls_in_window'] = entry.get('calls_in_window', 1) + 1
+    state[key] = entry
+    print(f"SUPPRESS:{entry['calls_in_window']}")
+else:
+    state[key] = {'last_sent': now, 'window_seconds': win, 'calls_in_window': 1}
+    print("SEND")
+tmp = path + '.tmp'
+with open(tmp, 'w') as f:
+    json.dump(state, f, indent=2)
+os.replace(tmp, path)
+PYEOF
+  )
+  if [[ "$RESULT" == SUPPRESS:* ]]; then
+    SUPPRESSED=true
+    COUNT="${RESULT#SUPPRESS:}"
+    mkdir -p "$EDGE_DIR/logs" 2>/dev/null
+    echo "[$(date '+%Y-%m-%d %H:%M')] notify $TYPE: SUPPRESSED key=$ONCE_PER count=$COUNT msg=\"$MESSAGE\"" \
+      >> "$EDGE_DIR/logs/notify.log" 2>/dev/null || true
+    echo "suppressed (within window) — key=$ONCE_PER count=$COUNT"
+    exit 0
+  fi
 fi
 
 # ─── Load config ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Resolves #206.

## Summary

Replaces the silent-skip pattern in the publication pipeline with an
explicit three-state protocol for mandatory steps (**PASS / FAIL /
BLOCKED**). The agents can no longer silently continue past a review
that couldn't run.

## What changed

| Commit | File | What |
|---|---|---|
| 16517c6 | `tools/notify.sh` | Add `--once-per <key> --window <dur>` for idempotent escalation during blackouts |
| 0310591 | `tools/edge-source` | On exit 127 (primitive not found/implemented), append to `state/missing-primitives.jsonl` so preflight can see it |
| d5b3863 | `blog/consolidate-state.sh` | Phase 0.3 rewritten: remove silent-continue paths, classify edge-consult failures, write `holding/<date>/<slug>.blocked.json` + `holding/index.json`, idempotent notify per error class, new exit code 4 (BLOCKED). Drain on resolution |
| 500613a | `tools/heartbeat-preflight.sh` | Surface PRIMITIVE and HOLD signals so next beat routes to remediation |
| cce8839 | `memory/rules-core.md` | Codify PASS/FAIL/BLOCKED semantics; frame "silent skip" as genotype bug to file, not runtime workaround |

## Error classification (heuristic, stderr-based)

| Class | Heuristic | Expected operator action |
|---|---|---|
| `tool_not_found` | exit 127 or "not found in PATH" | install tool / fix PATH |
| `auth_failed` | 401 / "Incorrect API key" / Unauthorized | refresh key in `secrets/keys.env` |
| `rate_or_quota` | 429 / rate limit / quota / credits | wait for reset or buy credits |
| `transient_network` | timeout / ECONNREFUSED / network | retry (usually self-resolves) |
| `unknown_failure` | exit ≠ 0, no pattern match | inspect `stderr_excerpt` in blocked.json |

## Not in this PR (follow-up issues)

- Local fallback reviewer (structural heuristic for when cross-model unavailable >72h)
- Per-skill `on_failure:` declaration in skill frontmatter
- Automatic synonym merge in workflow recall index
- Auto-thread creation after M consecutive primitive failures
- Exit-code classification in `edge-consult.py` itself (currently heuristic in
  consolidate-state; could be moved upstream)

## Test plan

- [x] Syntax check on all modified shell files
- [x] notify.sh idempotency verified end-to-end (suppress, distinct keys independent, window expiry)
- [x] edge-source halt-flag verified (not-found and not-implemented both recorded)
- [x] Hold-queue python logic verified standalone (write, increment attempts, drain)
- [ ] Smoke test on ed (local instance): simulate edge-consult failure, verify hold queue populated, notify suppressed on second call, preflight surfaces HOLD
- [ ] Propagate to gauss, drucker, roberto, bracis via git pull + edge-apply
- [ ] Confirm next beat on each sibling shows new PRIMITIVE/HOLD signals when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)