### PR TITLE
Agnostic OpenAI-compatible router handler — #222

### DIFF
--- a/agent.yaml.example
+++ b/agent.yaml.example
@@ -187,11 +187,65 @@ public_url: ""                  # public URL of the blog (if exposed)
 repo_owner: "lucasrp"           # GitHub user/org
 repo_name: "edge-of-chaos"     # GitHub repo name
 
-# --- LLM Models (used by tools — override if needed) ---
+# --- LLM Models (legacy flat keys — kept for back-compat) ---
+# router_client.py falls back to these when routers: is missing.
 openai_model: "gpt-5.4"                    # edge-consult primary, review-gate
 openai_model_mini: "gpt-4.1-mini"          # seed generation, cheap tasks
 grok_model: "grok-4.20-multi-agent-beta-0309"  # edge-consult secondary
 image_model: "gpt-image-1"                 # avatar generation
+
+# --- Routers (agnostic LLM handler — issue #222) ---
+# Each router binds a PURPOSE (chat, review, embedding, deepresearch, …) to an
+# OpenAI-compatible v1 endpoint. Code has zero branches on provider kind —
+# anything that speaks the OpenAI contract (Azure, xAI, OpenRouter, LiteLLM,
+# Groq, Together, vLLM, self-hosted) is reachable by declaring it here.
+# Non-OpenAI-compatible providers sit behind a translator (LiteLLM/OpenRouter/
+# portkey); the agent only sees the translator.
+#
+# Fields:
+#   base_url    — full OpenAI-compatible v1 endpoint
+#   secret_ref  — "<file.env>:<VAR_NAME>" → resolved from secrets/ or env
+#   model       — model slug sent in requests
+#   headers     — optional default headers (supports ${key} substitution for
+#                 Azure api-key style)
+#   query       — optional default query params (Azure api-version, etc.)
+#
+# Example — switch 'chat' to Azure OpenAI without touching code:
+#   chat:
+#     base_url: https://oai-eastus2.openai.azure.com/openai/deployments/gpt_4_1
+#     secret_ref: openai.env:AZURE_OPENAI_KEY
+#     headers:
+#       api-key: "${key}"
+#     query:
+#       api-version: "2024-02-15-preview"
+#     model: gpt_4_1
+#
+# Example — route 'review' through OpenRouter:
+#   review:
+#     base_url: https://openrouter.ai/api/v1
+#     secret_ref: openrouter.env:OPENROUTER_API_KEY
+#     model: anthropic/claude-opus-4.7
+routers:
+  chat:
+    base_url: https://api.openai.com/v1
+    secret_ref: openai.env:OPENAI_API_KEY
+    model: gpt-5.4
+  chat_mini:
+    base_url: https://api.openai.com/v1
+    secret_ref: openai.env:OPENAI_API_KEY
+    model: gpt-4.1-mini
+  review:
+    base_url: https://api.x.ai/v1
+    secret_ref: xai.env:XAI_API_KEY
+    model: grok-4.20-multi-agent-beta-0309
+  embedding:
+    base_url: https://api.openai.com/v1
+    secret_ref: openai.env:OPENAI_API_KEY
+    model: text-embedding-3-small
+  deepresearch:
+    base_url: https://api.openai.com/v1
+    secret_ref: openai.env:OPENAI_API_KEY
+    model: gpt-5.4
 
 # --- API Keys (secrets/keys.env — NEVER commit values here) ---
 # Copy secrets/keys.env.example → secrets/keys.env and fill in.

--- a/search/embed.py
+++ b/search/embed.py
@@ -1,51 +1,31 @@
-"""Embedding provider for edge-memory."""
+"""Embedding provider for edge-memory.
 
-import os
+Uses the agnostic router handler (#222). Endpoint/key/model are declared in
+agent.yaml routers.embedding — no provider knowledge in this file.
+"""
+
+import sys
 from pathlib import Path
 
-from openai import OpenAI
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+from _shared.router_client import make_client  # noqa: E402
 
