### PR TITLE
fix(heartbeat): PreToolUse dispatch guard — rebased supersede of #213

### DIFF
--- a/bin/heartbeat-dispatch-guard.sh
+++ b/bin/heartbeat-dispatch-guard.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# heartbeat-dispatch-guard.sh — enforce heartbeat Step 2 skill dispatch
+#
+# Claude Code PreToolUse hook. Receives tool invocation JSON on stdin.
+# Blocks Write/Edit into artifact paths (~/edge/blog/entries, ~/edge/reports)
+# when a heartbeat beat is active but no skill has been dispatched yet.
+#
+# Rationale: /ed-heartbeat Step 2 mandates dispatching one skill per beat.
+# Under strong operator signal, the instruction-level rule fails (see #212,
+# research enforcement-ladder 2026-04-09). This hook enforces the invariant
+# at L3 (executable) — the earliest checkpoint in the pipeline.
+#
+# Exit codes:
+#   0 — allow tool call (not in heartbeat, or skill already dispatched, or
+#       write target is outside guarded paths)
+#   2 — block tool call (message on stderr)
+#
+# Sentinel file: $EDGE_ROOT/state/current-beat.json
+#   {
+#     "active": bool,              # set true at Step 2 entry
+#     "started_at": ISO8601,       # auto-expires after 1h
+#     "skill_dispatched": bool,    # flipped to true immediately before dispatch
+#     "skill": string|null
+#   }
+#
+# Wire-up: add to ~/.claude/settings.json:
+#   "hooks": {
+#     "PreToolUse": [{
+#       "matcher": "Write|Edit",
+#       "hooks": [{ "type": "command",
+#                   "command": "bash ~/edge/bin/heartbeat-dispatch-guard.sh" }]
+#     }]
+#   }
+
+set -euo pipefail
+
+STATE_FILE="${EDGE_ROOT:-$HOME/edge}/state/current-beat.json"
+
+# Read PreToolUse payload from stdin
+TOOL_INPUT=$(cat)
+
+# Fast path: if no sentinel file, not in heartbeat → allow immediately
+[ -f "$STATE_FILE" ] || exit 0
+
+python3 - <<'PY' "$STATE_FILE" "$TOOL_INPUT"
+import json
+import sys
+import datetime
+import pathlib
+
+state_path = pathlib.Path(sys.argv[1])
+try:
+    payload = json.loads(sys.argv[2])
+except Exception:
+    sys.exit(0)  # malformed payload, do not block
+
+tool_input = payload.get("tool_input", {}) or {}
+file_path = tool_input.get("file_path", "") or ""
+
+# Only guard artifact paths
+GUARDED = ("/edge/blog/entries/", "/edge/reports/")
+if not any(seg in file_path for seg in GUARDED):
+    sys.exit(0)
+
+try:
+    state = json.loads(state_path.read_text())
+except Exception:
+    sys.exit(0)  # unreadable sentinel, fail open
+
+# Stale sentinel (>1h) — not a live beat
+started_at = state.get("started_at")
+if started_at:
+    try:
+        started = datetime.datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        age_s = (datetime.datetime.now(datetime.timezone.utc) - started).total_seconds()
+        if age_s > 3600:
+            sys.exit(0)
+    except Exception:
+        pass
+
+if not state.get("active"):
+    sys.exit(0)
+
+if state.get("skill_dispatched"):
+    sys.exit(0)
+
+# Active heartbeat, no skill dispatched, writing guarded path → block
+sys.stderr.write(
+    "BLOCK(heartbeat-dispatch-guard): heartbeat is active but no skill "
+    "has been dispatched yet.\n"
+    f"  target: {file_path}\n"
+    "  fix: run `edge-skill-step <skill> start` and flip "
+    "state/current-beat.json:skill_dispatched to true before writing "
+    "artifacts.\n"
+    "  See /ed-heartbeat Step 2 and issue #212.\n"
+)
+sys.exit(2)
+PY

