### PR TITLE
[codex] add dashboard runtime transparency surfaces

### DIFF
--- a/blog/api_dashboard.py
+++ b/blog/api_dashboard.py
@@ -6,6 +6,8 @@ from blog.services import (
     load_hotspots, load_git_signals, load_curadoria, load_threads_enriched,
     get_publish_commits, get_error_pressure_24h,
     get_heartbeat_status, get_production_stats, get_briefing_html,
+    load_autonomy_summary, load_current_dispatch_state, load_primitive_runtime_summary,
+    load_recent_dispatch_cycles, load_skill_evidence_summary,
 )
 
 dashboard_bp = Blueprint("dashboard", __name__)
@@ -421,3 +423,27 @@ def partial_briefing():
     """HTMX partial: daily briefing section fragment."""
     data = _build_briefing_data()
     return render_template("partials/briefing.html", **data)
+
+
+def _build_runtime_data():
+    """Build context dict for runtime transparency surfaces."""
+    return {
+        "runtime_current_cycle": load_current_dispatch_state(),
+        "runtime_recent_cycles": load_recent_dispatch_cycles(limit=6),
+        "runtime_skill_evidence": load_skill_evidence_summary(limit=5),
+        "runtime_primitives": load_primitive_runtime_summary(limit=5),
+        "runtime_autonomy": load_autonomy_summary(),
+    }
+
+
+@dashboard_bp.route("/api/dashboard/runtime")
+def runtime():
+    """Runtime transparency read model for dispatch/evidence/primitives/autonomy."""
+    return jsonify(_build_runtime_data())
+
+
+@dashboard_bp.route("/partials/runtime")
+def partial_runtime():
+    """HTMX partial: runtime transparency section fragment."""
+    data = _build_runtime_data()
+    return render_template("partials/runtime.html", **data)

--- a/blog/app.py
+++ b/blog/app.py
@@ -51,7 +51,7 @@ sys.path.insert(0, str(ROOT))
 
 import yaml as _yaml
 
-from blog.api_dashboard import dashboard_bp, _build_status_strip_data, _build_alerts_data, _build_pipeline_data, _build_hotspots_data, _build_corpus_data, _build_briefing_data
+from blog.api_dashboard import dashboard_bp, _build_status_strip_data, _build_alerts_data, _build_pipeline_data, _build_hotspots_data, _build_corpus_data, _build_briefing_data, _build_runtime_data
 
 # ─── Branding ───
 _branding_path = ROOT / "config" / "branding.yaml"
@@ -1333,6 +1333,7 @@ def dashboard_page():
     hotspots_data = _build_hotspots_data()
     corpus_data = _build_corpus_data()
     briefing_data = _build_briefing_data()
+    runtime_data = _build_runtime_data()
     threads_data = _build_threads_data()
 
     return render_template(
@@ -1349,6 +1350,7 @@ def dashboard_page():
         **hotspots_data,
         **corpus_data,
         **briefing_data,
+        **runtime_data,
         **threads_data,
     )
 

--- a/blog/services.py
+++ b/blog/services.py
@@ -13,20 +13,27 @@ import yaml
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import (  # noqa: E402
+    AUTONOMY_CAPABILITIES_FILE,
     BRIEFING_FILE,
+    CURRENT_DISPATCH_FILE,
     CURADORIA_CANDIDATES_FILE as CURADORIA_CANDIDATES,
     EDGE_REPO_DIR,
     ENTRIES_DIR,
     EXECUTION_LEDGER_FILE as EXECUTION_LEDGER,
+    FRONTIER_FILE,
     GIT_SIGNALS_FILE as GIT_SIGNALS,
     LOGS_DIR,
     OPS_HOTSPOTS,
     REPORTS_DIR,
+    SKILL_STEPS_FILE,
+    SOURCES_MANIFEST_FILE,
+    STATE_EVENTS_FILE,
     STATE_DIR,
     THREADS_DIR,
 )
 
 ROOT = EDGE_REPO_DIR
+PRIMITIVE_USAGE_ROLLUP_FILE = STATE_DIR / "primitive-usage-rollup.json"
 
 
 def load_json_safe(path, default=None):
@@ -39,6 +46,348 @@ def load_json_safe(path, default=None):
     except Exception:
         pass
     return default
