### PR TITLE
Telemetry layer — primitives + workflow lifecycle + LLM calls + resolution + cost — #226

### DIFF
--- a/search/db.py
+++ b/search/db.py
@@ -87,6 +87,24 @@ def init_db(conn: sqlite3.Connection) -> None:
         CREATE INDEX IF NOT EXISTS idx_search_events_ts ON search_events(ts);
     """)
 
+    # Primitive call telemetry (#226 item 2). One row per call, rolled up
+    # by tools/rollup-primitives.py into state/primitive-usage-rollup.json.
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS telemetry_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+            source TEXT NOT NULL,
+            calls INTEGER DEFAULT 0,
+            ok INTEGER DEFAULT 0,
+            fail INTEGER DEFAULT 0,
+            avg_ms INTEGER DEFAULT 0,
+            cost_usd REAL DEFAULT 0,
+            notes TEXT DEFAULT '{}'
+        );
+        CREATE INDEX IF NOT EXISTS idx_telemetry_ts ON telemetry_snapshots(ts);
+        CREATE INDEX IF NOT EXISTS idx_telemetry_source ON telemetry_snapshots(source);
+    """)
+
     # Dashboard: signals and chat
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS signals (

--- a/tools/_shared/router_client.py
+++ b/tools/_shared/router_client.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 import os
 import re
 import sys
+import time
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
+
+from .telemetry import log_llm_call
 
 try:
     import yaml  # type: ignore
@@ -244,7 +247,116 @@ def make_client(
         client_kwargs["timeout"] = timeout
     client_kwargs.update(kwargs)
 
-    return OpenAI(**client_kwargs), cfg["model"]
+    client = OpenAI(**client_kwargs)
+    purpose_name = purpose if purpose is not None else _resolve_purpose_name(cfg["model"])
+    return _wrap_with_telemetry(client, purpose_name, cfg["model"]), cfg["model"]
+
+
+def _resolve_purpose_name(model: str) -> str:
+    try:
+        name, _ = find_router_for_model(model)
+        return name
+    except KeyError:
+        return "unknown"
+
+
+class _InstrumentedCreate:
+    """Wrap `resource.create(...)` so every call emits an llm_call event."""
+
+    def __init__(self, inner_create: Any, router: str, default_model: str) -> None:
+        self._inner = inner_create
+        self._router = router
+        self._default_model = default_model
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        model = kwargs.get("model") or self._default_model
+        t0 = time.monotonic()
+        try:
+            resp = self._inner(*args, **kwargs)
+        except Exception:
+            dt_ms = int((time.monotonic() - t0) * 1000)
+            log_llm_call(
+                router=self._router, model=model, tokens_in=0, tokens_out=0,
+                latency_ms=dt_ms, error=True,
+            )
+            raise
+        dt_ms = int((time.monotonic() - t0) * 1000)
+        tokens_in, tokens_out = _extract_tokens(resp)
+        log_llm_call(
+            router=self._router, model=model,
+            tokens_in=tokens_in, tokens_out=tokens_out, latency_ms=dt_ms,
+        )
+        return resp
+
+
+class _InstrumentedResource:
+    """Proxy a resource object (e.g., chat.completions). Wraps `.create` only."""
+
+    def __init__(self, inner: Any, router: str, default_model: str) -> None:
+        self._inner = inner
+        self._router = router
+        self._default_model = default_model
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._inner, name)
+        if name == "create":
+            return _InstrumentedCreate(attr, self._router, self._default_model)
+        return attr
+
+
+class _InstrumentedChat:
+    """Proxy client.chat, wrap client.chat.completions."""
+
+    def __init__(self, inner: Any, router: str, default_model: str) -> None:
+        self._inner = inner
+        self._router = router
+        self._default_model = default_model
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._inner, name)
+        if name == "completions":
+            return _InstrumentedResource(attr, self._router, self._default_model)
+        return attr
+
+
+class _InstrumentedClient:
+    """Thin proxy over the OpenAI SDK client. Wraps `chat.completions.create`,
+    `embeddings.create`, and `responses.create` to emit llm_call telemetry.
+    Every other attribute passes through unchanged."""
+
+    def __init__(self, inner: Any, router: str, default_model: str) -> None:
+        self._inner = inner
+        self._router = router
+        self._default_model = default_model
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._inner, name)
+        if name == "chat":
+            return _InstrumentedChat(attr, self._router, self._default_model)
+        if name in ("embeddings", "responses"):
+            return _InstrumentedResource(attr, self._router, self._default_model)
+        return attr
+
+
+def _wrap_with_telemetry(client: Any, router: str, default_model: str) -> Any:
+    """Opt-out via env: ED_TELEMETRY_DISABLE=1."""
+    if os.environ.get("ED_TELEMETRY_DISABLE") == "1":
+        return client
+    return _InstrumentedClient(client, router, default_model)
+
+
+def _extract_tokens(resp: Any) -> tuple[int, int]:
+    """Pull (prompt, completion) tokens from OpenAI-shaped responses.
+    Returns (0, 0) when usage is missing — don't block on it."""
+    try:
+        usage = getattr(resp, "usage", None)
+        if usage is None:
+            return 0, 0
+        ti = getattr(usage, "prompt_tokens", None) or getattr(usage, "input_tokens", 0) or 0
+        to = getattr(usage, "completion_tokens", None) or getattr(usage, "output_tokens", 0) or 0
+        return int(ti), int(to)
+    except Exception:
+        return 0, 0
 
 
 __all__ = [

--- a/tools/_shared/telemetry.py
+++ b/tools/_shared/telemetry.py
@@ -1,0 +1,277 @@
+"""Telemetry helpers — passive writers, no LLM friction.
+
+Append-only event logging to `logs/events.jsonl` plus targeted writes to the
+`telemetry_snapshots` SQLite table. Readers (rollup scripts in tools/) digest
+these into small JSON files that skills consume.
+
+Design rules (issue #226):
+- Writers MUST NOT prompt, decide, or call LLMs. Pure observation.
+- Failures are swallowed — telemetry MUST NOT break the caller.
+- Consumers never read raw events — always pre-digested rollups.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "config"))
+from paths import EVENTS_FILE, SEARCH_DIR  # noqa: E402
+
+DB_PATH = SEARCH_DIR / "edge-memory.db"
+
+# --- Price table (USD per 1M tokens). Missing models map to 0 cost rather than
+# block the call; rollup flags unknown models separately.
+# Keep this table small — update when new models are added to agent.yaml.
+_PRICE_PER_M: dict[str, tuple[float, float]] = {
+    # model: (input_per_1m, output_per_1m)
+    "gpt-5.4":                 (5.00, 15.00),
+    "gpt-5.4-pro":            (15.00, 60.00),
+    "gpt-4.1-mini":            (0.40, 1.60),
+    "gpt-4o":                  (2.50, 10.00),
+    "gpt-4o-mini":             (0.15, 0.60),
+    "text-embedding-3-small":  (0.02, 0.00),
+    "text-embedding-3-large":  (0.13, 0.00),
+    "grok-4.20-multi-agent-beta-0309": (5.00, 15.00),
+}
+
+
+def estimate_cost_usd(model: str, tokens_in: int, tokens_out: int) -> float:
+    """Return estimated cost in USD. Unknown models return 0.0."""
+    price = _PRICE_PER_M.get(model)
+    if price is None:
+        return 0.0
+    ti, to = price
+    return round((tokens_in / 1_000_000) * ti + (tokens_out / 1_000_000) * to, 6)
+
+
+def current_skill() -> str | None:
+    """Best-effort current skill name. Reads env var set by skill runner."""
+    return os.environ.get("ED_SKILL") or os.environ.get("CLAUDE_SKILL") or None
+
+
+def current_beat() -> str | None:
+    """Current heartbeat rotation number, if tracked by state/beat-rotation.json."""
+    return os.environ.get("ED_BEAT") or None
+
+
+def _append_event(event: dict[str, Any]) -> None:
+    """Append a JSON line to EVENTS_FILE. Swallows all errors."""
+    try:
+        EVENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(EVENTS_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+
+
+def log_event(event_type: str, **fields: Any) -> None:
+    """Append a typed event to events.jsonl. Always includes ts + type."""
+    event = {"ts": datetime.now(timezone.utc).isoformat(), "type": event_type}
+    event.update(fields)
+    _append_event(event)
+
+
+def log_llm_call(
+    *,
+    router: str,
+    model: str,
+    tokens_in: int = 0,
+    tokens_out: int = 0,
+    latency_ms: int = 0,
+    caller: str | None = None,
+    cost_usd: float | None = None,
+    **extra: Any,
+) -> None:
+    """Telemetry for a single LLM call. Derives cost if not passed."""
+    if cost_usd is None:
+        cost_usd = estimate_cost_usd(model, tokens_in, tokens_out)
+    extra.setdefault("skill", current_skill())
+    extra.setdefault("beat", current_beat())
+    log_event(
+        "llm_call",
+        router=router,
+        model=model,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        cost_usd=cost_usd,
+        latency_ms=latency_ms,
+        caller=caller or _detect_caller(),
+        **extra,
+    )
+
+
+def _detect_caller() -> str:
+    """Best-effort caller detection from sys.argv[0]."""
+    try:
+        return Path(sys.argv[0]).name
+    except Exception:
+        return "unknown"
+
+
+def _ensure_telemetry_table(conn: sqlite3.Connection) -> None:
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS telemetry_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+            source TEXT NOT NULL,
+            calls INTEGER DEFAULT 0,
+            ok INTEGER DEFAULT 0,
+            fail INTEGER DEFAULT 0,
+            avg_ms INTEGER DEFAULT 0,
+            cost_usd REAL DEFAULT 0,
+            notes TEXT DEFAULT '{}'
+        );
+        CREATE INDEX IF NOT EXISTS idx_telemetry_ts ON telemetry_snapshots(ts);
+        CREATE INDEX IF NOT EXISTS idx_telemetry_source ON telemetry_snapshots(source);
+    """)
+
+
+def log_primitive_call(
+    source: str,
+    *,
+    ok: bool,
+    latency_ms: int = 0,
+    cost_usd: float = 0.0,
+    notes: dict[str, Any] | None = None,
+) -> None:
+    """Insert one row into telemetry_snapshots per primitive call.
+
+    Called by edge-sources/edge-x/edge-hn/etc. as a side-effect. All errors
+    swallowed — telemetry never breaks the primitive.
+    """
+    try:
+        if not DB_PATH.exists():
+            return
+        conn = sqlite3.connect(str(DB_PATH), timeout=2.0)
+        try:
+            _ensure_telemetry_table(conn)
+            conn.execute(
+                """
+                INSERT INTO telemetry_snapshots
+                (source, calls, ok, fail, avg_ms, cost_usd, notes)
+                VALUES (?, 1, ?, ?, ?, ?, ?)
+                """,
+                (
+                    source,
+                    1 if ok else 0,
+                    0 if ok else 1,
+                    int(latency_ms),
+                    float(cost_usd),
+                    json.dumps(notes or {}, ensure_ascii=False),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception:
+        pass
+
+
+@contextmanager
+def time_primitive(source: str, notes: dict[str, Any] | None = None):
+    """Context manager that times a primitive block and logs success/failure.
+
+    Usage:
+        with time_primitive("x", notes={"q": query}):
+            ...call X API...
+    """
+    t0 = time.monotonic()
+    ok = True
+    try:
+        yield
+    except Exception:
+        ok = False
+        raise
+    finally:
+        dt_ms = int((time.monotonic() - t0) * 1000)
+        log_primitive_call(source, ok=ok, latency_ms=dt_ms, notes=notes)
+
+
+def log_workflow_transition(
+    slug: str,
+    from_state: str,
+    to_state: str,
+    *,
+    approved_by: str | None = None,
+    **extra: Any,
+) -> None:
+    """Workflow lifecycle event: claim → cluster → draft → approved → cited → broken → healed → retired."""
+    extra.setdefault("skill", current_skill())
+    extra.setdefault("beat", current_beat())
+    log_event(
+        "workflow_transition",
+        slug=slug,
+        **{"from": from_state, "to": to_state},
+        approved_by=approved_by,
+        **extra,
+    )
+
+
+def log_resolution(
+    *,
+    obj_type: str,  # claim | friction | workflow_broken | issue | thread
+    obj_id: str,
+    opened_at: str | None,
+    resolution: str,
+    **extra: Any,
+) -> None:
+    """Time-to-resolution event. Duration derived from opened_at if present."""
+    duration_h: float | None = None
+    if opened_at:
+        try:
+            start = datetime.fromisoformat(opened_at.replace("Z", "+00:00"))
+            now = datetime.now(timezone.utc)
+            duration_h = round((now - start).total_seconds() / 3600.0, 2)
+        except Exception:
+            duration_h = None
+    extra.setdefault("skill", current_skill())
+    extra.setdefault("beat", current_beat())
+    log_event(
+        f"{obj_type}_resolved",
+        obj_type=obj_type,
+        id=obj_id,
+        opened_at=opened_at,
+        duration_h=duration_h,
+        resolution=resolution,
+        **extra,
+    )
+
+
+def log_operator_correction(
+    *,
+    session_id: str,
+    trigger: str,
+    category: str,
+    **extra: Any,
+) -> None:
+    """Operator correction event (scope_drift | wrong_tool | over_engineering | other)."""
+    log_event(
+        "operator_correction",
+        session_id=session_id,
+        trigger=trigger,
+        category=category,
+        **extra,
+    )
+
+
+__all__ = [
+    "log_event",
+    "log_llm_call",
+    "log_primitive_call",
+    "time_primitive",
+    "log_workflow_transition",
+    "log_resolution",
+    "log_operator_correction",
+    "estimate_cost_usd",
+    "current_skill",
+    "current_beat",
+]

--- a/tools/edge-crystallize
+++ b/tools/edge-crystallize
@@ -23,6 +23,13 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+_SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_SCRIPT_DIR.parent / "tools"))
+try:
+    from _shared.telemetry import log_workflow_transition
+except Exception:
+    def log_workflow_transition(*a, **kw): pass
+
 
 def slugify(text):
     """Convert title to a URL-friendly slug."""
