### PR TITLE
[codex] expand observability across lifecycle and publish

### DIFF
--- a/blog/app.py
+++ b/blog/app.py
@@ -20,16 +20,32 @@ import markdown
 import yaml
 
 # ─── Paths ───
-ROOT = Path.home() / "edge"
-BLOG_DIR = ROOT / "blog"
-ENTRIES_DIR = BLOG_DIR / "entries"
-COMMENTS_FILE = BLOG_DIR / "comments.json"
-DIFFS_DIR = BLOG_DIR / "diffs"
-DIFFS_DIR.mkdir(parents=True, exist_ok=True)
-META_REPORTS_DIR = ROOT / "meta-reports"
-REPORTS_DIR = ROOT / "reports"
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import (  # noqa: E402
+    AUTONOMY_CAPABILITIES_FILE,
+    BLOG_COMMENTS_FILE,
+    BLOG_DIFFS_DIR,
+    BLOG_DIR,
+    BLOG_FTS_DB_FILE,
+    BUILDS_DIR,
+    EDGE_REPO_DIR,
+    ENTRIES_DIR,
+    FRONTIER_FILE,
+    META_REPORTS_DIR,
+    NOTES_DIR,
+    PROPOSALS_FILE,
+    REPORTS_DIR,
+    SEARCH_DIR,
+    SIGNALS_DIR,
+    STATE_DIR,
+    THREADS_DIR,
+)
 
-SEARCH_DIR = ROOT / "search"
+ROOT = EDGE_REPO_DIR
+COMMENTS_FILE = BLOG_COMMENTS_FILE
+DIFFS_DIR = BLOG_DIFFS_DIR
+DIFFS_DIR.mkdir(parents=True, exist_ok=True)
 sys.path.insert(0, str(SEARCH_DIR))
 sys.path.insert(0, str(ROOT))
 