-MODEL = "text-embedding-3-small"
 MAX_CHARS = 8000  # ~2000 tokens, safe limit
 
 
-def _load_key() -> str:
-    import sys as _sys
-    _sys.path.insert(0, str(Path(__file__).parent.parent / "config"))
-    from paths import OPENAI_ENV
-    env_file = OPENAI_ENV
-    if env_file.exists():
-        for line in env_file.read_text().splitlines():
-            line = line.strip()
-            if line and not line.startswith("#") and "=" in line:
-                key, val = line.split("=", 1)
-                os.environ[key.strip()] = val.strip()
-
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        raise RuntimeError(
-            "OPENAI_API_KEY not found. Set it in ~/edge/secrets/openai.env"
-        )
-    return api_key
-
-
 def embed_text(text: str) -> list[float]:
-    api_key = _load_key()
-    client = OpenAI(api_key=api_key)
-    # Truncate to avoid token limits
-    truncated = text[:MAX_CHARS]
-    resp = client.embeddings.create(model=MODEL, input=truncated)
+    client, model = make_client("embedding")
+    resp = client.embeddings.create(model=model, input=text[:MAX_CHARS])
     return resp.data[0].embedding
 
 
 def embed_batch(texts: list[str], batch_size: int = 100) -> list[list[float]]:
-    api_key = _load_key()
-    client = OpenAI(api_key=api_key)
+    client, model = make_client("embedding")
     all_embeddings = []
 
     for i in range(0, len(texts), batch_size):
         batch = [t[:MAX_CHARS] for t in texts[i : i + batch_size]]
-        resp = client.embeddings.create(model=MODEL, input=batch)
+        resp = client.embeddings.create(model=model, input=batch)
         all_embeddings.extend([d.embedding for d in resp.data])
 
     return all_embeddings