--- a/docs/heartbeat-dispatch-guard.md
+++ b/docs/heartbeat-dispatch-guard.md
@@ -1,0 +1,108 @@
+# Heartbeat Dispatch Guard (#212)
+
+Enforces the `/ed-heartbeat` invariant: **every beat dispatches exactly one skill before producing artifacts**. Implements L3 (executable hook) from the enforcement-ladder research (2026-04-09).
+
+## Problem
+
+`/ed-heartbeat` Step 2 is explicit: "ABSOLUTE RULE: The heartbeat ALWAYS dispatches a skill. There is no empty beat." Under strong operator signal ("do X now"), the agent can short-circuit Step 2 and produce artifacts (blog entries, reports) directly, bypassing `edge-consult` review, `edge-skill-step` telemetry, and `post-skill.md` procedures.
+
+Reported in [issue #212](https://github.com/lucasrp/edge-of-chaos/issues/212).
+
+## Solution
+
+Three components:
+
+1. **Sentinel file** (`$EDGE_ROOT/state/current-beat.json`) — written at Step 2 entry, flipped at skill dispatch, cleared at Step 3 end.
+2. **PreToolUse hook** (`bin/heartbeat-dispatch-guard.sh`) — refuses `Write`/`Edit` into `~/edge/blog/entries/**` and `~/edge/reports/**` when the sentinel says active but no skill dispatched.
+3. **SKILL.md lifecycle** — writes added at Step 2.0 (open), inside Dispatch (flip), Step 3e (close).
+
+## Sentinel schema
+
+```json
+{
+  "active": true,
+  "started_at": "2026-04-16T22:30:00+00:00",
+  "skill_dispatched": false,
+  "skill": null
+}
+```
+
+| Field | When written | Meaning |
+|-------|--------------|---------|
+| `active` | Step 2.0 → true; Step 3e → false | beat is in-flight |
+| `started_at` | Step 2.0 | auto-expires sentinel after 1h (fail-open) |
+| `skill_dispatched` | immediately before `edge-skill-step start` | unblocks artifact writes |
+| `skill` | same time as dispatched flip | name of dispatched skill |
+
+## Hook behavior
+
+- Target paths: anything containing `/edge/blog/entries/` or `/edge/reports/`
+- No sentinel file → allow (not in heartbeat)
+- Sentinel `active=false` → allow (beat closed)
+- Sentinel older than 1h → allow (fail-open; abandoned beat)
+- Sentinel `skill_dispatched=true` → allow
+- Otherwise → block (exit 2, message to stderr)
+
+The hook is conservative on malformed input, unreadable sentinel, and unparseable JSON — all fail open. The narrow binary invariant (heartbeat active AND skill not dispatched AND writing guarded path) is the only block condition.
+
+## Wire-up
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/edge/bin/heartbeat-dispatch-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Why L3 is appropriate here
+
+The enforcement-ladder research (`blog/entries/2026-04-09-research-enforcement-mechanisms-agent-compliance.md`) argues:
+
+> L3 hooks are appropriate for **binary invariants only**. For non-binary judgments (quality, relevance, style), hooks Goodhart.
+
+"Heartbeat active AND no skill dispatched AND writing artifact path" is a pure binary predicate — no ambiguity, no quality dimension. Ideal L3 target.
+
+## Interaction with Step 2.95
+
+Step 2.95 (prose-level post-hoc check) is **not removed**. It remains as a mechanical double-check that reads `skill-steps.jsonl` after work is done. The hook is the early L3 gate; Step 2.95 is the late L1/L2 audit. Defense in depth.
+
+If the hook ever fires, Step 2.95 would also flag the same beat — but the hook prevents the bad artifact from ever being written, while Step 2.95 only observes that it was.
+
+## Failure modes
+
+| Scenario | Outcome |
+|----------|---------|
+| Operator-driven edit (not in a heartbeat) | No sentinel → allow |
+| `/ed-execute` direct work | No sentinel → allow |
+| Heartbeat abandoned mid-beat | Sentinel ages past 1h → allow on next write |
+| Sentinel file corrupted | JSON parse fails → allow (fail open) |
+| Hook script missing | Claude Code hook system passes through → no block |
+| Skill writes artifact legitimately | Sentinel `skill_dispatched=true` → allow |
+| Heartbeat tries to publish without dispatch | Block, message directs to run `edge-skill-step start` |
+
+## Testing
+
+1. Open sentinel manually:
+   ```bash
+   python3 -c "import json, datetime, pathlib; p=pathlib.Path.home()/'edge/state/current-beat.json'; p.parent.mkdir(parents=True, exist_ok=True); p.write_text(json.dumps({'active':True,'started_at':datetime.datetime.now(datetime.timezone.utc).isoformat(),'skill_dispatched':False,'skill':None}))"
+   ```
+2. Attempt a Write into `~/edge/blog/entries/test.md` via Claude Code — hook should block.
+3. Flip sentinel:
+   ```bash
+   python3 -c "import json, pathlib; p=pathlib.Path.home()/'edge/state/current-beat.json'; s=json.loads(p.read_text()); s['skill_dispatched']=True; p.write_text(json.dumps(s))"
+   ```
+4. Retry Write — hook should allow.
+5. Clear: set `active=false`.

--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -375,6 +375,33 @@ After reading all context from Step 1, classify the beat:
 
 ---
 
+## Step 2.0: Open the guard sentinel (BEFORE dispatch logic)
+
+Write the beat sentinel so the PreToolUse hook
+(`bin/heartbeat-dispatch-guard.sh`, #212) can block artifact writes until
+a skill is dispatched. This is L3 enforcement — the earliest checkpoint.
+
+```bash
+python3 -c "
+import json, datetime, pathlib
+p = pathlib.Path.home() / 'edge' / 'state' / 'current-beat.json'
+p.parent.mkdir(parents=True, exist_ok=True)
+p.write_text(json.dumps({
+    'active': True,
+    'started_at': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    'skill_dispatched': False,
+    'skill': None,
+}, indent=2))
+"
+```
+
+From this point until `edge-skill-step <skill> start` runs, any Write/Edit
+into `~/edge/blog/entries/**` or `~/edge/reports/**` will be refused by
+the hook. The sentinel auto-expires after 1h (fail-open if the beat is
+abandoned mid-way).
+
+---
+
 ## Step 2: Do (dispatch ONE skill)
 
 ### Decision tree (simple)
@@ -436,7 +463,97 @@ If GPT suggests a better direction, consider it. The entire beat costs ~2h of ti
 
 ### Dispatch
 
-Run the chosen skill. It produces: blog entry + report + note (per its own protocol). The dispatched skill already includes its own internal edge-consult (mandatory in every skill).
+Run the chosen skill with step tracking (#113):
+
+```bash
+# Flip the guard sentinel — authorizes artifact writes (#212)
+python3 -c "
+import json, pathlib, sys
+p = pathlib.Path.home() / 'edge' / 'state' / 'current-beat.json'
+state = json.loads(p.read_text())
+state['skill_dispatched'] = True
+state['skill'] = sys.argv[1]
+p.write_text(json.dumps(state, indent=2))
+" <skill>
+
+# Before dispatching
+edge-skill-step <skill> start
+
+# The skill runs — it produces blog entry + report + note per its own protocol.
+# The dispatched skill already includes its own internal edge-consult (mandatory).
+
+# After skill completes
+edge-skill-step <skill> end
+```
+
+Individual steps within the skill should call `edge-skill-step <skill> <step_id>` as they execute. Silent skips (steps not logged as executed or skipped) are flagged by reflection.
+
+---
+
+## Step 2.9: Post-skill execution (MANDATORY after work completes)
+
+After the skill's main work is done (Step 2) and before logging (Step 3):
+
+1. Re-read `config/post-skill.md`
+2. Execute EVERY procedure defined there, one by one
+3. **CRITICAL: each procedure is independent. A failure in one MUST NOT
+   stop the others.** Execute all of them, every time, regardless of
+   prior failures. The sequence is:
+   - Procedure 1 (e.g. LaTeX render) → try → log success or failure → CONTINUE
+   - Procedure 2 (e.g. Overleaf mirror) → try → log success or failure → CONTINUE
+   - Procedure 3 (e.g. notify operator) → try → log success or failure → CONTINUE
+4. For each procedure, log the outcome to `logs/post-skill.log`:
+   ```
+   [TIMESTAMP] procedure: LaTeX render | status: FAIL | reason: pandoc not installed
+   [TIMESTAMP] procedure: Overleaf mirror | status: OK | files: 2
+   [TIMESTAMP] procedure: notify | status: SKIP | reason: no notification channel configured
+   ```
+5. If a tool is missing (pandoc, latexmk), log it and move on — do not
+   attempt to install packages mid-beat. **Dependency remediation
+   happens during reflection, not mid-beat** (see reflection HN-1c)
+6. If a primitive exists for the task (e.g. `libexec/<codename>/overleaf-sync`),
+   use it instead of raw git commands
+7. notify.sh is ALWAYS the last call, even if everything else failed —
+   the operator needs to know what happened
+
+**A post-skill that stops at the first failure is a bug, not caution.**
+
+---
+
+## Step 2.95: Dispatch verification (MANDATORY — mechanical check)
+
+Before logging, verify that a skill was actually dispatched. This is not optional.
+
+```bash
+# Check if edge-skill-step recorded a 'start' for this beat
+today=$(date +%Y-%m-%d)
+DISPATCHED=$(python3 -c "
+import json, sys
+try:
+    steps = [json.loads(l) for l in open('$HOME/edge/logs/skill-steps.jsonl') if l.strip()]
+    today_starts = [s for s in steps if s.get('step') == 'start' and '$today' in s.get('timestamp', '')]
+    if today_starts:
+        last = today_starts[-1]
+        print(f'OK: {last.get(\"skill\", \"unknown\")}')
+    else:
+        print('FAIL: no skill dispatched')
+except Exception as e:
+    print(f'FAIL: {e}')
+" 2>/dev/null)
+echo "$DISPATCHED"
+```
+
+**If `FAIL`:** The heartbeat did work without dispatching a skill. This violates the protocol. Do NOT proceed to Step 3. Instead:
+1. Log the violation to `debugging.md`
+2. Log to the heartbeat log: `[HH:MM] Beat #N — VIOLATION: no skill dispatched. Work done inline without tracking.`
+3. The beat is invalid. The work is invisible to reflection.
+
+**If `OK`:** Proceed to Step 3.
+
+**Note:** With `bin/heartbeat-dispatch-guard.sh` wired into `PreToolUse`
+(#212), reaching this step without dispatching a skill is only possible if
+the heartbeat never attempted to write an artifact. The hook is the
+earliest checkpoint; this step is the mechanical double-check.
 
 ---
 
@@ -494,6 +611,22 @@ edge-event log -t error_logged -s "[error description]" --thread [thread_id]
 The `--update-thread N` automatically updates `updated:` and `resurface:` in the thread file. Without this, threads age silently.
 
 **Follow ~/.claude/skills/_shared/state-protocol.md for status management.**
+
+### 3e: Close the guard sentinel (MANDATORY — last step)
+
+Mark the beat as inactive. The hook will stop blocking writes until the
+next beat opens a new sentinel.
+
+```bash
+python3 -c "
+import json, pathlib
+p = pathlib.Path.home() / 'edge' / 'state' / 'current-beat.json'
+if p.exists():
+    state = json.loads(p.read_text())
+    state['active'] = False
+    p.write_text(json.dumps(state, indent=2))
+"
+```
 
 ---
 


### PR DESCRIPTION
Supersedes #213 (stale branch, 90+ commits behind main, apparent bloat was rebase noise).
Closes #212.

## What

Cherry-picks the single real delta from #213 onto current `origin/main`:

- `bin/heartbeat-dispatch-guard.sh` — PreToolUse hook that blocks `Write|Edit` into `blog/entries/**` and `reports/**` when the beat sentinel shows `active=true` + `skill_dispatched=false`.
- `docs/heartbeat-dispatch-guard.md` — wire-up instructions, sentinel schema, test cases.
- `skills/heartbeat/SKILL.md` — adds Step 2.0 (open sentinel), sentinel flip in Dispatch, Step 3e (close sentinel). Merged cleanly with the Step 1a0 rolling-digest work already on `main`.

## Why a fresh branch

#213's diff against main showed 29 files / 13k lines, which looked kitchen-sink. Inspection: only 3 files are the actual change; the rest is stale-base artifact from the branch falling far behind main. Rebasing that branch in place would have been noisier than cherry-picking the one commit (`032fad8`) clean.

## Enforcement ladder context

- L1 prose ("ALWAYS dispatch a skill") — already present, failed twice (issue #212, 2026-04-18 incident)
- **L2 PreToolUse hook — this PR** (blocks artifact writes when dispatch flag is down)
- L3 Stop hook — tracked separately in #228

## Test plan

- [ ] Install hook in `.claude/settings.json` per `docs/heartbeat-dispatch-guard.md`
- [ ] Run `/ed-heartbeat` end-to-end; verify Step 2.0 writes sentinel, Dispatch flips it, Step 3e closes it
- [ ] Simulate skipped dispatch: delete the flip step, attempt Write into `blog/entries/` → expect hook denial
- [ ] Verify `edge-apply --skip-venv` propagates SKILL.md changes to `~/.claude/skills/ed-heartbeat/`