### PR TITLE
[codex] make /dashboard the canonical operator surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # edge-of-chaos — Autonomous AI Agent Framework
 
-Framework for deploying autonomous AI agents based on Claude Code. Each agent has its own identity, blog, skills, and heartbeat cycle.
+Framework for deploying autonomous AI agents based on Claude Code. Each agent has its own identity, dashboard, skills, and heartbeat cycle.
 
 ## Quick Start (5 min)
 
@@ -21,7 +21,7 @@ python3 tools/edge-apply
 python3 tools/edge-doctor --config agent.yaml
 ```
 
-Done. Blog running, 22 skills installed, heartbeat ready.
+Done. Dashboard running, 22 skills installed, heartbeat ready.
 
 ## agent.yaml
 
@@ -40,18 +40,18 @@ Everything else has smart defaults. See `agent.yaml.example` for all options.
 ## What edge-apply Does (8 phases)
 
 1. **Render** — generates all files from agent.yaml + templates
-2. **Directories** — creates blog/, reports/, logs/, etc.
+2. **Directories** — creates content dirs (`blog/`, `reports/`, `logs/`, etc.)
 3. **Skills** — installs 22 skills with your prefix to ~/.claude/skills/
 4. **Identity** — CLAUDE.md, memory files, config, onboarding templates
-5. **Blog venv** — Flask server with FTS5 search
+5. **Dashboard venv** — Flask operator surface with FTS5 search
 6. **Tools venv** — edge-consult, review-gate, edge-deepresearch
-7. **Systemd** — heartbeat timer + blog server service
+7. **Systemd** — heartbeat timer + dashboard server service (`blog-server` name kept for compatibility)
 8. **Tools** — CLI tools + symlinks to ~/.local/bin/
 
 ## After Install
 
 ```bash
-# Start blog
+# Start dashboard (service name kept as blog-server for compatibility)
 systemctl --user enable --now blog-server
 
 # Start autonomous heartbeat (every 2h)
@@ -74,10 +74,10 @@ my-agent/
 │   ├── post-skill.md       ← runs after every skill (notify, update strategy)
 │   ├── strategy.md         ← operator direction (agent reads, proposes)
 │   ├── interests.md        ← shared interests (guides exploration)
-│   └── branding.yaml       ← agent phenotype (name, colors, blog config)
+│   └── branding.yaml       ← agent phenotype (name, colors, dashboard config via legacy `blog` key)
 ├── skills/                 ← 22 core skills (genotype)
 ├── tools/                  ← CLI tools (edge-consult, edge-fontes, etc.)
-├── blog/                   ← Flask + htmx blog server
+├── blog/                   ← Flask + htmx dashboard server (legacy package name)
 ├── search/                 ← FTS5 + vector search engine
 ├── templates/              ← .tpl files rendered by edge-render
 ├── memory/                 ← personality, rules, method (genotype)
@@ -91,9 +91,9 @@ my-agent/
 
 Every change goes through one question: is this genotype or phenotype?
 
-- **Genotype** — shared code (skills, tools, blog server). Lives in the repo. Propagates via git pull.
+- **Genotype** — shared code (skills, tools, dashboard server). Lives in the repo. Propagates via git pull.
 - **Phenotype** — instance config (agent.yaml, branding, strategy). Per-agent. Generated at install.
-- **Epigenetics** — runtime state (blog entries, reports, memory). Never replicates.
+- **Epigenetics** — runtime state (feed entries, reports, memory). Never replicates.
 
 **Heartbeat**
 
