### PR TITLE
fix(heartbeat): resolve claude on minimal systemd PATH (#240)

### DIFF
--- a/config/heartbeat.sh.tpl
+++ b/config/heartbeat.sh.tpl
@@ -9,6 +9,18 @@ LOCKFILE="/tmp/edge-heartbeat-{{ CODENAME }}.lock"
 LOGFILE="$EDGE_DIR/logs/heartbeat-$(date +%Y-%m-%d).log"
 SKILL="/{{ SKILL_PREFIX }}-heartbeat"
 
+# Ensure `claude` is reachable. systemd user timers inherit a minimal PATH
+# that does NOT include nvm's node-version bindir (where `claude` typically
+# lives), so the wrapper silently fails with `command not found` (#240).
+if ! command -v claude >/dev/null 2>&1; then
+    for P in "$HOME"/.nvm/versions/node/*/bin "$HOME/.local/bin" "$HOME/bin"; do
+        if [ -x "$P/claude" ]; then
+            export PATH="$P:$PATH"
+            break
+        fi
+    done
+fi
+
 # Load secrets
 [ -f "$EDGE_DIR/secrets/keys.env" ] && set -a && source "$EDGE_DIR/secrets/keys.env" && set +a
 


### PR DESCRIPTION
Closes #240. systemd user timers inherit a minimal PATH without nvm's per-version bindir (where the \`claude\` CLI lives). Heartbeat wrapper fails silently — \`set -uo pipefail\` without \`-e\` lets the post-run \`edge-index\` loop continue, producing a log entry with no Claude session.

## Fix

\`config/heartbeat.sh.tpl\`: probe \`claude\` on PATH; if missing, glob nvm install dirs and common user-local bindirs, prepending the first hit to PATH.

\`\`\`bash
if ! command -v claude >/dev/null 2>&1; then
    for P in \"\$HOME\"/.nvm/versions/node/*/bin \"\$HOME/.local/bin\" \"\$HOME/bin\"; do
        if [ -x \"\$P/claude\" ]; then
            export PATH=\"\$P:\$PATH\"
            break
        fi
    done
fi
\`\`\`

## Verification

Simulated minimal systemd env:
\`\`\`
env -i HOME=\$HOME PATH=/usr/local/bin:/usr/bin bash -c '<glob block>'
→ /home/vboxuser/.nvm/versions/node/v24.13.0/bin/claude
\`\`\`

## Rollout

Template only. Render (\`edge-render\`) emits \`config/heartbeat.sh\`; apply (\`edge-apply\`) copies it to \`~/.local/bin/heartbeat.sh\`. No systemd unit change.

Complementary to #228 — that catches \"Claude ran but didn't dispatch a skill\", this catches \"Claude never ran at all\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)