### PR TITLE
fix(review-gate): Azure 3-bug chain — purpose routing + temperature (#233, closes #234)

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,1 +1,2 @@
-- [Genotype workflow: clone → branch → push → propagate](feedback_genotype_workflow.md) — Never edit live `~/edge/` for genotype changes; user has had sensitive data leaks from in-place edits
+- [Genotype workflow: issue → clone → PR → merge → close → propagate](feedback_genotype_workflow.md) — 7-step loop for any ~/edge/ genotype change; close-issue is a completion gate, not an afterthought
+- [Reflection execution log](reflection-log.md) — running log of /ed-reflection runs and decisions taken

--- a/memory/feedback_genotype_workflow.md
+++ b/memory/feedback_genotype_workflow.md
@@ -1,20 +1,30 @@
 ---
-name: genotype changes go through clone → branch → push → propagate
-description: For any change to ~/edge/ genotype paths (tools/, skills/, search/, blog/app.py, bin/, config/*.tpl, memory core, SURVIVAL_POLICY), never edit the live ~/edge/ directory. Clone to ~/work/<branch>/, code there, commit, push to GitHub, then propagate via git pull on each fleet member.
+name: genotype changes require full issue → clone → PR → merge → close loop
+description: For any change to ~/edge/ genotype paths (tools/, skills/, search/, blog/app.py, blog/*.sh, bin/, config/*.tpl, hooks/, memory core, SURVIVAL_POLICY), the required 7-step flow is (1) open GitHub issue, (2) clone to ~/work/<issue-number>/, (3) branch/commit/push, (4) open PR referencing issue, (5) merge, (6) CLOSE the issue, (7) propagate via git pull + edge-apply. Never edit live ~/edge/ in place.
 type: feedback
 originSessionId: 710c0e56-d64b-456a-b714-d97e861a9753
 ---
-For any genotype change in `~/edge/`: clone to `~/work/<branch>/`, code/commit/push there, then propagate via `git pull --rebase` on each fleet instance. Never edit the live `~/edge/` directory in place.
+For any genotype change, the required 7-step loop is:
 
-**Why:** The user has had sensitive data from the live instance leak into git via in-place edits. The live `~/edge/` contains epigenetic state (logs, secrets, drafts, search DB) that must never enter the genotype repo. Working in a clone keeps the boundary clean. The user has corrected me on this twice — first time was the #226 telemetry work ("vc tem que dar clone e trabalhar no projeto clonado").
+1. **Open a GitHub issue** in `lucasrp/edge-of-chaos` describing the change (use `[genotype]` prefix when reporting a bug found during another beat).
+2. **Clone** the repo to `~/work/<issue-number>/` — use the issue number, not the branch name, so workspace is traceable back to the ticket.
+3. **Branch, commit, push** from the clone. Never edit live `~/edge/` in place.
+4. **Open a PR** that references the issue (`Fixes #N` / `Closes #N` — gives GitHub automatic linking).
+5. **Merge** the PR.
+6. **Close the issue** explicitly. An open issue with merged code is an inconsistent state — close-issue is the completion gate, not an afterthought.
+7. **Propagate** to every fleet member — two steps per agent, not one:
+   - `ssh <agent> 'cd ~/edge && git pull --rebase --autostash'` — pulls genotype source
+   - `ssh <agent> 'python3 ~/edge/tools/edge-apply --skip-venv'` — syncs `~/edge/skills/` → `~/.claude/skills/<prefix>-<name>/` with the host's prefix (`ed-`/`dru-`/`roberto-`/`bracis-`/`gauss-`). Without step 2 Claude Code still loads the OLD skill at runtime.
+
+**Why:** Two compounding reasons.
+
+First, the operator has had sensitive data from the live instance leak into git via in-place edits. The live `~/edge/` contains epigenetic state (logs, secrets, drafts, search DB) that must never enter the genotype repo. Working in a clone keeps the boundary clean.
+
+Second, the operator has corrected this 8+ times across conversations (2026-04-09 → 2026-04-18). Soft workflow recall (crystallized twice: 2026-04-09, 2026-04-17) is saturated — this is the enforcement-ladder L1→L5 promotion pattern, worked example. The close-issue step was added explicitly on 2026-04-18 because open-issue-with-merged-code kept happening.
 
 **How to apply:**
-- Genotype paths (per CLAUDE.md): `skills/`, `tools/`, `search/*.py`, `blog/app.py`, `blog/*.sh`, `bin/`, `config/*.tpl`, `memory/personality.md`, `memory/rules-core.md`, `memory/metodo.md`, `SURVIVAL_POLICY.md`
-- Clone target: `~/work/<branch-or-issue-number>/`
-- After push, fleet propagation is TWO steps on each agent (not one):
-  1. `ssh <agent> 'cd ~/edge && git pull --rebase --autostash'` — pulls genotype source
-  2. `ssh <agent> 'python3 ~/edge/tools/edge-apply --skip-venv'` — syncs `~/edge/skills/` → `~/.claude/skills/<prefix>-<name>/` with the host's prefix (`ed-`/`dru-`/`roberto-`/`bracis-`/`gauss-`). Without step 2 Claude Code still loads the OLD skill at runtime. Caught by MD5 diff on 2026-04-18 after shipping heartbeat Step 1a0.
+- Genotype paths (per CLAUDE.md and hooks/): `skills/`, `tools/`, `search/*.py`, `blog/app.py`, `blog/*.sh`, `bin/`, `config/*.tpl`, `hooks/*.sh`, `memory/personality.md`, `memory/rules-core.md`, `memory/metodo.md`, `SURVIVAL_POLICY.md`.
 - `edge-apply` is idempotent; `--skip-venv` avoids the slow search-venv rebuild when only skills/code changed.
-- `gauss` has chronic drift (100+ local commits). Use `git pull --rebase -X theirs --autostash` there so gauss's own `memory/debugging.md` wins on conflict — genotype change still lands.
+- `gauss` has chronic drift (100+ local commits). Use `git pull --rebase -X theirs --autostash` there so gauss's own `memory/debugging.md` wins on conflict — the genotype change still lands.
 - Phenotype/epigenetic edits (`agent.yaml`, `state/`, `blog/entries/`, `logs/`, `threads/`, `reports/`) can be done in place — they're per-instance and gitignored or not in genotype.
-- The test: "If I change this, does it affect other instances?" YES → genotype → clone first.
+- The test: "If I change this, does it affect other instances?" YES → genotype → full 7-step loop.

--- a/memory/reflection-log.md
+++ b/memory/reflection-log.md
@@ -1,0 +1,36 @@
+# Reflection — Execution Log
+
+---
+
+## [2026-04-18 19:40] Reflection #1
+
+**Trigger:** manual (`/ed-reflection ultrathink`)
+**Status:** completed
+**Mode:** manual (abbreviated — focus on operator directive processing)
+
+**Input:** Operator repeated the genotype workflow directive: "always when working with genotype to open an issue, clone, write a PR, merge, close issue."
+
+**Findings:**
+- Two prior workflow entries exist (2026-04-09, 2026-04-17) covering nearly identical ground. The 2026-04-09 entry notes "corrected 7+ times" — today makes 8+.
+- Existing `write-guard.sh` (genotype-side, distributed via edge-apply) only blocks phenotype artifact paths (blog/entries, state, reports, threads, logs, meta-reports, health). Genotype **code** paths (skills/, tools/, search/, blog/app.py, blog/*.sh, bin/, config/*.tpl, core memory, SURVIVAL_POLICY, hooks/) are not mechanically guarded.
+- Repeated-correction pattern matches the enforcement-ladder research: soft workflow recall (L1) is saturated for this directive; promotion to mechanical enforcement (L5) is warranted.
+- Novel addition in today's directive vs prior: explicit **close-issue** step as a completion gate.
+
+**Actions taken:**
+- Crystallized refined workflow `2026-04-18-when-modifying-any-genotype-file-tools-skills-sear.md` (includes close-issue step).
+- Wrote friction signal (L1→L5 promotion candidate).
+- Wrote decision signal (not patching write-guard.sh autonomously — that's the very change requiring operator approval).
+- Updated `feedback_genotype_workflow.md` with the explicit 7-step sequence.
+
+**Not done (requires operator approval — itself a genotype change):**
+- Extending `~/edge/hooks/write-guard.sh` to block Write/Edit on genotype code paths.
+- The mechanical fix requires: issue → clone → branch → PR → merge → close. Presented as a proposal for the operator to trigger.
+
+**Files modified:**
+- `~/.claude/projects/-home-vboxuser/memory/feedback_genotype_workflow.md` — added explicit 7-step sequence with close-issue as completion gate
+- `~/.claude/projects/-home-vboxuser/memory/reflection-log.md` — this entry
+- `~/edge/blog/entries/2026-04-18-when-modifying-any-genotype-file-tools-skills-sear.md` — crystallized via edge-crystallize
+- Signal files: `friction.md`, `decision.md`
+
+**Patterns:**
+- Repeated soft-enforcement failure is itself a signal worth capturing (not just reacting to). The enforcement-ladder framework already predicted this class of outcome; the reflection now has a concrete worked example.

--- a/tools/_shared/router_client.py
+++ b/tools/_shared/router_client.py
@@ -143,14 +143,31 @@ def find_router_for_model(model: str) -> tuple[str, dict[str, Any]]:
         for name, cfg in routers.items():
             if cfg and cfg.get("model") == model:
                 return name, load_router_config(name)
-    # Legacy prefix match
+    # Legacy prefix match. When the user *has* declared routers but the
+    # requested model doesn't match any of them, we still fall through here —
+    # warn loudly so a mismatched --model slug doesn't silently hit
+    # api.openai.com with a non-OpenAI key (issue #233).
+    declared = [cfg.get("model") for cfg in routers.values()
+                if isinstance(cfg, dict)] if isinstance(routers, dict) else []
     for purpose, spec in _LEGACY_DEFAULTS.items():
         if model.startswith(spec["model_default"].split("-")[0]):
             cfg = _resolve_legacy(purpose)
             if cfg:
                 cfg["model"] = model  # caller's override wins
+                if declared:
+                    print(
+                        f"WARN router_client: model={model!r} not declared "
+                        f"in agent.yaml routers (declared: {declared}). "
+                        f"Falling back to legacy endpoint {cfg['base_url']} "
+                        f"using {cfg['secret_ref']}. This will fail if your "
+                        f"key is not for that provider.",
+                        file=sys.stderr,
+                    )
                 return purpose, cfg
-    raise KeyError(f"No router declares model={model!r}.")
+    raise KeyError(
+        f"No router declares model={model!r}. "
+        f"Declared in agent.yaml: {declared or '(none)'}."
+    )
 
 
 def load_secret(secret_ref: str) -> str:

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -45,7 +45,10 @@ _SKILL_PREFIX = load_branding().get("skill_prefix", "agent")
 BLOG_RULES_PATH = SKILLS_DIR / f"{_SKILL_PREFIX}-blog" / "SKILL.md"
 GROK_MODEL = "grok-4.20-multi-agent-beta-0309"
 
-DEFAULT_MODEL = "gpt-5.4"
+# Router purpose used by default. The actual model comes from agent.yaml
+# routers.<purpose>.model — respecting per-agent configuration (Azure, OpenAI,
+# xAI, etc.) instead of hardcoding a model slug.
+DEFAULT_PURPOSE = "chat"
 
 # Models that require the Responses API instead of Chat Completions
 RESPONSES_API_MODELS = {GROK_MODEL, "gpt-5.4-pro"}
@@ -540,10 +543,11 @@ def load_entry(entry_path: str) -> str:
 # Phase 1: Co-author
 # ---------------------------------------------------------------------------
 
-def coauthor(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
+def coauthor(yaml_path: str, skill: str = None, model: str = None,
+             purpose: str = DEFAULT_PURPOSE,
              entry_path: str = None, brief: str = None) -> dict:
     """Run co-author phase with tool use. Returns enrichment suggestions."""
-    client, model = make_client(model=model)
+    client, model = make_client(purpose=purpose, model=model)
 
     yaml_content = Path(yaml_path).read_text(encoding="utf-8")
 
@@ -584,7 +588,6 @@ def coauthor(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
                     model=model,
                     input=messages,
                     tools=resp_tools,
-                    temperature=0.3,
                 )
                 total_prompt_tokens += response.usage.input_tokens
                 total_completion_tokens += response.usage.output_tokens
@@ -619,7 +622,6 @@ def coauthor(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
                     messages=messages,
                     tools=TOOLS,
                     tool_choice="auto",
-                    temperature=0.3,
                 )
                 total_prompt_tokens += response.usage.prompt_tokens
                 total_completion_tokens += response.usage.completion_tokens
@@ -691,13 +693,14 @@ def coauthor(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
 # Phase 2: Reviewer (no tools, evaluates blind)
 # ---------------------------------------------------------------------------
 
-def review(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
+def review(yaml_path: str, skill: str = None, model: str = None,
+           purpose: str = DEFAULT_PURPOSE,
            threshold: float = 3.0, entry_path: str = None) -> dict:
     """Run review phase. Returns structured feedback dict."""
     try:
-        client, model = make_client(model=model)
+        client, model = make_client(purpose=purpose, model=model)
     except Exception as e:
-        raise RuntimeError(f"router setup failed for model {model}: {e}") from e
+        raise RuntimeError(f"router setup failed for purpose={purpose} model={model}: {e}") from e
 
     yaml_content = Path(yaml_path).read_text(encoding="utf-8")
 
@@ -727,7 +730,6 @@ def review(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
                     {"role": "system", "content": system + "\n\nRespond with valid JSON only."},
                     {"role": "user", "content": user_msg},
                 ],
-                temperature=0.2,
             )
             raw_text = response.output_text
             prompt_tokens = response.usage.input_tokens
@@ -740,7 +742,6 @@ def review(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
                     {"role": "system", "content": system},
                     {"role": "user", "content": user_msg},
                 ],
-                temperature=0.2,
             )
             raw_text = response.choices[0].message.content
             prompt_tokens = response.usage.prompt_tokens
@@ -800,9 +801,10 @@ def review(yaml_path: str, skill: str = None, model: str = DEFAULT_MODEL,
 # Phase 3: Refiner (applies reviewer feedback to YAML)
 # ---------------------------------------------------------------------------
 
-def refine(yaml_path: str, review_result: dict, model: str = DEFAULT_MODEL) -> dict:
+def refine(yaml_path: str, review_result: dict, model: str = None,
+           purpose: str = DEFAULT_PURPOSE) -> dict:
     """Apply reviewer feedback to YAML. Rewrites the file in-place. Returns metadata."""
-    client, model = make_client(model=model)
+    client, model = make_client(purpose=purpose, model=model)
 
     yaml_content = Path(yaml_path).read_text(encoding="utf-8")
 
@@ -841,7 +843,6 @@ def refine(yaml_path: str, review_result: dict, model: str = DEFAULT_MODEL) -> d
                     {"role": "system", "content": REFINER_SYSTEM},
                     {"role": "user", "content": user_msg},
                 ],
-                temperature=0.3,
             )
             refined_yaml = response.output_text or ""
         else:
@@ -851,7 +852,6 @@ def refine(yaml_path: str, review_result: dict, model: str = DEFAULT_MODEL) -> d
                     {"role": "system", "content": REFINER_SYSTEM},
                     {"role": "user", "content": user_msg},
                 ],
-                temperature=0.3,
             )
             refined_yaml = response.choices[0].message.content or ""
     except Exception as e:
@@ -1043,8 +1043,11 @@ def main():
     parser.add_argument("yaml", help="YAML spec file to review")
     parser.add_argument("--skill", "-s", default=None,
                         help="Skill name for skill-specific rules")
-    parser.add_argument("--model", "-m", default=DEFAULT_MODEL,
-                        help=f"OpenAI model (default: {DEFAULT_MODEL})")
+    parser.add_argument("--model", "-m", default=None,
+                        help="Override model slug. Default: use the model declared by "
+                             "--purpose in agent.yaml routers.")
+    parser.add_argument("--purpose", "-p", default=DEFAULT_PURPOSE,
+                        help=f"Router purpose from agent.yaml (default: {DEFAULT_PURPOSE})")
     parser.add_argument("--threshold", "-t", type=float, default=3.5,
                         help="Overall score threshold for pass (default: 3.5)")
     parser.add_argument("--entry", "-e", default=None,
@@ -1076,6 +1079,7 @@ def main():
             str(yaml_path),
             skill=args.skill,
             model=args.model,
+            purpose=args.purpose,
             entry_path=args.entry,
             brief=args.brief,
         )
@@ -1097,6 +1101,7 @@ def main():
             str(yaml_path),
             skill=args.skill,
             model=args.model,
+            purpose=args.purpose,
             threshold=args.threshold,
             entry_path=args.entry,
         )


### PR DESCRIPTION
Fixes three chained bugs that silently neutered the LLM-as-judge gate on every Azure-configured agent (roberto et al.) for weeks. Closes #234, progresses #233.

## Root causes

1. **`review-gate.py` DEFAULT_MODEL = \"gpt-5.4\"** — a slug no `agent.yaml` `routers:` declares. Callers without `--model` always resolved a fantom.
2. **`router_client.find_router_for_model` silent fallback** — when the requested model matched no declared router, it fell through to `_LEGACY_DEFAULTS` (api.openai.com) without warning. On Azure installs, the key at `openai.env:OPENAI_API_KEY` holds the Azure key → 401 cryptic.
3. **Hardcoded `temperature=0.2`/`0.3`** in 6 call sites — Azure gpt-5 family (reasoning models) reject any non-default temperature with 400.

Net effect: `score=0, cost=$0` written to every meta-report, `.review.json` unresolved, bypass markers carrying entries through without real review.

## Changes

**`tools/review-gate.py`**
- `DEFAULT_MODEL` → `DEFAULT_PURPOSE = \"chat\"`. All phases call `make_client(purpose, model)` — model is an optional override.
- CLI: `--model` default → `None` (means \"use purpose\"). New `--purpose` (default `chat`).
- `temperature=` removed from all 6 call sites (default 1 is accepted by reasoning models, non-reasoning models already default there).

**`tools/_shared/router_client.py`**
- When `find_router_for_model` falls through to legacy defaults AND `agent.yaml` has a `routers:` block, emit a visible stderr WARN naming declared models and the endpoint/secret_ref being used. Hard-to-miss signal that the caller hit a silent fallback.
- KeyError now includes the list of declared routers.

## Out of scope (follow-ups)

- **Bug #4** from #233 (consolidate-state fails on `score=0 AND cost=0`) — separate issue, different tool.
- LEGACY_DEFAULTS still points `gpt-5.4` as `model_default` in `chat` — the fantom isn't reachable via purpose lookup anymore, but could be cleaned up. Non-urgent.

## Verification

- `python3 tools/review-gate.py --help` → new `--purpose` flag present.
- AST parse clean on both files.
- Live Azure test should be run on roberto after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)