--- a/tools/_shared/router_client.py
+++ b/tools/_shared/router_client.py
@@ -1,0 +1,255 @@
+"""Agnostic OpenAI-compatible router client.
+
+Single abstraction for every LLM/embedding call in the codebase. The YAML
+declares everything (base_url, secret ref, headers, query, model). The code
+has no per-provider branches — anything that speaks the OpenAI contract
+(direct OpenAI, Azure, xAI, OpenRouter, LiteLLM, Groq, Together, vLLM…) is
+reachable with the same function.
+
+Providers that do NOT speak OpenAI-compatible (Bedrock native, Vertex native)
+are expected to sit behind a translator (LiteLLM, OpenRouter, portkey). The
+agent never sees them directly.
+
+Resolves issue #222.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml  # type: ignore
+except ImportError:
+    yaml = None  # type: ignore
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "config"))
+from paths import EDGE_DIR, SECRETS_DIR  # noqa: E402
+
+AGENT_YAML = EDGE_DIR / "agent.yaml"
+
+# --- Legacy fallback: used when agent.yaml has no routers: block. Mirrors
+# the pre-#222 behavior (OpenAI default + xAI for grok). Prefix-match on the
+# model slug picks the right one. Kept tight so installs without routers:
+# keep working.
+_LEGACY_DEFAULTS: dict[str, dict[str, Any]] = {
+    "chat": {
+        "base_url": "https://api.openai.com/v1",
+        "secret_ref": "openai.env:OPENAI_API_KEY",
+        "model_key": "openai_model",
+        "model_default": "gpt-5.4",
+    },
+    "chat_mini": {
+        "base_url": "https://api.openai.com/v1",
+        "secret_ref": "openai.env:OPENAI_API_KEY",
+        "model_key": "openai_model_mini",
+        "model_default": "gpt-4.1-mini",
+    },
+    "review": {
+        "base_url": "https://api.x.ai/v1",
+        "secret_ref": "xai.env:XAI_API_KEY",
+        "model_key": "grok_model",
+        "model_default": "grok-4.20-multi-agent-beta-0309",
+    },
+    "embedding": {
+        "base_url": "https://api.openai.com/v1",
+        "secret_ref": "openai.env:OPENAI_API_KEY",
+        "model_key": None,
+        "model_default": "text-embedding-3-small",
+    },
+    "deepresearch": {
+        "base_url": "https://api.openai.com/v1",
+        "secret_ref": "openai.env:OPENAI_API_KEY",
+        "model_key": "openai_model",
+        "model_default": "gpt-5.4",
+    },
+}
+
+
+@lru_cache(maxsize=1)
+def _load_agent_yaml() -> dict[str, Any]:
+    if yaml is None or not AGENT_YAML.exists():
+        return {}
+    try:
+        data = yaml.safe_load(AGENT_YAML.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _resolve_legacy(purpose: str) -> dict[str, Any] | None:
+    spec = _LEGACY_DEFAULTS.get(purpose)
+    if spec is None:
+        return None
+    agent = _load_agent_yaml()
+    model = spec["model_default"]
+    if spec["model_key"] and agent.get(spec["model_key"]):
+        model = agent[spec["model_key"]]
+    return {
+        "base_url": spec["base_url"],
+        "secret_ref": spec["secret_ref"],
+        "model": model,
+        "headers": {},
+        "query": {},
+    }
+
+
+def load_router_config(purpose: str) -> dict[str, Any]:
+    """Return the resolved router config for a purpose.
+
+    Lookup order:
+      1. agent.yaml routers.<purpose>
+      2. legacy defaults (_LEGACY_DEFAULTS) — back-compat for installs that
+         haven't declared routers: yet.
+    """
+    agent = _load_agent_yaml()
+    routers = agent.get("routers") or {}
+    cfg = routers.get(purpose) if isinstance(routers, dict) else None
+    if cfg:
+        return {
+            "base_url": cfg["base_url"],
+            "secret_ref": cfg["secret_ref"],
+            "model": cfg["model"],
+            "headers": dict(cfg.get("headers") or {}),
+            "query": dict(cfg.get("query") or {}),
+        }
+    legacy = _resolve_legacy(purpose)
+    if legacy:
+        return legacy
+    raise KeyError(
+        f"No router found for purpose={purpose!r}. "
+        "Declare it under routers: in agent.yaml."
+    )
+
+
+def find_router_for_model(model: str) -> tuple[str, dict[str, Any]]:
+    """Reverse lookup — find the first router whose model == <model>.
+
+    Used when a caller has a hard model slug (e.g. from --model CLI flag) and
+    needs to resolve which router owns it. Falls back to legacy defaults so
+    pre-existing model strings like 'grok-4.20-...' still work.
+    """
+    agent = _load_agent_yaml()
+    routers = agent.get("routers") or {}
+    if isinstance(routers, dict):
+        for name, cfg in routers.items():
+            if cfg and cfg.get("model") == model:
+                return name, load_router_config(name)
+    # Legacy prefix match
+    for purpose, spec in _LEGACY_DEFAULTS.items():
+        if model.startswith(spec["model_default"].split("-")[0]):
+            cfg = _resolve_legacy(purpose)
+            if cfg:
+                cfg["model"] = model  # caller's override wins
+                return purpose, cfg
+    raise KeyError(f"No router declares model={model!r}.")
+
+
+def load_secret(secret_ref: str) -> str:
+    """Resolve a secret reference like 'openai.env:OPENAI_API_KEY'.
+
+    Lookup order:
+      1. process environment (always wins — allows --env overrides)
+      2. file named secrets/<file>, KEY=VALUE lines
+    """
+    if ":" not in secret_ref:
+        raise ValueError(
+            f"Invalid secret_ref={secret_ref!r}; expected 'file.env:VAR_NAME'."
+        )
+    filename, var = secret_ref.split(":", 1)
+    val = os.environ.get(var)
+    if val:
+        return val
+    path = SECRETS_DIR / filename
+    if path.exists():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            if k.strip() == var:
+                return v.strip()
+    raise RuntimeError(
+        f"Secret {var!r} not found in environment or {path}."
+    )
+
+
+_SUBST_RE = re.compile(r"\$\{(\w+)\}")
+
+
+def _substitute(template: str, mapping: dict[str, str]) -> str:
+    """Replace ${NAME} tokens using mapping. Leaves unknown tokens untouched."""
+    def _sub(m: re.Match[str]) -> str:
+        return mapping.get(m.group(1), m.group(0))
+    return _SUBST_RE.sub(_sub, template)
+
+
+def make_client(
+    purpose: str | None = None,
+    *,
+    model: str | None = None,
+    timeout: float | None = None,
+    **kwargs: Any,
+) -> tuple[Any, str]:
+    """Build an OpenAI-compatible client for the given purpose (or model).
+
+    Returns (client, model_name). Caller uses the client like any OpenAI SDK
+    instance: client.chat.completions.create(...), client.embeddings.create(...),
+    client.responses.create(...).
+
+    Args:
+      purpose: router name from agent.yaml (chat, review, embedding, …).
+      model: override — if passed, resolves the router by model lookup.
+             When both purpose and model are passed, purpose's router is used
+             but model overrides the router-declared model slug.
+      timeout: passed to the OpenAI SDK constructor.
+      **kwargs: forwarded to OpenAI() (e.g., max_retries).
+    """
+    try:
+        from openai import OpenAI  # imported lazily so tests without SDK don't break on import
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "openai package is required: pip install openai"
+        ) from exc
+
+    if purpose is None and model is None:
+        raise ValueError("make_client requires purpose or model.")
+
+    if purpose is not None:
+        cfg = load_router_config(purpose)
+        if model is not None:
+            cfg["model"] = model
+    else:
+        _, cfg = find_router_for_model(model)  # type: ignore[arg-type]
+
+    api_key = load_secret(cfg["secret_ref"])
+    subst = {"key": api_key, "KEY": api_key}
+    headers = {k: _substitute(str(v), subst) for k, v in cfg.get("headers", {}).items()}
+    query = {k: _substitute(str(v), subst) for k, v in cfg.get("query", {}).items()}
+
+    client_kwargs: dict[str, Any] = {
+        "api_key": api_key,
+        "base_url": cfg["base_url"],
+    }
+    if headers:
+        client_kwargs["default_headers"] = headers
+    if query:
+        client_kwargs["default_query"] = query
+    if timeout is not None:
+        client_kwargs["timeout"] = timeout
+    client_kwargs.update(kwargs)
+
+    return OpenAI(**client_kwargs), cfg["model"]
+
+
+__all__ = [
+    "load_router_config",
+    "find_router_for_model",
+    "load_secret",
+    "make_client",
+]

--- a/tools/_shared/routines.py
+++ b/tools/_shared/routines.py
@@ -87,16 +87,14 @@ def _call_claude_cli(prompt: str, timeout: int = 60) -> str | None:
     return None
 
 
-def _call_openai(prompt: str, model: str = "gpt-4o-mini", timeout: int = 60) -> str | None:
-    """Tier 2: OpenAI API via openai SDK. Requires OPENAI_API_KEY."""
-    if not os.environ.get("OPENAI_API_KEY"):
-        return None
+def _call_openai(prompt: str, timeout: int = 60) -> str | None:
+    """Tier 2: OpenAI-compatible chat_mini router. Falls back when claude-cli absent."""
     try:
-        from openai import OpenAI
+        from .router_client import make_client
     except ImportError:
-        return None
+        from router_client import make_client  # type: ignore
     try:
-        client = OpenAI(timeout=timeout)
+        client, model = make_client("chat_mini", timeout=timeout)
         response = client.chat.completions.create(
             model=model,
             messages=[{"role": "user", "content": prompt}],
@@ -117,7 +115,7 @@ def _call_llm(prompt: str) -> tuple[str | None, str | None]:
         return out, "claude-cli"
     out = _call_openai(prompt)
     if out is not None:
-        return out, "openai-gpt-4o-mini"
+        return out, "openai-chat_mini"
     return None, None
 
 

--- a/tools/edge-adversarial-research.py
+++ b/tools/edge-adversarial-research.py
@@ -34,7 +34,9 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import LOGS_DIR as _LOGS_DIR, SECRETS_DIR
+sys.path.insert(0, str(SCRIPT_DIR))
+from paths import LOGS_DIR as _LOGS_DIR, SECRETS_DIR  # noqa: E402
+from _shared.router_client import make_client  # noqa: E402
 
 LOG_DIR = _LOGS_DIR / "adversarial-research"
 
@@ -247,18 +249,6 @@ If APPROVED, also provide:
 # API Key loading
 # ---------------------------------------------------------------------------
 
-def load_openai_key() -> str:
-    key = os.environ.get("OPENAI_API_KEY") or os.environ.get("AGENT_OPENAI_API_KEY")
-    if key:
-        return key
-    secrets_file = SECRETS_DIR / "openai.env"
-    if secrets_file.exists():
-        for line in secrets_file.read_text().strip().split("\n"):
-            if line.startswith("OPENAI_API_KEY="):
-                return line.split("=", 1)[1].strip()
-    return ""
-
-
 def load_gemini_key() -> str:
     key = (os.environ.get("GEMINI_API_KEY")
            or os.environ.get("GOOGLE_API_KEY")
@@ -297,18 +287,15 @@ def estimate_cost(model: str, input_tokens: int, output_tokens: int) -> str:
 # ---------------------------------------------------------------------------
 
 def call_openai(system: str, user_msg: str, model: str = None) -> dict:
-    """Call OpenAI with web_search tool."""
+    """Call OpenAI-compatible deepresearch router with web_search tool."""
+    model = model or os.environ.get("EDGE_MODEL_ADVERSARIAL_OPENAI")
     try:
-        from openai import OpenAI
-    except ImportError:
-        return {"error": "openai package not installed"}
-
-    api_key = load_openai_key()
-    if not api_key:
-        return {"error": "OPENAI_API_KEY not found"}
-
-    model = model or os.environ.get("EDGE_MODEL_ADVERSARIAL_OPENAI", "gpt-4.1")
-    client = OpenAI(api_key=api_key, timeout=180)
+        if model:
+            client, model = make_client(model=model, timeout=180)
+        else:
+            client, model = make_client("deepresearch", timeout=180)
+    except Exception as e:
+        return {"error": f"router setup failed: {e}"}
 
     try:
         response = client.responses.create(

--- a/tools/edge-consult.py
+++ b/tools/edge-consult.py
@@ -25,14 +25,12 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-try:
-    from openai import OpenAI
-except ImportError:
-    sys.exit("openai package required: pip install openai")
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import SECRETS_DIR, LOGS_DIR
+sys.path.insert(0, str(SCRIPT_DIR))
+from paths import SECRETS_DIR, LOGS_DIR  # noqa: E402  (kept for downstream consumers)
+from _shared.router_client import make_client  # noqa: E402
+
 LOG_DIR = LOGS_DIR / "consult"
 
 # Hard timeouts to avoid silent hangs (#92). These are client-side limits on
@@ -106,19 +104,8 @@ def _check_contention() -> list[tuple[int, str]]:
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
 
-# Provider configs: model prefix -> (secrets_file, env_var, base_url)
-PROVIDERS = {
-    "gpt": {
-        "secrets_file": SECRETS_DIR / "openai.env",
-        "env_var": "OPENAI_API_KEY",
-        "base_url": None,  # default OpenAI
-    },
-    "grok": {
-        "secrets_file": SECRETS_DIR / "xai.env",
-        "env_var": "XAI_API_KEY",
-        "base_url": "https://api.x.ai/v1",
-    },
-}
+# Provider resolution delegated to _shared/router_client.py (#222). Any new
+# model/endpoint is declared in agent.yaml routers: — no changes here.
 
 # ---------------------------------------------------------------------------
 # System prompts
@@ -170,34 +157,9 @@ game theory, design, psychology that apply here?
 # Infrastructure
 # ---------------------------------------------------------------------------
 
-def get_provider(model: str) -> dict:
-    """Determine provider config from model name prefix."""
-    for prefix, config in PROVIDERS.items():
-        if model.startswith(prefix):
-            return config
-    # Fallback to OpenAI
-    return PROVIDERS["gpt"]
-
-
-def load_api_key(model: str) -> tuple[str, str | None]:
-    """Load API key for the given model. Returns (api_key, base_url)."""
-    provider = get_provider(model)
-    env_var = provider["env_var"]
-    base_url = provider["base_url"]
-
-    # Check environment variable first
-    key = os.environ.get(env_var)
-    if key:
-        return key, base_url
-
-    # Check secrets file
-    secrets_file = provider["secrets_file"]
-    if secrets_file.exists():
-        for line in secrets_file.read_text().strip().split("\n"):
-            if line.startswith(f"{env_var}="):
-                return line.split("=", 1)[1].strip(), base_url
-
-    raise RuntimeError(f"{env_var} not found (needed for {model}). Set env var or create {secrets_file}")
+# Provider/key resolution now lives in _shared/router_client.py (#222). See
+# make_client() — it handles OpenAI-compatible endpoints, Azure, xAI, and
+# anything else that speaks the OpenAI contract.
 
 
 def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> str:
@@ -323,11 +285,7 @@ def _call_model(model: str, system: str, user_msg: str,
     The timeout parameter is passed to the OpenAI client constructor — any
     single HTTP call exceeding it raises APITimeoutError, which the caller
     converts to a logged failure (#92 fix 2: hard timeout default)."""