+
+
+def _load_yaml_safe(path, default=None):
+    if default is None:
+        default = {}
+    try:
+        if path.exists():
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+            return data if data is not None else default
+    except Exception:
+        pass
+    return default
+
+
+def _iter_jsonl(path):
+    try:
+        if not path.exists():
+            return []
+        rows = []
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except Exception:
+                continue
+        return rows
+    except Exception:
+        return []
+
+
+def _short_ts(value):
+    if not value:
+        return ""
+    return str(value).replace("T", " ")[:16]
+
+
+def _find_shadow_markers(*markers):
+    matches = []
+    marker_set = tuple(str(marker).lower() for marker in markers)
+    for event in _iter_jsonl(STATE_EVENTS_FILE):
+        blob = json.dumps(event, ensure_ascii=False).lower()
+        if any(marker in blob for marker in marker_set):
+            matches.append(event)
+    return matches
+
+
+def load_current_dispatch_state():
+    """Best-effort current dispatch cycle state."""
+    state = load_json_safe(CURRENT_DISPATCH_FILE, {})
+    request = state.get("request", {}) or {}
+    state_block = state.get("state", {}) or {}
+    if not state:
+        return {
+            "available": False,
+            "active": False,
+            "cycle_id": None,
+            "trigger": None,
+            "skill": None,
+            "phase": "no-dispatch",
+            "phase_label": "no dispatch",
+            "phase_color": "muted",
+            "preflight_status": "unknown",
+            "skill_status": "unknown",
+            "postflight_status": "unknown",
+            "close_status": None,
+            "opened_at_short": "",
+            "dispatched_at_short": "",
+            "closed_at_short": "",
+            "updated_at_short": "",
+        }
+
+    active = bool(state_block.get("active"))
+    close_status = state_block.get("close_status")
+    phase = state_block.get("phase") or ("active" if active else "closed")
+    if active:
+        phase_label = phase.replace("_", " ")
+        phase_color = "green" if state_block.get("skill_dispatched") else "yellow"
+    else:
+        phase_label = close_status or "closed"
+        phase_color = "green" if close_status == "completed" else "yellow"
+
+    return {
+        "available": True,
+        "active": active,
+        "cycle_id": state.get("cycle_id"),
+        "trigger": request.get("trigger"),
+        "skill": request.get("skill"),
+        "phase": phase,
+        "phase_label": phase_label,
+        "phase_color": phase_color,
+        "preflight_status": state_block.get("preflight_status", "unknown"),
+        "skill_status": state_block.get("skill_status", "unknown"),
+        "postflight_status": state_block.get("postflight_status", "unknown"),
+        "close_status": close_status,
+        "opened_at_short": _short_ts(state_block.get("opened_at")),
+        "dispatched_at_short": _short_ts(state_block.get("dispatched_at")),
+        "closed_at_short": _short_ts(state_block.get("closed_at")),
+        "updated_at_short": _short_ts(state_block.get("updated_at")),
+    }
+
+
+def load_recent_dispatch_cycles(limit=6):
+    """Aggregate recent dispatch cycles from the shadow event log."""
+    cycles = {}
+    for event in _iter_jsonl(STATE_EVENTS_FILE)[-400:]:
+        cycle_id = str(event.get("cycle_id") or "").strip()
+        if not cycle_id:
+            continue
+        event_type = event.get("type")
+        if event_type not in {"CycleStarted", "SkillDispatched", "CycleClosed"}:
+            continue
+        payload = event.get("payload", {}) or {}
+        item = cycles.setdefault(cycle_id, {
+            "cycle_id": cycle_id,
+            "trigger": None,
+            "skill": None,
+            "opened_at": None,
+            "dispatched_at": None,
+            "closed_at": None,
+            "close_status": None,
+            "event_count": 0,
+        })
+        item["event_count"] += 1
+        ts = event.get("ts")
+        if event_type == "CycleStarted":
+            item["opened_at"] = item["opened_at"] or ts
+            item["trigger"] = payload.get("trigger") or payload.get("requested_trigger") or item["trigger"]
+        elif event_type == "SkillDispatched":
+            item["dispatched_at"] = ts
+            item["skill"] = payload.get("skill") or item["skill"]
+            item["trigger"] = payload.get("trigger") or item["trigger"]
+        elif event_type == "CycleClosed":
+            item["closed_at"] = ts
+            item["close_status"] = payload.get("close_status")
+            item["skill"] = payload.get("skill") or item["skill"]
+            item["trigger"] = payload.get("trigger") or item["trigger"]
+
+    current = load_current_dispatch_state()
+    if current["available"] and current["cycle_id"] not in cycles:
+        cycles[current["cycle_id"]] = {
+            "cycle_id": current["cycle_id"],
+            "trigger": current["trigger"],
+            "skill": current["skill"],
+            "opened_at": current["opened_at_short"],
+            "dispatched_at": current["dispatched_at_short"],
+            "closed_at": current["closed_at_short"],
+            "close_status": current["close_status"],
+            "event_count": 0,
+            "from_current_dispatch": True,
+            "active": current["active"],
+        }
+
+    items = []
+    for cycle in cycles.values():
+        active = bool(cycle.get("active")) or (cycle.get("opened_at") and not cycle.get("closed_at"))
+        has_dispatch = bool(cycle.get("dispatched_at"))
+        has_close = bool(cycle.get("closed_at"))
+        if has_dispatch and has_close:
+            health_label = cycle.get("close_status") or "complete"
+            health_color = "green" if cycle.get("close_status") == "completed" else "yellow"
+        elif active and has_dispatch:
+            health_label = "in progress"
+            health_color = "yellow"
+        elif active:
+            health_label = "missing dispatch"
+            health_color = "red"
+        else:
+            health_label = "partial"
+            health_color = "red"
+
+        last_ts = cycle.get("closed_at") or cycle.get("dispatched_at") or cycle.get("opened_at") or ""
+        items.append({
+            **cycle,
+            "active": active,
+            "health_label": health_label,
+            "health_color": health_color,
+            "opened_at_short": _short_ts(cycle.get("opened_at")),
+            "dispatched_at_short": _short_ts(cycle.get("dispatched_at")),
+            "closed_at_short": _short_ts(cycle.get("closed_at")),
+            "last_ts": last_ts,
+            "last_ts_short": _short_ts(last_ts),
+        })
+
+    items.sort(key=lambda item: item.get("last_ts") or "", reverse=True)
+    return items[:limit]
+
+
+def load_skill_evidence_summary(limit=5):
+    """Summarize skill-step observability and explicit pre/post gaps."""
+    runs = []
+    total_silent = 0
+    total_explicit = 0
+    for entry in reversed(_iter_jsonl(SKILL_STEPS_FILE)):
+        if entry.get("event") != "end" or "expected" not in entry:
+            continue
+        silent = len(entry.get("silent_skips", []))
+        explicit = int(entry.get("explicit_skips", 0) or 0)
+        total_silent += silent
+        total_explicit += explicit
+        runs.append({
+            "skill": entry.get("skill"),
+            "completion_pct": entry.get("completion_pct", 0),
+            "silent_skips": silent,
+            "explicit_skips": explicit,
+            "ts_short": _short_ts(entry.get("ts")),
+        })
+        if len(runs) >= limit:
+            break
+
+    pre_events = _find_shadow_markers("preskill", "pre_skill")
+    post_events = _find_shadow_markers("postskill", "post_skill")
+    current = load_current_dispatch_state()
+    return {
+        "pre_skill": {
+            "status": "observed" if pre_events else "gap",
+            "color": "green" if pre_events else "red",
+            "detail": f"{len(pre_events)} explicit pre-skill events" if pre_events else "no explicit pre-skill runtime evidence in shadow log yet",
+            "protocol_status": current.get("preflight_status", "unknown"),
+        },
+        "post_skill": {
+            "status": "observed" if post_events else "gap",
+            "color": "green" if post_events else "red",
+            "detail": f"{len(post_events)} explicit post-skill events" if post_events else "no explicit post-skill runtime evidence in shadow log yet",
+            "protocol_status": current.get("postflight_status", "unknown"),
+        },
+        "skill_runs": runs,
+        "skill_runs_total": len(runs),
+        "silent_skips_total": total_silent,
+        "explicit_skips_total": total_explicit,
+    }
+
+
+def load_primitive_runtime_summary(limit=5):
+    """Summarize primitive usage and lifecycle state."""
+    usage = load_json_safe(PRIMITIVE_USAGE_ROLLUP_FILE, {
+        "window_days": 30,
+        "total_calls": 0,
+        "by_source": {},
+    })
+    manifest = _load_yaml_safe(SOURCES_MANIFEST_FILE, {"sources": []})
+    sources = manifest.get("sources", []) or []
+    status_counts = {}
+    for item in sources:
+        status = str(item.get("status", "unknown"))
+        status_counts[status] = status_counts.get(status, 0) + 1
+
+    top_used = []
+    top_failing = []
+    for source, data in (usage.get("by_source", {}) or {}).items():
+        row = {
+            "source": source,
+            "calls": int(data.get("calls", 0) or 0),
+            "fail": int(data.get("fail", 0) or 0),
+            "ok_rate": data.get("ok_rate", 0.0),
+            "avg_ms": int(data.get("avg_ms", 0) or 0),
+        }
+        top_used.append(row)
+        if row["fail"] > 0:
+            top_failing.append(row)
+
+    top_used.sort(key=lambda item: (-item["calls"], item["source"]))
+    top_failing.sort(key=lambda item: (-item["fail"], -item["calls"], item["source"]))
+
+    lifecycle_types = {
+        "PrimitiveMissingObserved",
+        "PrimitiveContractWritten",
+        "PrimitiveMaterialized",
+        "PrimitiveProbeCompleted",
+        "PrimitiveManifestUpdated",
+    }
+    lifecycle = []
+    for event in reversed(_iter_jsonl(STATE_EVENTS_FILE)):
+        if event.get("type") not in lifecycle_types:
+            continue
+        payload = event.get("payload", {}) or {}
+        lifecycle.append({
+            "type": event.get("type"),
+            "source": payload.get("source"),
+            "status": payload.get("status"),
+            "exit_code": payload.get("exit_code"),
+            "ts_short": _short_ts(event.get("ts")),
+        })
+        if len(lifecycle) >= limit:
+            break
+
+    return {
+        "window_days": usage.get("window_days", 30),
+        "total_calls": int(usage.get("total_calls", 0) or 0),
+        "sources_total": len(sources),
+        "status_counts": status_counts,
+        "top_used": top_used[:limit],
+        "top_failing": top_failing[:limit],
+        "lifecycle": lifecycle,
+    }
+
+
+def load_autonomy_summary():
+    """Read autonomy capability/frontier files for operator-facing summary."""
+    try:
+        if not AUTONOMY_CAPABILITIES_FILE.exists():
+            return {
+                "available": False,
+                "avg": None,
+                "total": 0,
+                "gaps": [],
+                "next_steps": [],
+            }
+        content = AUTONOMY_CAPABILITIES_FILE.read_text(encoding="utf-8")
+        rows = re.findall(r'^\|\s*\d+\s*\|([^|]+)\|\s*(\d+)\s*\|', content, re.MULTILINE)
+        if not rows:
+            return {
+                "available": False,
+                "avg": None,
+                "total": 0,
+                "gaps": [],
+                "next_steps": [],
+            }
+        caps = [{"name": row[0].strip(), "level": int(row[1])} for row in rows]
+        avg = round(sum(cap["level"] for cap in caps) / len(caps), 1)
+        gaps = sorted(caps, key=lambda cap: cap["level"])[:3]
+        next_steps = []
+        if FRONTIER_FILE.exists():
+            frontier = FRONTIER_FILE.read_text(encoding="utf-8")
+            for match in re.finditer(r'### (?!~~)(GAP-\d+): (.+)', frontier):
+                next_steps.append({"id": match.group(1), "title": match.group(2)})
+        return {
+            "available": True,
+            "avg": avg,
+            "total": len(caps),
+            "gaps": gaps,
+            "next_steps": next_steps[:4],
+        }
+    except Exception:
+        return {
+            "available": False,
+            "avg": None,
+            "total": 0,
+            "gaps": [],
+            "next_steps": [],
+        }
 
 
 def load_hotspots():

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -1445,6 +1445,104 @@
   .dash-section-title.dash-warn { color: var(--orange); }
   .dash-section-title.dash-muted { color: var(--text-muted); }
 
