### PR TITLE
fix(blog): arg hygiene + /blog/reindex endpoint for verify reliability (#236)

### DIFF
--- a/blog/app.py
+++ b/blog/app.py
@@ -738,6 +738,14 @@ def htmx_entry_comments(slug):
 
 
 # ─── Routes: JSON APIs (backward compatible) ───
+@app.route("/blog/reindex", methods=["POST"])
+def reindex():
+    """Invalidate the entries cache so the next request re-reads from disk.
+    Called by blog-publish.sh after writing a new entry (issue #236)."""
+    invalidate_cache()
+    return {"ok": True}, 200
+
+
 @app.route("/blog/entries/")
 @app.route("/blog/entries")
 def entries_json():

--- a/blog/blog-publish.sh
+++ b/blog/blog-publish.sh
@@ -26,6 +26,20 @@ if [[ -z "$ENTRY_PATH" ]]; then
     exit 1
 fi
 
+# Arg hygiene — reject inputs that are obviously not an entry .md path.
+# A caller forwarding flags or YAML spec files by mistake will land here
+# instead of producing a cryptic "File not found" (issue #236 root cause A).
+if [[ "$ENTRY_PATH" == -* ]]; then
+    echo "ERROR: blog-publish.sh expects a positional entry.md path — got a flag: '$ENTRY_PATH'"
+    echo "       Usage: blog-publish <path-to-entry.md>"
+    exit 1
+fi
+if [[ "$ENTRY_PATH" != *.md ]]; then
+    echo "ERROR: blog-publish.sh expects a .md entry file — got: '$ENTRY_PATH'"
+    echo "       Usage: blog-publish <path-to-entry.md>"
+    exit 1
+fi
+
 # Resolve to absolute path
 if [[ ! "$ENTRY_PATH" = /* ]]; then
     ENTRY_PATH="$(pwd)/$ENTRY_PATH"
@@ -154,6 +168,21 @@ else
     echo "$CHANGELOG_ENTRY" >> "$CHANGELOG"
 fi
 echo "  OK: Changelog updated"
+
+# --- Step 3.5: Ask blog server to reload its entry cache ---
+# Without this, load_entries() is cached for CACHE_TTL=300s and the freshly
+# written entry returns 404 on /blog/entries/{slug} until the cache expires
+# or the service restarts (issue #236 root cause B).
+echo "[3.5/6] Reloading blog server cache..."
+REINDEX_HTTP=$(curl -s -m 5 -o /dev/null -w "%{http_code}" $CURL_AUTH \
+    -X POST "$API_URL/blog/reindex" 2>/dev/null || echo "000")
+if [[ "$REINDEX_HTTP" == "200" ]]; then
+    echo "  OK: cache invalidated"
+elif [[ "$REINDEX_HTTP" == "404" ]]; then
+    echo "  SKIP: server lacks /blog/reindex (old version, fine for verify fallback)"
+else
+    echo "  WARN: reindex returned HTTP $REINDEX_HTTP (non-fatal — verify may miss the entry)"
+fi
 
 # --- Step 4: Verify ---
 echo "[4/5] Verifying..."


### PR DESCRIPTION
Fixes two independent Phase 1 failure modes that together produced ~24 false failures in \`pipeline-failures.jsonl\` over 10 days on gauss alone. Closes #236 (Parts A+B; Part C deferred).

## Part A — caller argument leak

\`blog-publish.sh\` accepted any positional arg and only complained at the generic \`File not found\` guard. Evidence records showed slugs of \`--entry\` and \`autonomy-report-spec.yaml\` — callers forwarding a flag name or a YAML spec file. Cryptic error hid the real bug.

Added two explicit checks after reading \`\$1\`:
- Starts with \`-\` → \`ERROR: expects a positional entry.md path — got a flag: '<value>'\`
- Doesn't end in \`.md\` → \`ERROR: expects a .md entry file — got: '<value>'\`

Tested:
\`\`\`
\$ bash blog/blog-publish.sh --entry
ERROR: blog-publish.sh expects a positional entry.md path — got a flag: '--entry'

\$ bash blog/blog-publish.sh autonomy-spec.yaml
ERROR: blog-publish.sh expects a .md entry file — got: 'autonomy-spec.yaml'
\`\`\`

## Part B — blog server never reindexes after write

\`blog/app.py\` caches \`load_entries()\` for 300s (\`CACHE_TTL\`). When \`blog-publish.sh\` writes a new entry and polls \`/blog/entries/\` during its verify step, the cached list still reflects the pre-write state → slug \`NOT FOUND\` → \`VERIFY_OK=false\`. Fixed itself on service restart, which is why the on-disk state was always correct.

Changes:
- **blog/app.py**: new \`POST /blog/reindex\` route that calls the existing \`invalidate_cache()\` helper. Returns \`{\"ok\": true}, 200\`.
- **blog/blog-publish.sh**: new Step 3.5 that hits \`/blog/reindex\` right before verify. Robust to older server versions — HTTP 404 from the endpoint is treated as \"skip, keep going\" so fleet rollout order doesn't matter. Any other non-200 logs a WARN but doesn't fail the publish.

## Out of scope

- **Part C** from #236 (verify-gate exit semantics). Code today already has \`exit 0\` on verify failure with a \"Non-fatal\" comment; the observed non-zero exit claimed in #236 is worth a follow-up diagnostic pass but not a blocker for this fix. The reindex step in Part B likely eliminates the main failure path anyway.
- Callers of \`blog-publish.sh\`: only \`consolidate-state.sh\` in genotype invokes it correctly. The bad calls (\`--entry\`, \`*.yaml\`) were external (manual/LLM sessions). The hardened arg guard is now the enforcement point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)