### PR TITLE
[codex] add dashboard epistemic and steering surfaces

### DIFF
--- a/blog/api_dashboard.py
+++ b/blog/api_dashboard.py
@@ -6,8 +6,9 @@ from blog.services import (
     load_hotspots, load_git_signals, load_curadoria, load_threads_enriched,
     get_publish_commits, get_error_pressure_24h,
     get_heartbeat_status, get_production_stats, get_briefing_html,
+    load_claims_dashboard, load_lineage_dashboard, load_proposals_dashboard,
     load_autonomy_summary, load_current_dispatch_state, load_primitive_runtime_summary,
-    load_recent_dispatch_cycles, load_skill_evidence_summary,
+    load_recent_dispatch_cycles, load_skill_evidence_summary, load_strategy_dashboard,
 )
 
 dashboard_bp = Blueprint("dashboard", __name__)
@@ -447,3 +448,26 @@ def partial_runtime():
     """HTMX partial: runtime transparency section fragment."""
     data = _build_runtime_data()
     return render_template("partials/runtime.html", **data)
+
+
+def _build_epistemic_data():
+    """Build context dict for epistemic and steering surfaces."""
+    return {
+        "ep_claims": load_claims_dashboard(limit=6),
+        "ep_strategy": load_strategy_dashboard(limit_topics=5, limit_objectives=5),
+        "ep_proposals": load_proposals_dashboard(limit=5),
+        "ep_lineage": load_lineage_dashboard(limit=6),
+    }
+
+
+@dashboard_bp.route("/api/dashboard/epistemics")
+def epistemics():
+    """Epistemic and steering read model for claims, strategy, proposals, and lineage."""
+    return jsonify(_build_epistemic_data())
+
+
+@dashboard_bp.route("/partials/epistemics")
+def partial_epistemics():
+    """HTMX partial: epistemic and steering section fragment."""
+    data = _build_epistemic_data()
+    return render_template("partials/epistemics.html", **data)

--- a/blog/app.py
+++ b/blog/app.py
@@ -51,7 +51,7 @@ sys.path.insert(0, str(ROOT))
 
 import yaml as _yaml
 
-from blog.api_dashboard import dashboard_bp, _build_status_strip_data, _build_alerts_data, _build_pipeline_data, _build_hotspots_data, _build_corpus_data, _build_briefing_data, _build_runtime_data
+from blog.api_dashboard import dashboard_bp, _build_status_strip_data, _build_alerts_data, _build_pipeline_data, _build_hotspots_data, _build_corpus_data, _build_briefing_data, _build_epistemic_data, _build_runtime_data
 
 # ─── Branding ───
 _branding_path = ROOT / "config" / "branding.yaml"
@@ -1333,6 +1333,7 @@ def dashboard_page():
     hotspots_data = _build_hotspots_data()
     corpus_data = _build_corpus_data()
     briefing_data = _build_briefing_data()
+    epistemic_data = _build_epistemic_data()
     runtime_data = _build_runtime_data()
     threads_data = _build_threads_data()
 
@@ -1350,6 +1351,7 @@ def dashboard_page():
         **hotspots_data,
         **corpus_data,
         **briefing_data,
+        **epistemic_data,
         **runtime_data,
         **threads_data,
     )

--- a/blog/services.py
+++ b/blog/services.py
@@ -24,16 +24,20 @@ from paths import (  # noqa: E402
     GIT_SIGNALS_FILE as GIT_SIGNALS,
     LOGS_DIR,
     OPS_HOTSPOTS,
+    PROPOSALS_FILE,
     REPORTS_DIR,
+    SIGNALS_DIR,
     SKILL_STEPS_FILE,
     SOURCES_MANIFEST_FILE,
     STATE_EVENTS_FILE,
     STATE_DIR,
+    TOPICS_DIR,
     THREADS_DIR,
 )
 
 ROOT = EDGE_REPO_DIR
 PRIMITIVE_USAGE_ROLLUP_FILE = STATE_DIR / "primitive-usage-rollup.json"
+STRATEGY_FILE = ROOT / "config" / "strategy.md"
 
 
 def load_json_safe(path, default=None):