@@ -100,7 +116,7 @@ SKILL_GROUPS = [
 
 
 # ─── FTS5 index ───
-FTS_DB_PATH = BLOG_DIR / "blog_fts.db"
+FTS_DB_PATH = BLOG_FTS_DB_FILE
 
 
 def get_fts_conn():
@@ -615,9 +631,8 @@ def workflow_reject(slug):
 def proposal_approve(proposal_id):
     """Approve a proposal: set status to approved."""
     import json as _j
-    proposals_path = ROOT / "state" / "proposals.json"
     try:
-        proposals = _j.loads(proposals_path.read_text())
+        proposals = _j.loads(PROPOSALS_FILE.read_text())
     except Exception:
         return jsonify({"error": "no proposals file"}), 404
     for p in proposals:
@@ -626,7 +641,7 @@ def proposal_approve(proposal_id):
             break
     else:
         return jsonify({"error": "not found"}), 404
-    proposals_path.write_text(_j.dumps(proposals, indent=2, ensure_ascii=False))
+    PROPOSALS_FILE.write_text(_j.dumps(proposals, indent=2, ensure_ascii=False))
     return "", 204
 
 
@@ -634,17 +649,17 @@ def proposal_approve(proposal_id):
 def proposal_reject(proposal_id):
     """Reject a proposal: set status to rejected, log in decision.md."""
     import json as _j
-    proposals_path = ROOT / "state" / "proposals.json"
     try:
-        proposals = _j.loads(proposals_path.read_text())
+        proposals = _j.loads(PROPOSALS_FILE.read_text())
     except Exception:
         return jsonify({"error": "no proposals file"}), 404
     for p in proposals:
         if p.get("id") == proposal_id:
             p["status"] = "rejected"
             # Log rejection in decision signals
-            signals_path = ROOT / "state" / "signals" / "decision.md"
+            signals_path = SIGNALS_DIR / "decision.md"
             try:
+                signals_path.parent.mkdir(parents=True, exist_ok=True)
                 existing = signals_path.read_text() if signals_path.exists() else ""
                 signals_path.write_text(existing + f"\n- Rejected proposal: {p.get('title', proposal_id)}\n")
             except Exception:
@@ -652,7 +667,7 @@ def proposal_reject(proposal_id):
             break
     else:
         return jsonify({"error": "not found"}), 404
-    proposals_path.write_text(_j.dumps(proposals, indent=2, ensure_ascii=False))
+    PROPOSALS_FILE.write_text(_j.dumps(proposals, indent=2, ensure_ascii=False))
     return "", 204
 
 
@@ -779,8 +794,8 @@ def get_autonomy_data():
     """Read ~/edge/autonomy/capabilities.md and compute Sheridan stats."""
     import re
     try:
-        cap_path = Path.home() / "edge" / "autonomy" / "capabilities.md"
-        frontier_path = Path.home() / "edge" / "autonomy" / "frontier.md"
+        cap_path = AUTONOMY_CAPABILITIES_FILE
+        frontier_path = FRONTIER_FILE
         content = cap_path.read_text()
         # Parse table rows: | # | Name | Sheridan | ...
         rows = re.findall(r'^\|\s*\d+\s*\|([^|]+)\|\s*(\d+)\s*\|', content, re.MULTILINE)
@@ -1127,7 +1142,7 @@ def api_thread_candidates():
 def api_promote_candidate(tag):
     """Create a thread from a candidate tag."""
     from datetime import timedelta
-    threads_dir = ROOT / "threads"
+    threads_dir = THREADS_DIR
     thread_path = threads_dir / f"{tag}.md"
     if thread_path.exists():
         return jsonify({"error": f"Thread '{tag}' already exists"}), 409
@@ -1164,7 +1179,7 @@ Thread criado a partir de candidate (tag '{tag}').
 def api_thread_snooze(thread_id):
     """Snooze: update resurface +7d."""
     from datetime import timedelta
-    thread_path = ROOT / "threads" / f"{thread_id}.md"
+    thread_path = THREADS_DIR / f"{thread_id}.md"
     if not thread_path.exists():
         return jsonify({"error": f"Thread {thread_id} not found"}), 404
     data = request.get_json(silent=True) or {}
@@ -1191,17 +1206,17 @@ def comments_json():
 # ─── Static files from ~/edge/ root ───
 @app.route("/reports/<path:filename>")
 def serve_reports(filename):
-    return send_from_directory(str(ROOT / "reports"), filename)
+    return send_from_directory(str(REPORTS_DIR), filename)
 
 
 @app.route("/builds/<path:filename>")
 def serve_builds(filename):
-    return send_from_directory(str(ROOT / "builds"), filename)
+    return send_from_directory(str(BUILDS_DIR), filename)
 
 
 @app.route("/notes/<path:filename>")
 def serve_notes(filename):
-    return send_from_directory(str(ROOT / "notes"), filename)
+    return send_from_directory(str(NOTES_DIR), filename)
 
 
 @app.route("/blog/entries/<path:filename>")
@@ -1220,14 +1235,6 @@ def serve_meta_reports(filename):
 
 
 # ─── Dashboard ───
-STATE_DIR = ROOT / "state"
-THREADS_DIR = ROOT / "threads"
-
-
-
-
-
-
 def _build_threads_data():
     """Build context for threads partial."""
     from blog.services import load_threads_enriched, compute_thread_candidates
@@ -1358,10 +1365,9 @@ _SETUP_MAX_CONTENT = 50_000  # truncate files larger than this in the setup view
 
 def _load_proposals():
     """Load active proposals from state/proposals.json."""
-    proposals_path = ROOT / "state" / "proposals.json"
     try:
         import json as _j
-        return [p for p in _j.loads(proposals_path.read_text()) if p.get("status") == "active"]
+        return [p for p in _j.loads(PROPOSALS_FILE.read_text()) if p.get("status") == "active"]
     except Exception:
         return []
 

--- a/blog/blog-publish.sh
+++ b/blog/blog-publish.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 # shellcheck source=../config/paths.sh
 REAL_SCRIPT="$(readlink -f "$0")"
 source "$(dirname "$REAL_SCRIPT")/../config/paths.sh"
-CHANGELOG="$BLOG_DIR/changelog.md"
+CHANGELOG="$BLOG_CHANGELOG_FILE"
 API_URL="$BLOG_URL"
 ENTRY_PATH="${1:-}"
 
@@ -122,9 +122,9 @@ fi
 
 # --- Step 2.5: Find related posts ---
 echo "[2.5/6] Finding related posts..."
-SEARCH_PYTHON="$EDGE_DIR/search/.venv/bin/python3"
+SEARCH_PYTHON="$SEARCH_DIR/.venv/bin/python3"
 [ -x "$SEARCH_PYTHON" ] || SEARCH_PYTHON="python3"
-RELATED_OUTPUT=$($SEARCH_PYTHON "$EDGE_DIR/search/related.py" "$ENTRY_PATH" 5 2>&1) || true
+RELATED_OUTPUT=$($SEARCH_PYTHON "$SEARCH_DIR/related.py" "$ENTRY_PATH" 5 2>&1) || true
 if echo "$RELATED_OUTPUT" | grep -q "^Related"; then
     echo "  $RELATED_OUTPUT" | head -6
 else
@@ -191,7 +191,14 @@ VERIFY_OK=true
 # Check SQLite
 python3 -c "
 import sys, os
-sys.path.insert(0, os.path.join(os.environ.get('EDGE_DIR', os.path.expanduser('~/edge')), 'search'))
+search_dir = os.environ.get(
+    'SEARCH_DIR',
+    os.path.join(
+        os.environ.get('EDGE_REPO_DIR', os.environ.get('EDGE_DIR', os.path.expanduser('~/edge'))),
+        'search',
+    ),
+)
+sys.path.insert(0, search_dir)
 try:
     from db import ensure_db
     conn = ensure_db()

--- a/blog/blog-publish.sh
+++ b/blog/blog-publish.sh
@@ -21,6 +21,48 @@ CHANGELOG="$BLOG_CHANGELOG_FILE"
 API_URL="$BLOG_URL"
 ENTRY_PATH="${1:-}"
 
+emit_publish_event() {
+    local status="$1" operation="${2:-}" error_text="${3:-}"
+    python3 - "$status" "$operation" "$error_text" <<'PYEOF' 2>/dev/null || true
+import os, sys
+from pathlib import Path
+
+status, operation, error_text = sys.argv[1:4]
+tools_dir = Path(
+    os.environ.get("TOOLS_DIR")
+    or (
+        Path(
+            os.environ.get(
+                "EDGE_REPO_DIR",
+                os.environ.get("EDGE_DIR", str(Path.home() / "edge")),
+            )
+        ).expanduser()
+        / "tools"
+    )
+)
+sys.path.insert(0, str(tools_dir))
+try:
+    from _shared.telemetry import log_run_step
+except Exception:
+    sys.exit(0)
+
+fields = {
+    "slug": os.environ.get("EDGE_PUBLISH_SLUG", "unknown"),
+}
+if operation:
+    fields["operation"] = operation
+if error_text:
+    fields["error"] = error_text[:240]
+log_run_step(
+    "blog-publish",
+    "publish",
+    status,
+    run_id=os.environ.get("EDGE_BLOG_PUBLISH_RUN_ID"),
+    **fields,
+)
+PYEOF
+}
+
 if [[ -z "$ENTRY_PATH" ]]; then
     echo "ERROR: Usage: blog-publish <path-to-entry.md>"
     exit 1
@@ -52,6 +94,8 @@ fi
 
 FILENAME=$(basename "$ENTRY_PATH")
 SLUG="${FILENAME%.md}"
+export EDGE_PUBLISH_SLUG="$SLUG"
+export EDGE_BLOG_PUBLISH_RUN_ID="${EDGE_BLOG_PUBLISH_RUN_ID:-blog-publish:${SLUG}:$(date -u +%Y%m%dT%H%M%SZ)}"
 
 # Guardrail: BLOCK direct calls — everything must go through consolidate-state
 if [[ -z "${CALLED_FROM_CONSOLIDAR_ESTADO:-}" && -z "${CALLED_FROM_FULL_PUBLISH:-}" ]]; then
@@ -62,6 +106,7 @@ if [[ -z "${CALLED_FROM_CONSOLIDAR_ESTADO:-}" && -z "${CALLED_FROM_FULL_PUBLISH:
 fi
 
 echo "=== blog-publish: $SLUG ==="
+emit_publish_event "started" "publish_start" ""
 
 # --- Step 1: Validate frontmatter ---
 echo "[1/6] Validating frontmatter..."
@@ -107,6 +152,7 @@ print(fm.get('title', '$SLUG'))
 
 if echo "$FRONTMATTER" | grep -q '^ERROR:'; then
     echo "$FRONTMATTER"
+    emit_publish_event "failed" "frontmatter_validation" "$FRONTMATTER"
     exit 1
 fi
 TITLE="$FRONTMATTER"
@@ -231,9 +277,11 @@ fi
 if $VERIFY_OK; then
     echo ""
     echo "=== PUBLISHED: $SLUG ==="
+    emit_publish_event "completed" "publish_complete" ""
     exit 0
 else
     echo ""
     echo "=== WARN: Published with issues (verify manually) ==="
+    emit_publish_event "failed" "publish_verify" "published with verify issues"
     exit 0  # Non-fatal — entry exists, just might need attention
 fi

--- a/blog/capture-diffs.sh
+++ b/blog/capture-diffs.sh
@@ -22,20 +22,30 @@ source "$(dirname "$REAL_SCRIPT")/../config/paths.sh"
 
 # Use Python for all diff processing (bash is unreliable with special chars in diffs)
 export CAPTURE_SLUG="$SLUG"
-export MEMORY_BASE EDGE_DIR BLOG_URL
+export MEMORY_BASE NOTES_DIR AUTONOMY_DIR BLOG_URL
 python3 << 'PYEOF'
 import subprocess, json, os, sys
 
 slug = os.environ.get("CAPTURE_SLUG", "")
 memory_base = os.environ.get("MEMORY_BASE", os.path.expanduser("~/.claude/projects/memory"))
-edge_dir = os.environ.get("EDGE_DIR", os.path.expanduser("~/edge"))
+notes_dir = os.environ.get(
+    "NOTES_DIR",
+    os.path.join(os.environ.get("EDGE_STATE_DIR", os.path.expanduser("~/edge")), "notes"),
+)
+autonomy_dir = os.environ.get(
+    "AUTONOMY_DIR",
+    os.path.join(
+        os.environ.get("EDGE_REPO_DIR", os.environ.get("EDGE_DIR", os.path.expanduser("~/edge"))),
+        "autonomy",
+    ),
+)
 blog_url = os.environ.get("BLOG_URL", "http://localhost:8766")
 
 TRACKED = {
     memory_base: "memory",
     os.path.expanduser("~/.claude/skills"): "skills",
-    os.path.join(edge_dir, "notes"): "notes",
-    os.path.join(edge_dir, "autonomy"): "autonomy",
+    notes_dir: "notes",
+    autonomy_dir: "autonomy",
 }
 
 BLOG_API = f"{blog_url}/api/diffs"

--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -246,7 +246,7 @@ echo ""
 echo "── Phase 0a: State Snapshot ──"
 ledger_record "phase-0a" "ok"
 if command -v edge-state-audit &>/dev/null; then
-    PRE_SNAPSHOT="$EDGE_DIR/state-snapshots/${SLUG}.pre.yaml"
+    PRE_SNAPSHOT="$SNAPSHOT_DIR/${SLUG}.pre.yaml"
     if [[ -f "$PRE_SNAPSHOT" ]]; then
         ok "PRE snapshot already exists (agent captured before changes)"
     else
@@ -658,7 +658,7 @@ try:
     if not ('curation' in tags or 'procedures' in tags):
         print('SKIP')
         sys.exit(0)
-    pc = os.path.expanduser('~/edge/state/procedure-curation.json')
+    pc = os.environ.get('PROCEDURE_CURATION_FILE', os.path.expanduser('~/edge/state/procedure-curation.json'))
     if not os.path.exists(pc):
         print('SKIP')
         sys.exit(0)
@@ -667,7 +667,7 @@ try:
     if not candidates:
         print('SKIP')
         sys.exit(0)
-    entries = glob.glob(os.path.expanduser('~/edge/blog/entries/*workflow*.md'))
+    entries = glob.glob(os.path.join(os.environ.get('ENTRIES_DIR', os.path.expanduser('~/edge/blog/entries')), '*workflow*.md'))
     drafts = 0
     for e in entries:
         head = open(e).read()[:500]
@@ -809,7 +809,7 @@ def ok(msg): print(f"  {GREEN}OK{NC}: {msg}")
 def warn(msg): print(f"  {YELLOW}WARN{NC}: {msg}")
 def fail(msg): print(f"  {RED}FAIL{NC}: {msg}")
 
-FAILURES_FILE = Path.home() / "edge" / "logs" / "pipeline-failures.jsonl"
+FAILURES_FILE = Path(os.environ.get("PIPELINE_FAILURES_FILE", os.path.expanduser("~/edge/logs/pipeline-failures.jsonl")))
 FAILURES_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 def log_failure(phase, operation, error, tb=None):
@@ -866,7 +866,7 @@ except Exception as e:
 
 # ── 2. Thread update ──
 try:
-    threads_dir = Path.home() / "edge" / "threads"
+    threads_dir = Path(os.environ.get("THREADS_DIR", os.path.expanduser("~/edge/threads")))
     updated_threads = []
     for tid in threads:
         tfile = threads_dir / f"{tid}.md"
@@ -885,7 +885,7 @@ except Exception as e:
 
 # ── 2b. Procedure & workflow signals ──
 try:
-    state_dir = Path.home() / "edge" / "state"
+    state_dir = Path(os.environ.get("STATE_DIR", os.path.expanduser("~/edge/state")))
     state_dir.mkdir(parents=True, exist_ok=True)
     health_file = state_dir / "workflow-health.json"
 
@@ -961,7 +961,7 @@ except Exception as e:
 
 # ── 3. Event log (idempotent) ──
 try:
-    events_file = Path.home() / "edge" / "logs" / "events.jsonl"
+    events_file = Path(os.environ.get("EVENTS_FILE", os.path.expanduser("~/edge/logs/events.jsonl")))
     artifacts = [f"blog/entries/{slug}.md"]
     if report_filename:
         artifacts.append(f"reports/{report_filename}")
@@ -1030,7 +1030,7 @@ echo "── Phase 5b: State Audit ──"
 ledger_record "phase-5b" "ok"
 if command -v edge-state-audit &>/dev/null; then
     # Check if proposal exists (agent should have written it during the session)
-    PROPOSAL_FILE="$EDGE_DIR/meta-reports/${SLUG}.state-proposal.yaml"
+    PROPOSAL_FILE="$META_DIR/${SLUG}.state-proposal.yaml"
     if [[ -f "$PROPOSAL_FILE" ]]; then
         ok "Proposal found: $(basename "$PROPOSAL_FILE")"
     else
@@ -1045,7 +1045,7 @@ if command -v edge-state-audit &>/dev/null; then
         echo "========================================="
         echo -e " ${RED}ABORTED${NC}: State audit detected violation"
         echo "  Proposal: $PROPOSAL_FILE"
-        echo "  Audit: $EDGE_DIR/meta-reports/${SLUG}.state-audit.yaml"
+        echo "  Audit: $META_DIR/${SLUG}.state-audit.yaml"
         echo "========================================="
         exit 5
     fi
@@ -1095,7 +1095,7 @@ def ok(msg): print(f"  {GREEN}OK{NC}: {msg}")
 def warn(msg): print(f"  {YELLOW}WARN{NC}: {msg}")
 def fail(msg): print(f"  {RED}FAIL{NC}: {msg}")
 
-FAILURES_FILE = Path.home() / "edge" / "logs" / "pipeline-failures.jsonl"
+FAILURES_FILE = Path(os.environ.get("PIPELINE_FAILURES_FILE", os.path.expanduser("~/edge/logs/pipeline-failures.jsonl")))
 FAILURES_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 def log_failure(phase, operation, error, tb=None):
@@ -1148,12 +1148,13 @@ def _claim_text(c):
     return str(c).lstrip("! ")
 
 # ── 1. Captura diffs dos mini-repos (memory, skills, notes) ──
-_edge_dir = os.environ.get("EDGE_DIR", os.path.expanduser("~/edge"))
+_edge_repo_dir = os.environ.get("EDGE_REPO_DIR", os.environ.get("EDGE_DIR", os.path.expanduser("~/edge")))
+_notes_dir = os.environ.get("NOTES_DIR", os.path.join(os.environ.get("EDGE_STATE_DIR", os.path.expanduser("~/edge")), "notes"))
 _memory_base = os.environ.get("MEMORY_BASE", os.path.expanduser("~/.claude/projects/memory"))
 TRACKED = {
     _memory_base: "memory",
     os.path.expanduser("~/.claude/skills"): "skills",
-    os.path.join(_edge_dir, "notes"): "notes",
+    _notes_dir: "notes",
 }
 
 all_diffs = []
@@ -1207,7 +1208,7 @@ for dirpath, prefix in TRACKED.items():
 
 # ── 2. Captura diffs do ~/edge/ (repo principal) ──
 try:
-    edge_dir = os.environ.get("EDGE_DIR", os.path.expanduser("~/edge"))
+    edge_dir = os.environ.get("EDGE_REPO_DIR", os.environ.get("EDGE_DIR", os.path.expanduser("~/edge")))
     subprocess.run(["git", "add", "-A"], cwd=edge_dir, capture_output=True, timeout=30)
 
     # ORPHAN GUARD: unstage blog entries/reports/meta-reports that don't belong to this slug.
@@ -1330,8 +1331,9 @@ if failures:
 lines.append("")
 
 # State audit summary (if audit ran)
-proposal_path = Path.home() / "edge" / "meta-reports" / f"{slug}.state-proposal.yaml"
-audit_path = Path.home() / "edge" / "meta-reports" / f"{slug}.state-audit.yaml"
+meta_dir = Path(os.environ.get("META_DIR", os.path.expanduser("~/edge/meta-reports")))
+proposal_path = meta_dir / f"{slug}.state-proposal.yaml"
+audit_path = meta_dir / f"{slug}.state-audit.yaml"
 if audit_path.exists():
     try:
         audit_data = yaml.safe_load(audit_path.read_text())
@@ -1396,7 +1398,7 @@ if audit_path.exists():
 
 # ── Execution summary from ops-hotspots.json ──
 try:
-    hotspots_path = Path.home() / "edge" / "state" / "ops-hotspots.json"
+    hotspots_path = Path(os.environ.get("OPS_HOTSPOTS", os.path.expanduser("~/edge/state/ops-hotspots.json")))
     if hotspots_path.exists():
         hotspots = json.loads(hotspots_path.read_text())
         incidents = hotspots.get("incidents", [])
@@ -1472,7 +1474,7 @@ if $ALL_OK && [[ "$REPORT_RESULT" != "fail" ]]; then
     [[ -n "$META_REPORT_PATH" ]] && echo -e " ${YELLOW}→ Read meta-report BEFORE editing state${NC}"
     echo "========================================="
     # Survival instinct: write success marker
-    HEALTH_OK="$EDGE_DIR/health/last_success"
+    HEALTH_OK="$HEALTH_DIR/last_success"
     mkdir -p "$HEALTH_OK"
     printf '{"ts":"%s","slug":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SLUG" > "$HEALTH_OK/consolidate.ok"
     ledger_record "pipeline-end" "ok"

--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -61,6 +61,48 @@ ledger_record() {
     fi
 }
 
+emit_run_step_event() {
+    local phase="$1" status="$2" operation="${3:-}" error_text="${4:-}"
+    python3 - "$phase" "$status" "$operation" "$error_text" <<'PYEOF' 2>/dev/null || true
+import os, sys
+from pathlib import Path
+
+phase, status, operation, error_text = sys.argv[1:5]
+tools_dir = Path(
+    os.environ.get("TOOLS_DIR")
+    or (
+        Path(
+            os.environ.get(
+                "EDGE_REPO_DIR",
+                os.environ.get("EDGE_DIR", str(Path.home() / "edge")),
+            )
+        ).expanduser()
+        / "tools"
+    )
+)
+sys.path.insert(0, str(tools_dir))
+try:
+    from _shared.telemetry import log_run_step
+except Exception:
+    sys.exit(0)
+
+fields = {
+    "slug": os.environ.get("EDGE_PUBLISH_SLUG", "unknown"),
+}
+if operation:
+    fields["operation"] = operation
+if error_text:
+    fields["error"] = error_text[:240]
+log_run_step(
+    "consolidate-state",
+    phase,
+    status,
+    run_id=os.environ.get("EDGE_CONSOLIDATE_RUN_ID"),
+    **fields,
+)
+PYEOF
+}
+
 # Parse flags
 REVIEW_ONLY=false
 RECOVER=false
@@ -129,6 +171,7 @@ entry = {
 with open('$FAILURES_LOG', 'a') as f:
     f.write(json.dumps(entry, ensure_ascii=False) + '\n')
 " "$phase" "$operation" "$error" 2>/dev/null
+    emit_run_step_event "phase-$phase" "failed" "$operation" "$error"
 }
 
 if [[ "$RECOVER" == "false" ]]; then
@@ -222,6 +265,8 @@ fi
 [[ -n "$REPORT_INPUT" && ! "$REPORT_INPUT" = /* ]] && REPORT_INPUT="$(pwd)/$REPORT_INPUT"
 
 SLUG=$(basename "$ENTRY_PATH" .md)
+export EDGE_PUBLISH_SLUG="$SLUG"
+export EDGE_CONSOLIDATE_RUN_ID="${EDGE_CONSOLIDATE_RUN_ID:-consolidate:${SLUG}:$(date -u +%Y%m%dT%H%M%SZ)}"
 REPORT_HTML=""
 REPORT_FILENAME=""
 REPORT_RESULT="skip"
@@ -236,6 +281,8 @@ ledger_record "pipeline-start" "ok"
 
 STATE_AUDIT_EXIT=0
 
+emit_run_step_event "pipeline" "started" "pipeline_start" ""
+
 echo "========================================="
 echo " consolidate-state: $SLUG"
 echo "========================================="
@@ -245,6 +292,7 @@ echo ""
 # If agent already took snapshot (before making state changes), skip.
 echo "── Phase 0a: State Snapshot ──"
 ledger_record "phase-0a" "ok"
+emit_run_step_event "phase-0a" "started" "state_snapshot" ""
 if command -v edge-state-audit &>/dev/null; then
     PRE_SNAPSHOT="$SNAPSHOT_DIR/${SLUG}.pre.yaml"
     if [[ -f "$PRE_SNAPSHOT" ]]; then
@@ -260,6 +308,7 @@ if command -v edge-state-audit &>/dev/null; then
 else
     warn "edge-state-audit not found — skipping state audit"
 fi
+emit_run_step_event "phase-0a" "completed" "state_snapshot" ""
 echo ""
 
 # ─── PHASE 0: Inject report: in frontmatter if needed ───
@@ -286,6 +335,7 @@ else:
 
         if [[ "$HAS_REPORT" == "no" ]]; then
             echo "── Phase 0: Frontmatter ──"
+            emit_run_step_event "phase-0" "started" "frontmatter_injection" ""
             # Inject report: field after the last frontmatter field (before closing ---)
             if python3 -c "
 try:
@@ -308,6 +358,7 @@ except Exception as e:
             else
                 log_failure "0" "frontmatter_injection" "Failed to inject report: field"
             fi
+            emit_run_step_event "phase-0" "completed" "frontmatter_injection" ""
             echo ""
         fi
     fi
@@ -330,6 +381,7 @@ else:
 
     if [[ "$HAS_NOTE" == "no" ]]; then
         echo "── Phase 0b: Note Link ──"
+        emit_run_step_event "phase-0b" "started" "note_link_injection" ""
         NOTE_BASENAME="${NOTE_SLUG}.md"
         if python3 -c "
 try:
@@ -352,6 +404,7 @@ except Exception as e:
         else
             log_failure "0b" "note_link_injection" "Failed to inject note: field"
         fi
+        emit_run_step_event "phase-0b" "completed" "note_link_injection" ""
         echo ""
     else
         echo "── Phase 0b: Note Link ──"
@@ -372,6 +425,7 @@ if [[ -n "$REPORT_INPUT" && ("$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.y
 
     if [[ -f "$REVIEW_JSON_FILE" && ! -f "$RESOLVED_FILE" ]]; then
         echo "── Phase 0.3: Adversarial Review ──"
+        emit_run_step_event "phase-0.3" "started" "adversarial_review" ""
         fail "Adversarial review pending: $(basename "$REVIEW_JSON_FILE")"
         echo ""
         echo "  edge-consult generated feedback that has not been addressed."
@@ -394,10 +448,13 @@ try:
 except: pass
 " 2>/dev/null
         echo ""
+        emit_run_step_event "phase-0.3" "failed" "adversarial_review" "pending unresolved review"
         exit 3
     elif [[ -f "$REVIEW_JSON_FILE" && -f "$RESOLVED_FILE" ]]; then
         echo "── Phase 0.3: Adversarial Review ──"
+        emit_run_step_event "phase-0.3" "started" "adversarial_review" ""
         ok "Adversarial review resolved ($(basename "$RESOLVED_FILE") present)"
+        emit_run_step_event "phase-0.3" "completed" "adversarial_review" ""
         echo ""
     fi
 fi
@@ -406,6 +463,7 @@ fi
 if [[ -n "$REPORT_INPUT" && ("$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.yml) ]]; then
     if command -v review-gate &>/dev/null; then
         echo "── Phase 0.5: Review Gate ──"
+        emit_run_step_event "phase-0.5" "started" "review_gate" ""
         # Detect skill from YAML filename (spec-SKILL-slug.yaml)
         YAML_BASENAME=$(basename "$REPORT_INPUT")
         SKILL_NAME=""
@@ -484,10 +542,12 @@ if suggestions:
         fi
 
         if [[ "$REVIEW_ONLY" == "true" ]]; then
+            emit_run_step_event "phase-0.5" "completed" "review_gate" ""
             echo ""
             echo "Review-only mode. Nothing published."
             exit 0
         fi
+        emit_run_step_event "phase-0.5" "completed" "review_gate" ""
         echo ""
     fi
 fi
@@ -495,8 +555,10 @@ fi
 # ─── PHASE 1: Blog entry ───
 echo "── Phase 1: Blog Entry ──"
 ledger_record "phase-1" "ok"
+emit_run_step_event "phase-1" "started" "blog_publish" ""
 if CALLED_FROM_CONSOLIDAR_ESTADO=1 bash "$BLOG_DIR/blog-publish.sh" "$ENTRY_PATH"; then
     ok "Entry published"
+    emit_run_step_event "phase-1" "completed" "blog_publish" ""
 else
     fail "blog-publish.sh failed"
     log_failure "1" "blog_publish" "blog-publish.sh returned non-zero"
@@ -507,6 +569,7 @@ echo ""
 # ─── PHASE 2: Report (opcional) ───
 if [[ -n "$REPORT_INPUT" ]]; then
     echo "── Phase 2: Report ──"
+    emit_run_step_event "phase-2" "started" "report_generation" ""
 
     if [[ ! -f "$REPORT_INPUT" ]]; then
         fail "Report not found: $REPORT_INPUT"
@@ -553,12 +616,18 @@ if [[ -n "$REPORT_INPUT" ]]; then
             warn "edge-index not found"
         fi
     fi
+    if [[ "$REPORT_RESULT" == "ok" ]]; then
+        emit_run_step_event "phase-2" "completed" "report_generation" ""
+    else
+        emit_run_step_event "phase-2" "failed" "report_generation" "report phase ended in fail"
+    fi
     echo ""
 fi
 
 # ─── PHASE 3: Verificacao final ───
 echo "── Phase 3: Verification ──"
 ledger_record "phase-3" "ok"
+emit_run_step_event "phase-3" "started" "verification" ""
 ALL_OK=true
 
 # Entry visible?
@@ -715,6 +784,11 @@ except Exception as e:
         log_failure "3.4" "llm_cost_injection" "Failed to inject llm_cost into frontmatter"
     fi
 fi
+if $ALL_OK && [[ "$REPORT_RESULT" != "fail" ]]; then
+    emit_run_step_event "phase-3" "completed" "verification" ""
+else
+    emit_run_step_event "phase-3" "failed" "verification" "verification ended with warnings or failures"
+fi
 
 # ─── PHASE 4: Meta-report (cognitive mirror) ───
 # Captures state delta + scratchpad + adversarial BEFORE state commit.
@@ -723,6 +797,8 @@ fi
 echo ""
 echo "── Phase 4: Meta-report ──"
 ledger_record "phase-4" "ok"
+emit_run_step_event "phase-4" "started" "meta_report" ""
+PHASE4_OK=true
 if command -v edge-meta-report &>/dev/null || [[ -x "$TOOLS_DIR/edge-meta-report" ]]; then
     META_CMD="edge-meta-report --slug $SLUG --entry $ENTRY_PATH"
     # Use tools dir if not in PATH
@@ -779,10 +855,15 @@ REVIEW_EOF
     else
         warn "edge-meta-report failed (exit $META_EXIT)"
         log_failure "4" "meta_report_generation" "edge-meta-report exit $META_EXIT"
+        PHASE4_OK=false
     fi
 else
     warn "edge-meta-report not found — skipping"
     log_failure "4" "meta_report_missing" "edge-meta-report tool not available"
+    PHASE4_OK=false
+fi
+if $PHASE4_OK; then
+    emit_run_step_event "phase-4" "completed" "meta_report" ""
 fi
 echo ""
 
@@ -790,6 +871,7 @@ echo ""
 # Tudo acontece aqui. Zero LLM. Um script, uma leitura do frontmatter.
 echo "── Phase 5: State Commit ──"
 ledger_record "phase-5" "ok"
+emit_run_step_event "phase-5" "started" "state_commit" ""
 REPORT_FOR_COMMIT="${REPORT_FILENAME:-}"
 python3 - "$ENTRY_PATH" "$SLUG" "$REPORT_FOR_COMMIT" <<'PYEOF'
 import sys, json, yaml, re, os, traceback, subprocess
@@ -1024,10 +1106,12 @@ except Exception as e:
     log_failure("5", "digest", e, traceback.format_exc())
     warn(f"edge-digest error: {e}")
 PYEOF
+emit_run_step_event "phase-5" "completed" "state_commit" ""
 
 # ─── PHASE 5b: State audit (compare PRE vs POST, validate proposal) ───
 echo "── Phase 5b: State Audit ──"
 ledger_record "phase-5b" "ok"
+emit_run_step_event "phase-5b" "started" "state_audit" ""
 if command -v edge-state-audit &>/dev/null; then
     # Check if proposal exists (agent should have written it during the session)
     PROPOSAL_FILE="$META_DIR/${SLUG}.state-proposal.yaml"
@@ -1047,14 +1131,22 @@ if command -v edge-state-audit &>/dev/null; then
         echo "  Proposal: $PROPOSAL_FILE"
         echo "  Audit: $META_DIR/${SLUG}.state-audit.yaml"
         echo "========================================="
+        emit_run_step_event "phase-5b" "failed" "state_audit" "state audit violation or divergence"
         exit 5
     fi
+fi
+if [[ $STATE_AUDIT_EXIT -eq 2 ]]; then
+    emit_run_step_event "phase-5b" "failed" "state_audit" "state audit partial"
+else
+    emit_run_step_event "phase-5b" "completed" "state_audit" ""
 fi
 echo ""
 
 # ─── PHASE 5c: Post-state meta-report (what actually changed) ───
 echo "── Phase 5c: Post-state meta-report ──"
 ledger_record "phase-5c" "ok"
+emit_run_step_event "phase-5c" "started" "post_state_meta_report" ""
+PHASE5C_OK=true
 if command -v edge-meta-report &>/dev/null || [[ -x "$TOOLS_DIR/edge-meta-report" ]]; then
     POST_CMD="edge-meta-report --slug $SLUG --post-state"
     command -v edge-meta-report &>/dev/null || POST_CMD="$TOOLS_DIR/edge-meta-report --slug $SLUG --post-state"
@@ -1066,15 +1158,23 @@ if command -v edge-meta-report &>/dev/null || [[ -x "$TOOLS_DIR/edge-meta-report
         ok "$(echo "$POST_OUTPUT" | head -1)"
     else
         warn "post-state meta-report failed (exit $POST_EXIT)"
+        PHASE5C_OK=false
     fi
 else
     warn "edge-meta-report not found -- skipping post-state"
+    PHASE5C_OK=false
+fi
+if $PHASE5C_OK; then
+    emit_run_step_event "phase-5c" "completed" "post_state_meta_report" ""
+else
+    emit_run_step_event "phase-5c" "failed" "post_state_meta_report" "post-state meta-report unavailable or failed"
 fi
 echo ""
 
 # ─── PHASE 6: Diffs + Git commit (audit trail) ───
 echo "── Phase 6: Diffs + Git Commit ──"
 ledger_record "phase-6" "ok"
+emit_run_step_event "phase-6" "started" "diffs_and_git_commit" ""
 
 # Note: BLOG_PORT, BLOG_AUTH_USER, BLOG_AUTH_PASS already exported by paths.sh
 
@@ -1463,6 +1563,7 @@ except Exception as e:
     log_failure("6", "commit_edge", e, traceback.format_exc())
     fail(f"Git commit failed: {e}")
 PYPHASE5
+emit_run_step_event "phase-6" "completed" "diffs_and_git_commit" ""
 
 echo ""
 echo "========================================="
@@ -1478,16 +1579,19 @@ if $ALL_OK && [[ "$REPORT_RESULT" != "fail" ]]; then
     mkdir -p "$HEALTH_OK"
     printf '{"ts":"%s","slug":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SLUG" > "$HEALTH_OK/consolidate.ok"
     ledger_record "pipeline-end" "ok"
+    emit_run_step_event "pipeline" "completed" "pipeline_end" ""
     exit 0
 elif $ALL_OK; then
     echo -e " ${YELLOW}PARTIAL${NC}: Entry OK, report with issues"
     [[ -n "$META_REPORT_PATH" ]] && echo " Meta-report: $META_REPORT_PATH"
     echo "========================================="
     ledger_record "pipeline-end" "partial"
+    emit_run_step_event "pipeline" "failed" "pipeline_end" "partial publication"
     exit 2
 else
     echo -e " ${RED}ISSUES${NC}: verify manually"
     echo "========================================="
     ledger_record "pipeline-end" "fail"
+    emit_run_step_event "pipeline" "failed" "pipeline_end" "verification issues"
     exit 2
 fi

--- a/blog/services.py
+++ b/blog/services.py
@@ -3,22 +3,30 @@
 import json
 import re
 import subprocess
+import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
 
 import markdown
 import yaml
 
-ROOT = Path.home() / "edge"
-STATE_DIR = ROOT / "state"
-THREADS_DIR = ROOT / "threads"
-LOGS_DIR = ROOT / "logs"
-ENTRIES_DIR = ROOT / "blog" / "entries"
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import (  # noqa: E402
+    BRIEFING_FILE,
+    CURADORIA_CANDIDATES_FILE as CURADORIA_CANDIDATES,
+    EDGE_REPO_DIR,
+    ENTRIES_DIR,
+    EXECUTION_LEDGER_FILE as EXECUTION_LEDGER,
+    GIT_SIGNALS_FILE as GIT_SIGNALS,
+    LOGS_DIR,
+    OPS_HOTSPOTS,
+    REPORTS_DIR,
+    STATE_DIR,
+    THREADS_DIR,
+)
 
-OPS_HOTSPOTS = STATE_DIR / "ops-hotspots.json"
-GIT_SIGNALS = STATE_DIR / "git-signals.json"
-CURADORIA_CANDIDATES = STATE_DIR / "curadoria-candidates.json"
-EXECUTION_LEDGER = LOGS_DIR / "execution-ledger.jsonl"
+ROOT = EDGE_REPO_DIR
 
 
 def load_json_safe(path, default=None):
@@ -156,10 +164,6 @@ def get_production_stats():
         "reports_total": total_reports,
         "published_today": published_today,
     }
-
-
-BRIEFING_FILE = ROOT / "briefing.md"
-
 
 def get_briefing_html(max_lines=50):
     """Load first max_lines of briefing.md and render as HTML. Returns None if missing."""
@@ -369,7 +373,7 @@ def load_thread_detail(thread_id):
     # Check which reports exist on disk
     reports = []
     for rf in sorted(reports_set):
-        rpath = ROOT / "reports" / rf
+        rpath = REPORTS_DIR / rf
         reports.append({
             "filename": rf,
             "exists": rpath.exists(),

--- a/config/paths.py
+++ b/config/paths.py
@@ -1,7 +1,12 @@
 """Shared path resolution — single source of truth for all tools.
 
-All Python tools import paths from here instead of hardcoding.
-Resolves edge_dir and memory_project_dir from branding.yaml with auto-detect fallback.
+Genotype and phenotype intentionally have different roots:
+
+- EDGE_REPO_DIR: shared code/runtime root
+- EDGE_STATE_DIR: instance-local mutable state root
+
+During the migration, EDGE_STATE_DIR falls back to EDGE_REPO_DIR so existing
+instances keep working until their runtime env is updated.
 """
 
 import os
@@ -18,15 +23,38 @@ from branding import load_branding
 _branding = load_branding()
 HOME = Path.home()
 
-# --- EDGE_DIR: where the agent repo lives ---
-_edge_dir_cfg = _branding.get("edge_dir", "")
-if _edge_dir_cfg:
-    EDGE_DIR = Path(os.path.expanduser(_edge_dir_cfg))
-elif os.environ.get("EDGE_DIR"):
-    EDGE_DIR = Path(os.environ["EDGE_DIR"])
-else:
-    # Auto-detect: config/ is inside the repo root
-    EDGE_DIR = _CONFIG_DIR.parent
+
+def _expand(value: str | None) -> Path | None:
+    if not value:
+        return None
+    return Path(os.path.expanduser(value))
+
+
+# --- Shared genotype root (repo checkout) ---
+EDGE_REPO_DIR = (
+    _expand(os.environ.get("EDGE_REPO_DIR"))
+    or _expand(_branding.get("edge_dir", ""))
+    or _expand(os.environ.get("EDGE_DIR"))
+    or _CONFIG_DIR.parent
+)
+
+# Legacy alias kept during migration.
+EDGE_DIR = EDGE_REPO_DIR
+
+# --- Instance identity / mutable phenotype root ---
+EDGE_INSTANCE = (
+    os.environ.get("EDGE_INSTANCE")
+    or os.environ.get("EDGE_CODENAME")
+    or _branding.get("codename", "")
+    or _branding.get("skill_prefix", "")
+    or ""
+)
+
+EDGE_STATE_DIR = (
+    _expand(os.environ.get("EDGE_STATE_DIR"))
+    or _expand(_branding.get("edge_state_dir", ""))
+    or EDGE_REPO_DIR
+)
 
 # --- MEMORY_PROJECT_DIR: Claude Code project directory name ---
 _memory_project = _branding.get("memory_project_dir", "")
@@ -46,34 +74,64 @@ MEMORY_PROJECT_DIR = _memory_project
 MEMORY_DIR = HOME / ".claude" / "projects" / MEMORY_PROJECT_DIR / "memory" if MEMORY_PROJECT_DIR else HOME / ".claude" / "memory"
 TOPICS_DIR = MEMORY_DIR / "topics"
 
-# Edge subdirectories
-BLOG_DIR = EDGE_DIR / "blog"
-ENTRIES_DIR = BLOG_DIR / "entries"
-REPORTS_DIR = EDGE_DIR / "reports"
-NOTES_DIR = EDGE_DIR / "notes"
-TOOLS_DIR = EDGE_DIR / "tools"
-LOGS_DIR = EDGE_DIR / "logs"
-THREADS_DIR = EDGE_DIR / "threads"
-SECRETS_DIR = EDGE_DIR / "secrets"
-META_DIR = EDGE_DIR / "meta-reports"
-SNAPSHOT_DIR = EDGE_DIR / "state-snapshots"
-SCRATCHPADS_DIR = EDGE_DIR / "scratchpads"
-STATE_DIR = EDGE_DIR / "state"
+# Genotype subdirectories
+BLOG_DIR = EDGE_REPO_DIR / "blog"
+TOOLS_DIR = EDGE_REPO_DIR / "tools"
+SECRETS_DIR = EDGE_REPO_DIR / "secrets"
+AUTONOMY_DIR = EDGE_REPO_DIR / "autonomy"
+CONFIG_DIR = EDGE_REPO_DIR / "config"
+SEARCH_DIR = EDGE_REPO_DIR / "search"
+
+# Phenotype subdirectories
+BLOG_STATE_DIR = EDGE_STATE_DIR / "blog"
+ENTRIES_DIR = BLOG_STATE_DIR / "entries"
+BLOG_DIFFS_DIR = BLOG_STATE_DIR / "diffs"
+BLOG_COMMENTS_FILE = BLOG_STATE_DIR / "comments.json"
+BLOG_CHANGELOG_FILE = BLOG_STATE_DIR / "changelog.md"
+COMMENTS_FILE = BLOG_COMMENTS_FILE
+DIFFS_DIR = BLOG_DIFFS_DIR
+REPORTS_DIR = EDGE_STATE_DIR / "reports"
+NOTES_DIR = EDGE_STATE_DIR / "notes"
+BUILDS_DIR = EDGE_STATE_DIR / "builds"
+LOGS_DIR = EDGE_STATE_DIR / "logs"
+THREADS_DIR = EDGE_STATE_DIR / "threads"
+HEALTH_DIR = EDGE_STATE_DIR / "health"
+META_DIR = EDGE_STATE_DIR / "meta-reports"
+META_REPORTS_DIR = META_DIR
+SNAPSHOT_DIR = EDGE_STATE_DIR / "state-snapshots"
+SCRATCHPADS_DIR = EDGE_STATE_DIR / "scratchpads"
+STATE_DIR = EDGE_STATE_DIR / "state"
 STATE_EVENTS_DIR = STATE_DIR / "events"
-AUTONOMY_DIR = EDGE_DIR / "autonomy"
-CONFIG_DIR = EDGE_DIR / "config"
-SEARCH_DIR = EDGE_DIR / "search"
+SIGNALS_DIR = STATE_DIR / "signals"
+SEARCH_STATE_DIR = EDGE_STATE_DIR / "search"
+DB_DIR = EDGE_STATE_DIR / "db"
+SEARCH_DB_FILE = SEARCH_STATE_DIR / "edge-memory.db"
+BLOG_FTS_DB_FILE = BLOG_STATE_DIR / "blog_fts.db"
 
 # Specific files
 EVENTS_FILE = LOGS_DIR / "events.jsonl"
 STATE_EVENTS_FILE = STATE_EVENTS_DIR / "log.jsonl"
 LEDGER_FILE = LOGS_DIR / "execution-ledger.jsonl"
-BRIEFING_FILE = EDGE_DIR / "briefing.md"
+EXECUTION_LEDGER_FILE = LEDGER_FILE
+PIPELINE_FAILURES_FILE = LOGS_DIR / "pipeline-failures.jsonl"
+SKILL_STEPS_FILE = LOGS_DIR / "skill-steps.jsonl"
+STATE_LINT_FILE = LOGS_DIR / "state-lint.jsonl"
+YAML_RENDER_FILE = LOGS_DIR / "yaml-render.jsonl"
+BRIEFING_FILE = EDGE_STATE_DIR / "briefing.md"
+GIT_SIGNALS_FILE = STATE_DIR / "git-signals.json"
+CURADORIA_CANDIDATES_FILE = STATE_DIR / "curadoria-candidates.json"
+PROPOSALS_FILE = STATE_DIR / "proposals.json"
+PROCEDURE_CURATION_FILE = STATE_DIR / "procedure-curation.json"
+SOURCE_USAGE_FILE = STATE_DIR / "source-usage.jsonl"
 DEBUGGING_FILE = MEMORY_DIR / "debugging.md"
 INSIGHTS_FILE = MEMORY_DIR / "insights.md"
 BREAKS_ACTIVE = MEMORY_DIR / "breaks-active.md"
 FRONTIER_FILE = AUTONOMY_DIR / "frontier.md"
+AUTONOMY_CAPABILITIES_FILE = AUTONOMY_DIR / "capabilities.md"
 OPS_HOTSPOTS = STATE_DIR / "ops-hotspots.json"
+HEALTH_CURRENT_FILE = HEALTH_DIR / "current.json"
+HEALTH_HISTORY_FILE = HEALTH_DIR / "history.jsonl"
+HEALTH_LAST_SUCCESS_FILE = HEALTH_DIR / "last_success"
 
 # Skills
 SKILLS_DIR = HOME / ".claude" / "skills"

--- a/config/paths.sh
+++ b/config/paths.sh
@@ -2,13 +2,17 @@
 # paths.sh — Shared path resolution for shell scripts.
 # Source this from any script: source "$(dirname "$0")/../config/paths.sh"
 
-# --- EDGE_DIR: derive from this script's location (repo root) ---
-if [ -z "${EDGE_DIR:-}" ]; then
-  EDGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-fi
+set -u
 
-# --- Load branding.yaml ---
-BRANDING_FILE="$EDGE_DIR/config/branding.yaml"
+_PATHS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_PATHS_REPO_DEFAULT="$(cd "${_PATHS_SCRIPT_DIR}/.." && pwd)"
+
+# --- Shared genotype root (repo checkout) ---
+EDGE_REPO_DIR="${EDGE_REPO_DIR:-${EDGE_DIR:-${_PATHS_REPO_DEFAULT}}}"
+EDGE_DIR="$EDGE_REPO_DIR"   # Legacy alias kept during migration.
+
+# --- Load branding.yaml from genotype root ---
+BRANDING_FILE="$EDGE_REPO_DIR/config/branding.yaml"
 if [ -f "$BRANDING_FILE" ]; then
   BLOG_PORT=$(grep '^  port:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}')
   BLOG_AUTH_ENABLED=$(grep '^  auth_enabled:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}')
@@ -16,6 +20,8 @@ if [ -f "$BRANDING_FILE" ]; then
   BLOG_AUTH_PASS=$(grep '^  auth_pass:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
   MEMORY_PROJECT_DIR=$(grep '^memory_project_dir:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
   SKILL_PREFIX=$(grep '^skill_prefix:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
+  EDGE_INSTANCE_FROM_BRANDING=$(grep '^codename:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
+  EDGE_STATE_DIR_FROM_BRANDING=$(grep '^edge_state_dir:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
 else
   BLOG_PORT=8766
   BLOG_AUTH_ENABLED=false
@@ -23,7 +29,13 @@ else
   BLOG_AUTH_PASS=""
   MEMORY_PROJECT_DIR=""
   SKILL_PREFIX="agent"
+  EDGE_INSTANCE_FROM_BRANDING=""
+  EDGE_STATE_DIR_FROM_BRANDING=""
 fi
+
+EDGE_INSTANCE="${EDGE_INSTANCE:-${EDGE_CODENAME:-${EDGE_INSTANCE_FROM_BRANDING:-}}}"
+EDGE_STATE_DIR="${EDGE_STATE_DIR:-${EDGE_STATE_DIR_FROM_BRANDING:-${EDGE_REPO_DIR}}}"
+EDGE_HOME="$EDGE_STATE_DIR"  # Legacy mutable-root alias used by some tools.
 
 # Defaults
 BLOG_PORT=${BLOG_PORT:-8766}
@@ -46,15 +58,64 @@ else
   PROJECT_DIR="$HOME/.claude/projects/${_first_proj}"
 fi
 
-# Export key variables for embedded Python heredocs
-export EDGE_DIR MEMORY_BASE MEMORY_PROJECT_DIR BLOG_URL PROJECT_DIR BLOG_AUTH_USER BLOG_AUTH_PASS BLOG_AUTH_ENABLED BLOG_PORT
+# --- Genotype paths ---
+BLOG_DIR="$EDGE_REPO_DIR/blog"
+TOOLS_DIR="$EDGE_REPO_DIR/tools"
+SECRETS_DIR="$EDGE_REPO_DIR/secrets"
+CONFIG_DIR="$EDGE_REPO_DIR/config"
+SEARCH_DIR="$EDGE_REPO_DIR/search"
+AUTONOMY_DIR="$EDGE_REPO_DIR/autonomy"
 
-# --- Derived paths ---
-BLOG_DIR="$EDGE_DIR/blog"
-ENTRIES_DIR="$BLOG_DIR/entries"
-REPORTS_DIR="$EDGE_DIR/reports"
-NOTES_DIR="$EDGE_DIR/notes"
-TOOLS_DIR="$EDGE_DIR/tools"
-LOGS_DIR="$EDGE_DIR/logs"
-THREADS_DIR="$EDGE_DIR/threads"
-SECRETS_DIR="$EDGE_DIR/secrets"
+# --- Phenotype paths ---
+BLOG_STATE_DIR="$EDGE_STATE_DIR/blog"
+ENTRIES_DIR="$BLOG_STATE_DIR/entries"
+BLOG_DIFFS_DIR="$BLOG_STATE_DIR/diffs"
+COMMENTS_FILE="$BLOG_STATE_DIR/comments.json"
+BLOG_CHANGELOG_FILE="$BLOG_STATE_DIR/changelog.md"
+REPORTS_DIR="$EDGE_STATE_DIR/reports"
+NOTES_DIR="$EDGE_STATE_DIR/notes"
+BUILDS_DIR="$EDGE_STATE_DIR/builds"
+LOGS_DIR="$EDGE_STATE_DIR/logs"
+THREADS_DIR="$EDGE_STATE_DIR/threads"
+HEALTH_DIR="$EDGE_STATE_DIR/health"
+META_DIR="$EDGE_STATE_DIR/meta-reports"
+SNAPSHOT_DIR="$EDGE_STATE_DIR/state-snapshots"
+SCRATCHPADS_DIR="$EDGE_STATE_DIR/scratchpads"
+STATE_DIR="$EDGE_STATE_DIR/state"
+STATE_EVENTS_DIR="$STATE_DIR/events"
+SIGNALS_DIR="$STATE_DIR/signals"
+SEARCH_STATE_DIR="$EDGE_STATE_DIR/search"
+DB_DIR="$EDGE_STATE_DIR/db"
+SEARCH_DB_FILE="$SEARCH_STATE_DIR/edge-memory.db"
+BLOG_FTS_DB_FILE="$BLOG_STATE_DIR/blog_fts.db"
+BRIEFING_FILE="$EDGE_STATE_DIR/briefing.md"
+EVENTS_FILE="$LOGS_DIR/events.jsonl"
+GIT_SIGNALS_FILE="$STATE_DIR/git-signals.json"
+CURADORIA_CANDIDATES_FILE="$STATE_DIR/curadoria-candidates.json"
+PROPOSALS_FILE="$STATE_DIR/proposals.json"
+PROCEDURE_CURATION_FILE="$STATE_DIR/procedure-curation.json"
+SOURCE_USAGE_FILE="$STATE_DIR/source-usage.jsonl"
+OPS_HOTSPOTS="$STATE_DIR/ops-hotspots.json"
+EXECUTION_LEDGER_FILE="$LOGS_DIR/execution-ledger.jsonl"
+PIPELINE_FAILURES_FILE="$LOGS_DIR/pipeline-failures.jsonl"
+SKILL_STEPS_FILE="$LOGS_DIR/skill-steps.jsonl"
+STATE_LINT_FILE="$LOGS_DIR/state-lint.jsonl"
+YAML_RENDER_FILE="$LOGS_DIR/yaml-render.jsonl"
+HEALTH_CURRENT_FILE="$HEALTH_DIR/current.json"
+HEALTH_HISTORY_FILE="$HEALTH_DIR/history.jsonl"
+HEALTH_LAST_SUCCESS_FILE="$HEALTH_DIR/last_success"
+AUTONOMY_CAPABILITIES_FILE="$AUTONOMY_DIR/capabilities.md"
+AUTONOMY_FRONTIER_FILE="$AUTONOMY_DIR/frontier.md"
+
+# Export key variables for shell + embedded Python heredocs
+export \
+  EDGE_REPO_DIR EDGE_DIR EDGE_STATE_DIR EDGE_HOME EDGE_INSTANCE MEMORY_BASE MEMORY_PROJECT_DIR PROJECT_DIR \
+  BLOG_URL BLOG_AUTH_USER BLOG_AUTH_PASS BLOG_AUTH_ENABLED BLOG_PORT SKILL_PREFIX CURL_AUTH \
+  BLOG_DIR TOOLS_DIR SECRETS_DIR CONFIG_DIR SEARCH_DIR AUTONOMY_DIR \
+  BLOG_STATE_DIR ENTRIES_DIR BLOG_DIFFS_DIR COMMENTS_FILE BLOG_CHANGELOG_FILE REPORTS_DIR NOTES_DIR LOGS_DIR THREADS_DIR \
+  BUILDS_DIR HEALTH_DIR META_DIR SNAPSHOT_DIR SCRATCHPADS_DIR STATE_DIR STATE_EVENTS_DIR SIGNALS_DIR \
+  SEARCH_STATE_DIR DB_DIR SEARCH_DB_FILE BLOG_FTS_DB_FILE BRIEFING_FILE EVENTS_FILE GIT_SIGNALS_FILE \
+  CURADORIA_CANDIDATES_FILE PROPOSALS_FILE PROCEDURE_CURATION_FILE SOURCE_USAGE_FILE OPS_HOTSPOTS \
+  EXECUTION_LEDGER_FILE PIPELINE_FAILURES_FILE SKILL_STEPS_FILE STATE_LINT_FILE YAML_RENDER_FILE \
+  HEALTH_CURRENT_FILE HEALTH_HISTORY_FILE HEALTH_LAST_SUCCESS_FILE AUTONOMY_CAPABILITIES_FILE \
+  AUTONOMY_FRONTIER_FILE

--- a/search/db.py
+++ b/search/db.py
@@ -2,20 +2,91 @@
 
 import sqlite3
 import sys
+import time
 from pathlib import Path
 
 import sqlite_vec
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+sys.path.insert(0, str(SCRIPT_DIR.parent / "tools"))
 from paths import SEARCH_DB_FILE  # noqa: E402
+
+try:
+    from _shared.telemetry import log_db_query
+except Exception:
+    log_db_query = None
 
 DB_PATH = SEARCH_DB_FILE
 EMBEDDING_DIM = 1536  # text-embedding-3-small
 
 
+class TelemetryConnection(sqlite3.Connection):
+    """sqlite connection that passively emits telemetry for reads/writes."""
+
+    def _log_sql(
+        self,
+        statement: str,
+        started_at: float,
+        *,
+        ok: bool,
+        rowcount: int | None = None,
+        batch_size: int | None = None,
+        error: str | None = None,
+    ) -> None:
+        if log_db_query is None:
+            return
+        log_db_query(
+            db_name=Path(getattr(self, "_edge_db_path", "db")).name,
+            statement=statement,
+            latency_ms=int((time.monotonic() - started_at) * 1000),
+            ok=ok,
+            rows=rowcount,
+            batch_size=batch_size,
+            error=error,
+            caller="search.db",
+        )
+
+    def execute(self, sql, parameters=(), /):
+        started_at = time.monotonic()
+        try:
+            cur = super().execute(sql, parameters)
+            self._log_sql(sql, started_at, ok=True, rowcount=cur.rowcount)
+            return cur
+        except Exception as exc:
+            self._log_sql(sql, started_at, ok=False, error=str(exc))
+            raise
+
+    def executemany(self, sql, seq_of_parameters, /):
+        started_at = time.monotonic()
+        batch_size = None
+        try:
+            if hasattr(seq_of_parameters, "__len__"):
+                batch_size = len(seq_of_parameters)
+        except Exception:
+            batch_size = None
+        try:
+            cur = super().executemany(sql, seq_of_parameters)
+            self._log_sql(sql, started_at, ok=True, rowcount=cur.rowcount, batch_size=batch_size)
+            return cur
+        except Exception as exc:
+            self._log_sql(sql, started_at, ok=False, batch_size=batch_size, error=str(exc))
+            raise
+
+    def executescript(self, sql_script, /):
+        started_at = time.monotonic()
+        try:
+            cur = super().executescript(sql_script)
+            self._log_sql(sql_script, started_at, ok=True)
+            return cur
+        except Exception as exc:
+            self._log_sql(sql_script, started_at, ok=False, error=str(exc))
+            raise
+
+
 def get_connection(db_path: Path = DB_PATH) -> sqlite3.Connection:
-    conn = sqlite3.connect(str(db_path))
+    conn = sqlite3.connect(str(db_path), factory=TelemetryConnection)
+    conn._edge_db_path = str(db_path)
     conn.enable_load_extension(True)
     sqlite_vec.load(conn)
     conn.enable_load_extension(False)

--- a/search/db.py
+++ b/search/db.py
@@ -1,11 +1,16 @@
 """Database schema and connection for edge-memory."""
 
 import sqlite3
+import sys
 from pathlib import Path
 
 import sqlite_vec
 
-DB_PATH = Path(__file__).parent / "edge-memory.db"
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import SEARCH_DB_FILE  # noqa: E402
+
+DB_PATH = SEARCH_DB_FILE
 EMBEDDING_DIM = 1536  # text-embedding-3-small
 
 

--- a/search/search.py
+++ b/search/search.py
@@ -8,11 +8,19 @@ from pathlib import Path
 
 import yaml
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import EDGE_STATE_DIR, NOTES_DIR  # noqa: E402
+
 from db import EMBEDDING_DIM, ensure_db
 from embed import embed_text
 
-EDGE_HOME = Path.home() / "edge"
-NOTES_DIR = EDGE_HOME / "notes"
+
+def _resolve_state_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return EDGE_STATE_DIR / path
 
 
 def _parse_frontmatter_note(filepath: Path) -> str | None:
@@ -35,7 +43,7 @@ def _enrich_with_notes(results: list[dict]) -> list[dict]:
 
     For each result where type == "blog", reads the entry file, parses its
     frontmatter for a ``note:`` field, and if present reads the note file
-    from ~/edge/notes/{note_filename}.  Adds ``note_path`` (str) and
+    from the instance-local notes root. Adds ``note_path`` (str) and
     ``note_content`` (first 2000 chars) to the result dict.
 
     Fault-tolerant: any failure is silently skipped.
@@ -44,7 +52,7 @@ def _enrich_with_notes(results: list[dict]) -> list[dict]:
         if result.get("type") != "blog":
             continue
         try:
-            entry_path = EDGE_HOME / result["path"]
+            entry_path = _resolve_state_path(result["path"])
             note_filename = _parse_frontmatter_note(entry_path)
             if not note_filename:
                 continue

--- a/search/search.py
+++ b/search/search.py
@@ -4,23 +4,30 @@ import json
 import re
 import struct
 import sys
+import uuid
 from pathlib import Path
 
 import yaml
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+sys.path.insert(0, str(SCRIPT_DIR.parent / "tools"))
 from paths import EDGE_STATE_DIR, NOTES_DIR  # noqa: E402
 
 from db import EMBEDDING_DIM, ensure_db
 from embed import embed_text
-
 
 def _resolve_state_path(raw_path: str) -> Path:
     path = Path(raw_path)
     if path.is_absolute():
         return path
     return EDGE_STATE_DIR / path
+
+try:
+    from _shared.telemetry import log_run_step, log_search_query
+except Exception:
+    log_run_step = None
+    log_search_query = None
 
 
 def _parse_frontmatter_note(filepath: Path) -> str | None:
@@ -459,35 +466,89 @@ def main():
 
     conn = ensure_db()
     workflows = []
+    run_id = f"search:{uuid.uuid4().hex[:8]}"
 
-    if args.fts:
-        results = fts_search(query, limit=args.k, doc_type=args.doc_type, conn=conn)
-        mode = "fts"
-    elif args.semantic:
-        query_embedding = embed_text(query)
-        results = vec_search(
-            query_embedding, limit=args.k, doc_type=args.doc_type, conn=conn
+    if log_run_step is not None:
+        log_run_step(
+            "edge-search",
+            "query",
+            "started",
+            run_id=run_id,
+            query_norm=re.sub(r"\s+", " ", query.lower()).strip()[:160],
+            doc_type=args.doc_type or "",
         )
-        mode = "semantic"
-    elif not args.no_sidecar and args.doc_type != "workflow":
-        results, workflows = search_with_sidecar(
-            query, limit=args.k, doc_type=args.doc_type, conn=conn
-        )
-        mode = "hybrid"
-    else:
-        results = hybrid_search(
-            query, limit=args.k, doc_type=args.doc_type, conn=conn
-        )
-        mode = "hybrid"
 
-    print(format_results(results, mode, workflows=workflows))
+    try:
+        if args.fts:
+            results = fts_search(query, limit=args.k, doc_type=args.doc_type, conn=conn)
+            mode = "fts"
+        elif args.semantic:
+            query_embedding = embed_text(query)
+            results = vec_search(
+                query_embedding, limit=args.k, doc_type=args.doc_type, conn=conn
+            )
+            mode = "semantic"
+        elif not args.no_sidecar and args.doc_type != "workflow":
+            results, workflows = search_with_sidecar(
+                query, limit=args.k, doc_type=args.doc_type, conn=conn
+            )
+            mode = "hybrid"
+        else:
+            results = hybrid_search(
+                query, limit=args.k, doc_type=args.doc_type, conn=conn
+            )
+            mode = "hybrid"
 
-    # Log telemetry (includes workflow hits)
-    all_results = results + workflows
-    if not args.no_telemetry and all_results:
-        log_search_telemetry(query, all_results, conn=conn)
+        print(format_results(results, mode, workflows=workflows))
 
-    conn.close()
+        all_results = results + workflows
+        if not args.no_telemetry and all_results:
+            log_search_telemetry(query, all_results, conn=conn)
+
+        if log_search_query is not None:
+            log_search_query(
+                query,
+                mode=mode,
+                status="completed",
+                result_count=len(results),
+                workflow_count=len(workflows),
+                doc_type=args.doc_type,
+                run_id=run_id,
+                no_sidecar=bool(args.no_sidecar),
+            )
+        if log_run_step is not None:
+            log_run_step(
+                "edge-search",
+                "query",
+                "completed",
+                run_id=run_id,
+                mode=mode,
+                result_count=len(results),
+                workflow_count=len(workflows),
+            )
+    except Exception as exc:
+        if log_search_query is not None:
+            log_search_query(
+                query,
+                mode="unknown",
+                status="failed",
+                result_count=0,
+                workflow_count=0,
+                doc_type=args.doc_type,
+                run_id=run_id,
+                error=str(exc),
+            )
+        if log_run_step is not None:
+            log_run_step(
+                "edge-search",
+                "query",
+                "failed",
+                run_id=run_id,
+                error=str(exc),
+            )
+        raise
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/tools/_shared/telemetry.py
+++ b/tools/_shared/telemetry.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sqlite3
 import sys
 import time
@@ -140,7 +141,11 @@ def emit_shadow_event(
 
 def log_event(event_type: str, **fields: Any) -> None:
     """Append a typed event to events.jsonl. Always includes ts + type."""
-    event = {"ts": datetime.now(timezone.utc).isoformat(), "type": event_type}
+    event = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "type": event_type,
+        "actor": fields.pop("actor", current_actor()),
+    }
     event.update(fields)
     _append_event(event)
     emit_shadow_event(
@@ -181,12 +186,183 @@ def log_llm_call(
     )
 
 
+def log_run_step(
+    run_kind: str,
+    phase: str,
+    status: str,
+    *,
+    run_id: str | None = None,
+    **extra: Any,
+) -> None:
+    """Generic lifecycle event for deterministic runs and pipeline phases."""
+    extra.setdefault("skill", current_skill())
+    extra.setdefault("beat", current_beat())
+    log_event(
+        "run_step",
+        run_kind=run_kind,
+        phase=phase,
+        status=status,
+        run_id=run_id or current_cycle_id(),
+        **extra,
+    )
+
+
+def log_search_query(
+    query: str,
+    *,
+    mode: str,
+    status: str,
+    result_count: int = 0,
+    workflow_count: int = 0,
+    doc_type: str | None = None,
+    **extra: Any,
+) -> None:
+    """Structured search/workflow-recall event."""
+    query_norm = re.sub(r"\s+", " ", query.lower()).strip()
+    extra.setdefault("skill", current_skill())
+    extra.setdefault("beat", current_beat())
+    log_event(
+        "search_query",
+        query_norm=query_norm[:160],
+        query_len=len(query.strip()),
+        mode=mode,
+        status=status,
+        result_count=result_count,
+        workflow_count=workflow_count,
+        doc_type=doc_type or "",
+        **extra,
+    )
+
+
+def log_source_query(
+    query: str,
+    *,
+    intent: str,
+    status: str,
+    sources: list[str],
+    total_results: int = 0,
+    ok_sources: int = 0,
+    failed_sources: int = 0,
+    wildcard_source: str | None = None,
+    **extra: Any,
+) -> None:
+    """Structured edge-sources query event."""
+    query_norm = re.sub(r"\s+", " ", query.lower()).strip()
+    extra.setdefault("skill", current_skill())
+    extra.setdefault("beat", current_beat())
+    log_event(
+        "source_query",
+        query_norm=query_norm[:160],
+        query_len=len(query.strip()),
+        intent=intent,
+        status=status,
+        sources=sources,
+        source_count=len(sources),
+        total_results=total_results,
+        ok_sources=ok_sources,
+        failed_sources=failed_sources,
+        wildcard_source=wildcard_source,
+        **extra,
+    )
+
+
 def _detect_caller() -> str:
     """Best-effort caller detection from sys.argv[0]."""
     try:
         return Path(sys.argv[0]).name
     except Exception:
         return "unknown"
+
+
+def _classify_sql(statement: str) -> dict[str, Any]:
+    """Classify SQL into a compact, low-cardinality telemetry shape."""
+    cleaned = re.sub(r"\s+", " ", (statement or "").strip())
+    if not cleaned:
+        return {"should_log": False}
+
+    upper = cleaned.upper()
+    op = upper.split(" ", 1)[0]
+    write = False
+
+    if op == "WITH":
+        if " INSERT INTO " in upper:
+            op = "INSERT"
+            write = True
+        elif " UPDATE " in upper:
+            op = "UPDATE"
+            write = True
+        elif " DELETE FROM " in upper:
+            op = "DELETE"
+            write = True
+        elif " REPLACE INTO " in upper:
+            op = "REPLACE"
+            write = True
+        else:
+            op = "SELECT"
+    elif op in {"INSERT", "UPDATE", "DELETE", "REPLACE"}:
+        write = True
+    elif op != "SELECT":
+        return {"should_log": False}
+
+    table = ""
+    patterns = {
+        "SELECT": r"\bFROM\s+([A-Za-z_][\w.]*)",
+        "INSERT": r"\bINTO\s+([A-Za-z_][\w.]*)",
+        "REPLACE": r"\bINTO\s+([A-Za-z_][\w.]*)",
+        "UPDATE": r"\bUPDATE\s+([A-Za-z_][\w.]*)",
+        "DELETE": r"\bFROM\s+([A-Za-z_][\w.]*)",
+    }
+    pattern = patterns.get(op)
+    if pattern:
+        match = re.search(pattern, cleaned, flags=re.IGNORECASE)
+        if match:
+            table = match.group(1)
+
+    return {
+        "should_log": True,
+        "op": op,
+        "table": table,
+        "write": write,
+        "statement": cleaned[:160],
+    }
+
+
+def log_db_query(
+    *,
+    db_name: str,
+    statement: str,
+    latency_ms: int,
+    ok: bool = True,
+    rows: int | None = None,
+    batch_size: int | None = None,
+    error: str | None = None,
+    caller: str | None = None,
+    **extra: Any,
+) -> None:
+    """Telemetry for DB reads/writes. Ignores non-query/non-DML statements."""
+    meta = _classify_sql(statement)
+    if not meta.get("should_log"):
+        return
+    extra.setdefault("skill", current_skill())
+    extra.setdefault("beat", current_beat())
+    event = {
+        "db": db_name,
+        "op": meta["op"],
+        "table": meta["table"],
+        "write": meta["write"],
+        "latency_ms": latency_ms,
+        "ok": ok,
+        "statement": meta["statement"],
+        "caller": caller or _detect_caller(),
+    }
+    if rows is not None and rows >= 0:
+        event["rows"] = rows
+    if batch_size is not None:
+        event["batch_size"] = batch_size
+    if error:
+        event["error"] = error[:240]
+    event.update(extra)
+    log_event("db_query", **event)
 
 
 def _ensure_telemetry_table(conn: sqlite3.Connection) -> None:
@@ -221,6 +397,16 @@ def log_primitive_call(
     swallowed — telemetry never breaks the primitive.
     """
     try:
+        log_event(
+            "primitive_call",
+            source=source,
+            ok=ok,
+            latency_ms=int(latency_ms),
+            cost_usd=float(cost_usd),
+            notes=notes or {},
+            skill=current_skill(),
+            beat=current_beat(),
+        )
         if not DB_PATH.exists():
             return
         conn = sqlite3.connect(str(DB_PATH), timeout=2.0)

--- a/tools/_shared/telemetry.py
+++ b/tools/_shared/telemetry.py
@@ -25,9 +25,9 @@ from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "config"))
-from paths import EVENTS_FILE, SEARCH_DIR, STATE_EVENTS_FILE  # noqa: E402
+from paths import EVENTS_FILE, SEARCH_DB_FILE, STATE_EVENTS_FILE  # noqa: E402
 
-DB_PATH = SEARCH_DIR / "edge-memory.db"
+DB_PATH = SEARCH_DB_FILE
 _LAST_SHADOW_HASH: str | None = None
 
 # --- Price table (USD per 1M tokens). Missing models map to 0 cost rather than

--- a/tools/edge-consult.py
+++ b/tools/edge-consult.py
@@ -22,6 +22,7 @@ import json
 import os
 import subprocess
 import sys
+import uuid
 from datetime import datetime
 from pathlib import Path
 
@@ -30,6 +31,7 @@ sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 sys.path.insert(0, str(SCRIPT_DIR))
 from paths import SECRETS_DIR, LOGS_DIR  # noqa: E402  (kept for downstream consumers)
 from _shared.router_client import make_client  # noqa: E402
+from _shared.telemetry import log_run_step  # noqa: E402
 
 LOG_DIR = LOGS_DIR / "consult"
 
@@ -379,8 +381,19 @@ def consult(question: str, mode: str = "adversarial", context_files: list = None
     """
     import time
     started = time.time()
+    run_id = f"consult:{uuid.uuid4().hex[:8]}"
 
     system = ADVERSARIAL_SYSTEM if mode == "adversarial" else COLLABORATIVE_SYSTEM
+    log_run_step(
+        "edge-consult",
+        "consult",
+        "started",
+        run_id=run_id,
+        mode=mode,
+        context_files=len(context_files or []),
+        stdin=bool(stdin_content),
+        gate_spec=bool(gate_spec),
+    )
 
     _progress(f"Building prompt (question={len(question)} chars, "
               f"context_files={len(context_files or [])}, "
@@ -491,6 +504,19 @@ def consult(question: str, mode: str = "adversarial", context_files: list = None
     # Combine outputs from both models
     combined = "\n\n".join(
         f"── {m} ──\n{text}" for m, text in results
+    )
+    ok_attempts = sum(1 for a in attempts if a["status"] == "ok")
+    failed_attempts = sum(1 for a in attempts if a["status"] == "error")
+    final_status = "completed" if ok_attempts else "failed"
+    log_run_step(
+        "edge-consult",
+        "consult",
+        final_status,
+        run_id=run_id,
+        mode=mode,
+        ok_attempts=ok_attempts,
+        failed_attempts=failed_attempts,
+        fallback_used=bool(fallback_used),
     )
 
     # Gate: save combined review alongside YAML spec

--- a/tools/edge-crystallize
+++ b/tools/edge-crystallize
@@ -25,10 +25,12 @@ from pathlib import Path
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPT_DIR.parent / "tools"))
+sys.path.insert(0, str(_SCRIPT_DIR.parent / "config"))
 try:
     from _shared.telemetry import log_workflow_transition
 except Exception:
     def log_workflow_transition(*a, **kw): pass
+from paths import ENTRIES_DIR, PROCEDURE_CURATION_FILE  # noqa: E402
 
 
 def slugify(text):
@@ -50,9 +52,9 @@ def index_entry(filepath):
         pass
 
 
-def create_from_operator(directive, edge, dry_run=False):
+def create_from_operator(directive, dry_run=False):
     """Create an approved workflow directly from an operator directive."""
-    entries_dir = edge / "blog" / "entries"
+    entries_dir = ENTRIES_DIR
     entries_dir.mkdir(parents=True, exist_ok=True)
     today = datetime.now().strftime("%Y-%m-%d")
 
@@ -100,10 +102,10 @@ def create_from_operator(directive, edge, dry_run=False):
     return 1
 
 
-def create_from_curation(args, edge):
+def create_from_curation(args):
     """Create workflow-draft entries from procedure-curation.json candidates."""
-    curation_file = edge / "state" / "procedure-curation.json"
-    entries_dir = edge / "blog" / "entries"
+    curation_file = PROCEDURE_CURATION_FILE
+    entries_dir = ENTRIES_DIR
     entries_dir.mkdir(parents=True, exist_ok=True)
     today = datetime.now().strftime("%Y-%m-%d")
 
@@ -241,15 +243,13 @@ def main():
                         help="Create approved workflow from operator instruction (skips draft)")
     args = parser.parse_args()
 
-    edge = Path(os.environ.get("EDGE_DIR", Path.home() / "edge"))
-
     if args.from_operator:
-        n = create_from_operator(args.from_operator, edge, args.dry_run)
+        n = create_from_operator(args.from_operator, args.dry_run)
         if n and not args.dry_run:
             print(f"\nWorkflow created with tag 'workflow' (approved — operator authority).")
             print("Enters edge-search recall immediately.")
     else:
-        create_from_curation(args, edge)
+        create_from_curation(args)
 
 
 if __name__ == "__main__":

--- a/tools/edge-digest
+++ b/tools/edge-digest
@@ -20,16 +20,28 @@ import yaml
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-HOME = Path.home()
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import (EVENTS_FILE, THREADS_DIR, ENTRIES_DIR as BLOG_DIR,
-                   LOGS_DIR, DEBUGGING_FILE as DEBUG_FILE,
+                   LOGS_DIR, STATE_DIR, DEBUGGING_FILE as DEBUG_FILE,
                    INSIGHTS_FILE, BRIEFING_FILE as OUTPUT_FILE)
 HEARTBEAT_LOG = LOGS_DIR / f"heartbeat-{datetime.now().strftime('%Y-%m-%d')}.log"
+OBSERVABILITY_FILE = STATE_DIR / "observability-rollup.json"
 
 TODAY = datetime.now().strftime("%Y-%m-%d")
 NOW = datetime.now().strftime("%H:%M")
+
+
+def refresh_rollups():
+    """Refresh deterministic rollups used by the briefing."""
+    rollups = [
+        SCRIPT_DIR / "rollup-observability.py",
+    ]
+    for rollup in rollups:
+        try:
+            subprocess.run([sys.executable, str(rollup)], check=False, capture_output=True, text=True)
+        except Exception:
+            continue
 
 
 def read_threads():
@@ -158,8 +170,19 @@ def count_blog_entries():
     return total, with_claims
 
 
+def read_observability():
+    """Read consolidated observability rollup if present."""
+    if not OBSERVABILITY_FILE.exists():
+        return {}
+    try:
+        return json.loads(OBSERVABILITY_FILE.read_text())
+    except Exception:
+        return {}
+
+
 def generate_briefing():
     """Gera o briefing completo."""
+    refresh_rollups()
     threads = read_threads()
     events = read_events(20)
     open_claims = read_open_claims()
@@ -167,6 +190,7 @@ def generate_briefing():
     errors = read_open_errors()
     insights = read_unread_insights()
     total_entries, entries_with_claims = count_blog_entries()
+    observability = read_observability()
 
     lines = []
     lines.append(f"# Briefing — {TODAY} {NOW}")
@@ -263,6 +287,41 @@ def generate_briefing():
     lines.append(f"- Gaps abertos: {len(open_claims)}")
     lines.append(f"- Erros ativos: {len(errors)}")
     lines.append("")
+
+    if observability:
+        backlog = observability.get("backlog", {})
+        freshness = observability.get("freshness_by_actor", {})
+        stale = [
+            f"{actor} ({data.get('age_minutes', 0)}m)"
+            for actor, data in freshness.items()
+            if float(data.get("age_minutes", 0)) >= 180
+        ][:5]
+        publish = observability.get("blog_publish_failures", {}).get("by_class", {})
+        lifecycle = observability.get("lifecycle", {})
+        failed_steps = []
+        for run_kind, phases in lifecycle.items():
+            for phase, statuses in phases.items():
+                failed = int(statuses.get("failed", 0))
+                if failed:
+                    failed_steps.append((failed, run_kind, phase))
+        failed_steps.sort(reverse=True)
+
+        lines.append("## Observability")
+        lines.append(
+            f"- Backlog: {backlog.get('active_threads', 0)} threads ativos, "
+            f"{backlog.get('waiting_threads', 0)} waiting, "
+            f"{backlog.get('resurface_due', 0)} resurface vencidos, "
+            f"{backlog.get('open_claims', 0)} claims abertas"
+        )
+        if stale:
+            lines.append(f"- Atores stale: {', '.join(stale)}")
+        if publish:
+            top_publish = ", ".join(f"{k}:{v}" for k, v in list(publish.items())[:4])
+            lines.append(f"- blog_publish classes: {top_publish}")
+        if failed_steps:
+            top_failed = ", ".join(f"{rk}/{ph}:{n}" for n, rk, ph in failed_steps[:4])
+            lines.append(f"- Lifecycle failures: {top_failed}")
+        lines.append("")
 
     return "\n".join(lines)
 

--- a/tools/edge-meta-report
+++ b/tools/edge-meta-report
@@ -23,11 +23,22 @@ import yaml
 from datetime import datetime
 from pathlib import Path
 
-HOME = Path.home()
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import (META_DIR, SCRATCHPADS_DIR as SCRATCHPADS_ARCHIVE,
-                   EDGE_DIR, TOOLS_DIR, MEMORY_DIR, SKILLS_DIR, NOTES_DIR)
+from paths import (  # noqa: E402
+    BRIEFING_FILE,
+    EDGE_REPO_DIR,
+    EDGE_STATE_DIR,
+    ENTRIES_DIR,
+    EVENTS_FILE,
+    MEMORY_DIR,
+    META_DIR,
+    NOTES_DIR,
+    SCRATCHPADS_DIR as SCRATCHPADS_ARCHIVE,
+    SKILLS_DIR,
+    THREADS_DIR,
+    TOOLS_DIR,
+)
 CONSULT_SCRIPT = TOOLS_DIR / "edge-consult.py"
 
 TRACKED_REPOS = {
@@ -75,11 +86,11 @@ def capture_diffs_preview():
     # Edge repo
     result = subprocess.run(
         ["git", "diff", "HEAD", "--stat"],
-        cwd=str(EDGE_DIR), capture_output=True, text=True
+        cwd=str(EDGE_REPO_DIR), capture_output=True, text=True
     )
     result2 = subprocess.run(
         ["git", "status", "--short"],
-        cwd=str(EDGE_DIR), capture_output=True, text=True
+        cwd=str(EDGE_REPO_DIR), capture_output=True, text=True
     )
     stat = result.stdout.strip()
     status = result2.stdout.strip()
@@ -290,10 +301,9 @@ def capture_post_state_changes(slug, entry_path):
 
     # ── Threads touched ──
     if threads:
-        threads_dir = HOME / "edge" / "threads"
         lines.append(f"### Threads tocados ({len(threads)})")
         for tid in threads:
-            tfile = threads_dir / f"{tid}.md"
+            tfile = THREADS_DIR / f"{tid}.md"
             if tfile.exists():
                 # Read status and title
                 content = tfile.read_text()
@@ -310,10 +320,9 @@ def capture_post_state_changes(slug, entry_path):
         lines.append("")
 
     # ── Event logged ──
-    events_file = HOME / "edge" / "logs" / "events.jsonl"
-    if events_file.exists():
+    if EVENTS_FILE.exists():
         slug_artifact = f"blog/entries/{slug}.md"
-        for raw_line in reversed(events_file.read_text().splitlines()[-20:]):
+        for raw_line in reversed(EVENTS_FILE.read_text().splitlines()[-20:]):
             try:
                 evt = json.loads(raw_line)
                 if slug_artifact in evt.get("artifacts", []):
@@ -350,31 +359,39 @@ def capture_post_state_changes(slug, entry_path):
             lines.append("```")
 
     # Edge repo state files specifically
-    state_files = ["briefing.md", "threads/", "logs/events.jsonl"]
-    result = subprocess.run(
-        ["git", "diff", "HEAD", "--stat", "--", *state_files],
-        cwd=str(EDGE_DIR), capture_output=True, text=True
-    )
-    if result.stdout.strip():
-        found_diffs = True
-        lines.append("**edge/ (state files)**")
-        lines.append("```")
-        lines.append(result.stdout.strip())
-        lines.append("```")
+    state_git_root = None
+    if EDGE_STATE_DIR == EDGE_REPO_DIR:
+        state_git_root = EDGE_REPO_DIR
+    elif (EDGE_STATE_DIR / ".git").is_dir():
+        state_git_root = EDGE_STATE_DIR
+
+    if state_git_root is not None:
+        state_files = ["briefing.md", "threads/", "logs/events.jsonl"]
+        result = subprocess.run(
+            ["git", "diff", "HEAD", "--stat", "--", *state_files],
+            cwd=str(state_git_root), capture_output=True, text=True
+        )
+        if result.stdout.strip():
+            found_diffs = True
+            lines.append("**state/ (git-backed)**")
+            lines.append("```")
+            lines.append(result.stdout.strip())
+            lines.append("```")
+    else:
+        lines.append("*State root is outside git; showing only filesystem checks above.*")
 
     if not found_diffs:
         lines.append("*Nenhuma mudança detectada nos arquivos de estado.*")
     lines.append("")
 
     # ── Briefing updated? ──
-    briefing = HOME / "edge" / "briefing.md"
-    if briefing.exists():
-        mtime = datetime.fromtimestamp(briefing.stat().st_mtime)
+    if BRIEFING_FILE.exists():
+        mtime = datetime.fromtimestamp(BRIEFING_FILE.stat().st_mtime)
         age_seconds = (datetime.now() - mtime).total_seconds()
         if age_seconds < 120:  # Updated in last 2 min = this pipeline
             lines.append("### briefing.md")
             # Show first 10 lines
-            content = briefing.read_text().split("\n")[:10]
+            content = BRIEFING_FILE.read_text().split("\n")[:10]
             lines.append("```")
             lines.append("\n".join(content))
             lines.append("```")
@@ -401,7 +418,7 @@ def main():
         entry_path = args.entry
         # Try to find entry if not provided
         if not entry_path:
-            candidate = HOME / "edge" / "blog" / "entries" / f"{args.slug}.md"
+            candidate = ENTRIES_DIR / f"{args.slug}.md"
             if candidate.exists():
                 entry_path = str(candidate)
 

--- a/tools/edge-signal
+++ b/tools/edge-signal
@@ -20,8 +20,13 @@
 
 set -uo pipefail
 
+# --- Load shared paths ---
+# shellcheck source=../config/paths.sh
+REAL_SCRIPT="$(readlink -f "$0")"
+source "$(dirname "$REAL_SCRIPT")/../config/paths.sh"
+
 VALID_TYPES="autonomy strategy reflection friction decision serendipity"
-SIGNALS_DIR="${EDGE_DIR:-$HOME/edge}/state/signals"
+SIGNALS_DIR="${SIGNALS_DIR:-$STATE_DIR/signals}"
 
 # --- Args ---
 if [[ $# -lt 2 ]]; then
@@ -60,8 +65,18 @@ import os
 import sys
 from pathlib import Path
 
-edge_dir = Path(os.environ.get("EDGE_DIR", str(Path.home() / "edge"))).expanduser()
-tools_dir = edge_dir / "tools"
+tools_dir = Path(
+    os.environ.get("TOOLS_DIR")
+    or (
+        Path(
+            os.environ.get(
+                "EDGE_REPO_DIR",
+                os.environ.get("EDGE_DIR", str(Path.home() / "edge")),
+            )
+        ).expanduser()
+        / "tools"
+    )
+)
 if str(tools_dir) not in sys.path:
     sys.path.insert(0, str(tools_dir))
 

--- a/tools/edge-sources
+++ b/tools/edge-sources
@@ -12,7 +12,7 @@ Runs all sources concurrently, curates by signal, outputs structured markdown.
 Sources that can't be scripted (WebSearch/WebFetch) are noted in output.
 """
 
-import sys, os, json, argparse, subprocess, random
+import sys, os, json, argparse, subprocess, random, uuid
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.request import urlopen, Request
@@ -23,7 +23,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 sys.path.insert(0, str(SCRIPT_DIR.parent / "tools"))
 from paths import TOOLS_DIR, SECRETS_DIR
-from _shared.telemetry import log_primitive_call
+from _shared.telemetry import log_primitive_call, log_run_step, log_source_query
 
 # --- Routing table: intent -> sources ---
 ROUTING = {
@@ -459,15 +459,84 @@ def main():
         if wildcard_src:
             sources.append(wildcard_src)
 
-    # Execute
-    print(f"Querying {len(sources)} sources for \"{args.topic}\" (intent: {args.intent})...", file=sys.stderr)
-    results = run_sources(args.topic, sources)
+    run_id = f"sources:{uuid.uuid4().hex[:8]}"
+    log_run_step(
+        "edge-sources",
+        "fanout",
+        "started",
+        run_id=run_id,
+        intent=args.intent,
+        source_count=len(sources),
+    )
+    log_source_query(
+        args.topic,
+        intent=args.intent,
+        status="started",
+        sources=sources,
+        wildcard_source=wildcard_src,
+        run_id=run_id,
+    )
 
-    # Output
-    if args.json:
-        print(format_json(results, wildcard_src))
-    else:
-        print(format_markdown(args.topic, args.intent, results, wildcard_src))
+    try:
+        # Execute
+        print(f"Querying {len(sources)} sources for \"{args.topic}\" (intent: {args.intent})...", file=sys.stderr)
+        results = run_sources(args.topic, sources)
+
+        ok_sources = 0
+        total_results = 0
+        for items in results.values():
+            has_error = any('error' in item.get('title', '').lower() for item in items)
+            if not has_error:
+                ok_sources += 1
+            total_results += len([
+                item for item in items
+                if item.get("url") or "error" not in item.get("title", "").lower()
+            ])
+
+        log_source_query(
+            args.topic,
+            intent=args.intent,
+            status="completed",
+            sources=sources,
+            total_results=total_results,
+            ok_sources=ok_sources,
+            failed_sources=max(0, len(sources) - ok_sources),
+            wildcard_source=wildcard_src,
+            run_id=run_id,
+        )
+        log_run_step(
+            "edge-sources",
+            "fanout",
+            "completed",
+            run_id=run_id,
+            total_results=total_results,
+            ok_sources=ok_sources,
+            failed_sources=max(0, len(sources) - ok_sources),
+        )
+
+        # Output
+        if args.json:
+            print(format_json(results, wildcard_src))
+        else:
+            print(format_markdown(args.topic, args.intent, results, wildcard_src))
+    except Exception as exc:
+        log_source_query(
+            args.topic,
+            intent=args.intent,
+            status="failed",
+            sources=sources,
+            wildcard_source=wildcard_src,
+            run_id=run_id,
+            error=str(exc),
+        )
+        log_run_step(
+            "edge-sources",
+            "fanout",
+            "failed",
+            run_id=run_id,
+            error=str(exc),
+        )
+        raise
 
 
 if __name__ == "__main__":

--- a/tools/git_signals.py
+++ b/tools/git_signals.py
@@ -23,9 +23,9 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import EDGE_DIR, STATE_DIR
+from paths import EDGE_REPO_DIR, GIT_SIGNALS_FILE
 
-OUTPUT_FILE = STATE_DIR / "git-signals.json"
+OUTPUT_FILE = GIT_SIGNALS_FILE
 SEPARATOR = "---SEPARATOR---"
 
 
@@ -47,7 +47,7 @@ def parse_since(since_str):
 def get_commits(since_git):
     """Get commits from git log with full body."""
     cmd = [
-        "git", "-C", str(EDGE_DIR), "log",
+        "git", "-C", str(EDGE_REPO_DIR), "log",
         f"--since={since_git}",
         f"--format=%H%n%aI%n%s%n%b%n{SEPARATOR}",
     ]

--- a/tools/heartbeat-preflight.sh
+++ b/tools/heartbeat-preflight.sh
@@ -15,7 +15,7 @@ source "$(dirname "$0")/../config/paths.sh"
 
 # 0. Health check (runs edge-check.sh, updates health/current.json)
 HEALTH_SCRIPT="$(dirname "$0")/../bin/edge-check.sh"
-HEALTH_FILE="$EDGE_DIR/health/current.json"
+HEALTH_FILE="$HEALTH_CURRENT_FILE"
 
 if [ -x "$HEALTH_SCRIPT" ]; then
   bash "$HEALTH_SCRIPT" >/dev/null 2>&1

--- a/tools/notify.sh
+++ b/tools/notify.sh
@@ -13,8 +13,9 @@
 
 set -euo pipefail
 
+# shellcheck source=../config/paths.sh
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-EDGE_DIR="$(dirname "$SCRIPT_DIR")"
+source "$SCRIPT_DIR/../config/paths.sh"
 
 TYPE="${1:-default}"
 MESSAGE="${2:-}"
@@ -36,8 +37,8 @@ fi
 
 # ─── Load config ─────────────────────────────────────────────────────────────
 
-FEATURES_FILE="$EDGE_DIR/config/features.yaml"
-SECRETS_FILE="$EDGE_DIR/secrets/_shared.yaml"
+FEATURES_FILE="$EDGE_REPO_DIR/config/features.yaml"
+SECRETS_FILE="$EDGE_REPO_DIR/secrets/_shared.yaml"
 
 # Read a YAML value (simple — no nested arrays)
 yaml_val() {
@@ -135,13 +136,14 @@ if [[ "$SENT" == "false" ]] && [[ -n "$WEBHOOK_URL" ]]; then
 fi
 
 # Method 3: Local chat API (always available)
-BLOG_PORT=$(yaml_val "$EDGE_DIR/config/branding.yaml" "blog.port" 2>/dev/null || echo "8080")
+BLOG_PORT=$(yaml_val "$EDGE_REPO_DIR/config/branding.yaml" "blog.port" 2>/dev/null || echo "8080")
 curl -s -X POST "http://localhost:${BLOG_PORT}/api/chat" \
   -H "Content-Type: application/json" \
   -d "{\"author\": \"system\", \"text\": \"[$TYPE] $MESSAGE\"}" 2>/dev/null >/dev/null || true
 
 # Log
-echo "[$(date '+%Y-%m-%d %H:%M')] notify $TYPE: $MESSAGE (slack=$SENT)" >> "$EDGE_DIR/logs/notify.log" 2>/dev/null || true
+mkdir -p "$LOGS_DIR"
+echo "[$(date '+%Y-%m-%d %H:%M')] notify $TYPE: $MESSAGE (slack=$SENT)" >> "$LOGS_DIR/notify.log" 2>/dev/null || true
 
 if [[ "$SENT" == "true" ]]; then
   echo "sent via slack → $CHANNEL"

--- a/tools/primitives/_shared/usage_log.py
+++ b/tools/primitives/_shared/usage_log.py
@@ -20,6 +20,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 TOOLS_DIR = SCRIPT_DIR.parent.parent
 if str(TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(TOOLS_DIR))
+CONFIG_DIR = SCRIPT_DIR.parents[2] / "config"
+if str(CONFIG_DIR) not in sys.path:
+    sys.path.insert(0, str(CONFIG_DIR))
 
 try:
     from _shared.telemetry import current_cycle_id, emit_shadow_event
@@ -27,10 +30,17 @@ except Exception:
     current_cycle_id = None
     emit_shadow_event = None
 
+try:
+    from paths import SOURCE_USAGE_FILE
+except Exception:
+    SOURCE_USAGE_FILE = None
+
 
 def _log_path() -> Path:
-    edge_home = os.environ.get("EDGE_HOME", str(Path.home() / "edge"))
-    return Path(edge_home).expanduser() / "state" / "source-usage.jsonl"
+    if SOURCE_USAGE_FILE is not None:
+        return SOURCE_USAGE_FILE
+    edge_state_dir = os.environ.get("EDGE_STATE_DIR") or os.environ.get("EDGE_HOME") or str(Path.home() / "edge")
+    return Path(edge_state_dir).expanduser() / "state" / "source-usage.jsonl"
 
 
 def log_invocation(

--- a/tools/primitives/_shared/usage_log.py
+++ b/tools/primitives/_shared/usage_log.py
@@ -25,10 +25,11 @@ if str(CONFIG_DIR) not in sys.path:
     sys.path.insert(0, str(CONFIG_DIR))
 
 try:
-    from _shared.telemetry import current_cycle_id, emit_shadow_event
+    from _shared.telemetry import current_cycle_id, emit_shadow_event, log_event
 except Exception:
     current_cycle_id = None
     emit_shadow_event = None
+    log_event = None
 
 try:
     from paths import SOURCE_USAGE_FILE
@@ -78,6 +79,9 @@ def log_invocation(
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+        if log_event is not None:
+            log_event("primitive_usage", **entry)
 
         if emit_shadow_event is not None:
             payload = {

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -37,7 +37,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 sys.path.insert(0, str(SCRIPT_DIR))
 from branding import load_branding  # noqa: E402
-from paths import (MEMORY_DIR, REPORTS_DIR, NOTES_DIR, SKILLS_DIR,  # noqa: E402
+from paths import (ENTRIES_DIR, MEMORY_DIR, REPORTS_DIR, NOTES_DIR, SKILLS_DIR,  # noqa: E402
                    RUBRIC_PATH)
 from _shared.router_client import make_client  # noqa: E402
 _AGENT_NAME = load_branding().get("agent_name", "agent")
@@ -216,11 +216,10 @@ def _tool_search_corpus(query: str, k: int = 5) -> str:
 def _tool_read_blog_entries(tag: str = "", n: int = 3) -> str:
     """Read recent blog entries."""
     n = min(n, 5)
-    entries_dir = Path.home() / "edge/blog/entries"
-    if not entries_dir.exists():
+    if not ENTRIES_DIR.exists():
         return "Blog entries directory not found"
 
-    files = sorted(entries_dir.glob("*.md"), key=lambda p: p.name, reverse=True)
+    files = sorted(ENTRIES_DIR.glob("*.md"), key=lambda p: p.name, reverse=True)
     results = []
     for f in files:
         if len(results) >= n:

--- a/tools/rollup-observability.py
+++ b/tools/rollup-observability.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""rollup-observability — Consolidate operational telemetry into one state file.
+
+Produces `state/observability-rollup.json` from events, failures, threads and
+entries. Focus areas:
+- lifecycle by run kind and phase
+- success/failure by phase
+- freshness by actor
+- backlog/open loop
+- structured blog_publish failure classes
+- primitives, sources, workflow queries/lifecycle
+- database reads/writes
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import ENTRIES_DIR, EVENTS_FILE, LOGS_DIR, STATE_DIR, THREADS_DIR  # noqa: E402
+
+OUT_PATH = STATE_DIR / "observability-rollup.json"
+WINDOW_DAYS = 30
+WORKFLOW_WINDOW_DAYS = 120
+
+
+def _iter_jsonl(path: Path):
+    if not path.exists():
+        return
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _frontmatter(path: Path) -> dict:
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        parts = raw.split("---", 2)
+        if len(parts) < 3:
+            return {}
+        return yaml.safe_load(parts[1]) or {}
+    except Exception:
+        return {}
+
+
+def _classify_publish_error(text: str) -> str:
+    msg = (text or "").lower()
+    if not msg:
+        return "unknown"
+    rules = [
+        ("auth_or_credits", r"invalid|unauthoriz|forbidden|401|403|credits|quota|api key|token"),
+        ("validation_or_schema", r"yaml|schema|validation|review-gate|frontmatter|claim|glossary"),
+        ("render_or_content", r"render|html|grep|phase 2|phase 3|report generation|quoted error"),
+        ("filesystem_or_path", r"no such file|permission denied|read-only|not found|path|directory"),
+        ("service_or_http", r"http|curl|connection refused|service=|502|503|504|timeout"),
+        ("git_or_state", r"git|commit|dirty|index|sqlite|state_snapshot"),
+        ("process_or_exit", r"returned non-zero|exit \d+|killed|signal"),
+    ]
+    for label, pattern in rules:
+        if re.search(pattern, msg):
+            return label
+    return "unknown"
+
+
+def _rollup_backlog(today: str) -> dict:
+    active = 0
+    waiting = 0
+    due = 0
+    open_claims = 0
+    workflow_drafts = 0
+
+    for path in THREADS_DIR.glob("*.md"):
+        fm = _frontmatter(path)
+        status = str(fm.get("status", ""))
+        if status == "active":
+            active += 1
+        elif status == "waiting":
+            waiting += 1
+        resurface = str(fm.get("resurface", ""))
+        if status in {"active", "waiting"} and resurface and resurface <= today:
+            due += 1
+
+    for path in ENTRIES_DIR.glob("*.md"):
+        fm = _frontmatter(path)
+        tags = fm.get("tags", [])
+        if isinstance(tags, list) and "workflow-draft" in tags:
+            workflow_drafts += 1
+        for claim in fm.get("claims", []) or []:
+            if isinstance(claim, dict):
+                if str(claim.get("status", "")).lower() in {"open", "unverified", "disputed"}:
+                    open_claims += 1
+            elif isinstance(claim, str) and claim.startswith("!"):
+                open_claims += 1
+
+    return {
+        "active_threads": active,
+        "waiting_threads": waiting,
+        "resurface_due": due,
+        "open_claims": open_claims,
+        "workflow_drafts": workflow_drafts,
+    }
+
+
+def main() -> int:
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=WINDOW_DAYS)
+    workflow_cutoff = now - timedelta(days=WORKFLOW_WINDOW_DAYS)
+
+    lifecycle: dict[str, dict[str, dict[str, int]]] = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+    phase_outcomes: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    freshness_raw: dict[str, datetime] = {}
+    primitive_by_source: dict[str, dict] = defaultdict(lambda: {"calls": 0, "ok": 0, "fail": 0, "latencies": [], "last_ts": None})
+    primitive_usage_by_source: dict[str, dict] = defaultdict(lambda: {"events": 0, "start": 0, "end": 0, "last_ts": None})
+    source_queries: dict[str, dict] = defaultdict(lambda: {"started": 0, "completed": 0, "failed": 0, "total_results": 0, "last_ts": None})
+    workflow_queries = {"total": 0, "with_hits": 0, "workflow_only": 0, "workflow_hits": 0}
+    db_by_table: dict[str, dict] = defaultdict(lambda: {"reads": 0, "writes": 0, "fail": 0, "latencies": []})
+    db_by_op: dict[str, int] = defaultdict(int)
+    workflow_transitions: dict[str, int] = defaultdict(int)
+    workflow_state_by_slug: dict[str, str] = {}
+
+    for ev in _iter_jsonl(EVENTS_FILE):
+        ts = _parse_ts(ev.get("ts") or ev.get("timestamp"))
+        if ts is None:
+            continue
+
+        actor = ev.get("actor") or "unknown"
+        if actor not in freshness_raw or ts > freshness_raw[actor]:
+            freshness_raw[actor] = ts
+
+        etype = ev.get("type")
+        if ts < cutoff:
+            if etype != "workflow_transition" or ts < workflow_cutoff:
+                continue
+
+        if etype == "run_step":
+            run_kind = ev.get("run_kind") or "unknown"
+            phase = ev.get("phase") or "unknown"
+            status = ev.get("status") or "unknown"
+            lifecycle[run_kind][phase][status] += 1
+            phase_outcomes[phase][status] += 1
+        elif etype == "primitive_call":
+            src = ev.get("source") or "unknown"
+            bucket = primitive_by_source[src]
+            bucket["calls"] += 1
+            if ev.get("ok"):
+                bucket["ok"] += 1
+            else:
+                bucket["fail"] += 1
+            latency = ev.get("latency_ms")
+            if isinstance(latency, (int, float)) and latency >= 0:
+                bucket["latencies"].append(int(latency))
+            bucket["last_ts"] = ev.get("ts")
+        elif etype == "primitive_usage":
+            src = ev.get("source") or "unknown"
+            bucket = primitive_usage_by_source[src]
+            bucket["events"] += 1
+            phase = ev.get("phase") or "unknown"
+            bucket[phase] = bucket.get(phase, 0) + 1
+            bucket["last_ts"] = ev.get("ts")
+        elif etype == "source_query":
+            intent = ev.get("intent") or "unknown"
+            bucket = source_queries[intent]
+            status = ev.get("status") or "unknown"
+            bucket[status] = bucket.get(status, 0) + 1
+            bucket["total_results"] += int(ev.get("total_results") or 0)
+            bucket["last_ts"] = ev.get("ts")
+        elif etype == "search_query":
+            workflow_queries["total"] += 1
+            if int(ev.get("workflow_count") or 0) > 0:
+                workflow_queries["with_hits"] += 1
+            workflow_queries["workflow_hits"] += int(ev.get("workflow_count") or 0)
+            if (ev.get("doc_type") or "") == "workflow":
+                workflow_queries["workflow_only"] += 1
+        elif etype == "db_query":
+            table = ev.get("table") or "unknown"
+            bucket = db_by_table[table]
+            if ev.get("write"):
+                bucket["writes"] += 1
+            else:
+                bucket["reads"] += 1
+            if not ev.get("ok", True):
+                bucket["fail"] += 1
+            latency = ev.get("latency_ms")
+            if isinstance(latency, (int, float)) and latency >= 0:
+                bucket["latencies"].append(int(latency))
+            op = ev.get("op") or "unknown"
+            db_by_op[op] += 1
+        elif etype == "workflow_transition":
+            frm = ev.get("from") or "unknown"
+            to = ev.get("to") or "unknown"
+            workflow_transitions[f"{frm}->{to}"] += 1
+            slug = ev.get("slug") or ""
+            if slug:
+                workflow_state_by_slug[slug] = to
+
+    freshness = {
+        actor: {
+            "last_ts": dt.isoformat(),
+            "age_minutes": round((now - dt).total_seconds() / 60.0, 1),
+        }
+        for actor, dt in sorted(freshness_raw.items(), key=lambda item: item[1], reverse=True)
+    }
+
+    primitive_payload = {}
+    for src, bucket in primitive_by_source.items():
+        calls = bucket["calls"]
+        primitive_payload[src] = {
+            "calls": calls,
+            "ok": bucket["ok"],
+            "fail": bucket["fail"],
+            "ok_rate": round(bucket["ok"] / calls, 3) if calls else 0.0,
+            "avg_ms": round(statistics.mean(bucket["latencies"]), 1) if bucket["latencies"] else 0.0,
+            "last_ts": bucket["last_ts"],
+        }
+
+    primitive_usage_payload = {
+        src: bucket
+        for src, bucket in sorted(primitive_usage_by_source.items(), key=lambda item: (-item[1]["events"], item[0]))
+    }
+
+    db_payload = {}
+    for table, bucket in db_by_table.items():
+        db_payload[table] = {
+            "reads": bucket["reads"],
+            "writes": bucket["writes"],
+            "fail": bucket["fail"],
+            "avg_ms": round(statistics.mean(bucket["latencies"]), 1) if bucket["latencies"] else 0.0,
+        }
+
+    blog_publish = {"total": 0, "by_class": defaultdict(int), "recent": []}
+    failures_path = LOGS_DIR / "pipeline-failures.jsonl"
+    for row in _iter_jsonl(failures_path):
+        if (row.get("operation") or "") != "blog_publish":
+            continue
+        klass = _classify_publish_error(row.get("error", ""))
+        blog_publish["total"] += 1
+        blog_publish["by_class"][klass] += 1
+        blog_publish["recent"].append({
+            "timestamp": row.get("timestamp"),
+            "slug": row.get("slug"),
+            "class": klass,
+            "error": (row.get("error") or "")[:200],
+        })
+    blog_publish["recent"] = blog_publish["recent"][-10:]
+    blog_publish["by_class"] = dict(sorted(blog_publish["by_class"].items(), key=lambda item: -item[1]))
+
+    workflow_states = defaultdict(int)
+    for state in workflow_state_by_slug.values():
+        workflow_states[state] += 1
+
+    payload = {
+        "window_days": WINDOW_DAYS,
+        "generated_at": now.isoformat(),
+        "lifecycle": {
+            run_kind: {phase: dict(statuses) for phase, statuses in phases.items()}
+            for run_kind, phases in lifecycle.items()
+        },
+        "phase_outcomes": {phase: dict(statuses) for phase, statuses in phase_outcomes.items()},
+        "freshness_by_actor": freshness,
+        "backlog": _rollup_backlog(now.date().isoformat()),
+        "blog_publish_failures": blog_publish,
+        "primitives": {
+            "calls_by_source": dict(sorted(primitive_payload.items(), key=lambda item: -item[1]["calls"])),
+            "usage_events_by_source": primitive_usage_payload,
+        },
+        "sources": {
+            "queries_by_intent": dict(sorted(source_queries.items())),
+        },
+        "workflows": {
+            "query_stats": workflow_queries,
+            "transitions": dict(sorted(workflow_transitions.items(), key=lambda item: -item[1])),
+            "current_state": dict(sorted(workflow_states.items(), key=lambda item: -item[1])),
+            "tracked_workflows": len(workflow_state_by_slug),
+        },
+        "database": {
+            "by_table": dict(sorted(db_payload.items(), key=lambda item: -(item[1]["reads"] + item[1]["writes"]))),
+            "by_op": dict(sorted(db_by_op.items(), key=lambda item: -item[1])),
+            "total_reads": sum(item["reads"] for item in db_payload.values()),
+            "total_writes": sum(item["writes"] for item in db_payload.values()),
+            "total_failures": sum(item["fail"] for item in db_payload.values()),
+        },
+    }
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(f"OK: {OUT_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/rollup-primitives.py
+++ b/tools/rollup-primitives.py
@@ -16,9 +16,9 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import SEARCH_DIR, STATE_DIR  # noqa: E402
+from paths import SEARCH_DB_FILE, STATE_DIR  # noqa: E402
 
-DB_PATH = SEARCH_DIR / "edge-memory.db"
+DB_PATH = SEARCH_DB_FILE
 OUT_PATH = STATE_DIR / "primitive-usage-rollup.json"
 WINDOW_DAYS = 30
 


### PR DESCRIPTION
## What changed

This expands observability from isolated events into end-to-end operational telemetry.

It adds:
- lifecycle events for `edge-search`, `edge-sources`, `edge-consult`, `blog-publish`, and `consolidate-state`
- database read/write telemetry for the search SQLite layer
- structured search/source query telemetry, including workflow sidecar hits
- primitive usage events in `events.jsonl`
- a deterministic `tools/rollup-observability.py` that consolidates lifecycle, freshness, backlog, workflow, source, primitive, database, and `blog_publish` failure data into `state/observability-rollup.json`
- `edge-digest` integration so the briefing includes the new observability summary

## Why

Previously we could see activity, but not the full lifecycle of runs or where work was being lost.

This patch closes the main gaps by measuring:
- lifecycle by run and phase
- success/failure by phase
- freshness by actor
- backlog/open loop
- structured `blog_publish` failure classes
- primitive/source/workflow usage
- database queries and writes

## Impact

Operators and skills can now reason over a single digested observability state file instead of inferring from scattered logs.

This also instruments `consolidate-state` and `blog-publish` directly, so one future propagation after merge should be enough.

## Validation

- `bash -n blog/consolidate-state.sh blog/blog-publish.sh`
- `python3 -m py_compile search/db.py search/search.py tools/_shared/telemetry.py tools/edge-consult.py tools/edge-digest tools/edge-sources tools/primitives/_shared/usage_log.py tools/rollup-observability.py`
- `python3 tools/rollup-observability.py`
- `python3 tools/edge-digest --dry-run`