@@ -109,7 +109,7 @@ New agents produce from the first heartbeat. A checklist tracks progress (identi
 
 **Publication Pipeline (consolidate-state)**
 
-8-phase atomic publication: state snapshot → adversarial review → quality gate → blog publish → HTML report → meta-report → state commit → git commit.
+8-phase atomic publication: state snapshot → adversarial review → quality gate → entry publish → HTML report → meta-report → state commit → git commit.
 
 ## Tools
 

--- a/blog/app.py
+++ b/blog/app.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Blog server: Flask + Jinja2 + htmx. Replaces server.py."""
+"""Dashboard server in the legacy ``blog`` package: Flask + Jinja2 + htmx."""
 
 import html as html_mod
 import json
@@ -99,7 +99,7 @@ def enforce_auth():
             return None
         auth = request.authorization
         if not auth or auth.username != _auth_user or auth.password != _auth_pass:
-            return ("Unauthorized", 401, {"WWW-Authenticate": 'Basic realm="Blog"'})
+            return ("Unauthorized", 401, {"WWW-Authenticate": 'Basic realm="Dashboard"'})
 
 # ─── Tag normalization ───
 TAG_MAP = {
@@ -481,12 +481,13 @@ def inject_globals():
 # ─── Routes: Main pages ───
 @app.route("/")
 def root_redirect():
-    return redirect("/blog/")
+    return redirect("/dashboard")
 
 
 @app.route("/blog/")
 @app.route("/blog")
 def blog_index():
+    """Legacy compatibility surface for feed/chat/workflow views."""
     tab = request.args.get("tab", "feed")
     if tab not in ("feed", "chat", "workflows"):
         tab = "feed"
@@ -1318,6 +1319,7 @@ def get_health_data(entries):
 
 
 @app.route("/dashboard")
+@app.route("/dashboard/")
 def dashboard_page():
     """Operational dashboard — 30-second health check for operator."""
     entries = get_entries()
@@ -1336,8 +1338,8 @@ def dashboard_page():
     return render_template(
         "dashboard.html",
         tab="dashboard",
-        page_title="edge_of_chaos — ops console",
-        header_sub="ops console",
+        page_title="edge_of_chaos — dashboard",
+        header_sub="dashboard",
         stats=get_stats_data(),
         health=health,
         knowledge_clusters=kc_summary,
@@ -1725,5 +1727,5 @@ if __name__ == "__main__":
     get_entries()
     port = int(os.environ.get("BLOG_PORT", 8766))
     host = os.environ.get("BLOG_HOST", "127.0.0.1")
-    print(f"Blog server (Flask) on http://localhost:{port}/blog/")
+    print(f"Dashboard server (legacy blog package) on http://localhost:{port}/dashboard")
     app.run(host=host, port=port, debug=False, threaded=True)

--- a/blog/setup_examples.py
+++ b/blog/setup_examples.py
@@ -117,16 +117,16 @@ improvements to the platform.
 Skills are invoked via `/atlas-{name}` slash commands.
 Shared protocols: `~/.claude/skills/_shared/`
 
-## Blog
+## Dashboard
 
-Internal blog at `http://localhost:8080/blog/`
-Always blog insights — primary communication channel.
+Internal dashboard at `http://localhost:8080/dashboard`
+Publish durable insights into the dashboard feed — primary communication channel.
 
 ## Preferences
 
 - Always use venv for Python packages.
 - Prompts outside code — never embed in .py.
-- Blog ALWAYS — insights must go to the blog.
+- Dashboard feed ALWAYS — insights must go to the dashboard feed.
 """,
     },
     # ── Group 2: Direction ──
@@ -185,8 +185,8 @@ Se os últimos 3 breaks exploraram a mesma área, MUDAR para outra.
 1. **Derive before searching.** Try to reconstruct from first principles
    before looking up. Where does reasoning break? That's the real gap.
 
-2. **Blog ALWAYS.** Every insight, discovery, or analysis goes to the
-   internal blog. It's the primary communication channel.
+2. **Dashboard feed ALWAYS.** Every insight, discovery, or analysis goes
+   to the internal dashboard feed. It's the primary communication channel.
 
 3. **Prompts outside code.** Never embed prompts in .py files. Always .md.
 
@@ -199,7 +199,7 @@ Se os últimos 3 breaks exploraram a mesma área, MUDAR para outra.
    are the #1 source of drift.
 
 7. **Student data is sacred.** Never include real student names, scores,
-   or PII in blog entries, reports, or external outputs.
+   or PII in dashboard feed entries, reports, or external outputs.
 
 8. **Verify after acting.** Grep after refactoring. Test after changes.
    Re-read what was written.