@@ -88,6 +95,8 @@ def create_from_operator(directive, edge, dry_run=False):
     filepath.write_text(content)
     print(f"  CREATED {filename} (operator directive, tag=workflow)")
     index_entry(filepath)
+    log_workflow_transition(slug, from_state="claim", to_state="approved",
+                            approved_by="operator", source="operator-directive")
     return 1
 
 
@@ -197,6 +206,12 @@ def create_from_curation(args, edge):
             filepath.write_text(content)
             print(f"  CREATED {filename} ({claim_count} claims, tag={tag})")
             index_entry(filepath)
+            target_state = "approved" if tag == "workflow" else "draft"
+            log_workflow_transition(
+                slug, from_state="cluster", to_state=target_state,
+                approved_by=("auto" if tag == "workflow" else None),
+                cluster_id=cluster_id, claim_count=claim_count,
+            )
 
         created += 1
 

--- a/tools/edge-hn
+++ b/tools/edge-hn
@@ -12,9 +12,14 @@ No auth needed. Free API. Zero config.
 """
 
 import sys, json, argparse, time
+from pathlib import Path
 from urllib.request import urlopen, Request
 from urllib.parse import quote, urlencode
 from datetime import datetime, timedelta
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_SCRIPT_DIR.parent / "tools"))
+from _shared.telemetry import log_primitive_call
 
 
 HN_SEARCH = "https://hn.algolia.com/api/v1/search"
@@ -134,6 +139,8 @@ def main():
     if not args.topic and not args.front_page:
         parser.error("Provide a topic or use --front-page")
 
+    _t0 = time.monotonic()
+    _ok = True
     all_output = {}
 
     # Front page
@@ -185,6 +192,12 @@ def main():
 
     if args.json:
         print(json.dumps(all_output, indent=2, ensure_ascii=False))
+
+    _n = len(all_output.get("stories", [])) + len(all_output.get("comments", []))
+    log_primitive_call(
+        "hn", ok=_ok, latency_ms=int((time.monotonic() - _t0) * 1000),
+        notes={"topic": (args.topic or "front_page")[:80], "n": _n},
+    )
 
 
 if __name__ == "__main__":

--- a/tools/edge-sources
+++ b/tools/edge-sources
@@ -21,7 +21,9 @@ import xml.etree.ElementTree as ET
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+sys.path.insert(0, str(SCRIPT_DIR.parent / "tools"))
 from paths import TOOLS_DIR, SECRETS_DIR
+from _shared.telemetry import log_primitive_call
 
 # --- Routing table: intent -> sources ---
 ROUTING = {
@@ -299,19 +301,27 @@ def pick_wildcard(selected_sources):
 
 def run_sources(topic, sources, max_workers=6):
     """Run multiple sources concurrently."""
+    import time as _time
     all_results = {}
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         futures = {}
+        start_by_src = {}
         for src in sources:
             fn = SOURCE_FN.get(src)
             if fn:
                 futures[pool.submit(fn, topic)] = src
+                start_by_src[src] = _time.monotonic()
         for future in as_completed(futures):
             src = futures[future]
+            dt_ms = int((_time.monotonic() - start_by_src.get(src, _time.monotonic())) * 1000)
             try:
-                all_results[src] = future.result()
+                items = future.result()
+                all_results[src] = items
+                ok = bool(items) and not (len(items) == 1 and "error" in str(items[0].get("title", "")).lower())
+                log_primitive_call(src, ok=ok, latency_ms=dt_ms, notes={"topic": topic[:80], "n": len(items)})
             except Exception as e:
                 all_results[src] = [{"title": f"{src} error: {e}", "url": "", "source": src, "detail": "", "score": 0}]
+                log_primitive_call(src, ok=False, latency_ms=dt_ms, notes={"topic": topic[:80], "err": str(e)[:120]})
     return all_results
 
 

--- a/tools/edge-x
+++ b/tools/edge-x
@@ -14,8 +14,10 @@ import os, sys, json, argparse
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "tools"))
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import SECRETS_DIR
+from _shared.telemetry import log_primitive_call
 
 # Load credentials
 env_file = SECRETS_DIR / "x-api.env"
@@ -190,14 +192,27 @@ def main():
     parser.add_argument("--light", action="store_true", help="Light mode: 2 API calls instead of 8 (for serendipity/heartbeat)")
     args = parser.parse_args()
 
-    results, total_raw = search_x(
-        args.topic,
-        from_accounts=args.from_accounts,
-        min_followers=args.min_followers,
-        min_engagement=args.min_engagement,
-        verbose=args.verbose,
-        light=args.light
-    )
+    import time as _time
+    _t0 = _time.monotonic()
+    _ok = True
+    _err = None
+    try:
+        results, total_raw = search_x(
+            args.topic,
+            from_accounts=args.from_accounts,
+            min_followers=args.min_followers,
+            min_engagement=args.min_engagement,
+            verbose=args.verbose,
+            light=args.light
+        )
+    except Exception as _e:
+        _ok = False
+        _err = str(_e)[:120]
+        log_primitive_call("x", ok=False, latency_ms=int((_time.monotonic() - _t0) * 1000),
+                           notes={"topic": args.topic[:80], "err": _err})
+        raise
+    log_primitive_call("x", ok=_ok, latency_ms=int((_time.monotonic() - _t0) * 1000),
+                       notes={"topic": args.topic[:80], "n": len(results), "light": args.light})
 
     if args.json:
         print(json.dumps(results[:args.max], indent=2, ensure_ascii=False))

--- a/tools/rollup-corrections.py
+++ b/tools/rollup-corrections.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""rollup-corrections — Operator correction detector + rollup (issue #226 item 4).
+
+Reads Claude session jsonl files (~/.claude/projects/*/*.jsonl), detects
+correction patterns in user messages (don't / stop / actually / no / again),
+emits one `operator_correction` event per match to `logs/events.jsonl`, and
+produces `state/operator-corrections.json` with the 30d trend.
+
+Idempotent: tracks last-processed message id per session in
+`state/.corrections-cursor.json` so re-running doesn't double-count.
+
+Consumer: /ed-reflection.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "tools"))
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import EVENTS_FILE, STATE_DIR  # noqa: E402
+from _shared.telemetry import log_operator_correction  # noqa: E402
+
+OUT_PATH = STATE_DIR / "operator-corrections.json"
+CURSOR_PATH = STATE_DIR / ".corrections-cursor.json"
+WINDOW_DAYS = 30
+
+SESSIONS_GLOB = Path.home() / ".claude" / "projects"
+
+# Patterns -> category. Order matters: first match wins.
+PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"\b(stop|para de|chega de)\b", re.I),                          "course_correction"),
+    (re.compile(r"\b(don'?t|nao faça|não faça|nao deve|não deve)\b", re.I),    "course_correction"),
+    (re.compile(r"\b(actually|na verdade|na real)\b", re.I),                   "scope_drift"),
+    (re.compile(r"\b(again|de novo|outra vez)\b", re.I),                       "repeat_request"),
+    (re.compile(r"\b(no|nao|não)[\s,!.]", re.I),                               "rejection"),
+    (re.compile(r"\b(over.?engineer|too much|exagerou|exagerado)\b", re.I),    "over_engineering"),
+    (re.compile(r"\b(wrong tool|errou|errado)\b", re.I),                       "wrong_tool"),
+]
+
+
+def _load_cursor() -> dict[str, int]:
+    if not CURSOR_PATH.exists():
+        return {}
+    try:
+        return json.loads(CURSOR_PATH.read_text())
+    except Exception:
+        return {}
+
+
+def _save_cursor(cursor: dict[str, int]) -> None:
+    CURSOR_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CURSOR_PATH.write_text(json.dumps(cursor, indent=2))
+
+
+def _classify(text: str) -> str | None:
+    for pat, cat in PATTERNS:
+        if pat.search(text):
+            return cat
+    return None
+
+
+def _iter_user_messages(jsonl: Path):
+    """Yield (idx, ts, text) for each user message in a session jsonl."""
+    try:
+        with open(jsonl, encoding="utf-8") as f:
+            for idx, line in enumerate(f):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if msg.get("type") != "user":
+                    continue
+                ts = msg.get("timestamp") or ""
+                content = msg.get("message", {})
+                if isinstance(content, dict):
+                    text = content.get("content", "")
+                    if isinstance(text, list):
+                        text = " ".join(p.get("text", "") for p in text if isinstance(p, dict))
+                else:
+                    text = str(content or "")
+                if not text or not isinstance(text, str):
+                    continue
+                yield idx, ts, text
+    except FileNotFoundError:
+        return
+
+
+def main() -> int:
+    cursor = _load_cursor()
+    new_corrections = 0
+    sessions_scanned = 0
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=WINDOW_DAYS)
+
+    for jsonl in SESSIONS_GLOB.rglob("*.jsonl"):
+        sessions_scanned += 1
+        sid = jsonl.stem
+        last_idx = cursor.get(sid, -1)
+        max_seen = last_idx
+        for idx, ts, text in _iter_user_messages(jsonl):
+            if idx <= last_idx:
+                continue
+            max_seen = max(max_seen, idx)
+            if len(text) < 10 or len(text) > 2000:
+                continue
+            category = _classify(text)
+            if not category:
+                continue
+            try:
+                dt = datetime.fromisoformat(ts.replace("Z", "+00:00")) if ts else None
+            except Exception:
+                dt = None
+            if dt and dt < cutoff:
+                continue
+            log_operator_correction(
+                session_id=sid,
+                trigger=text[:200],
+                category=category,
+                msg_idx=idx,
+                source_file=jsonl.name,
+            )
+            new_corrections += 1
+        if max_seen > last_idx:
+            cursor[sid] = max_seen
+
+    _save_cursor(cursor)
+
+    # Now build the rollup from events.jsonl (includes prior runs).
+    by_category: dict[str, int] = defaultdict(int)
+    by_session: dict[str, int] = defaultdict(int)
+    samples: list[dict] = []
+    total = 0
+    if EVENTS_FILE.exists():
+        with open(EVENTS_FILE, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if ev.get("type") != "operator_correction":
+                    continue
+                ts = ev.get("ts") or ""
+                try:
+                    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                except (ValueError, AttributeError):
+                    continue
+                if dt < cutoff:
+                    continue
+                cat = ev.get("category") or "other"
+                sid = ev.get("session_id") or "unknown"
+                by_category[cat] += 1
+                by_session[sid] += 1
+                total += 1
+                if len(samples) < 5:
+                    samples.append({"ts": ts, "category": cat, "trigger": ev.get("trigger", "")[:140]})
+
+    payload = {
+        "window_days": WINDOW_DAYS,
+        "total": total,
+        "by_category": dict(sorted(by_category.items(), key=lambda x: -x[1])),
+        "top_sessions": dict(sorted(by_session.items(), key=lambda x: -x[1])[:5]),
+        "recent_samples": samples,
+        "sessions_scanned": sessions_scanned,
+        "new_this_run": new_corrections,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(f"OK: {OUT_PATH} ({total} corrections / {WINDOW_DAYS}d, +{new_corrections} new)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/rollup-cost.py
+++ b/tools/rollup-cost.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""rollup-cost — Derive cost-rollup.json from llm_call events.
+
+Reads `logs/events.jsonl`, filters `type == "llm_call"`, aggregates into
+`state/cost-rollup.json` with per-day, per-skill, per-model breakdowns and
+a monthly burn estimate.
+
+Consumers: /ed-strategy (budget gating), /ed-autonomy (per-artifact cost).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import EVENTS_FILE, STATE_DIR  # noqa: E402
+
+OUT_PATH = STATE_DIR / "cost-rollup.json"
+WINDOW_DAYS = 30
+
+
+def _iter_events():
+    if not EVENTS_FILE.exists():
+        return
+    with open(EVENTS_FILE, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def main() -> int:
+    cutoff = datetime.now(timezone.utc) - timedelta(days=WINDOW_DAYS)
+    by_day: dict[str, dict] = defaultdict(lambda: {"usd": 0.0, "calls": 0, "tokens_in": 0, "tokens_out": 0})
+    by_skill: dict[str, float] = defaultdict(float)
+    by_model: dict[str, float] = defaultdict(float)
+    by_router: dict[str, float] = defaultdict(float)
+
+    total_usd = 0.0
+    total_calls = 0
+    unknown_models: set[str] = set()
+
+    for ev in _iter_events():
+        if ev.get("type") != "llm_call":
+            continue
+        ts = ev.get("ts")
+        if not ts:
+            continue
+        try:
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if dt < cutoff:
+            continue
+
+        day = dt.date().isoformat()
+        cost = float(ev.get("cost_usd") or 0.0)
+        skill = ev.get("skill") or "unknown"
+        model = ev.get("model") or "unknown"
+        router = ev.get("router") or "unknown"
+        ti = int(ev.get("tokens_in") or 0)
+        to = int(ev.get("tokens_out") or 0)
+
+        by_day[day]["usd"] += cost
+        by_day[day]["calls"] += 1
+        by_day[day]["tokens_in"] += ti
+        by_day[day]["tokens_out"] += to
+        by_skill[skill] += cost
+        by_model[model] += cost
+        by_router[router] += cost
+        total_usd += cost
+        total_calls += 1
+        if cost == 0.0 and (ti or to):
+            unknown_models.add(model)
+
+    by_day_list = sorted(
+        ({"date": d, **{k: round(v, 4) if isinstance(v, float) else v for k, v in vals.items()}}
+         for d, vals in by_day.items()),
+        key=lambda r: r["date"],
+    )
+
+    daily_avg = total_usd / WINDOW_DAYS if total_usd else 0.0
+    payload = {
+        "window_days": WINDOW_DAYS,
+        "total_usd": round(total_usd, 4),
+        "total_calls": total_calls,
+        "monthly_burn_estimate_usd": round(daily_avg * 30, 2),
+        "by_day": by_day_list,
+        "by_skill": {k: round(v, 4) for k, v in sorted(by_skill.items(), key=lambda x: -x[1])},
+        "by_model": {k: round(v, 4) for k, v in sorted(by_model.items(), key=lambda x: -x[1])},
+        "by_router": {k: round(v, 4) for k, v in sorted(by_router.items(), key=lambda x: -x[1])},
+        "unknown_models": sorted(unknown_models),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(f"OK: {OUT_PATH} (${total_usd:.4f} / {total_calls} calls / {WINDOW_DAYS}d)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/rollup-primitives.py
+++ b/tools/rollup-primitives.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""rollup-primitives — Aggregate telemetry_snapshots into a small JSON.
+
+Reads `telemetry_snapshots` table (one row per primitive call) and writes
+`state/primitive-usage-rollup.json` with 30-day per-source counters.
+
+Consumers: /ed-autonomy (fan-out check), /ed-reflection (failure rates).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import SEARCH_DIR, STATE_DIR  # noqa: E402
+
+DB_PATH = SEARCH_DIR / "edge-memory.db"
+OUT_PATH = STATE_DIR / "primitive-usage-rollup.json"
+WINDOW_DAYS = 30
+
+
+def main() -> int:
+    if not DB_PATH.exists():
+        print(f"db not found: {DB_PATH}", file=sys.stderr)
+        return 1
+    conn = sqlite3.connect(str(DB_PATH))
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT
+              source,
+              COUNT(*)            AS calls,
+              SUM(ok)             AS ok,
+              SUM(fail)           AS fail,
+              AVG(NULLIF(avg_ms, 0)) AS avg_ms,
+              MAX(ts)             AS last_ts
+            FROM telemetry_snapshots
+            WHERE ts >= datetime('now', '-{WINDOW_DAYS} days')
+            GROUP BY source
+            ORDER BY calls DESC
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    by_source = {}
+    total_calls = 0
+    for src, calls, ok, fail, avg_ms, last_ts in rows:
+        ok = int(ok or 0)
+        fail = int(fail or 0)
+        calls = int(calls or 0)
+        by_source[src] = {
+            "calls": calls,
+            "ok": ok,
+            "fail": fail,
+            "ok_rate": round(ok / calls, 3) if calls else 0.0,
+            "avg_ms": int(avg_ms) if avg_ms else 0,
+            "last_ts": last_ts,
+        }
+        total_calls += calls
+
+    payload = {
+        "window_days": WINDOW_DAYS,
+        "total_calls": total_calls,
+        "by_source": by_source,
+        "generated_at": __import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat(),
+    }
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(f"OK: {OUT_PATH} ({total_calls} calls across {len(by_source)} sources)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/rollup-resolution.py
+++ b/tools/rollup-resolution.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""rollup-resolution — Time-to-resolution rollup (issue #226 item 5).
+
+Reads `*_resolved` events from `logs/events.jsonl` and produces
+`state/resolution-rollup.json` with median, p95 and counts per object type
+(claim, friction, workflow_broken, issue, thread). Also reports stale items
+that were opened > 30d ago and are still unresolved (best-effort — works
+when an `obj_open` event matched the id).
+
+Consumers: /ed-reflection (resolution decay), /ed-autonomy (stale resurface).
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import EVENTS_FILE, STATE_DIR  # noqa: E402
+
+OUT_PATH = STATE_DIR / "resolution-rollup.json"
+WINDOW_DAYS = 90
+
+OBJ_TYPES = ("claim", "friction", "workflow_broken", "issue", "thread")
+
+
+def _iter_events():
+    if not EVENTS_FILE.exists():
+        return
+    with open(EVENTS_FILE, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    return round(statistics.quantiles(sorted(values), n=100)[int(pct) - 1], 2)
+
+
+def main() -> int:
+    cutoff = datetime.now(timezone.utc) - timedelta(days=WINDOW_DAYS)
+    durations: dict[str, list[float]] = defaultdict(list)
+    counts: dict[str, int] = defaultdict(int)
+
+    for ev in _iter_events():
+        etype = ev.get("type", "")
+        if not etype.endswith("_resolved"):
+            continue
+        ts = ev.get("ts")
+        try:
+            dt = datetime.fromisoformat((ts or "").replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        if dt < cutoff:
+            continue
+
+        obj_type = ev.get("obj_type") or etype.removesuffix("_resolved")
+        counts[obj_type] += 1
+        d = ev.get("duration_h")
+        if isinstance(d, (int, float)):
+            durations[obj_type].append(float(d))
+
+    summary: dict[str, dict] = {}
+    for obj_type in OBJ_TYPES:
+        durs = durations.get(obj_type, [])
+        summary[obj_type] = {
+            "resolved_count": counts.get(obj_type, 0),
+            "median_h": round(statistics.median(durs), 2) if durs else 0.0,
+            "p95_h": _percentile(durs, 95) if durs else 0.0,
+            "max_h": round(max(durs), 2) if durs else 0.0,
+        }
+
+    payload = {
+        "window_days": WINDOW_DAYS,
+        "by_type": summary,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(f"OK: {OUT_PATH} ({sum(counts.values())} resolution events / {WINDOW_DAYS}d)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/rollup-workflow-funnel.py
+++ b/tools/rollup-workflow-funnel.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""rollup-workflow-funnel — Workflow lifecycle funnel (issue #226 item 3).
+
+Reads `workflow_transition` events from `logs/events.jsonl` and produces
+`state/workflow-funnel.json` counting transitions: claim → cluster → draft →
+approved → cited → broken → healed → retired.
+
+Consumers: /ed-corpus-curation procedures, /ed-autonomy.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import EVENTS_FILE, STATE_DIR  # noqa: E402
+
+OUT_PATH = STATE_DIR / "workflow-funnel.json"
+WINDOW_DAYS = 60
+
+STATES = ("claim", "cluster", "draft", "approved", "cited", "broken", "healed", "retired")
+
+
+def _iter_events():
+    if not EVENTS_FILE.exists():
+        return
+    with open(EVENTS_FILE, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def main() -> int:
+    cutoff = datetime.now(timezone.utc) - timedelta(days=WINDOW_DAYS)
+    transitions: dict[str, int] = defaultdict(int)
+    state_count: dict[str, int] = defaultdict(int)
+    by_slug_state: dict[str, str] = {}
+
+    for ev in _iter_events():
+        if ev.get("type") != "workflow_transition":
+            continue
+        try:
+            dt = datetime.fromisoformat((ev.get("ts") or "").replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        if dt < cutoff:
+            continue
+        frm = ev.get("from") or "unknown"
+        to = ev.get("to") or "unknown"
+        slug = ev.get("slug") or ""
+        transitions[f"{frm}->{to}"] += 1
+        if slug:
+            by_slug_state[slug] = to
+
+    for state in by_slug_state.values():
+        state_count[state] += 1
+
+    payload = {
+        "window_days": WINDOW_DAYS,
+        "current_state": {s: state_count.get(s, 0) for s in STATES},
+        "transitions": dict(sorted(transitions.items(), key=lambda x: -x[1])),
+        "tracked_workflows": len(by_slug_state),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(f"OK: {OUT_PATH} ({len(by_slug_state)} workflows, {sum(transitions.values())} transitions)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #226.

Implements all 6 sub-tasks of the telemetry umbrella in one PR. Passive
observation only — no enforcement, no gates, no compensation. Writers are
swallowed-on-error to ensure telemetry never breaks the caller.

## What's in

| # | Item | Writer | Rollup | Consumer |
|---|---|---|---|---|
| 1 | LLM router calls | `_shared/router_client._InstrumentedClient` | `state/cost-rollup.json` | autonomy, strategy |
| 2 | Primitive usage | `edge-sources/edge-x/edge-hn` | `state/primitive-usage-rollup.json` | autonomy, reflection |
| 3 | Workflow funnel | `edge-crystallize` | `state/workflow-funnel.json` | corpus-curation, autonomy |
| 4 | Operator corrections | `tools/rollup-corrections.py` (detector + rollup) | `state/operator-corrections.json` | reflection |
| 5 | Time-to-resolution | `_shared.telemetry.log_resolution` | `state/resolution-rollup.json` | reflection, autonomy |
| 6 | Cost rollup | derived from #1 | `state/cost-rollup.json` | strategy, autonomy |

## Foundation

- `tools/_shared/telemetry.py` — single helper module. All writers funnel through `log_event()` (events.jsonl) or directly to `telemetry_snapshots` (primitive calls).
- `search/db.py` — adds `telemetry_snapshots` table to genotype (was only created out-of-band in the live runtime).

## Item 1 — LLM router calls

`make_client()` returns a `_InstrumentedClient` proxy that wraps `chat.completions.create`, `embeddings.create`, and `responses.create`. Every call emits an `llm_call` event with `tokens_in`, `tokens_out`, `latency_ms`, `cost_usd` (derived from a small price table), `router`, `model`, `skill`, `beat`, `caller`. Other client attributes pass through unchanged. Opt-out via `ED_TELEMETRY_DISABLE=1`.

**Bypass paths still need wiring** (out of scope for this PR): Gemini and Claude CLI subprocess. Use `log_llm_call()` at those call sites when added.

## Item 2 — Primitive usage

`edge-sources` instruments per-source futures inside `run_sources()`. `edge-x` and `edge-hn` wrap their `main()` body. Each emits one `telemetry_snapshots` row per call.

## Item 3 — Workflow funnel

`edge-crystallize` emits `workflow_transition` events:
- operator-directive: `claim → approved` (approved_by=operator)
- curation-cluster: `cluster → draft` (or `cluster → approved` when `--approve`)

Other transitions (`approved → cited`, `cited → broken`, `broken → healed`, `* → retired`) are NOT wired in this PR — they happen in other tools (corpus-curation, reflection) and need separate instrumentation.

## Item 4 — Operator corrections

Standalone script `tools/rollup-corrections.py`. Walks `~/.claude/projects/*/*.jsonl`, applies regex patterns against user messages, classifies into `course_correction | scope_drift | repeat_request | rejection | over_engineering | wrong_tool`, and emits one event per match. Idempotent via `state/.corrections-cursor.json`.

## Item 5 — Time-to-resolution

`log_resolution(obj_type=…, obj_id=…, opened_at=…, resolution=…)` derives `duration_h`. Emits typed events (`claim_resolved`, `friction_resolved`, etc.). Rollup script computes median/p95/max per object type over a 90d window.

This PR ships the writer helper but doesn't wire it into resolution call sites — that needs separate touch points in claim-curation and thread management. The rollup will start populating as soon as those wires land.

## Item 6 — Cost rollup

`tools/rollup-cost.py` reads `llm_call` events, aggregates by day/skill/model/router, computes `monthly_burn_estimate_usd` from 30-day average. Lists `unknown_models` so the price table can be kept honest.

## Smoke test

Ran end-to-end against fixture data:
- 6 events written + 2 primitive rows
- 4 rollup scripts produce expected JSON shape
- Pattern classifier correctly tags `don't`, `actually`, ignores plain requests

## What's intentionally NOT in

- No new tables beyond what live runtime had
- No LLM-assisted writing of telemetry (passive only)
- No dashboards (separate concern)
- No enforcement / gates / compensation — this is the failure mode #161/#217 already taught us to avoid

## Test plan

- [ ] `python3 tools/rollup-primitives.py` after a few `edge-sources` calls — verify per-source counts
- [ ] `python3 tools/rollup-cost.py` after a few LLM calls — verify monthly burn looks sane
- [ ] `python3 tools/rollup-workflow-funnel.py` after `edge-crystallize` — verify `cluster->draft` transition counted
- [ ] `python3 tools/rollup-corrections.py` against existing sessions — verify classification distribution
- [ ] `ED_TELEMETRY_DISABLE=1 edge-consult ...` — verify opt-out works (no llm_call events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)