### PR TITLE
[codex] Separate genotype and phenotype runtime paths

### DIFF
--- a/blog/app.py
+++ b/blog/app.py
@@ -20,16 +20,32 @@ import markdown
 import yaml
 
 # ─── Paths ───
-ROOT = Path.home() / "edge"
-BLOG_DIR = ROOT / "blog"
-ENTRIES_DIR = BLOG_DIR / "entries"
-COMMENTS_FILE = BLOG_DIR / "comments.json"
-DIFFS_DIR = BLOG_DIR / "diffs"
-DIFFS_DIR.mkdir(parents=True, exist_ok=True)
-META_REPORTS_DIR = ROOT / "meta-reports"
-REPORTS_DIR = ROOT / "reports"
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import (  # noqa: E402
+    AUTONOMY_CAPABILITIES_FILE,
+    BLOG_COMMENTS_FILE,
+    BLOG_DIFFS_DIR,
+    BLOG_DIR,
+    BLOG_FTS_DB_FILE,
+    BUILDS_DIR,
+    EDGE_REPO_DIR,
+    ENTRIES_DIR,
+    FRONTIER_FILE,
+    META_REPORTS_DIR,
+    NOTES_DIR,
+    PROPOSALS_FILE,
+    REPORTS_DIR,
+    SEARCH_DIR,
+    SIGNALS_DIR,
+    STATE_DIR,
+    THREADS_DIR,
+)
 
-SEARCH_DIR = ROOT / "search"
+ROOT = EDGE_REPO_DIR
+COMMENTS_FILE = BLOG_COMMENTS_FILE
+DIFFS_DIR = BLOG_DIFFS_DIR
+DIFFS_DIR.mkdir(parents=True, exist_ok=True)
 sys.path.insert(0, str(SEARCH_DIR))
 sys.path.insert(0, str(ROOT))
 