@@ -388,6 +392,189 @@ def load_autonomy_summary():
             "gaps": [],
             "next_steps": [],
         }
+
+
+def _entry_records():
+    records = []
+    if not ENTRIES_DIR.exists():
+        return records
+    for fp in sorted(ENTRIES_DIR.glob("*.md"), reverse=True):
+        try:
+            raw = fp.read_text(encoding="utf-8", errors="replace")
+            parts = raw.split("---", 2)
+            if len(parts) < 3:
+                continue
+            fm = yaml.safe_load(parts[1]) or {}
+            claims = fm.get("claims", [])
+            if isinstance(claims, str):
+                claims = [claims]
+            if not isinstance(claims, list):
+                claims = []
+            threads = fm.get("threads", [])
+            if isinstance(threads, str):
+                threads = [t.strip() for t in threads.split(",") if t.strip()]
+            if not isinstance(threads, list):
+                threads = []
+            records.append({
+                "path": fp,
+                "filename": fp.name,
+                "slug": fp.stem,
+                "title": fm.get("title", fp.stem),
+                "date": str(fm.get("date", "")),
+                "claims": claims,
+                "threads": [str(t).strip() for t in threads if str(t).strip()],
+                "report": fm.get("report"),
+            })
+        except Exception:
+            continue
+    return records
+
+
+def load_claims_dashboard(limit=6):
+    """Summarize claim state from entry frontmatter."""
+    verified_total = 0
+    open_total = 0
+    recent = []
+    for entry in _entry_records():
+        for raw_claim in entry["claims"]:
+            text = raw_claim.get("claim", "") if isinstance(raw_claim, dict) else str(raw_claim)
+            status = raw_claim.get("status") if isinstance(raw_claim, dict) else None
+            is_gap = str(text).startswith("!") or status in {"open", "disputed", "stale"}
+            clean_text = str(text).lstrip("! ").strip()
+            if not clean_text:
+                continue
+            if is_gap:
+                open_total += 1
+            else:
+                verified_total += 1
+            if len(recent) < limit:
+                recent.append({
+                    "text": clean_text,
+                    "kind": "gap" if is_gap else "verified",
+                    "kind_color": "red" if is_gap else "green",
+                    "artifact_title": entry["title"],
+                    "artifact_filename": entry["filename"],
+                    "threads": entry["threads"],
+                    "date": entry["date"],
+                })
+    return {
+        "total": verified_total + open_total,
+        "verified_total": verified_total,
+        "open_total": open_total,
+        "recent": recent,
+    }
+
+
+def load_strategy_dashboard(limit_topics=5, limit_objectives=5):
+    """Summarize strategy text, topics, and active objectives."""
+    summary_lines = []
+    priorities = []
+    if STRATEGY_FILE.exists():
+        try:
+            for line in STRATEGY_FILE.read_text(encoding="utf-8", errors="replace").splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith("<!--"):
+                    continue
+                if stripped.startswith(("- ", "* ")):
+                    priorities.append(stripped[2:].strip())
+                elif not stripped.startswith("#") and len(summary_lines) < 2:
+                    summary_lines.append(stripped)
+        except Exception:
+            pass
+
+    topics = []
+    if TOPICS_DIR.exists():
+        for fp in sorted(TOPICS_DIR.glob("*.md")):
+            try:
+                raw = fp.read_text(encoding="utf-8", errors="replace")
+                heading = next((line.lstrip("# ").strip() for line in raw.splitlines() if line.startswith("# ")), fp.stem)
+                topics.append({"name": fp.stem, "title": heading})
+            except Exception:
+                continue
+
+    thread_data = load_threads_enriched()
+    objectives = []
+    for thread in thread_data.get("threads", []):
+        if thread.get("status") not in {"active", "proposed"}:
+            continue
+        objectives.append({
+            "thread_id": thread["id"],
+            "title": thread["title"],
+            "goal": thread.get("goal") or thread["title"],
+            "status": thread.get("status"),
+            "next_step": thread.get("next_step"),
+        })
+
+    return {
+        "available": STRATEGY_FILE.exists(),
+        "summary": " ".join(summary_lines[:2]).strip(),
+        "priorities": priorities[:4],
+        "topics": topics[:limit_topics],
+        "topics_total": len(topics),
+        "objectives": objectives[:limit_objectives],
+    }
+
+
+def load_proposals_dashboard(limit=5):
+    """Summarize active proposals and recent decisions."""
+    active = []
+    for proposal in load_json_safe(PROPOSALS_FILE, []):
+        if proposal.get("status") != "active":
+            continue
+        active.append({
+            "id": proposal.get("id"),
+            "title": proposal.get("title", "untitled"),
+            "type": proposal.get("type", "proposal"),
+            "updated_short": _short_ts(proposal.get("updated") or proposal.get("created")),
+            "evidence_count": len(proposal.get("evidence", []) or []),
+            "cost": proposal.get("cost"),
+        })
+    active.sort(key=lambda item: item.get("updated_short", ""), reverse=True)
+
+    decisions = []
+    decision_path = SIGNALS_DIR / "decision.md"
+    if decision_path.exists():
+        try:
+            for line in reversed(decision_path.read_text(encoding="utf-8", errors="replace").splitlines()):
+                stripped = line.strip()
+                if stripped.startswith(("- ", "* ")):
+                    decisions.append(stripped[2:].strip())
+                if len(decisions) >= limit:
+                    break
+        except Exception:
+            pass
+
+    return {
+        "active_count": len(active),
+        "active": active[:limit],
+        "decisions": decisions,
+    }
+
+
+def load_lineage_dashboard(limit=6):
+    """Build recent claim -> thread -> artifact lineage rows."""
+    lineage = []
+    for entry in _entry_records():
+        for raw_claim in entry["claims"]:
+            text = raw_claim.get("claim", "") if isinstance(raw_claim, dict) else str(raw_claim)
+            status = raw_claim.get("status") if isinstance(raw_claim, dict) else None
+            clean_text = str(text).lstrip("! ").strip()
+            if not clean_text:
+                continue
+            is_gap = str(text).startswith("!") or status in {"open", "disputed", "stale"}
+            lineage.append({
+                "claim": clean_text,
+                "claim_status": "gap" if is_gap else "verified",
+                "claim_color": "red" if is_gap else "green",
+                "threads": entry["threads"],
+                "artifact_title": entry["title"],
+                "artifact_filename": entry["filename"],
+                "report": entry["report"],
+                "date": entry["date"],
+            })
+            if len(lineage) >= limit:
+                return lineage
+    return lineage
 
 
 def load_hotspots():