+  .runtime-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 0.8rem;
+  }
+
+  .runtime-card {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.75rem;
+    background: var(--bg);
+  }
+
+  .runtime-card-title {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    margin-bottom: 0.6rem;
+  }
+
+  .runtime-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.35rem;
+    font-size: 0.8rem;
+  }
+
+  .runtime-row strong {
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .runtime-meta {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.66rem;
+    color: var(--text-muted);
+  }
+
+  .runtime-note {
+    font-size: 0.74rem;
+    color: var(--text-muted);
+    margin: 0.15rem 0 0.45rem 0;
+  }
+
+  .runtime-subtitle {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin: 0.7rem 0 0.35rem 0;
+  }
+
+  .runtime-pill {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    padding: 0.1rem 0.35rem;
+    border-radius: 999px;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .runtime-pill-green { background: var(--green); color: #000; }
+  .runtime-pill-yellow { background: var(--yellow); color: #000; }
+  .runtime-pill-red { background: var(--red); color: #fff; }
+  .runtime-pill-muted { background: transparent; color: var(--text-muted); border: 1px solid var(--border); }
+
+  .runtime-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .runtime-list-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.45rem 0.5rem;
+    border-radius: 6px;
+    background: rgba(255,255,255,0.02);
+    border: 1px solid var(--border);
+  }
+
+  .runtime-primary {
+    font-size: 0.8rem;
+    color: var(--text);
+  }
+
+  .runtime-empty {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+
   .dash-task {
     padding: 0.5rem 0;
     border-bottom: 1px solid var(--border);

--- a/blog/templates/dashboard.html
+++ b/blog/templates/dashboard.html
@@ -17,6 +17,11 @@
     {% include 'partials/pipeline.html' %}
   </div>
 
+  <!-- Runtime transparency (dispatch/evidence/primitives/autonomy) -->
+  <div hx-get="/partials/runtime" hx-trigger="every 120s" hx-swap="innerHTML">
+    {% include 'partials/runtime.html' %}
+  </div>
+
   <!-- Operational Hotspots (collapsible) -->
   <div hx-get="/partials/hotspots" hx-trigger="every 120s" hx-swap="innerHTML">
     {% include 'partials/hotspots.html' %}

--- a/blog/templates/partials/runtime.html
+++ b/blog/templates/partials/runtime.html
@@ -1,0 +1,174 @@
+<div class="dash-section">
+  <h2 class="dash-section-title">runtime transparency</h2>
+
+  <div class="runtime-grid">
+    <div class="runtime-card">
+      <div class="runtime-card-title">dispatch cycle</div>
+      {% if runtime_current_cycle.available %}
+      <div class="runtime-row">
+        <strong>{{ runtime_current_cycle.skill or 'no skill yet' }}</strong>
+        <span class="runtime-pill runtime-pill-{{ runtime_current_cycle.phase_color }}">{{ runtime_current_cycle.phase_label }}</span>
+      </div>
+      <div class="runtime-meta">{{ runtime_current_cycle.trigger or '?' }} · {{ runtime_current_cycle.cycle_id }}</div>
+      <div class="runtime-subtitle">protocol slots</div>
+      <div class="runtime-row"><span>preflight</span><span class="runtime-meta">{{ runtime_current_cycle.preflight_status }}</span></div>
+      <div class="runtime-row"><span>skill</span><span class="runtime-meta">{{ runtime_current_cycle.skill_status }}</span></div>
+      <div class="runtime-row"><span>postflight</span><span class="runtime-meta">{{ runtime_current_cycle.postflight_status }}</span></div>
+      {% if runtime_current_cycle.opened_at_short %}
+      <div class="runtime-note">opened {{ runtime_current_cycle.opened_at_short }}{% if runtime_current_cycle.dispatched_at_short %} · dispatched {{ runtime_current_cycle.dispatched_at_short }}{% endif %}{% if runtime_current_cycle.closed_at_short %} · closed {{ runtime_current_cycle.closed_at_short }}{% endif %}</div>
+      {% endif %}
+      {% else %}
+      <div class="runtime-empty">no current dispatch file</div>
+      {% endif %}
+
+      {% if runtime_recent_cycles %}
+      <div class="runtime-subtitle">recent cycles</div>
+      <div class="runtime-list">
+        {% for cycle in runtime_recent_cycles %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ cycle.skill or 'no skill' }}</strong>
+            <span class="runtime-pill runtime-pill-{{ cycle.health_color }}">{{ cycle.health_label }}</span>
+          </div>
+          <div class="runtime-meta">{{ cycle.trigger or '?' }} · {{ cycle.cycle_id }}</div>
+          <div class="runtime-meta">{{ cycle.last_ts_short }}</div>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+
+    <div class="runtime-card">
+      <div class="runtime-card-title">lifecycle evidence</div>
+      <div class="runtime-row">
+        <strong>pre-skill</strong>
+        <span class="runtime-pill runtime-pill-{{ runtime_skill_evidence.pre_skill.color }}">{{ runtime_skill_evidence.pre_skill.status }}</span>
+      </div>
+      <div class="runtime-note">{{ runtime_skill_evidence.pre_skill.detail }} · protocol={{ runtime_skill_evidence.pre_skill.protocol_status }}</div>
+      <div class="runtime-row">
+        <strong>post-skill</strong>
+        <span class="runtime-pill runtime-pill-{{ runtime_skill_evidence.post_skill.color }}">{{ runtime_skill_evidence.post_skill.status }}</span>
+      </div>
+      <div class="runtime-note">{{ runtime_skill_evidence.post_skill.detail }} · protocol={{ runtime_skill_evidence.post_skill.protocol_status }}</div>
+
+      <div class="runtime-subtitle">skill-step runs</div>
+      <div class="runtime-row">
+        <span>recent runs</span>
+        <span class="runtime-meta">{{ runtime_skill_evidence.skill_runs_total }}</span>
+      </div>
+      <div class="runtime-row">
+        <span>silent skips</span>
+        <span class="runtime-meta">{{ runtime_skill_evidence.silent_skips_total }}</span>
+      </div>
+      <div class="runtime-row">
+        <span>explicit skips</span>
+        <span class="runtime-meta">{{ runtime_skill_evidence.explicit_skips_total }}</span>
+      </div>
+      {% if runtime_skill_evidence.skill_runs %}
+      <div class="runtime-list">
+        {% for run in runtime_skill_evidence.skill_runs %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ run.skill }}</strong>
+            <span class="runtime-meta">{{ run.completion_pct }}%</span>
+          </div>
+          <div class="runtime-meta">{{ run.ts_short }} · silent {{ run.silent_skips }} · explicit {{ run.explicit_skips }}</div>
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no skill-step runs recorded yet</div>
+      {% endif %}
+    </div>
+
+    <div class="runtime-card">
+      <div class="runtime-card-title">primitives & sources</div>
+      <div class="runtime-row">
+        <strong>calls ({{ runtime_primitives.window_days }}d)</strong>
+        <span class="runtime-meta">{{ runtime_primitives.total_calls }}</span>
+      </div>
+      <div class="runtime-row">
+        <span>manifested sources</span>
+        <span class="runtime-meta">{{ runtime_primitives.sources_total }}</span>
+      </div>
+      <div class="runtime-row">
+        <span>active</span>
+        <span class="runtime-meta">{{ runtime_primitives.status_counts.get('active', 0) }}</span>
+      </div>
+      <div class="runtime-row">
+        <span>contract-only</span>
+        <span class="runtime-meta">{{ runtime_primitives.status_counts.get('contract-only', 0) }}</span>
+      </div>
+
+      {% if runtime_primitives.top_used %}
+      <div class="runtime-subtitle">top used</div>
+      <div class="runtime-list">
+        {% for item in runtime_primitives.top_used %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ item.source }}</strong>
+            <span class="runtime-meta">{{ item.calls }} calls</span>
+          </div>
+          <div class="runtime-meta">fail={{ item.fail }} · avg={{ item.avg_ms }}ms · ok={{ item.ok_rate }}</div>
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no primitive usage rollup yet</div>
+      {% endif %}
+
+      {% if runtime_primitives.lifecycle %}
+      <div class="runtime-subtitle">recent lifecycle</div>
+      <div class="runtime-list">
+        {% for item in runtime_primitives.lifecycle %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ item.source or 'unknown' }}</strong>
+            <span class="runtime-meta">{{ item.type }}</span>
+          </div>
+          <div class="runtime-meta">{{ item.ts_short }}{% if item.status %} · {{ item.status }}{% endif %}{% if item.exit_code is not none %} · exit {{ item.exit_code }}{% endif %}</div>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+
+    <div class="runtime-card">
+      <div class="runtime-card-title">autonomy</div>
+      {% if runtime_autonomy.available %}
+      <div class="runtime-row">
+        <strong>sheridan</strong>
+        <span class="runtime-meta">{{ runtime_autonomy.avg }}/10 across {{ runtime_autonomy.total }} caps</span>
+      </div>
+      {% if runtime_autonomy.gaps %}
+      <div class="runtime-subtitle">lowest caps</div>
+      <div class="runtime-list">
+        {% for gap in runtime_autonomy.gaps %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ gap.name }}</strong>
+            <span class="runtime-meta">{{ gap.level }}/10</span>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% if runtime_autonomy.next_steps %}
+      <div class="runtime-subtitle">frontier</div>
+      <div class="runtime-list">
+        {% for step in runtime_autonomy.next_steps %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ step.id }}</strong>
+          </div>
+          <div class="runtime-meta">{{ step.title }}</div>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% else %}
+      <div class="runtime-empty">no autonomy capability file yet</div>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/tests/test_dashboard_runtime.sh
+++ b/tests/test_dashboard_runtime.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VENV_PY="${EDGE_BLOG_VENV:-$EDGE_DIR/blog/.venv/bin/python3}"
+if [ ! -x "$VENV_PY" ]; then
+    echo "Missing blog venv python: $VENV_PY" >&2
+    echo "Set EDGE_BLOG_VENV=/path/to/blog/.venv/bin/python3 when running from a clean worktree." >&2
+    exit 2
+fi
+
+TMP_BASE="$(mktemp -d /tmp/edge-dashboard-runtime-XXXXXX)"
+TMP_STATE="$TMP_BASE/state-root"
+AUTONOMY_DIR="$EDGE_DIR/autonomy"
+CAP_FILE="$AUTONOMY_DIR/capabilities.md"
+FRONTIER_FILE="$AUTONOMY_DIR/frontier.md"
+CAP_BACKUP="$TMP_BASE/capabilities.md.bak"
+FRONTIER_BACKUP="$TMP_BASE/frontier.md.bak"
+
+cleanup() {
+    if [ -f "$CAP_BACKUP" ]; then
+        mv "$CAP_BACKUP" "$CAP_FILE"
+    else
+        rm -f "$CAP_FILE"
+    fi
+    if [ -f "$FRONTIER_BACKUP" ]; then
+        mv "$FRONTIER_BACKUP" "$FRONTIER_FILE"
+    else
+        rm -f "$FRONTIER_FILE"
+    fi
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE/state/events" "$TMP_STATE/logs" "$TMP_STATE/blog/entries" "$AUTONOMY_DIR"
+
+if [ -f "$CAP_FILE" ]; then cp "$CAP_FILE" "$CAP_BACKUP"; fi
+if [ -f "$FRONTIER_FILE" ]; then cp "$FRONTIER_FILE" "$FRONTIER_BACKUP"; fi
+
+cat >"$TMP_STATE/state/current-dispatch.json" <<'JSON'
+{
+  "version": 1,
+  "cycle_id": "cycle-20260420T210000Z-test01",
+  "request": {
+    "trigger": "heartbeat",
+    "skill": "reflection",
+    "policy": "autonomous"
+  },
+  "state": {
+    "active": true,
+    "phase": "skill_dispatched",
+    "skill_dispatched": true,
+    "preflight_status": "completed",
+    "skill_status": "running",
+    "postflight_status": "pending",
+    "opened_at": "2026-04-20T21:00:00+00:00",
+    "dispatched_at": "2026-04-20T21:01:00+00:00",
+    "updated_at": "2026-04-20T21:01:30+00:00"
+  }
+}
+JSON
+
+cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
+{"ts":"2026-04-20T20:00:00+00:00","type":"CycleStarted","cycle_id":"cycle-a","payload":{"trigger":"heartbeat"}}
+{"ts":"2026-04-20T20:01:00+00:00","type":"SkillDispatched","cycle_id":"cycle-a","payload":{"trigger":"heartbeat","skill":"planner","dispatch_mode":"normal"}}
+{"ts":"2026-04-20T20:20:00+00:00","type":"CycleClosed","cycle_id":"cycle-a","payload":{"trigger":"heartbeat","skill":"planner","close_status":"completed"}}
+{"ts":"2026-04-20T20:30:00+00:00","type":"CycleStarted","cycle_id":"cycle-b","payload":{"trigger":"operator"}}
+{"ts":"2026-04-20T20:31:00+00:00","type":"SkillDispatched","cycle_id":"cycle-b","payload":{"trigger":"operator","skill":"research","dispatch_mode":"normal"}}
+{"ts":"2026-04-20T20:40:00+00:00","type":"PrimitiveContractWritten","cycle_id":"cycle-b","payload":{"source":"overleaf","status":"contract-only"}}
+{"ts":"2026-04-20T20:41:00+00:00","type":"PrimitiveProbeCompleted","cycle_id":"cycle-b","payload":{"source":"exa","exit_code":1,"ok":false}}
+JSONL
+
+cat >"$TMP_STATE/logs/skill-steps.jsonl" <<'JSONL'
+{"skill":"reflection","event":"end","expected":5,"done":4,"explicit_skips":1,"silent_skips":["crossref"],"completion_pct":80,"ts":"2026-04-20T20:02:00"}
+{"skill":"research","event":"end","expected":6,"done":6,"explicit_skips":0,"silent_skips":[],"completion_pct":100,"ts":"2026-04-20T20:32:00"}
+JSONL
+
+cat >"$TMP_STATE/state/primitive-usage-rollup.json" <<'JSON'
+{
+  "window_days": 30,
+  "total_calls": 17,
+  "by_source": {
+    "exa": {"calls": 10, "ok": 8, "fail": 2, "ok_rate": 0.8, "avg_ms": 410, "last_ts": "2026-04-20T20:41:00+00:00"},
+    "grok": {"calls": 5, "ok": 5, "fail": 0, "ok_rate": 1.0, "avg_ms": 900, "last_ts": "2026-04-20T19:41:00+00:00"},
+    "overleaf": {"calls": 2, "ok": 0, "fail": 2, "ok_rate": 0.0, "avg_ms": 120, "last_ts": "2026-04-20T20:40:00+00:00"}
+  }
+}
+JSON
+
+cat >"$TMP_STATE/state/sources-manifest.yaml" <<'YAML'
+version: 1
+sources:
+  - name: exa
+    status: active
+  - name: grok
+    status: active
+  - name: overleaf
+    status: contract-only
+YAML
+
+cat >"$CAP_FILE" <<'MD'
+| # | Name | Sheridan |
+|---|------|----------|
+| 1 | Safe execution | 8 |
+| 2 | Runtime transparency | 4 |
+| 3 | Primitive stewardship | 3 |
+MD
+
+cat >"$FRONTIER_FILE" <<'MD'
+### GAP-101: instrument explicit pre-skill evidence
+### GAP-102: instrument explicit post-skill evidence
+MD
+
+EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$VENV_PY" - <<'PY'
+import os
+import sys
+
+edge_dir = os.environ["EDGE_REPO_DIR"]
+sys.path.insert(0, edge_dir)
+sys.path.insert(0, os.path.join(edge_dir, "blog"))
+os.chdir(os.path.join(edge_dir, "blog"))
+
+from app import app
+
+client = app.test_client()
+runtime = client.get("/api/dashboard/runtime")
+assert runtime.status_code == 200, runtime.status_code
+data = runtime.get_json()
+
+assert data["runtime_current_cycle"]["active"] is True
+assert data["runtime_current_cycle"]["skill"] == "reflection"
+assert data["runtime_skill_evidence"]["pre_skill"]["status"] == "gap"
+assert data["runtime_skill_evidence"]["post_skill"]["status"] == "gap"
+assert data["runtime_skill_evidence"]["skill_runs_total"] == 2
+assert data["runtime_primitives"]["total_calls"] == 17
+assert data["runtime_primitives"]["status_counts"]["contract-only"] == 1
+assert data["runtime_autonomy"]["available"] is True
+assert data["runtime_autonomy"]["avg"] == 5.0
+assert len(data["runtime_recent_cycles"]) >= 2
+
+partial = client.get("/partials/runtime")
+assert partial.status_code == 200, partial.status_code
+text = partial.get_data(as_text=True)
+assert "runtime transparency" in text
+assert "reflection" in text
+assert "contract-only" in text
+assert "GAP-101" in text
+print("ok")
+PY

--- a/tests/test_ops_console.sh
+++ b/tests/test_ops_console.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 BLOG_DIR="$EDGE_DIR/blog"
+export EDGE_REPO_DIR="$EDGE_DIR"
 VENV_PY="${EDGE_BLOG_VENV:-$BLOG_DIR/.venv/bin/python3}"
 if [ ! -x "$VENV_PY" ]; then
     echo "Missing blog venv python: $VENV_PY" >&2
@@ -51,7 +52,20 @@ fi
 echo ""
 echo "[2/3] Flask app starts"
 
-if cd "$BLOG_DIR" && "$VENV_PY" -c "from app import app; print('OK')" >/dev/null 2>&1; then
+if cd "$EDGE_DIR" && "$VENV_PY" - <<'PYEOF' "$EDGE_DIR" >/dev/null 2>&1
+import os
+import sys
+
+edge_dir = sys.argv[1]
+sys.path.insert(0, edge_dir)
+sys.path.insert(0, os.path.join(edge_dir, "blog"))
+os.chdir(os.path.join(edge_dir, "blog"))
+
+from app import app
+
+print("OK")
+PYEOF
+then
     pass_test "Flask app creates successfully"
 else
     fail_test "Flask app creates successfully"
@@ -93,6 +107,7 @@ def check_redirect(name, response, expect_location, expect_status=302):
 check("GET /api/dashboard/overview", client.get("/api/dashboard/overview"))
 check("GET /api/dashboard/alerts", client.get("/api/dashboard/alerts"))
 check("GET /api/dashboard/pipeline", client.get("/api/dashboard/pipeline"))
+check("GET /api/dashboard/runtime", client.get("/api/dashboard/runtime"))
 check("GET /api/dashboard/hotspots", client.get("/api/dashboard/hotspots"))
 check("GET /api/dashboard/corpus", client.get("/api/dashboard/corpus"))
 check_redirect("GET / -> /dashboard", client.get("/"), "/dashboard")
@@ -109,6 +124,7 @@ mark = "PASS" if ok else "FAIL"
 print(f'{mark}|POST /api/heartbeat/trigger|{r.status_code}|200 or 429')
 
 check("GET /partials/status-strip", client.get("/partials/status-strip"))
+check("GET /partials/runtime", client.get("/partials/runtime"))
 check("GET /dashboard", client.get("/dashboard"))
 PYEOF
 


### PR DESCRIPTION
## Summary

- add a new dashboard runtime transparency section covering dispatch cycles, lifecycle evidence, primitive/source behavior, and autonomy summary
- add `/api/dashboard/runtime` and `/partials/runtime` so the surface is available both as JSON and as a live dashboard fragment
- add fixture-driven runtime tests and make the ops-console test pin `EDGE_REPO_DIR` to the current worktree so multi-checkout environments do not import the wrong app

## Why

Implements #266.

The dashboard previously exposed health, pipeline, hotspots, corpus, briefing, and threads, but still lacked a first-class runtime surface for:

- current/recent dispatch cycles
- explicit visibility into missing pre-skill/post-skill evidence
- primitive usage/lifecycle state
- autonomy/self-model signals

This PR turns those runtime states into operator-facing read models without changing the execution pipeline itself.

## Validation

Commands used:

```bash
EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_runtime.sh
EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_ops_console.sh
/home/vboxuser/edge/blog/.venv/bin/python3 -m py_compile blog/app.py blog/api_dashboard.py blog/services.py
```

Results:

- `tests/test_dashboard_runtime.sh` passes with fixture state covering dispatch, skill-step evidence gaps, primitive rollups, manifest status, and autonomy frontier
- `py_compile` passes for `blog/app.py`, `blog/api_dashboard.py`, and `blog/services.py`
- `tests/test_ops_console.sh` reaches `16/17` passing checks
- the only remaining failure is the same pre-existing one already observed on `main`: `POST /api/tasks/TASK-20260309-001/action` returns `405`

## Notes

- pre-skill and post-skill are surfaced explicitly as evidence gaps when no runtime event exists yet; they are no longer silently assumed
- `/blog` compatibility remains untouched; this PR only adds runtime transparency to the canonical dashboard surface