@@ -488,7 +488,7 @@ SYSTEM_FILES = [
         "path": "blog/entries/",
         "group": "production",
         "group_label": "Produção do agente",
-        "purpose": "Entradas do blog (markdown com frontmatter). Uma por skill executada. Canal primário de comunicação",
+        "purpose": "Entradas do feed do dashboard (markdown com frontmatter). Uma por skill executada. Canal primário de comunicação",
         "owner": "agent",
         "managed_by": "consolidate-state",
         "is_dir": True,

--- a/blog/templates/base.html
+++ b/blog/templates/base.html
@@ -30,12 +30,12 @@
 </header>
 
 <div class="view-tabs">
+  <a class="view-tab {{ 'active' if tab == 'dashboard' }}" href="/dashboard">dashboard</a>
   <a class="view-tab {{ 'active' if tab == 'feed' }}" href="/blog/?tab=feed">feed</a>
   <a class="view-tab {{ 'active' if tab == 'workflows' }}" href="/blog/?tab=workflows">workflows</a>
-  <a class="view-tab {{ 'active' if tab == 'chat' }}" href="/blog/?tab=chat">chat</a>
-  <a class="view-tab {{ 'active' if tab == 'dashboard' }}" href="/dashboard">ops</a>
-  <a class="view-tab {{ 'active' if tab == 'setup' }}" href="/setup">setup</a>
   <a class="view-tab {{ 'active' if tab == 'knowledge' }}" href="/knowledge">knowledge</a>
+  <a class="view-tab {{ 'active' if tab == 'chat' }}" href="/blog/?tab=chat">chat</a>
+  <a class="view-tab {{ 'active' if tab == 'setup' }}" href="/setup">setup</a>
 </div>
 
 <div id="tabContent">

--- a/tests/test_ops_console.sh
+++ b/tests/test_ops_console.sh
@@ -6,7 +6,12 @@ set -euo pipefail
 
 EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 BLOG_DIR="$EDGE_DIR/blog"
-VENV_PY="$BLOG_DIR/.venv/bin/python3"
+VENV_PY="${EDGE_BLOG_VENV:-$BLOG_DIR/.venv/bin/python3}"
+if [ ! -x "$VENV_PY" ]; then
+    echo "Missing blog venv python: $VENV_PY" >&2
+    echo "Set EDGE_BLOG_VENV=/path/to/blog/.venv/bin/python3 when running from a clean worktree." >&2
+    exit 2
+fi
 PASS=0
 FAIL=0
 ERRORS=""
@@ -78,11 +83,20 @@ def check(name, response, expect_status=200):
     mark = "PASS" if ok else "FAIL"
     print(f'{mark}|{name}|{response.status_code}|{expect_status}')
 
+def check_redirect(name, response, expect_location, expect_status=302):
+    ok = response.status_code == expect_status and response.headers.get("Location") == expect_location
+    mark = "PASS" if ok else "FAIL"
+    got = f'{response.status_code} {response.headers.get("Location")}'
+    expected = f'{expect_status} {expect_location}'
+    print(f'{mark}|{name}|{got}|{expected}')
+
 check("GET /api/dashboard/overview", client.get("/api/dashboard/overview"))
 check("GET /api/dashboard/alerts", client.get("/api/dashboard/alerts"))
 check("GET /api/dashboard/pipeline", client.get("/api/dashboard/pipeline"))
 check("GET /api/dashboard/hotspots", client.get("/api/dashboard/hotspots"))
 check("GET /api/dashboard/corpus", client.get("/api/dashboard/corpus"))
+check_redirect("GET / -> /dashboard", client.get("/"), "/dashboard")
+check("GET /blog", client.get("/blog"))
 
 r = client.post("/api/tasks/TASK-20260309-001/action",
                 json={"action": "note", "value": "integration-test-ping"},


### PR DESCRIPTION
## Summary

- make `/dashboard` the canonical operator entry point and keep `/blog` as a legacy compatibility surface
- refresh operator-facing copy/docs/navigation so the product is framed as a dashboard instead of a blog
- let `tests/test_ops_console.sh` accept `EDGE_BLOG_VENV` so the suite can run from a clean worktree that reuses the provisioned blog venv

## Why

Implements #265, the first delivery slice under epic #264.

The codebase already had dashboard/ops-console semantics in routes, tests, and service helpers, but root routing and user-facing framing still centered `blog`. This PR aligns the operator-facing product identity without attempting a risky internal package rename.

## Validation

Validated with the provisioned server venv against the clean worktree:

- `GET /` -> `302 /dashboard`
- `GET /dashboard` -> `200`
- `GET /dashboard/` -> `200`
- `GET /blog` -> `200`
- `GET /api/dashboard/overview` -> `200`
- `GET /api/dashboard/alerts` -> `200`
- `GET /api/dashboard/pipeline` -> `200`
- `GET /api/dashboard/hotspots` -> `200`
- `GET /api/dashboard/corpus` -> `200`

Command used:

```bash
EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_ops_console.sh
```

Current result:

- `14/15` checks pass
- one unrelated pre-existing failure remains: `POST /api/tasks/TASK-20260309-001/action` returns `405`
- verified separately that this same `405` occurs on current `origin/main`, so it is not introduced by this PR

## Notes

- internal package/config/service naming still uses `blog` in some places intentionally for compatibility
- this PR only changes the canonical operator-facing surface and product framing; it does not remove `/blog/*` compatibility routes