--- a/blog/templates/dashboard.html
+++ b/blog/templates/dashboard.html
@@ -22,6 +22,11 @@
     {% include 'partials/runtime.html' %}
   </div>
 
+  <!-- Epistemic + steering (claims/strategy/proposals/lineage) -->
+  <div hx-get="/partials/epistemics" hx-trigger="every 120s" hx-swap="innerHTML">
+    {% include 'partials/epistemics.html' %}
+  </div>
+
   <!-- Operational Hotspots (collapsible) -->
   <div hx-get="/partials/hotspots" hx-trigger="every 120s" hx-swap="innerHTML">
     {% include 'partials/hotspots.html' %}

--- a/blog/templates/partials/epistemics.html
+++ b/blog/templates/partials/epistemics.html
@@ -1,0 +1,149 @@
+<div class="dash-section">
+  <h2 class="dash-section-title">epistemic & steering</h2>
+
+  <div class="runtime-grid">
+    <div class="runtime-card">
+      <div class="runtime-card-title">claims</div>
+      <div class="runtime-row">
+        <strong>verified</strong>
+        <span class="runtime-meta">{{ ep_claims.verified_total }}</span>
+      </div>
+      <div class="runtime-row">
+        <strong>open / disputed</strong>
+        <span class="runtime-meta">{{ ep_claims.open_total }}</span>
+      </div>
+      {% if ep_claims.recent %}
+      <div class="runtime-subtitle">recent claims</div>
+      <div class="runtime-list">
+        {% for item in ep_claims.recent %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ item.text }}</strong>
+            <span class="runtime-pill runtime-pill-{{ item.kind_color }}">{{ item.kind }}</span>
+          </div>
+          <div class="runtime-meta"><a href="/blog/entries/{{ item.artifact_filename }}" style="color:inherit">{{ item.artifact_title }}</a>{% if item.threads %} · {{ item.threads|join(', ') }}{% endif %}</div>
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no claims indexed from entries yet</div>
+      {% endif %}
+    </div>
+
+    <div class="runtime-card">
+      <div class="runtime-card-title">strategy, topics, objectives</div>
+      {% if ep_strategy.available %}
+      <div class="runtime-note">{{ ep_strategy.summary or 'strategy file present but no summary text extracted yet' }}</div>
+      {% if ep_strategy.priorities %}
+      <div class="runtime-subtitle">priorities</div>
+      <div class="runtime-list">
+        {% for item in ep_strategy.priorities %}
+        <div class="runtime-list-item"><div class="runtime-primary">{{ item }}</div></div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% else %}
+      <div class="runtime-empty">no strategy.md yet</div>
+      {% endif %}
+
+      <div class="runtime-subtitle">topics ({{ ep_strategy.topics_total }})</div>
+      {% if ep_strategy.topics %}
+      <div class="runtime-list">
+        {% for topic in ep_strategy.topics %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ topic.name }}</strong>
+          </div>
+          <div class="runtime-meta">{{ topic.title }}</div>
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no topic files loaded yet</div>
+      {% endif %}
+
+      <div class="runtime-subtitle">active objectives</div>
+      {% if ep_strategy.objectives %}
+      <div class="runtime-list">
+        {% for objective in ep_strategy.objectives %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong><a href="/thread/{{ objective.thread_id }}" style="color:inherit">{{ objective.title }}</a></strong>
+            <span class="runtime-meta">{{ objective.status }}</span>
+          </div>
+          <div class="runtime-meta">{{ objective.goal }}</div>
+          {% if objective.next_step %}
+          <div class="runtime-meta">next: {{ objective.next_step }}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no active thread objectives yet</div>
+      {% endif %}
+    </div>
+
+    <div class="runtime-card">
+      <div class="runtime-card-title">proposals & decisions</div>
+      <div class="runtime-row">
+        <strong>active proposals</strong>
+        <span class="runtime-meta">{{ ep_proposals.active_count }}</span>
+      </div>
+      {% if ep_proposals.active %}
+      <div class="runtime-list">
+        {% for proposal in ep_proposals.active %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ proposal.title }}</strong>
+            <span class="runtime-meta">{{ proposal.type }}</span>
+          </div>
+          <div class="runtime-meta">{{ proposal.updated_short }} · evidence {{ proposal.evidence_count }}{% if proposal.cost %} · {{ proposal.cost }}{% endif %}</div>
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no active proposals</div>
+      {% endif %}
+
+      <div class="runtime-subtitle">recent decisions</div>
+      {% if ep_proposals.decisions %}
+      <div class="runtime-list">
+        {% for item in ep_proposals.decisions %}
+        <div class="runtime-list-item"><div class="runtime-primary">{{ item }}</div></div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no decision log entries yet</div>
+      {% endif %}
+    </div>
+
+    <div class="runtime-card">
+      <div class="runtime-card-title">lineage</div>
+      {% if ep_lineage %}
+      <div class="runtime-list">
+        {% for item in ep_lineage %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ item.claim }}</strong>
+            <span class="runtime-pill runtime-pill-{{ item.claim_color }}">{{ item.claim_status }}</span>
+          </div>
+          <div class="runtime-meta">
+            {% if item.threads %}
+              {% for tid in item.threads %}
+                <a href="/thread/{{ tid }}" style="color:inherit">{{ tid }}</a>{% if not loop.last %}, {% endif %}
+              {% endfor %}
+            {% else %}
+              no thread
+            {% endif %}
+            → <a href="/blog/entries/{{ item.artifact_filename }}" style="color:inherit">{{ item.artifact_title }}</a>
+            {% if item.report %} · <a href="/reports/{{ item.report }}" style="color:inherit">report</a>{% endif %}
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no claim/thread/artifact lineage yet</div>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/tests/test_dashboard_epistemics.sh
+++ b/tests/test_dashboard_epistemics.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VENV_PY="${EDGE_BLOG_VENV:-$EDGE_DIR/blog/.venv/bin/python3}"
+if [ ! -x "$VENV_PY" ]; then
+    echo "Missing blog venv python: $VENV_PY" >&2
+    echo "Set EDGE_BLOG_VENV=/path/to/blog/.venv/bin/python3 when running from a clean worktree." >&2
+    exit 2
+fi
+
+TMP_BASE="$(mktemp -d /tmp/edge-dashboard-epistemics-XXXXXX)"
+TMP_STATE="$TMP_BASE/state-root"
+TMP_HOME="$TMP_BASE/home"
+STRATEGY_FILE="$EDGE_DIR/config/strategy.md"
+STRATEGY_BACKUP="$TMP_BASE/strategy.md.bak"
+
+cleanup() {
+    if [ -f "$STRATEGY_BACKUP" ]; then
+        mv "$STRATEGY_BACKUP" "$STRATEGY_FILE"
+    else
+        rm -f "$STRATEGY_FILE"
+    fi
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE/blog/entries" "$TMP_STATE/state/signals" "$TMP_STATE/threads" "$TMP_HOME/.claude/projects/test-project/memory/topics"
+
+if [ -f "$STRATEGY_FILE" ]; then cp "$STRATEGY_FILE" "$STRATEGY_BACKUP"; fi
+
+cat >"$STRATEGY_FILE" <<'MD'
+# Strategy
+
+Stabilize runtime visibility while tightening epistemic curation.
+
+- make hidden belief-state visible in the dashboard
+- connect active threads to operator direction
+- reduce ambiguity between artifacts and steering state
+MD
+
+cat >"$TMP_HOME/.claude/projects/test-project/memory/topics/dispatch.md" <<'MD'
+# Dispatch transparency
+MD
+
+cat >"$TMP_HOME/.claude/projects/test-project/memory/topics/lineage.md" <<'MD'
+# Knowledge lineage
+MD
+
+cat >"$TMP_STATE/blog/entries/2026-04-20-claims-a.md" <<'MD'
+---
+title: "Dispatch evidence review"
+date: "2026-04-20"
+claims:
+  - "Dispatch cycles need explicit close evidence"
+  - "!Pre-skill is still not instrumented"
+threads:
+  - runtime-transparency
+report: dispatch-evidence.html
+---
+body
+MD
+
+cat >"$TMP_STATE/blog/entries/2026-04-20-claims-b.md" <<'MD'
+---
+title: "Strategy alignment note"
+date: "2026-04-20"
+claims:
+  - "Threads should be linked to operator-visible objectives"
+threads:
+  - strategy-alignment
+---
+body
+MD
+
+cat >"$TMP_STATE/threads/runtime-transparency.md" <<'MD'
+---
+id: runtime-transparency
+title: "Runtime transparency"
+status: active
+owner: ed
+goal: "Expose dispatch and evidence state to the operator"
+---
+## Next
+Ship the runtime dashboard section.
+MD
+
+cat >"$TMP_STATE/threads/strategy-alignment.md" <<'MD'
+---
+id: strategy-alignment
+title: "Strategy alignment"
+status: proposed
+owner: ed
+goal: "Make direction explicit and inspectable"
+---
+## Next
+Link active work to strategy.
+MD
+
+cat >"$TMP_STATE/state/proposals.json" <<'JSON'
+[
+  {"id":"prop-1","title":"Surface lineage in dashboard","type":"execution","status":"active","created":"2026-04-20T20:00:00+00:00","updated":"2026-04-20T20:10:00+00:00","evidence":["Dispatch evidence review","Strategy alignment note"],"cost":"medium"},
+  {"id":"prop-2","title":"Promote claim gap tracker","type":"experiment","status":"active","created":"2026-04-20T20:05:00+00:00","updated":"2026-04-20T20:12:00+00:00","evidence":["Pre-skill is still not instrumented"]}
+]
+JSON
+
+cat >"$TMP_STATE/state/signals/decision.md" <<'MD'
+- Approved dashboard lineage slice
+- Deferred workflow board cleanup
+MD
+
+HOME="$TMP_HOME" MEMORY_PROJECT_DIR="test-project" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$VENV_PY" - <<'PY'
+import os
+import sys
+
+edge_dir = os.environ["EDGE_REPO_DIR"]
+sys.path.insert(0, edge_dir)
+sys.path.insert(0, os.path.join(edge_dir, "blog"))
+os.chdir(os.path.join(edge_dir, "blog"))
+
+from app import app
+
+client = app.test_client()
+resp = client.get("/api/dashboard/epistemics")
+assert resp.status_code == 200, resp.status_code
+data = resp.get_json()
+
+assert data["ep_claims"]["verified_total"] == 2
+assert data["ep_claims"]["open_total"] == 1
+assert data["ep_strategy"]["available"] is True
+assert data["ep_strategy"]["topics_total"] == 2
+assert len(data["ep_strategy"]["objectives"]) >= 2
+assert data["ep_proposals"]["active_count"] == 2
+assert len(data["ep_proposals"]["decisions"]) == 2
+assert len(data["ep_lineage"]) >= 2
+
+partial = client.get("/partials/epistemics")
+assert partial.status_code == 200, partial.status_code
+text = partial.get_data(as_text=True)
+assert "epistemic & steering" in text
+assert "Dispatch evidence review" in text
+assert "Surface lineage in dashboard" in text
+assert "Runtime transparency" in text
+print("ok")
+PY

--- a/tests/test_ops_console.sh
+++ b/tests/test_ops_console.sh
@@ -108,6 +108,7 @@ check("GET /api/dashboard/overview", client.get("/api/dashboard/overview"))
 check("GET /api/dashboard/alerts", client.get("/api/dashboard/alerts"))
 check("GET /api/dashboard/pipeline", client.get("/api/dashboard/pipeline"))
 check("GET /api/dashboard/runtime", client.get("/api/dashboard/runtime"))
+check("GET /api/dashboard/epistemics", client.get("/api/dashboard/epistemics"))
 check("GET /api/dashboard/hotspots", client.get("/api/dashboard/hotspots"))
 check("GET /api/dashboard/corpus", client.get("/api/dashboard/corpus"))
 check_redirect("GET / -> /dashboard", client.get("/"), "/dashboard")
@@ -125,6 +126,7 @@ print(f'{mark}|POST /api/heartbeat/trigger|{r.status_code}|200 or 429')
 
 check("GET /partials/status-strip", client.get("/partials/status-strip"))
 check("GET /partials/runtime", client.get("/partials/runtime"))
+check("GET /partials/epistemics", client.get("/partials/epistemics"))
 check("GET /dashboard", client.get("/dashboard"))
 PYEOF
 


### PR DESCRIPTION
## Summary

- add a new epistemic/steering dashboard section for claims, strategy/topics/objectives, proposals/decisions, and lineage
- add `/api/dashboard/epistemics` and `/partials/epistemics` so the same read model is available as JSON and as a live dashboard fragment
- add a fixture-driven test for epistemic surfaces and extend the ops-console smoke test to cover the new routes

## Why

Implements #267.

The dashboard already had runtime transparency and thread views, but it still lacked a single operator-facing surface for belief-state and steering-state:

- claims and gaps
- operator-visible direction via strategy/topics/objectives
- proposals and decisions
- lineage between claims, threads, and artifacts

This PR exposes those states without rewriting existing feed/workflow/thread surfaces.

## Validation

Commands used:

```bash
EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_epistemics.sh
EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_ops_console.sh
/home/vboxuser/edge/blog/.venv/bin/python3 -m py_compile blog/app.py blog/api_dashboard.py blog/services.py
```

Results:

- `tests/test_dashboard_epistemics.sh` passes with fixture state for claims, threads/objectives, strategy, topics, proposals, decisions, and lineage
- `py_compile` passes for `blog/app.py`, `blog/api_dashboard.py`, and `blog/services.py`
- `tests/test_ops_console.sh` reaches `18/19` passing checks
- the only remaining failure is still the same pre-existing one on `main`: `POST /api/tasks/TASK-20260309-001/action` returns `405`

## Notes

- this PR complements the existing threads panel rather than replacing it
- lineage is surfaced as claim -> thread -> artifact/report links so epistemic state and outputs are visible from one place