### PR TITLE
feat(rite): uniform artifact rite for every /ed-* skill — no carve-outs

### DIFF
--- a/memory/rules-core.md
+++ b/memory/rules-core.md
@@ -16,6 +16,7 @@ Specific topics go in `memory/topics/`. Core should not exceed 15 rules.
 - When generating a report or blog entry: **verify that key insights enter memory/topics/**. Without distillation = write-only.
 - When publishing an entry: **include claims, threads, keywords, report link**. An entry without metadata is invisible in the corpus.
 - When producing an artifact: **blog ALWAYS**. Primary communication channel with the user.
+- When dispatching any `/ed-*` skill (round-robin or manual): **produce a full-rite artifact — no carve-outs**. The rite is defined once in `skills/_shared/report-template.md` and applies uniformly to every skill (including `/ed-execute`). No minimal-meta, signal-only, or blackout-degraded mode. If an external adversarial provider is unavailable, fall back to Claude — never skip the rite.
 
 ## Recognition
 

--- a/skills/_shared/report-template.md
+++ b/skills/_shared/report-template.md
@@ -1,7 +1,14 @@
-# Report Template — Shared Reference
+# Uniform Artifact Rite — Shared Protocol
 
-Used by: /ed-research, /ed-discovery, /ed-leisure, /ed-strategy, /ed-planner, /ed-reflection.
-Each skill defines its own mandatory sections and golden rules 1-3. This file defines what is COMMON to all.
+**Applies to every `/ed-*` skill, without exception.** Every skill dispatch
+— round-robin heartbeat or manual — produces a full-rite artifact following
+this protocol. No minimal-meta, signal-only, voluntary-minimal, or
+blackout-degraded variants (see `memory/rules-core.md` → Production).
+
+Each skill contributes its own section titles and domain-specific YAML
+blocks. This file defines the **uniform floor** every skill must meet:
+blog entry + YAML spec + HTML report + meta-report + adversarial review,
+with Lineage, Gaps, Glossary, Bibliography, ≥1 SVG all MANDATORY.
 
 ---
 
@@ -33,10 +40,9 @@ Each skill defines its own mandatory sections and golden rules 1-3. This file de
    - Phase 5: State commit (claims, threads, events, digest)
    - Phase 6: Diffs + git commit
 
-   Content report is optional — publishing without YAML generates only the meta-report:
-   ```bash
-   consolidate-state ~/edge/blog/entries/<file>.md
-   ```
+   **YAML spec is MANDATORY — never publish without it.** Publishing a blog
+   entry without a YAML spec skips Phase 2 (content report), producing no
+   HTML. That path is forbidden by the uniform rite.
 
    Useful flags: `--scratchpad PATH`, `--reason TEXT`
    (Enforcement #218: bypass flags `--skip-review`, `--no-adversarial`, `--no-meta` were removed — all phases run unconditionally.)
@@ -138,7 +144,7 @@ SVG is not just for numbers — any information that communicates better as an i
 
 ## Mandatory Final Sections
 
-### Second-to-last Section: "What I Don't Know" (MANDATORY — except /ed-leisure)
+### Second-to-last Section: "What I Don't Know" (MANDATORY — all skills)
 
 - `gap-table` with open gaps (status: open/partial)
 - `callout` variant=danger for critical uncertainties (that could invalidate a recommendation)

--- a/skills/autonomy/SKILL.md
+++ b/skills/autonomy/SKILL.md
@@ -7,8 +7,9 @@ user-invocable: true
 # Autonomy — Evaluate, Propose, Act
 
 The agent's self-evolution mechanism. Reads declared state vs actual state,
-proposes changes, acts on what's approved. Produces blog + report like
-every skill — plus operational changes (primitives, workflows, config).
+proposes changes, acts on what's approved. **Produces a full-rite artifact
+every dispatch** — follow `_shared/report-template.md` like every other
+`/ed-*` skill. No minimal-meta, signal-only, or blackout-degraded mode.
 
 **Principle:** more agency = more quality. But agency without initiative
 is just a bigger toolbox. The value is in seeing what nobody asked for.

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -155,24 +155,22 @@ Create blog entry (`~/edge/blog/entries/`) and generate report in a single call:
 consolidate-state ~/edge/blog/entries/<slug>.md /tmp/<slug>.yaml
 ```
 
-Report YAML spec:
+**Follow the uniform rite — `~/.claude/skills/_shared/report-template.md`.** Execution-specific section titles for the YAML spec:
 
 ```yaml
-title: "Execution: [name]"
-subtitle: "[summary of what was done]"
-date: "DD/MM/YYYY"
-
 sections:
-  - title: "1. Lineage"                    # Where this change came from
-  - title: "2. Pre-Execution Derivation"   # Expectations (Step 3)
-  - title: "3. Execution"                  # What was done, file by file
-  - title: "4. Expectation vs Reality"     # Gaps between predicted and actual
-  - title: "5. Tests"                      # Baseline vs result
-  - title: "6. What I Don't Know"          # Residual risks
+  - title: "1. Lineage"
+  - title: "2. Pre-Execution Derivation"
+  - title: "3. Execution"                  # include ≥1 SVG (architecture, sequence, timeline)
+  - title: "4. Expectation vs Reality"
+  - title: "5. Tests"
+  - title: "6. What I Don't Know"
   - title: "7. Contextualization and Glossary"
+
+bibliography: [...]                        # MANDATORY per shared protocol
 ```
 
-**Block types and rules:** see `~/.claude/skills/_shared/report-template.md`.
+All other rite requirements (adversarial review, review gate, SVG, Lineage, Bibliography) are defined in the shared protocol — same as every other `/ed-*` skill.
 
 ### Step 8: Update State
 
@@ -205,7 +203,7 @@ Final message with:
 2. **Prefer Ralph** — whenever convenient, decompose via [Ralph](https://github.com/snarktank/ralph). Simple changes can be direct
 3. **Direct when simple** — trivial changes (1-2 files, no dependencies) don't need a PRD
 4. **Tests before AND after** — baseline mandatory for project profile. System profile: verify it works after the change
-5. **Blog + Report ALWAYS** — no exception, regardless of profile, even for small changes
+5. **Full rite ALWAYS** — no exception, regardless of profile. See `_shared/report-template.md` for the uniform rite that every `/ed-*` skill follows
 6. **Feynman: derive BEFORE, compare AFTER** — expectations before, gaps after
 7. **Partial is OK** — document and stop. Don't force completeness
 8. **Rollback snapshot** — branch + commit saved before any change (project profile)

--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -369,7 +369,7 @@ After reading all context from Step 1, classify the beat:
 - **WORK:** There is a clear signal (chat, error, thread, session with correction). Dispatch targeted skill.
 - **EXPLORE:** No urgent signal. Dispatch `/ed-discovery` or `/ed-research` (alternate). The value is in serendipity — seeing what we're doing and bringing the right terms, the right projects, the lateral connections.
 
-**ABSOLUTE RULE:** The heartbeat ALWAYS dispatches a skill. There is no empty beat.
+**ABSOLUTE RULE:** The heartbeat ALWAYS dispatches a skill and the dispatched skill ALWAYS produces a full-rite artifact. There is no empty beat and no minimal-meta / voluntary-minimal / signal-only / blackout-degraded variant. Every skill follows the uniform rite in `_shared/report-template.md`. If an external adversarial provider is unavailable, fall back to Claude; never skip the rite.
 
 **Anti-saturation** changes meaning: it's not "stop", it's "change topic". If the last 3 beats were on the same topic, switch to another. If they were all exploration, do /ed-research on a thread.
 

--- a/skills/prototype/SKILL.md
+++ b/skills/prototype/SKILL.md
@@ -100,20 +100,20 @@ Direct format:
 **Limitations:** [what the prototype does NOT show / simplified]
 ```
 
-No formal HTML report. No blog entry. The prototype IS the output.
+The prototype file in `~/edge/lab/proto-[slug].[ext]` is the primary output; the dispatch still produces a full-rite artifact recording it.
 
-### Step 5: Record (lightweight)
+### Step 5: Record + full-rite artifact (MANDATORY)
 
-Add 1-2 lines in `breaks-archive.md`:
+1. Add 1-2 lines in `breaks-archive.md`:
 
-```markdown
-## [YYYY-MM-DD] Prototype — [Name]
-- **File:** ~/edge/lab/proto-[slug].[ext]
-- **Illustrates:** [what it demonstrates]
-- **Reference:** [proposal/research that motivated it]
-```
+   ```markdown
+   ## [YYYY-MM-DD] Prototype — [Name]
+   - **File:** ~/edge/lab/proto-[slug].[ext]
+   - **Illustrates:** [what it demonstrates]
+   - **Reference:** [proposal/research that motivated it]
+   ```
 
-DO NOT update breaks-active.md (prototype is not a break). DO NOT generate report. DO NOT update blog.
+2. **Publish a blog entry + HTML report** following `_shared/report-template.md` — same rite as every other `/ed-*` skill. Prototype-specific section titles: "Lineage", "The Prototype" (with embedded link to the prototype file), "Design Choices", plus the mandatory final sections from the shared protocol. The prototype IS the output; the report IS the record. Both exist. DO NOT update breaks-active.md — a prototype is not a break.
 
 ---
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -279,8 +279,13 @@ Produce the snapshot in the format below. Exact numbers, no narrative.
 
 ## Isolation Rule (MANDATORY)
 
-**Read-only.** This skill does NOT modify ANY files — not state files, not projects, nothing.
-All commands are read-only (cat, wc, ls, grep, git status, stat).
+**Read-only on inspected targets.** This skill does NOT modify ANY inspected files — not state files, not projects, nothing. All inspection commands are read-only (cat, wc, ls, grep, git status, stat). The rite artifact it produces (blog entry + YAML spec + HTML report) is the skill's own output, not a modification of what it inspects.
+
+---
+
+## Artifact (MANDATORY — uniform rite)
+
+Follow `~/.claude/skills/_shared/report-template.md`. Status-specific section titles: "1. Lineage", "2. Inventory" (the factual snapshot — tables + metrics-grid), "3. Anomalies Detected", "4. Health Signals", "5. What I Don't Know", "6. Contextualization and Glossary". Metrics-grid with counts, ≥1 SVG (composition bars / health distribution), bibliography referring back to the state files and docs inspected. Tag: `status`. Adversarial review + review gate + `consolidate-state` — same as every other `/ed-*` skill.
 
 ---
 
@@ -289,4 +294,4 @@ All commands are read-only (cat, wc, ls, grep, git status, stat).
 - Output is factual and concise. No "I think", no "maybe". Numbers or "DOES NOT EXIST"
 - Anomalies are factual, not recommendations. E.g.: "proposal #3 references nonexistent file" — not "should create the file"
 - If a state file doesn't exist, report as anomaly — don't create it
-- Expected execution time: <30 seconds (all local, no network)
+- Expected execution time: inspection <30s; artifact production adds ~1-2 min (adversarial + consolidate-state)


### PR DESCRIPTION
Closes #242

## Summary

Every heartbeat dispatch — round-robin or manual — now produces a full-rite artifact (blog entry + YAML spec + HTML report + meta-report + adversarial review) following **one shared protocol**. Eliminates the minimal-meta / voluntary-minimal / blackout-degraded carve-outs that made gauss beat #67 (commit `9622e4d`) publish operational metadata without a content artifact.

## Architectural shift

**Before:** rite rules duplicated across ~8 skill SKILL.md files, diverging over time, with an escape hatch (`_shared/report-template.md` line 36-38: "Content report is optional — publishing without YAML generates only the meta-report"). Skills selectively opted in.

**After:** ONE definition in `skills/_shared/report-template.md`. Every skill SKILL.md points at it. Contradicting prose stripped. The shared protocol becomes the single source of truth; individual skills contribute only their section titles.

## Files

| File | Change |
|---|---|
| `memory/rules-core.md` | +1 rule under Production: \"every `/ed-*` skill produces a full-rite artifact per shared protocol\" |
| `skills/_shared/report-template.md` | Reframed as \"Uniform Artifact Rite\". Removed \"Content report is optional\" escape hatch. Removed `/ed-leisure` \"What I Don't Know\" exemption. Applies to ALL skills. |
| `skills/execute/SKILL.md` | Pointer to shared protocol; Rule #5 becomes \"Full rite ALWAYS\" |
| `skills/autonomy/SKILL.md` | Explicit: no minimal-meta / signal-only / blackout-degraded mode |
| `skills/heartbeat/SKILL.md` | Step 1.5 ABSOLUTE RULE strengthened; Claude as adversarial fallback |
| `skills/prototype/SKILL.md` | Removed \"DO NOT generate report. DO NOT update blog.\" exemption |
| `skills/status/SKILL.md` | Added Artifact section mandating the rite with status-specific sections |

## Why now

Operator directive (2026-04-18, after gauss beat #67): every beat must produce a high-level report; rules apply uniformly across skills; all artifacts best quality.

The two-tier implicit rule made the OpenAI blackout visible as a spike of minimal-meta beats (#62, #64, #65, #66), but also meant the first post-blackout beat (#67) was itself minimal-meta — unblocking the LLM did not automatically produce a content artifact. One code path closes that loop and makes #235 (Claude adversarial fallback) load-bearing instead of optional.

## Follow-ups (separate issues)

1. **Mechanical enforcement in `consolidate-state`**: Phase 2 (content report) becomes unconditional when publishing — error-out instead of skip if no YAML spec. Pairs with #235 Claude-fallback (required, not optional).
2. **Audit read-only orientation skills**: `context`, `loader`, `log` currently produce no artifacts. Decide if the uniform rule applies or if a narrow, named exemption lives in rules-core.

## Test plan

- [ ] After merge + `git pull` + `edge-apply --skip-venv` on every agent, verify next round-robin beat on at least one agent produces a full-rite artifact (blog entry in `blog/entries/`, HTML in `reports/`, not just signals + meta-report).
- [ ] Verify no agent publishes under minimal-meta pattern again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)