@@ -100,7 +116,7 @@ SKILL_GROUPS = [
 
 
 # ─── FTS5 index ───
-FTS_DB_PATH = BLOG_DIR / "blog_fts.db"
+FTS_DB_PATH = BLOG_FTS_DB_FILE
 
 
 def get_fts_conn():
@@ -615,9 +631,8 @@ def workflow_reject(slug):
 def proposal_approve(proposal_id):
     """Approve a proposal: set status to approved."""
     import json as _j
-    proposals_path = ROOT / "state" / "proposals.json"
     try:
-        proposals = _j.loads(proposals_path.read_text())
+        proposals = _j.loads(PROPOSALS_FILE.read_text())
     except Exception:
         return jsonify({"error": "no proposals file"}), 404
     for p in proposals:
@@ -626,7 +641,7 @@ def proposal_approve(proposal_id):
             break
     else:
         return jsonify({"error": "not found"}), 404
-    proposals_path.write_text(_j.dumps(proposals, indent=2, ensure_ascii=False))
+    PROPOSALS_FILE.write_text(_j.dumps(proposals, indent=2, ensure_ascii=False))
     return "", 204
 
 
@@ -634,17 +649,17 @@ def proposal_approve(proposal_id):
 def proposal_reject(proposal_id):
     """Reject a proposal: set status to rejected, log in decision.md."""
     import json as _j
-    proposals_path = ROOT / "state" / "proposals.json"
     try:
-        proposals = _j.loads(proposals_path.read_text())
+        proposals = _j.loads(PROPOSALS_FILE.read_text())
     except Exception:
         return jsonify({"error": "no proposals file"}), 404
     for p in proposals:
         if p.get("id") == proposal_id:
             p["status"] = "rejected"
             # Log rejection in decision signals
-            signals_path = ROOT / "state" / "signals" / "decision.md"
+            signals_path = SIGNALS_DIR / "decision.md"
             try:
+                signals_path.parent.mkdir(parents=True, exist_ok=True)
                 existing = signals_path.read_text() if signals_path.exists() else ""
                 signals_path.write_text(existing + f"\n- Rejected proposal: {p.get('title', proposal_id)}\n")
             except Exception:
@@ -652,7 +667,7 @@ def proposal_reject(proposal_id):
             break
     else:
         return jsonify({"error": "not found"}), 404
-    proposals_path.write_text(_j.dumps(proposals, indent=2, ensure_ascii=False))
+    PROPOSALS_FILE.write_text(_j.dumps(proposals, indent=2, ensure_ascii=False))
     return "", 204
 
 
@@ -779,8 +794,8 @@ def get_autonomy_data():
     """Read ~/edge/autonomy/capabilities.md and compute Sheridan stats."""
     import re
     try:
-        cap_path = Path.home() / "edge" / "autonomy" / "capabilities.md"
-        frontier_path = Path.home() / "edge" / "autonomy" / "frontier.md"
+        cap_path = AUTONOMY_CAPABILITIES_FILE
+        frontier_path = FRONTIER_FILE
         content = cap_path.read_text()
         # Parse table rows: | # | Name | Sheridan | ...
         rows = re.findall(r'^\|\s*\d+\s*\|([^|]+)\|\s*(\d+)\s*\|', content, re.MULTILINE)
@@ -1127,7 +1142,7 @@ def api_thread_candidates():
 def api_promote_candidate(tag):
     """Create a thread from a candidate tag."""
     from datetime import timedelta
-    threads_dir = ROOT / "threads"
+    threads_dir = THREADS_DIR
     thread_path = threads_dir / f"{tag}.md"
     if thread_path.exists():
         return jsonify({"error": f"Thread '{tag}' already exists"}), 409
@@ -1164,7 +1179,7 @@ Thread criado a partir de candidate (tag '{tag}').
 def api_thread_snooze(thread_id):
     """Snooze: update resurface +7d."""
     from datetime import timedelta
-    thread_path = ROOT / "threads" / f"{thread_id}.md"
+    thread_path = THREADS_DIR / f"{thread_id}.md"
     if not thread_path.exists():
         return jsonify({"error": f"Thread {thread_id} not found"}), 404
     data = request.get_json(silent=True) or {}
@@ -1191,17 +1206,17 @@ def comments_json():
 # ─── Static files from ~/edge/ root ───
 @app.route("/reports/<path:filename>")
 def serve_reports(filename):
-    return send_from_directory(str(ROOT / "reports"), filename)
+    return send_from_directory(str(REPORTS_DIR), filename)
 
 
 @app.route("/builds/<path:filename>")
 def serve_builds(filename):
-    return send_from_directory(str(ROOT / "builds"), filename)
+    return send_from_directory(str(BUILDS_DIR), filename)
 
 
 @app.route("/notes/<path:filename>")
 def serve_notes(filename):
-    return send_from_directory(str(ROOT / "notes"), filename)
+    return send_from_directory(str(NOTES_DIR), filename)
 
 
 @app.route("/blog/entries/<path:filename>")
@@ -1220,14 +1235,6 @@ def serve_meta_reports(filename):
 
 
 # ─── Dashboard ───
-STATE_DIR = ROOT / "state"
-THREADS_DIR = ROOT / "threads"
-
-
-
-
-
-
 def _build_threads_data():
     """Build context for threads partial."""
     from blog.services import load_threads_enriched, compute_thread_candidates
@@ -1358,10 +1365,9 @@ _SETUP_MAX_CONTENT = 50_000  # truncate files larger than this in the setup view
 
 def _load_proposals():
     """Load active proposals from state/proposals.json."""
-    proposals_path = ROOT / "state" / "proposals.json"
     try:
         import json as _j
-        return [p for p in _j.loads(proposals_path.read_text()) if p.get("status") == "active"]
+        return [p for p in _j.loads(PROPOSALS_FILE.read_text()) if p.get("status") == "active"]
     except Exception:
         return []
 

--- a/blog/blog-publish.sh
+++ b/blog/blog-publish.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 # shellcheck source=../config/paths.sh
 REAL_SCRIPT="$(readlink -f "$0")"
 source "$(dirname "$REAL_SCRIPT")/../config/paths.sh"
-CHANGELOG="$BLOG_DIR/changelog.md"
+CHANGELOG="$BLOG_CHANGELOG_FILE"
 API_URL="$BLOG_URL"
 ENTRY_PATH="${1:-}"
 
@@ -122,9 +122,9 @@ fi
 
 # --- Step 2.5: Find related posts ---
 echo "[2.5/6] Finding related posts..."
-SEARCH_PYTHON="$EDGE_DIR/search/.venv/bin/python3"
+SEARCH_PYTHON="$SEARCH_DIR/.venv/bin/python3"
 [ -x "$SEARCH_PYTHON" ] || SEARCH_PYTHON="python3"
-RELATED_OUTPUT=$($SEARCH_PYTHON "$EDGE_DIR/search/related.py" "$ENTRY_PATH" 5 2>&1) || true
+RELATED_OUTPUT=$($SEARCH_PYTHON "$SEARCH_DIR/related.py" "$ENTRY_PATH" 5 2>&1) || true
 if echo "$RELATED_OUTPUT" | grep -q "^Related"; then
     echo "  $RELATED_OUTPUT" | head -6
 else
@@ -191,7 +191,14 @@ VERIFY_OK=true
 # Check SQLite
 python3 -c "
 import sys, os
-sys.path.insert(0, os.path.join(os.environ.get('EDGE_DIR', os.path.expanduser('~/edge')), 'search'))
+search_dir = os.environ.get(
+    'SEARCH_DIR',
+    os.path.join(
+        os.environ.get('EDGE_REPO_DIR', os.environ.get('EDGE_DIR', os.path.expanduser('~/edge'))),
+        'search',
+    ),
+)
+sys.path.insert(0, search_dir)
 try:
     from db import ensure_db
     conn = ensure_db()

--- a/blog/capture-diffs.sh
+++ b/blog/capture-diffs.sh
@@ -22,20 +22,30 @@ source "$(dirname "$REAL_SCRIPT")/../config/paths.sh"
 
 # Use Python for all diff processing (bash is unreliable with special chars in diffs)
 export CAPTURE_SLUG="$SLUG"
-export MEMORY_BASE EDGE_DIR BLOG_URL
+export MEMORY_BASE NOTES_DIR AUTONOMY_DIR BLOG_URL
 python3 << 'PYEOF'
 import subprocess, json, os, sys
 
 slug = os.environ.get("CAPTURE_SLUG", "")
 memory_base = os.environ.get("MEMORY_BASE", os.path.expanduser("~/.claude/projects/memory"))
-edge_dir = os.environ.get("EDGE_DIR", os.path.expanduser("~/edge"))
+notes_dir = os.environ.get(
+    "NOTES_DIR",
+    os.path.join(os.environ.get("EDGE_STATE_DIR", os.path.expanduser("~/edge")), "notes"),
+)
+autonomy_dir = os.environ.get(
+    "AUTONOMY_DIR",
+    os.path.join(
+        os.environ.get("EDGE_REPO_DIR", os.environ.get("EDGE_DIR", os.path.expanduser("~/edge"))),
+        "autonomy",
+    ),
+)
 blog_url = os.environ.get("BLOG_URL", "http://localhost:8766")
 
 TRACKED = {
     memory_base: "memory",
     os.path.expanduser("~/.claude/skills"): "skills",
-    os.path.join(edge_dir, "notes"): "notes",
-    os.path.join(edge_dir, "autonomy"): "autonomy",
+    notes_dir: "notes",
+    autonomy_dir: "autonomy",
 }
 
 BLOG_API = f"{blog_url}/api/diffs"

--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -246,7 +246,7 @@ echo ""
 echo "── Phase 0a: State Snapshot ──"
 ledger_record "phase-0a" "ok"
 if command -v edge-state-audit &>/dev/null; then
-    PRE_SNAPSHOT="$EDGE_DIR/state-snapshots/${SLUG}.pre.yaml"
+    PRE_SNAPSHOT="$SNAPSHOT_DIR/${SLUG}.pre.yaml"
     if [[ -f "$PRE_SNAPSHOT" ]]; then
         ok "PRE snapshot already exists (agent captured before changes)"
     else
@@ -658,7 +658,7 @@ try:
     if not ('curation' in tags or 'procedures' in tags):
         print('SKIP')
         sys.exit(0)
-    pc = os.path.expanduser('~/edge/state/procedure-curation.json')
+    pc = os.environ.get('PROCEDURE_CURATION_FILE', os.path.expanduser('~/edge/state/procedure-curation.json'))
     if not os.path.exists(pc):
         print('SKIP')
         sys.exit(0)
@@ -667,7 +667,7 @@ try:
     if not candidates:
         print('SKIP')
         sys.exit(0)
-    entries = glob.glob(os.path.expanduser('~/edge/blog/entries/*workflow*.md'))
+    entries = glob.glob(os.path.join(os.environ.get('ENTRIES_DIR', os.path.expanduser('~/edge/blog/entries')), '*workflow*.md'))
     drafts = 0
     for e in entries:
         head = open(e).read()[:500]
@@ -809,7 +809,7 @@ def ok(msg): print(f"  {GREEN}OK{NC}: {msg}")
 def warn(msg): print(f"  {YELLOW}WARN{NC}: {msg}")
 def fail(msg): print(f"  {RED}FAIL{NC}: {msg}")
 
-FAILURES_FILE = Path.home() / "edge" / "logs" / "pipeline-failures.jsonl"
+FAILURES_FILE = Path(os.environ.get("PIPELINE_FAILURES_FILE", os.path.expanduser("~/edge/logs/pipeline-failures.jsonl")))
 FAILURES_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 def log_failure(phase, operation, error, tb=None):
@@ -866,7 +866,7 @@ except Exception as e:
 
 # ── 2. Thread update ──
 try:
-    threads_dir = Path.home() / "edge" / "threads"
+    threads_dir = Path(os.environ.get("THREADS_DIR", os.path.expanduser("~/edge/threads")))
     updated_threads = []
     for tid in threads:
         tfile = threads_dir / f"{tid}.md"
@@ -885,7 +885,7 @@ except Exception as e:
 
 # ── 2b. Procedure & workflow signals ──
 try:
-    state_dir = Path.home() / "edge" / "state"
+    state_dir = Path(os.environ.get("STATE_DIR", os.path.expanduser("~/edge/state")))
     state_dir.mkdir(parents=True, exist_ok=True)
     health_file = state_dir / "workflow-health.json"
 
@@ -961,7 +961,7 @@ except Exception as e:
 
 # ── 3. Event log (idempotent) ──
 try:
-    events_file = Path.home() / "edge" / "logs" / "events.jsonl"
+    events_file = Path(os.environ.get("EVENTS_FILE", os.path.expanduser("~/edge/logs/events.jsonl")))
     artifacts = [f"blog/entries/{slug}.md"]
     if report_filename:
         artifacts.append(f"reports/{report_filename}")
@@ -1030,7 +1030,7 @@ echo "── Phase 5b: State Audit ──"
 ledger_record "phase-5b" "ok"
 if command -v edge-state-audit &>/dev/null; then
     # Check if proposal exists (agent should have written it during the session)
-    PROPOSAL_FILE="$EDGE_DIR/meta-reports/${SLUG}.state-proposal.yaml"
+    PROPOSAL_FILE="$META_DIR/${SLUG}.state-proposal.yaml"
     if [[ -f "$PROPOSAL_FILE" ]]; then
         ok "Proposal found: $(basename "$PROPOSAL_FILE")"
     else
@@ -1045,7 +1045,7 @@ if command -v edge-state-audit &>/dev/null; then
         echo "========================================="
         echo -e " ${RED}ABORTED${NC}: State audit detected violation"
         echo "  Proposal: $PROPOSAL_FILE"
-        echo "  Audit: $EDGE_DIR/meta-reports/${SLUG}.state-audit.yaml"
+        echo "  Audit: $META_DIR/${SLUG}.state-audit.yaml"
         echo "========================================="
         exit 5
     fi
@@ -1095,7 +1095,7 @@ def ok(msg): print(f"  {GREEN}OK{NC}: {msg}")
 def warn(msg): print(f"  {YELLOW}WARN{NC}: {msg}")
 def fail(msg): print(f"  {RED}FAIL{NC}: {msg}")
 
-FAILURES_FILE = Path.home() / "edge" / "logs" / "pipeline-failures.jsonl"
+FAILURES_FILE = Path(os.environ.get("PIPELINE_FAILURES_FILE", os.path.expanduser("~/edge/logs/pipeline-failures.jsonl")))
 FAILURES_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 def log_failure(phase, operation, error, tb=None):
@@ -1148,12 +1148,13 @@ def _claim_text(c):
     return str(c).lstrip("! ")
 
 # ── 1. Captura diffs dos mini-repos (memory, skills, notes) ──
-_edge_dir = os.environ.get("EDGE_DIR", os.path.expanduser("~/edge"))
+_edge_repo_dir = os.environ.get("EDGE_REPO_DIR", os.environ.get("EDGE_DIR", os.path.expanduser("~/edge")))
+_notes_dir = os.environ.get("NOTES_DIR", os.path.join(os.environ.get("EDGE_STATE_DIR", os.path.expanduser("~/edge")), "notes"))
 _memory_base = os.environ.get("MEMORY_BASE", os.path.expanduser("~/.claude/projects/memory"))
 TRACKED = {
     _memory_base: "memory",
     os.path.expanduser("~/.claude/skills"): "skills",
-    os.path.join(_edge_dir, "notes"): "notes",
+    _notes_dir: "notes",
 }
 
 all_diffs = []
@@ -1207,7 +1208,7 @@ for dirpath, prefix in TRACKED.items():
 
 # ── 2. Captura diffs do ~/edge/ (repo principal) ──
 try:
-    edge_dir = os.environ.get("EDGE_DIR", os.path.expanduser("~/edge"))
+    edge_dir = os.environ.get("EDGE_REPO_DIR", os.environ.get("EDGE_DIR", os.path.expanduser("~/edge")))
     subprocess.run(["git", "add", "-A"], cwd=edge_dir, capture_output=True, timeout=30)
 
     # ORPHAN GUARD: unstage blog entries/reports/meta-reports that don't belong to this slug.
@@ -1330,8 +1331,9 @@ if failures:
 lines.append("")
 
 # State audit summary (if audit ran)
-proposal_path = Path.home() / "edge" / "meta-reports" / f"{slug}.state-proposal.yaml"
-audit_path = Path.home() / "edge" / "meta-reports" / f"{slug}.state-audit.yaml"
+meta_dir = Path(os.environ.get("META_DIR", os.path.expanduser("~/edge/meta-reports")))
+proposal_path = meta_dir / f"{slug}.state-proposal.yaml"
+audit_path = meta_dir / f"{slug}.state-audit.yaml"
 if audit_path.exists():
     try:
         audit_data = yaml.safe_load(audit_path.read_text())
@@ -1396,7 +1398,7 @@ if audit_path.exists():
 
 # ── Execution summary from ops-hotspots.json ──
 try:
-    hotspots_path = Path.home() / "edge" / "state" / "ops-hotspots.json"
+    hotspots_path = Path(os.environ.get("OPS_HOTSPOTS", os.path.expanduser("~/edge/state/ops-hotspots.json")))
     if hotspots_path.exists():
         hotspots = json.loads(hotspots_path.read_text())
         incidents = hotspots.get("incidents", [])
@@ -1472,7 +1474,7 @@ if $ALL_OK && [[ "$REPORT_RESULT" != "fail" ]]; then
     [[ -n "$META_REPORT_PATH" ]] && echo -e " ${YELLOW}→ Read meta-report BEFORE editing state${NC}"
     echo "========================================="
     # Survival instinct: write success marker
-    HEALTH_OK="$EDGE_DIR/health/last_success"
+    HEALTH_OK="$HEALTH_DIR/last_success"
     mkdir -p "$HEALTH_OK"
     printf '{"ts":"%s","slug":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SLUG" > "$HEALTH_OK/consolidate.ok"
     ledger_record "pipeline-end" "ok"

--- a/blog/services.py
+++ b/blog/services.py
@@ -3,22 +3,30 @@
 import json
 import re
 import subprocess
+import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
 
 import markdown
 import yaml
 
-ROOT = Path.home() / "edge"
-STATE_DIR = ROOT / "state"
-THREADS_DIR = ROOT / "threads"
-LOGS_DIR = ROOT / "logs"
-ENTRIES_DIR = ROOT / "blog" / "entries"
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import (  # noqa: E402
+    BRIEFING_FILE,
+    CURADORIA_CANDIDATES_FILE as CURADORIA_CANDIDATES,
+    EDGE_REPO_DIR,
+    ENTRIES_DIR,
+    EXECUTION_LEDGER_FILE as EXECUTION_LEDGER,
+    GIT_SIGNALS_FILE as GIT_SIGNALS,
+    LOGS_DIR,
+    OPS_HOTSPOTS,
+    REPORTS_DIR,
+    STATE_DIR,
+    THREADS_DIR,
+)
 
-OPS_HOTSPOTS = STATE_DIR / "ops-hotspots.json"
-GIT_SIGNALS = STATE_DIR / "git-signals.json"
-CURADORIA_CANDIDATES = STATE_DIR / "curadoria-candidates.json"
-EXECUTION_LEDGER = LOGS_DIR / "execution-ledger.jsonl"
+ROOT = EDGE_REPO_DIR
 
 
 def load_json_safe(path, default=None):
@@ -156,10 +164,6 @@ def get_production_stats():
         "reports_total": total_reports,
         "published_today": published_today,
     }
