### PR TITLE
feat(CLAUDE.md): @import pre-skill for real-time session load (#244)

### DIFF
--- a/config/CLAUDE.md.tpl
+++ b/config/CLAUDE.md.tpl
@@ -21,13 +21,18 @@ Respond in: {{ LANGUAGE }}
 
 ## Required Reading (every session)
 
+Loaded automatically via Claude Code `@import` — edit the source, open a new terminal, changes apply:
+
+@{{ WORK_DIR }}/config/pre-skill.md
+
+Also required (not auto-imported — read on demand):
+
 | File | Contents |
 |------|----------|
 | `memory/rules-core.md` | Cross-cutting rules (max 15) |
 | `memory/personality.md` | Core identity and cognitive profile |
 | `memory/metodo.md` | Feynman method |
 | `memory/debugging.md` | Errors that must not recur |
-| `config/pre-skill.md` | Context activation (identity, strategy, anti-redundancy) |
 | `config/strategy.md` | Operator direction (phase, priorities, constraints) |
 
 ## Skills


### PR DESCRIPTION
## Summary

- Replace prose table entry for `pre-skill.md` in CLAUDE.md.tpl with a real Claude Code `@import` directive
- Content is loaded into session context on every new terminal — no `edge-apply` re-run needed
- Other Required Reading rows stay prose (context budget)

Closes #244.

## Test plan

- [ ] Render locally via `edge-render`, confirm `@{{ WORK_DIR }}/config/pre-skill.md` becomes `@/absolute/path/config/pre-skill.md`
- [ ] Deploy via `edge-apply`, verify `~/.claude/CLAUDE.md` has the `@import` line
- [ ] Open a new `claude` session, approve the import once, confirm pre-skill content is accessible
- [ ] Edit `config/pre-skill.md.tpl`, re-render phenotype, open a new terminal, confirm change is live without re-running `edge-apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)