-    api_key, base_url = load_api_key(model)
-    client_kwargs = {"api_key": api_key, "timeout": timeout}
-    if base_url:
-        client_kwargs["base_url"] = base_url
-    client = OpenAI(**client_kwargs)
+    client, _resolved_model = make_client(model=model, timeout=timeout)
 
     if model in RESPONSES_API_MODELS:
         response = client.responses.create(

--- a/tools/edge-deepresearch.py
+++ b/tools/edge-deepresearch.py
@@ -38,7 +38,9 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import LOGS_DIR as _LOGS_DIR, SECRETS_DIR
+sys.path.insert(0, str(SCRIPT_DIR))
+from paths import LOGS_DIR as _LOGS_DIR, SECRETS_DIR  # noqa: E402
+from _shared.router_client import make_client  # noqa: E402
 
 LOG_DIR = _LOGS_DIR / "deepresearch"
 
@@ -115,23 +117,6 @@ What couldn't be found? What needs primary research?
 # API Key loading
 # ---------------------------------------------------------------------------
 
-def load_openai_key() -> str:
-    """Load OpenAI API key from env or secrets."""
-    key = os.environ.get("OPENAI_API_KEY")
-    if key:
-        return key
-    secrets_file = SECRETS_DIR / "openai.env"
-    if secrets_file.exists():
-        for line in secrets_file.read_text().strip().split("\n"):
-            if line.startswith("OPENAI_API_KEY="):
-                return line.split("=", 1)[1].strip()
-    # Try agent-specific env var
-    key = os.environ.get("AGENT_OPENAI_API_KEY")
-    if key:
-        return key
-    return ""
-
-
 def load_gemini_key() -> str:
     """Load Gemini API key from env or secrets."""
     key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
@@ -177,18 +162,14 @@ def estimate_cost(provider: str, model: str, input_tokens: int, output_tokens: i
 
 def research_openai(query: str, system: str, context: str = "",
                     model: str = None) -> dict:
-    """Run deep research via OpenAI Responses API with web_search tool."""
+    """Run deep research via OpenAI-compatible Responses API with web_search."""
     try:
-        from openai import OpenAI
-    except ImportError:
-        return {"provider": "openai", "error": "openai package not installed: pip install openai"}
-
-    api_key = load_openai_key()
-    if not api_key:
-        return {"provider": "openai", "error": "OPENAI_API_KEY not found"}
-
-    model = model or DEFAULT_OPENAI_MODEL
-    client = OpenAI(api_key=api_key, timeout=180)
+        if model:
+            client, model = make_client(model=model, timeout=180)
+        else:
+            client, model = make_client("deepresearch", timeout=180)
+    except Exception as e:
+        return {"provider": "openai", "error": f"router setup failed: {e}"}
 
     user_msg = query
     if context:

--- a/tools/edge-dialogue.py
+++ b/tools/edge-dialogue.py
@@ -18,20 +18,9 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import OPENAI_ENV, LOGS_DIR
-
-def load_api_key():
-    """Load OpenAI API key from env or secrets file."""
-    key = os.environ.get("OPENAI_API_KEY")
-    if key:
-        return key
-    secrets = OPENAI_ENV
-    if secrets.exists():
-        for line in secrets.read_text().splitlines():
-            if line.startswith("OPENAI_API_KEY="):
-                return line.split("=", 1)[1].strip()
-    print("ERROR: No OPENAI_API_KEY found", file=sys.stderr)
-    sys.exit(1)
+sys.path.insert(0, str(SCRIPT_DIR))
+from paths import LOGS_DIR  # noqa: E402
+from _shared.router_client import make_client  # noqa: E402
 
 def dialogue_responses_api(client, model, system_prompt, messages, session_name):
     """Multi-turn dialogue using OpenAI Responses API (for pro models)."""
@@ -139,10 +128,8 @@ def main():
     for mf in args.messages:
         messages.append(Path(mf).read_text().strip())
 
-    # Setup
-    api_key = load_api_key()
-    from openai import OpenAI
-    client = OpenAI(api_key=api_key, timeout=300)  # 5min timeout per request
+    # Setup — resolve router via model slug so --model flag still works.
+    client, _ = make_client(model=args.model, timeout=300)
 
     log_dir = Path(args.log_dir)
     log_dir.mkdir(parents=True, exist_ok=True)

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -27,11 +27,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-try:
-    from openai import OpenAI
-except ImportError:
-    sys.exit("openai package required: pip install openai")
-
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
@@ -40,14 +35,14 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 
 # Load paths from shared config
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from branding import load_branding
-from paths import (MEMORY_DIR, REPORTS_DIR, NOTES_DIR, SKILLS_DIR,
-                   RUBRIC_PATH, OPENAI_ENV as SECRETS_PATH,
-                   XAI_ENV as XAI_SECRETS_PATH)
+sys.path.insert(0, str(SCRIPT_DIR))
+from branding import load_branding  # noqa: E402
+from paths import (MEMORY_DIR, REPORTS_DIR, NOTES_DIR, SKILLS_DIR,  # noqa: E402
+                   RUBRIC_PATH)
+from _shared.router_client import make_client  # noqa: E402
 _AGENT_NAME = load_branding().get("agent_name", "agent")
 _SKILL_PREFIX = load_branding().get("skill_prefix", "agent")
 BLOG_RULES_PATH = SKILLS_DIR / f"{_SKILL_PREFIX}-blog" / "SKILL.md"
-XAI_BASE_URL = "https://api.x.ai/v1"
 GROK_MODEL = "grok-4.20-multi-agent-beta-0309"
 
 DEFAULT_MODEL = "gpt-5.4"
@@ -499,38 +494,6 @@ Language: Portuguese (PT-BR). Output: ONLY the complete, corrected YAML. No mark
 # Loaders
 # ---------------------------------------------------------------------------
 
-def load_api_key() -> str:
-    key = os.environ.get("OPENAI_API_KEY")
-    if key:
-        return key
-    if SECRETS_PATH.exists():
-        for line in SECRETS_PATH.read_text().strip().split("\n"):
-            if line.startswith("OPENAI_API_KEY="):
-                return line.split("=", 1)[1].strip()
-    print("ERROR: OPENAI_API_KEY not found.", file=sys.stderr)
-    sys.exit(2)
-
-
-def load_xai_key() -> str | None:
-    """Load xAI API key. Returns None if not available (non-fatal)."""
-    key = os.environ.get("XAI_API_KEY")
-    if key:
-        return key
-    if XAI_SECRETS_PATH.exists():
-        for line in XAI_SECRETS_PATH.read_text().strip().split("\n"):
-            if line.startswith("XAI_API_KEY="):
-                return line.split("=", 1)[1].strip()
-    return None
-
-
-def get_xai_client() -> OpenAI | None:
-    """Get xAI client. Returns None if key not available."""
-    key = load_xai_key()
-    if not key:
-        return None
-    return OpenAI(api_key=key, base_url=XAI_BASE_URL)
-
-
 def load_rubric() -> str:
     if RUBRIC_PATH.exists():
         return RUBRIC_PATH.read_text(encoding="utf-8")
@@ -580,8 +543,7 @@ def load_entry(entry_path: str) -> str:
 def coauthor(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
              entry_path: str = None, brief: str = None) -> dict:
     """Run co-author phase with tool use. Returns enrichment suggestions."""
-    api_key = load_api_key()
-    client = OpenAI(api_key=api_key)
+    client, model = make_client(model=model)
 
     yaml_content = Path(yaml_path).read_text(encoding="utf-8")
 
@@ -732,13 +694,10 @@ def coauthor(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
 def review(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
            threshold: float = 3.0, entry_path: str = None) -> dict:
     """Run review phase. Returns structured feedback dict."""
-    if model.startswith("grok"):
-        client = get_xai_client()
-        if not client:
-            raise RuntimeError("xAI API key not available for Grok model")
-    else:
-        api_key = load_api_key()
-        client = OpenAI(api_key=api_key)
+    try:
+        client, model = make_client(model=model)
+    except Exception as e:
+        raise RuntimeError(f"router setup failed for model {model}: {e}") from e
 
     yaml_content = Path(yaml_path).read_text(encoding="utf-8")
 
@@ -843,8 +802,7 @@ def review(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
 
 def refine(yaml_path: str, review_result: dict, model: str = DEFAULT_MODEL) -> dict:
     """Apply reviewer feedback to YAML. Rewrites the file in-place. Returns metadata."""
-    api_key = load_api_key()
-    client = OpenAI(api_key=api_key)
+    client, model = make_client(model=model)
 
     yaml_content = Path(yaml_path).read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- Single abstraction (`tools/_shared/router_client.py`) replaces per-provider LLM/embedding setup across all tools. YAML declares `base_url`, `secret_ref`, `model`, `headers`, `query` per purpose — code has **zero branches on provider kind**.
- Anything speaking the OpenAI contract works via config alone (Azure, xAI, OpenRouter, LiteLLM, Groq, Together, vLLM, self-hosted). Non-compatible providers (Bedrock/Vertex native) sit behind translators.
- Migrated 7 call sites (embed, edge-consult, edge-deepresearch, edge-dialogue, edge-adversarial-research, review-gate, routines) to `make_client(purpose)` or `make_client(model=...)` reverse-lookup. **Net -151 lines.**
- `agent.yaml.example` documents both the new `routers:` block and legacy flat keys (`openai_model`, `grok_model`). Legacy installs keep working via fallback in `_LEGACY_DEFAULTS`.

## Test plan

- [x] Module imports for all 7 refactored files
- [x] Router lookups resolve all 5 purposes (chat, chat_mini, review, embedding, deepresearch)
- [x] Reverse model lookup (`grok-4.20-...` → `review`; `gpt-5.4` → `chat`)
- [x] Live embedding roundtrip — `embed_text('hello world')` returns 1536-dim vector
- [ ] Run one `edge-consult` call end-to-end against GPT + Grok (post-merge smoke test)
- [ ] Run one `consolidate-state` with `review-gate` (post-merge smoke test)

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)