-
-
-BRIEFING_FILE = ROOT / "briefing.md"
-
 
 def get_briefing_html(max_lines=50):
     """Load first max_lines of briefing.md and render as HTML. Returns None if missing."""
@@ -369,7 +373,7 @@ def load_thread_detail(thread_id):
     # Check which reports exist on disk
     reports = []
     for rf in sorted(reports_set):
-        rpath = ROOT / "reports" / rf
+        rpath = REPORTS_DIR / rf
         reports.append({
             "filename": rf,
             "exists": rpath.exists(),

--- a/config/paths.py
+++ b/config/paths.py
@@ -1,7 +1,12 @@
 """Shared path resolution — single source of truth for all tools.
 
-All Python tools import paths from here instead of hardcoding.
-Resolves edge_dir and memory_project_dir from branding.yaml with auto-detect fallback.
+Genotype and phenotype intentionally have different roots:
+
+- EDGE_REPO_DIR: shared code/runtime root
+- EDGE_STATE_DIR: instance-local mutable state root
+
+During the migration, EDGE_STATE_DIR falls back to EDGE_REPO_DIR so existing
+instances keep working until their runtime env is updated.
 """
 
 import os
@@ -18,15 +23,38 @@ from branding import load_branding
 _branding = load_branding()
 HOME = Path.home()
 
-# --- EDGE_DIR: where the agent repo lives ---
-_edge_dir_cfg = _branding.get("edge_dir", "")
-if _edge_dir_cfg:
-    EDGE_DIR = Path(os.path.expanduser(_edge_dir_cfg))
-elif os.environ.get("EDGE_DIR"):
-    EDGE_DIR = Path(os.environ["EDGE_DIR"])
-else:
-    # Auto-detect: config/ is inside the repo root
-    EDGE_DIR = _CONFIG_DIR.parent
+
+def _expand(value: str | None) -> Path | None:
+    if not value:
+        return None
+    return Path(os.path.expanduser(value))
+
+
+# --- Shared genotype root (repo checkout) ---
+EDGE_REPO_DIR = (
+    _expand(os.environ.get("EDGE_REPO_DIR"))
+    or _expand(_branding.get("edge_dir", ""))
+    or _expand(os.environ.get("EDGE_DIR"))
+    or _CONFIG_DIR.parent
+)
+
+# Legacy alias kept during migration.
+EDGE_DIR = EDGE_REPO_DIR
+
+# --- Instance identity / mutable phenotype root ---
+EDGE_INSTANCE = (
+    os.environ.get("EDGE_INSTANCE")
+    or os.environ.get("EDGE_CODENAME")
+    or _branding.get("codename", "")
+    or _branding.get("skill_prefix", "")
+    or ""
+)
+
+EDGE_STATE_DIR = (
+    _expand(os.environ.get("EDGE_STATE_DIR"))
+    or _expand(_branding.get("edge_state_dir", ""))
+    or EDGE_REPO_DIR
+)
 
 # --- MEMORY_PROJECT_DIR: Claude Code project directory name ---
 _memory_project = _branding.get("memory_project_dir", "")
@@ -46,34 +74,64 @@ MEMORY_PROJECT_DIR = _memory_project
 MEMORY_DIR = HOME / ".claude" / "projects" / MEMORY_PROJECT_DIR / "memory" if MEMORY_PROJECT_DIR else HOME / ".claude" / "memory"
 TOPICS_DIR = MEMORY_DIR / "topics"
 
-# Edge subdirectories
-BLOG_DIR = EDGE_DIR / "blog"
-ENTRIES_DIR = BLOG_DIR / "entries"
-REPORTS_DIR = EDGE_DIR / "reports"
-NOTES_DIR = EDGE_DIR / "notes"
-TOOLS_DIR = EDGE_DIR / "tools"
-LOGS_DIR = EDGE_DIR / "logs"
-THREADS_DIR = EDGE_DIR / "threads"
-SECRETS_DIR = EDGE_DIR / "secrets"
-META_DIR = EDGE_DIR / "meta-reports"
-SNAPSHOT_DIR = EDGE_DIR / "state-snapshots"
-SCRATCHPADS_DIR = EDGE_DIR / "scratchpads"
-STATE_DIR = EDGE_DIR / "state"
+# Genotype subdirectories
+BLOG_DIR = EDGE_REPO_DIR / "blog"
+TOOLS_DIR = EDGE_REPO_DIR / "tools"
+SECRETS_DIR = EDGE_REPO_DIR / "secrets"
+AUTONOMY_DIR = EDGE_REPO_DIR / "autonomy"
+CONFIG_DIR = EDGE_REPO_DIR / "config"
+SEARCH_DIR = EDGE_REPO_DIR / "search"
+
+# Phenotype subdirectories
+BLOG_STATE_DIR = EDGE_STATE_DIR / "blog"
+ENTRIES_DIR = BLOG_STATE_DIR / "entries"
+BLOG_DIFFS_DIR = BLOG_STATE_DIR / "diffs"
+BLOG_COMMENTS_FILE = BLOG_STATE_DIR / "comments.json"
+BLOG_CHANGELOG_FILE = BLOG_STATE_DIR / "changelog.md"
+COMMENTS_FILE = BLOG_COMMENTS_FILE
+DIFFS_DIR = BLOG_DIFFS_DIR
+REPORTS_DIR = EDGE_STATE_DIR / "reports"
+NOTES_DIR = EDGE_STATE_DIR / "notes"
+BUILDS_DIR = EDGE_STATE_DIR / "builds"
+LOGS_DIR = EDGE_STATE_DIR / "logs"
+THREADS_DIR = EDGE_STATE_DIR / "threads"
+HEALTH_DIR = EDGE_STATE_DIR / "health"
+META_DIR = EDGE_STATE_DIR / "meta-reports"
+META_REPORTS_DIR = META_DIR
+SNAPSHOT_DIR = EDGE_STATE_DIR / "state-snapshots"
+SCRATCHPADS_DIR = EDGE_STATE_DIR / "scratchpads"
+STATE_DIR = EDGE_STATE_DIR / "state"
 STATE_EVENTS_DIR = STATE_DIR / "events"
-AUTONOMY_DIR = EDGE_DIR / "autonomy"
-CONFIG_DIR = EDGE_DIR / "config"
-SEARCH_DIR = EDGE_DIR / "search"
+SIGNALS_DIR = STATE_DIR / "signals"
+SEARCH_STATE_DIR = EDGE_STATE_DIR / "search"
+DB_DIR = EDGE_STATE_DIR / "db"
+SEARCH_DB_FILE = SEARCH_STATE_DIR / "edge-memory.db"
+BLOG_FTS_DB_FILE = BLOG_STATE_DIR / "blog_fts.db"
 
 # Specific files
 EVENTS_FILE = LOGS_DIR / "events.jsonl"
 STATE_EVENTS_FILE = STATE_EVENTS_DIR / "log.jsonl"
 LEDGER_FILE = LOGS_DIR / "execution-ledger.jsonl"
-BRIEFING_FILE = EDGE_DIR / "briefing.md"
+EXECUTION_LEDGER_FILE = LEDGER_FILE
+PIPELINE_FAILURES_FILE = LOGS_DIR / "pipeline-failures.jsonl"
+SKILL_STEPS_FILE = LOGS_DIR / "skill-steps.jsonl"
+STATE_LINT_FILE = LOGS_DIR / "state-lint.jsonl"
+YAML_RENDER_FILE = LOGS_DIR / "yaml-render.jsonl"
+BRIEFING_FILE = EDGE_STATE_DIR / "briefing.md"
+GIT_SIGNALS_FILE = STATE_DIR / "git-signals.json"
+CURADORIA_CANDIDATES_FILE = STATE_DIR / "curadoria-candidates.json"
+PROPOSALS_FILE = STATE_DIR / "proposals.json"
+PROCEDURE_CURATION_FILE = STATE_DIR / "procedure-curation.json"
+SOURCE_USAGE_FILE = STATE_DIR / "source-usage.jsonl"
 DEBUGGING_FILE = MEMORY_DIR / "debugging.md"
 INSIGHTS_FILE = MEMORY_DIR / "insights.md"
 BREAKS_ACTIVE = MEMORY_DIR / "breaks-active.md"
 FRONTIER_FILE = AUTONOMY_DIR / "frontier.md"
+AUTONOMY_CAPABILITIES_FILE = AUTONOMY_DIR / "capabilities.md"
 OPS_HOTSPOTS = STATE_DIR / "ops-hotspots.json"
+HEALTH_CURRENT_FILE = HEALTH_DIR / "current.json"
+HEALTH_HISTORY_FILE = HEALTH_DIR / "history.jsonl"
+HEALTH_LAST_SUCCESS_FILE = HEALTH_DIR / "last_success"
 
 # Skills
 SKILLS_DIR = HOME / ".claude" / "skills"

--- a/config/paths.sh
+++ b/config/paths.sh
@@ -2,13 +2,17 @@
 # paths.sh — Shared path resolution for shell scripts.
 # Source this from any script: source "$(dirname "$0")/../config/paths.sh"
 
-# --- EDGE_DIR: derive from this script's location (repo root) ---
-if [ -z "${EDGE_DIR:-}" ]; then
-  EDGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-fi
+set -u
 
-# --- Load branding.yaml ---
-BRANDING_FILE="$EDGE_DIR/config/branding.yaml"
+_PATHS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_PATHS_REPO_DEFAULT="$(cd "${_PATHS_SCRIPT_DIR}/.." && pwd)"
+
+# --- Shared genotype root (repo checkout) ---
+EDGE_REPO_DIR="${EDGE_REPO_DIR:-${EDGE_DIR:-${_PATHS_REPO_DEFAULT}}}"
+EDGE_DIR="$EDGE_REPO_DIR"   # Legacy alias kept during migration.
+
+# --- Load branding.yaml from genotype root ---
+BRANDING_FILE="$EDGE_REPO_DIR/config/branding.yaml"
 if [ -f "$BRANDING_FILE" ]; then
   BLOG_PORT=$(grep '^  port:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}')
   BLOG_AUTH_ENABLED=$(grep '^  auth_enabled:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}')
@@ -16,6 +20,8 @@ if [ -f "$BRANDING_FILE" ]; then
   BLOG_AUTH_PASS=$(grep '^  auth_pass:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
   MEMORY_PROJECT_DIR=$(grep '^memory_project_dir:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
   SKILL_PREFIX=$(grep '^skill_prefix:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
+  EDGE_INSTANCE_FROM_BRANDING=$(grep '^codename:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
+  EDGE_STATE_DIR_FROM_BRANDING=$(grep '^edge_state_dir:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
 else
   BLOG_PORT=8766
   BLOG_AUTH_ENABLED=false
@@ -23,7 +29,13 @@ else
   BLOG_AUTH_PASS=""
   MEMORY_PROJECT_DIR=""
   SKILL_PREFIX="agent"
+  EDGE_INSTANCE_FROM_BRANDING=""
+  EDGE_STATE_DIR_FROM_BRANDING=""
 fi
+
+EDGE_INSTANCE="${EDGE_INSTANCE:-${EDGE_CODENAME:-${EDGE_INSTANCE_FROM_BRANDING:-}}}"
+EDGE_STATE_DIR="${EDGE_STATE_DIR:-${EDGE_STATE_DIR_FROM_BRANDING:-${EDGE_REPO_DIR}}}"
+EDGE_HOME="$EDGE_STATE_DIR"  # Legacy mutable-root alias used by some tools.
 
 # Defaults
 BLOG_PORT=${BLOG_PORT:-8766}
@@ -46,15 +58,64 @@ else
   PROJECT_DIR="$HOME/.claude/projects/${_first_proj}"
 fi
 
-# Export key variables for embedded Python heredocs
-export EDGE_DIR MEMORY_BASE MEMORY_PROJECT_DIR BLOG_URL PROJECT_DIR BLOG_AUTH_USER BLOG_AUTH_PASS BLOG_AUTH_ENABLED BLOG_PORT
+# --- Genotype paths ---
+BLOG_DIR="$EDGE_REPO_DIR/blog"
+TOOLS_DIR="$EDGE_REPO_DIR/tools"
+SECRETS_DIR="$EDGE_REPO_DIR/secrets"
+CONFIG_DIR="$EDGE_REPO_DIR/config"
+SEARCH_DIR="$EDGE_REPO_DIR/search"
+AUTONOMY_DIR="$EDGE_REPO_DIR/autonomy"
 
-# --- Derived paths ---
-BLOG_DIR="$EDGE_DIR/blog"
-ENTRIES_DIR="$BLOG_DIR/entries"
-REPORTS_DIR="$EDGE_DIR/reports"
-NOTES_DIR="$EDGE_DIR/notes"
-TOOLS_DIR="$EDGE_DIR/tools"
-LOGS_DIR="$EDGE_DIR/logs"
-THREADS_DIR="$EDGE_DIR/threads"
-SECRETS_DIR="$EDGE_DIR/secrets"
+# --- Phenotype paths ---
+BLOG_STATE_DIR="$EDGE_STATE_DIR/blog"
+ENTRIES_DIR="$BLOG_STATE_DIR/entries"
+BLOG_DIFFS_DIR="$BLOG_STATE_DIR/diffs"
+COMMENTS_FILE="$BLOG_STATE_DIR/comments.json"
+BLOG_CHANGELOG_FILE="$BLOG_STATE_DIR/changelog.md"
+REPORTS_DIR="$EDGE_STATE_DIR/reports"
+NOTES_DIR="$EDGE_STATE_DIR/notes"
+BUILDS_DIR="$EDGE_STATE_DIR/builds"
+LOGS_DIR="$EDGE_STATE_DIR/logs"
+THREADS_DIR="$EDGE_STATE_DIR/threads"
+HEALTH_DIR="$EDGE_STATE_DIR/health"
+META_DIR="$EDGE_STATE_DIR/meta-reports"
+SNAPSHOT_DIR="$EDGE_STATE_DIR/state-snapshots"
+SCRATCHPADS_DIR="$EDGE_STATE_DIR/scratchpads"
+STATE_DIR="$EDGE_STATE_DIR/state"
+STATE_EVENTS_DIR="$STATE_DIR/events"
+SIGNALS_DIR="$STATE_DIR/signals"
+SEARCH_STATE_DIR="$EDGE_STATE_DIR/search"
+DB_DIR="$EDGE_STATE_DIR/db"
+SEARCH_DB_FILE="$SEARCH_STATE_DIR/edge-memory.db"
+BLOG_FTS_DB_FILE="$BLOG_STATE_DIR/blog_fts.db"
+BRIEFING_FILE="$EDGE_STATE_DIR/briefing.md"
+EVENTS_FILE="$LOGS_DIR/events.jsonl"
+GIT_SIGNALS_FILE="$STATE_DIR/git-signals.json"
+CURADORIA_CANDIDATES_FILE="$STATE_DIR/curadoria-candidates.json"
+PROPOSALS_FILE="$STATE_DIR/proposals.json"
+PROCEDURE_CURATION_FILE="$STATE_DIR/procedure-curation.json"
+SOURCE_USAGE_FILE="$STATE_DIR/source-usage.jsonl"
+OPS_HOTSPOTS="$STATE_DIR/ops-hotspots.json"
+EXECUTION_LEDGER_FILE="$LOGS_DIR/execution-ledger.jsonl"
+PIPELINE_FAILURES_FILE="$LOGS_DIR/pipeline-failures.jsonl"
+SKILL_STEPS_FILE="$LOGS_DIR/skill-steps.jsonl"
+STATE_LINT_FILE="$LOGS_DIR/state-lint.jsonl"
+YAML_RENDER_FILE="$LOGS_DIR/yaml-render.jsonl"
+HEALTH_CURRENT_FILE="$HEALTH_DIR/current.json"
+HEALTH_HISTORY_FILE="$HEALTH_DIR/history.jsonl"
+HEALTH_LAST_SUCCESS_FILE="$HEALTH_DIR/last_success"
+AUTONOMY_CAPABILITIES_FILE="$AUTONOMY_DIR/capabilities.md"
+AUTONOMY_FRONTIER_FILE="$AUTONOMY_DIR/frontier.md"
+
+# Export key variables for shell + embedded Python heredocs
+export \
+  EDGE_REPO_DIR EDGE_DIR EDGE_STATE_DIR EDGE_HOME EDGE_INSTANCE MEMORY_BASE MEMORY_PROJECT_DIR PROJECT_DIR \
+  BLOG_URL BLOG_AUTH_USER BLOG_AUTH_PASS BLOG_AUTH_ENABLED BLOG_PORT SKILL_PREFIX CURL_AUTH \
+  BLOG_DIR TOOLS_DIR SECRETS_DIR CONFIG_DIR SEARCH_DIR AUTONOMY_DIR \
+  BLOG_STATE_DIR ENTRIES_DIR BLOG_DIFFS_DIR COMMENTS_FILE BLOG_CHANGELOG_FILE REPORTS_DIR NOTES_DIR LOGS_DIR THREADS_DIR \
+  BUILDS_DIR HEALTH_DIR META_DIR SNAPSHOT_DIR SCRATCHPADS_DIR STATE_DIR STATE_EVENTS_DIR SIGNALS_DIR \
+  SEARCH_STATE_DIR DB_DIR SEARCH_DB_FILE BLOG_FTS_DB_FILE BRIEFING_FILE EVENTS_FILE GIT_SIGNALS_FILE \
+  CURADORIA_CANDIDATES_FILE PROPOSALS_FILE PROCEDURE_CURATION_FILE SOURCE_USAGE_FILE OPS_HOTSPOTS \
+  EXECUTION_LEDGER_FILE PIPELINE_FAILURES_FILE SKILL_STEPS_FILE STATE_LINT_FILE YAML_RENDER_FILE \
+  HEALTH_CURRENT_FILE HEALTH_HISTORY_FILE HEALTH_LAST_SUCCESS_FILE AUTONOMY_CAPABILITIES_FILE \
+  AUTONOMY_FRONTIER_FILE

--- a/search/db.py
+++ b/search/db.py
@@ -1,11 +1,16 @@
 """Database schema and connection for edge-memory."""
 
 import sqlite3
+import sys
 from pathlib import Path
 
 import sqlite_vec
 
-DB_PATH = Path(__file__).parent / "edge-memory.db"
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import SEARCH_DB_FILE  # noqa: E402
+
+DB_PATH = SEARCH_DB_FILE
 EMBEDDING_DIM = 1536  # text-embedding-3-small
 
 

--- a/search/search.py
+++ b/search/search.py
@@ -8,11 +8,19 @@ from pathlib import Path
 
 import yaml
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import EDGE_STATE_DIR, NOTES_DIR  # noqa: E402
+
 from db import EMBEDDING_DIM, ensure_db
 from embed import embed_text
 
-EDGE_HOME = Path.home() / "edge"
-NOTES_DIR = EDGE_HOME / "notes"
+
+def _resolve_state_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return EDGE_STATE_DIR / path
 
 
 def _parse_frontmatter_note(filepath: Path) -> str | None:
@@ -35,7 +43,7 @@ def _enrich_with_notes(results: list[dict]) -> list[dict]:
 
     For each result where type == "blog", reads the entry file, parses its
     frontmatter for a ``note:`` field, and if present reads the note file
-    from ~/edge/notes/{note_filename}.  Adds ``note_path`` (str) and
+    from the instance-local notes root. Adds ``note_path`` (str) and
     ``note_content`` (first 2000 chars) to the result dict.
 
     Fault-tolerant: any failure is silently skipped.
@@ -44,7 +52,7 @@ def _enrich_with_notes(results: list[dict]) -> list[dict]:
         if result.get("type") != "blog":
             continue
         try:
-            entry_path = EDGE_HOME / result["path"]
+            entry_path = _resolve_state_path(result["path"])
             note_filename = _parse_frontmatter_note(entry_path)
             if not note_filename:
                 continue

--- a/tools/_shared/telemetry.py
+++ b/tools/_shared/telemetry.py
@@ -25,9 +25,9 @@ from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "config"))
-from paths import EVENTS_FILE, SEARCH_DIR, STATE_EVENTS_FILE  # noqa: E402
+from paths import EVENTS_FILE, SEARCH_DB_FILE, STATE_EVENTS_FILE  # noqa: E402
 
-DB_PATH = SEARCH_DIR / "edge-memory.db"
+DB_PATH = SEARCH_DB_FILE
 _LAST_SHADOW_HASH: str | None = None
 
 # --- Price table (USD per 1M tokens). Missing models map to 0 cost rather than

--- a/tools/edge-crystallize
+++ b/tools/edge-crystallize
@@ -25,10 +25,12 @@ from pathlib import Path
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPT_DIR.parent / "tools"))
+sys.path.insert(0, str(_SCRIPT_DIR.parent / "config"))
 try:
     from _shared.telemetry import log_workflow_transition
 except Exception:
     def log_workflow_transition(*a, **kw): pass
+from paths import ENTRIES_DIR, PROCEDURE_CURATION_FILE  # noqa: E402
 
 
 def slugify(text):
@@ -50,9 +52,9 @@ def index_entry(filepath):
         pass
 
 
-def create_from_operator(directive, edge, dry_run=False):
+def create_from_operator(directive, dry_run=False):
     """Create an approved workflow directly from an operator directive."""
-    entries_dir = edge / "blog" / "entries"
+    entries_dir = ENTRIES_DIR
     entries_dir.mkdir(parents=True, exist_ok=True)
     today = datetime.now().strftime("%Y-%m-%d")
 
@@ -100,10 +102,10 @@ def create_from_operator(directive, edge, dry_run=False):
     return 1
 
 
-def create_from_curation(args, edge):
+def create_from_curation(args):
     """Create workflow-draft entries from procedure-curation.json candidates."""
-    curation_file = edge / "state" / "procedure-curation.json"
-    entries_dir = edge / "blog" / "entries"
+    curation_file = PROCEDURE_CURATION_FILE
+    entries_dir = ENTRIES_DIR
     entries_dir.mkdir(parents=True, exist_ok=True)
     today = datetime.now().strftime("%Y-%m-%d")
 
@@ -241,15 +243,13 @@ def main():
                         help="Create approved workflow from operator instruction (skips draft)")
     args = parser.parse_args()
 
-    edge = Path(os.environ.get("EDGE_DIR", Path.home() / "edge"))
-
     if args.from_operator:
-        n = create_from_operator(args.from_operator, edge, args.dry_run)
+        n = create_from_operator(args.from_operator, args.dry_run)
         if n and not args.dry_run:
             print(f"\nWorkflow created with tag 'workflow' (approved — operator authority).")
             print("Enters edge-search recall immediately.")
     else:
-        create_from_curation(args, edge)
+        create_from_curation(args)
 
 
 if __name__ == "__main__":

--- a/tools/edge-meta-report
+++ b/tools/edge-meta-report
@@ -23,11 +23,22 @@ import yaml
 from datetime import datetime
 from pathlib import Path
 
-HOME = Path.home()
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import (META_DIR, SCRATCHPADS_DIR as SCRATCHPADS_ARCHIVE,
-                   EDGE_DIR, TOOLS_DIR, MEMORY_DIR, SKILLS_DIR, NOTES_DIR)
+from paths import (  # noqa: E402
+    BRIEFING_FILE,
+    EDGE_REPO_DIR,
+    EDGE_STATE_DIR,
+    ENTRIES_DIR,
+    EVENTS_FILE,
+    MEMORY_DIR,
+    META_DIR,
+    NOTES_DIR,
+    SCRATCHPADS_DIR as SCRATCHPADS_ARCHIVE,
+    SKILLS_DIR,
+    THREADS_DIR,
+    TOOLS_DIR,
+)
 CONSULT_SCRIPT = TOOLS_DIR / "edge-consult.py"
 
 TRACKED_REPOS = {
@@ -75,11 +86,11 @@ def capture_diffs_preview():
     # Edge repo
     result = subprocess.run(
         ["git", "diff", "HEAD", "--stat"],
-        cwd=str(EDGE_DIR), capture_output=True, text=True
+        cwd=str(EDGE_REPO_DIR), capture_output=True, text=True
     )
     result2 = subprocess.run(
         ["git", "status", "--short"],
-        cwd=str(EDGE_DIR), capture_output=True, text=True
+        cwd=str(EDGE_REPO_DIR), capture_output=True, text=True
     )
     stat = result.stdout.strip()
     status = result2.stdout.strip()
@@ -290,10 +301,9 @@ def capture_post_state_changes(slug, entry_path):
 
     # ── Threads touched ──
     if threads:
-        threads_dir = HOME / "edge" / "threads"
         lines.append(f"### Threads tocados ({len(threads)})")
         for tid in threads:
-            tfile = threads_dir / f"{tid}.md"
+            tfile = THREADS_DIR / f"{tid}.md"
             if tfile.exists():
                 # Read status and title
                 content = tfile.read_text()
@@ -310,10 +320,9 @@ def capture_post_state_changes(slug, entry_path):
         lines.append("")
 
     # ── Event logged ──
-    events_file = HOME / "edge" / "logs" / "events.jsonl"
-    if events_file.exists():
+    if EVENTS_FILE.exists():
         slug_artifact = f"blog/entries/{slug}.md"
-        for raw_line in reversed(events_file.read_text().splitlines()[-20:]):
+        for raw_line in reversed(EVENTS_FILE.read_text().splitlines()[-20:]):
             try:
                 evt = json.loads(raw_line)
                 if slug_artifact in evt.get("artifacts", []):
@@ -350,31 +359,39 @@ def capture_post_state_changes(slug, entry_path):
             lines.append("```")
 
     # Edge repo state files specifically
-    state_files = ["briefing.md", "threads/", "logs/events.jsonl"]
-    result = subprocess.run(
-        ["git", "diff", "HEAD", "--stat", "--", *state_files],
-        cwd=str(EDGE_DIR), capture_output=True, text=True
-    )
-    if result.stdout.strip():
-        found_diffs = True
-        lines.append("**edge/ (state files)**")
-        lines.append("```")
-        lines.append(result.stdout.strip())
-        lines.append("```")
+    state_git_root = None
+    if EDGE_STATE_DIR == EDGE_REPO_DIR:
+        state_git_root = EDGE_REPO_DIR
+    elif (EDGE_STATE_DIR / ".git").is_dir():
+        state_git_root = EDGE_STATE_DIR
+
+    if state_git_root is not None:
+        state_files = ["briefing.md", "threads/", "logs/events.jsonl"]
+        result = subprocess.run(
+            ["git", "diff", "HEAD", "--stat", "--", *state_files],
+            cwd=str(state_git_root), capture_output=True, text=True
+        )
+        if result.stdout.strip():
+            found_diffs = True
+            lines.append("**state/ (git-backed)**")
+            lines.append("```")
+            lines.append(result.stdout.strip())
+            lines.append("```")
+    else:
+        lines.append("*State root is outside git; showing only filesystem checks above.*")
 
     if not found_diffs:
         lines.append("*Nenhuma mudança detectada nos arquivos de estado.*")
     lines.append("")
 
     # ── Briefing updated? ──
-    briefing = HOME / "edge" / "briefing.md"
-    if briefing.exists():
-        mtime = datetime.fromtimestamp(briefing.stat().st_mtime)
+    if BRIEFING_FILE.exists():
+        mtime = datetime.fromtimestamp(BRIEFING_FILE.stat().st_mtime)
         age_seconds = (datetime.now() - mtime).total_seconds()
         if age_seconds < 120:  # Updated in last 2 min = this pipeline
             lines.append("### briefing.md")
             # Show first 10 lines
-            content = briefing.read_text().split("\n")[:10]
+            content = BRIEFING_FILE.read_text().split("\n")[:10]
             lines.append("```")
             lines.append("\n".join(content))
             lines.append("```")
@@ -401,7 +418,7 @@ def main():
         entry_path = args.entry
         # Try to find entry if not provided
         if not entry_path:
-            candidate = HOME / "edge" / "blog" / "entries" / f"{args.slug}.md"
+            candidate = ENTRIES_DIR / f"{args.slug}.md"
             if candidate.exists():
                 entry_path = str(candidate)
 

--- a/tools/edge-signal
+++ b/tools/edge-signal
@@ -20,8 +20,13 @@
 
 set -uo pipefail
 
+# --- Load shared paths ---
+# shellcheck source=../config/paths.sh
+REAL_SCRIPT="$(readlink -f "$0")"
+source "$(dirname "$REAL_SCRIPT")/../config/paths.sh"
+
 VALID_TYPES="autonomy strategy reflection friction decision serendipity"
-SIGNALS_DIR="${EDGE_DIR:-$HOME/edge}/state/signals"
+SIGNALS_DIR="${SIGNALS_DIR:-$STATE_DIR/signals}"
 
 # --- Args ---
 if [[ $# -lt 2 ]]; then
@@ -60,8 +65,18 @@ import os
 import sys
 from pathlib import Path
 
-edge_dir = Path(os.environ.get("EDGE_DIR", str(Path.home() / "edge"))).expanduser()
-tools_dir = edge_dir / "tools"
+tools_dir = Path(
+    os.environ.get("TOOLS_DIR")
+    or (
+        Path(
+            os.environ.get(
+                "EDGE_REPO_DIR",
+                os.environ.get("EDGE_DIR", str(Path.home() / "edge")),
+            )
+        ).expanduser()
+        / "tools"
+    )
+)
 if str(tools_dir) not in sys.path:
     sys.path.insert(0, str(tools_dir))
 

--- a/tools/git_signals.py
+++ b/tools/git_signals.py
@@ -23,9 +23,9 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import EDGE_DIR, STATE_DIR
+from paths import EDGE_REPO_DIR, GIT_SIGNALS_FILE
 
-OUTPUT_FILE = STATE_DIR / "git-signals.json"
+OUTPUT_FILE = GIT_SIGNALS_FILE
 SEPARATOR = "---SEPARATOR---"
 
 
@@ -47,7 +47,7 @@ def parse_since(since_str):
 def get_commits(since_git):
     """Get commits from git log with full body."""
     cmd = [
-        "git", "-C", str(EDGE_DIR), "log",
+        "git", "-C", str(EDGE_REPO_DIR), "log",
         f"--since={since_git}",
         f"--format=%H%n%aI%n%s%n%b%n{SEPARATOR}",
     ]

--- a/tools/heartbeat-preflight.sh
+++ b/tools/heartbeat-preflight.sh
@@ -15,7 +15,7 @@ source "$(dirname "$0")/../config/paths.sh"
 
 # 0. Health check (runs edge-check.sh, updates health/current.json)
 HEALTH_SCRIPT="$(dirname "$0")/../bin/edge-check.sh"
-HEALTH_FILE="$EDGE_DIR/health/current.json"
+HEALTH_FILE="$HEALTH_CURRENT_FILE"
 
 if [ -x "$HEALTH_SCRIPT" ]; then
   bash "$HEALTH_SCRIPT" >/dev/null 2>&1

--- a/tools/notify.sh
+++ b/tools/notify.sh
@@ -13,8 +13,9 @@
 
 set -euo pipefail
 
+# shellcheck source=../config/paths.sh
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-EDGE_DIR="$(dirname "$SCRIPT_DIR")"
+source "$SCRIPT_DIR/../config/paths.sh"
 
 TYPE="${1:-default}"
 MESSAGE="${2:-}"
@@ -36,8 +37,8 @@ fi
 
 # ─── Load config ─────────────────────────────────────────────────────────────
 
-FEATURES_FILE="$EDGE_DIR/config/features.yaml"
-SECRETS_FILE="$EDGE_DIR/secrets/_shared.yaml"
+FEATURES_FILE="$EDGE_REPO_DIR/config/features.yaml"
+SECRETS_FILE="$EDGE_REPO_DIR/secrets/_shared.yaml"
 
 # Read a YAML value (simple — no nested arrays)
 yaml_val() {
@@ -135,13 +136,14 @@ if [[ "$SENT" == "false" ]] && [[ -n "$WEBHOOK_URL" ]]; then
 fi
 
 # Method 3: Local chat API (always available)
-BLOG_PORT=$(yaml_val "$EDGE_DIR/config/branding.yaml" "blog.port" 2>/dev/null || echo "8080")
+BLOG_PORT=$(yaml_val "$EDGE_REPO_DIR/config/branding.yaml" "blog.port" 2>/dev/null || echo "8080")
 curl -s -X POST "http://localhost:${BLOG_PORT}/api/chat" \
   -H "Content-Type: application/json" \
   -d "{\"author\": \"system\", \"text\": \"[$TYPE] $MESSAGE\"}" 2>/dev/null >/dev/null || true
 
 # Log
-echo "[$(date '+%Y-%m-%d %H:%M')] notify $TYPE: $MESSAGE (slack=$SENT)" >> "$EDGE_DIR/logs/notify.log" 2>/dev/null || true
+mkdir -p "$LOGS_DIR"
+echo "[$(date '+%Y-%m-%d %H:%M')] notify $TYPE: $MESSAGE (slack=$SENT)" >> "$LOGS_DIR/notify.log" 2>/dev/null || true
 
 if [[ "$SENT" == "true" ]]; then
   echo "sent via slack → $CHANNEL"

--- a/tools/primitives/_shared/usage_log.py
+++ b/tools/primitives/_shared/usage_log.py
@@ -20,6 +20,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 TOOLS_DIR = SCRIPT_DIR.parent.parent
 if str(TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(TOOLS_DIR))
+CONFIG_DIR = SCRIPT_DIR.parents[2] / "config"
+if str(CONFIG_DIR) not in sys.path:
+    sys.path.insert(0, str(CONFIG_DIR))
 
 try:
     from _shared.telemetry import current_cycle_id, emit_shadow_event
@@ -27,10 +30,17 @@ except Exception:
     current_cycle_id = None
     emit_shadow_event = None
 
+try:
+    from paths import SOURCE_USAGE_FILE
+except Exception:
+    SOURCE_USAGE_FILE = None
+
 
 def _log_path() -> Path:
-    edge_home = os.environ.get("EDGE_HOME", str(Path.home() / "edge"))
-    return Path(edge_home).expanduser() / "state" / "source-usage.jsonl"
+    if SOURCE_USAGE_FILE is not None:
+        return SOURCE_USAGE_FILE
+    edge_state_dir = os.environ.get("EDGE_STATE_DIR") or os.environ.get("EDGE_HOME") or str(Path.home() / "edge")
+    return Path(edge_state_dir).expanduser() / "state" / "source-usage.jsonl"
 
 
 def log_invocation(

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -37,7 +37,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 sys.path.insert(0, str(SCRIPT_DIR))
 from branding import load_branding  # noqa: E402
-from paths import (MEMORY_DIR, REPORTS_DIR, NOTES_DIR, SKILLS_DIR,  # noqa: E402
+from paths import (ENTRIES_DIR, MEMORY_DIR, REPORTS_DIR, NOTES_DIR, SKILLS_DIR,  # noqa: E402
                    RUBRIC_PATH)
 from _shared.router_client import make_client  # noqa: E402
 _AGENT_NAME = load_branding().get("agent_name", "agent")
@@ -216,11 +216,10 @@ def _tool_search_corpus(query: str, k: int = 5) -> str:
 def _tool_read_blog_entries(tag: str = "", n: int = 3) -> str:
     """Read recent blog entries."""
     n = min(n, 5)
-    entries_dir = Path.home() / "edge/blog/entries"
-    if not entries_dir.exists():
+    if not ENTRIES_DIR.exists():
         return "Blog entries directory not found"
 
-    files = sorted(entries_dir.glob("*.md"), key=lambda p: p.name, reverse=True)
+    files = sorted(ENTRIES_DIR.glob("*.md"), key=lambda p: p.name, reverse=True)
     results = []
     for f in files:
         if len(results) >= n:

--- a/tools/rollup-primitives.py
+++ b/tools/rollup-primitives.py
@@ -16,9 +16,9 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import SEARCH_DIR, STATE_DIR  # noqa: E402
+from paths import SEARCH_DB_FILE, STATE_DIR  # noqa: E402
 
-DB_PATH = SEARCH_DIR / "edge-memory.db"
+DB_PATH = SEARCH_DB_FILE
 OUT_PATH = STATE_DIR / "primitive-usage-rollup.json"
 WINDOW_DAYS = 30
 


### PR DESCRIPTION
## What changed

This refactor starts enforcing a real runtime split between shared genotype and instance-local phenotype.

- introduces `EDGE_REPO_DIR`, `EDGE_STATE_DIR`, and `EDGE_INSTANCE` as the canonical path contract
- rewrites `config/paths.py` and `config/paths.sh` so mutable runtime paths resolve from the instance state root
- moves the main executable path bypasses off `~/edge`/repo-root assumptions across:
  - `blog/app.py`
  - `blog/services.py`
  - `blog/blog-publish.sh`
  - `blog/capture-diffs.sh`
  - `blog/consolidate-state.sh`
  - `search/db.py`
  - `search/search.py`
  - `tools/_shared/telemetry.py`
  - `tools/rollup-primitives.py`
  - `tools/primitives/_shared/usage_log.py`
  - `tools/edge-signal`
  - `tools/edge-crystallize`
  - `tools/edge-meta-report`
  - `tools/git_signals.py`
  - `tools/heartbeat-preflight.sh`
  - `tools/notify.sh`
  - `tools/review-gate.py`
- routes blog/dashboard reads and writes so notes, reports, entries, meta-reports, telemetry, DBs, and logs come from phenotype paths while templates/static/config stay in the repo
- redirects search and blog SQLite files to phenotype-backed locations
- moves blog changelog to the phenotype-side blog state area

## Why

The current system still treats the repo checkout as code root, state root, output root, and database root at the same time. That blocks clean instantiation and keeps reintroducing vibecoded `~/edge` assumptions.

This PR separates the path model broadly enough to support per-instance mutable state without rewriting the full runtime in one shot.

## Validation

- `python3 -m py_compile` passed for the modified Python entrypoints/modules
- `bash -n` passed for the modified shell scripts

## Remaining risky decisions

These are not blockers for the draft PR, but they are the architectural follow-ups that still need operator review before deploy:

1. `consolidate-state` Phase 6 still commits the repo git history only. If phenotype eventually lives outside the repo and is not git-backed, state commit semantics need an explicit replacement.
2. `edge-meta-report` now degrades gracefully when the state root is outside git, but that means state diff visibility becomes partial until phenotype versioning is defined.
3. `autonomy/` is still a mixed tree conceptually. This PR only stops the worst path coupling; it does not fully separate genotype autonomy rules from phenotype autonomy telemetry/artifacts.
4. Dashboard catch-all serving still points at the repo root intentionally for backward compatibility. Dedicated phenotype routes were moved, but the generic fallback remains conservative.

## Impact

This is a broad path and runtime refactor in preparation for instance-aware execution. It should not be merged until the remaining deployment assumptions are reviewed and we decide how far Phase 1 should go before touching live `ed`, `gauss`, and `bobmarley`.
