### PR TITLE
[dashboard] Queue epistemic steering for next dispatch

### DIFF
--- a/blog/api_actions.py
+++ b/blog/api_actions.py
@@ -30,7 +30,7 @@ def _now_str():
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _log_operator_action(target_id, action, reason=None, value=None):
+def _log_operator_action(target_id, action, reason=None, value=None, **extra):
     entry = {
         "ts": _now_str(),
         "actor": "operator",
@@ -41,6 +41,9 @@ def _log_operator_action(target_id, action, reason=None, value=None):
         entry["reason"] = reason
     if value is not None:
         entry["value"] = value
+    for key, item in extra.items():
+        if item is not None:
+            entry[key] = item
     OPERATOR_LOG.parent.mkdir(parents=True, exist_ok=True)
     with open(OPERATOR_LOG, "a", encoding="utf-8") as f:
         f.write(json.dumps(entry, ensure_ascii=False) + "\n")
@@ -126,6 +129,13 @@ def heartbeat_trigger():
 
 
 VALID_THREAD_ACTIONS = {"active", "dormant", "done"}
+VALID_STEERING_ACTIONS = {
+    "proposal": {"approve", "reject", "defer", "request-revision"},
+    "claim": {"promote", "verified", "disputed", "stale"},
+    "topic": {"promote", "prioritize", "defer"},
+    "objective": {"attach", "retire", "defer"},
+    "strategy": {"align", "reprioritize", "redirect", "review-drift"},
+}
 
 
 @actions_bp.route('/api/threads/<thread_id>/action', methods=['POST'])
@@ -179,7 +189,16 @@ def task_action(task_id):
 
     intent_text = _build_task_intent_text(task_id, action, reason=reason, value=None if value is None else str(value))
     chat_id = add_chat("user", intent_text)
-    _log_operator_action(task_id, f"task-intent:{action}", reason=reason, value=value)
+    _log_operator_action(
+        task_id,
+        f"task-intent:{action}",
+        reason=reason,
+        value=value,
+        target_type="task",
+        label=task_id,
+        resulting_state="queued",
+        apply="next-dispatch",
+    )
     return jsonify({
         "ok": True,
         "queued": True,
@@ -187,4 +206,140 @@ def task_action(task_id):
         "task_id": task_id,
         "chat_id": chat_id,
         "dispatch_mode": "next-dispatch",
+    }), 200
+
+
+def _build_steering_intent_text(target_type, target_id, action, label=None, reference=None, reason=None, value=None):
+    lines = [
+        "[steering-intent]",
+        f"target_type: {target_type}",
+        f"target_id: {target_id}",
+        f"action: {action}",
+        "apply: next-dispatch",
+        "resulting_state: queued",
+    ]
+    if label:
+        lines.append(f"label: {label}")
+    if reference:
+        lines.append(f"reference: {reference}")
+    if reason:
+        lines.append(f"reason: {reason}")
+    if value is not None:
+        lines.append(f"value: {value}")
+    lines.append("note: queue this operator epistemic steering decision for the next dispatch; do not apply it immediately")
+    return "\n".join(lines)
+
+
+def _parse_steering_intent_text(text):
+    if not text or not str(text).startswith("[steering-intent]"):
+        return None
+    data = {}
+    for line in str(text).splitlines()[1:]:
+        if ":" not in line:
+            continue
+        key, raw_value = line.split(":", 1)
+        key = key.strip().lower()
+        value = raw_value.strip()
+        if key:
+            data[key] = value
+    target_type = data.get("target_type")
+    target_id = data.get("target_id")
+    action = data.get("action")
+    if not target_type or not target_id or not action:
+        return None
+    return {
+        "target_type": target_type,
+        "target_id": target_id,
+        "action": action,
+        "label": data.get("label"),
+        "reference": data.get("reference"),
+        "reason": data.get("reason"),
+        "value": data.get("value"),
+        "apply": data.get("apply"),
+        "resulting_state": data.get("resulting_state"),
+        "note": data.get("note"),
+    }
+
+
+def _find_pending_steering_intent(target_type, target_id, action, reason=None, value=None):
+    from dashboard_db import get_chats
+
+    for message in get_chats(unprocessed_only=True, limit=200):
+        if message.get("author") != "user":
+            continue
+        parsed = _parse_steering_intent_text(message.get("text", ""))
+        if not parsed:
+            continue
+        if parsed["target_type"] != target_type or parsed["target_id"] != target_id or parsed["action"] != action:
+            continue
+        if (parsed.get("reason") or None) != reason:
+            continue
+        if (parsed.get("value") or None) != (None if value is None else str(value)):
+            continue
+        return message
+    return None
+
+
+@actions_bp.route('/api/steering/<target_type>/<path:target_id>/action', methods=['POST'])
+def steering_action(target_type, target_id):
+    target_type = str(target_type or "").strip().lower()
+    if target_type not in VALID_STEERING_ACTIONS:
+        return jsonify({"error": f"Invalid target_type. Must be one of: {', '.join(sorted(VALID_STEERING_ACTIONS))}"}), 400
+
+    data = request.get_json(silent=True) or {}
+    action = str(data.get("action") or "").strip().lower()
+    reason = str(data.get("reason") or "").strip() or None
+    value = data.get("value")
+    label = str(data.get("label") or "").strip() or target_id
+    reference = str(data.get("reference") or "").strip() or None
+
+    if action not in VALID_STEERING_ACTIONS[target_type]:
+        valid = ", ".join(sorted(VALID_STEERING_ACTIONS[target_type]))
+        return jsonify({"error": f"Invalid action for {target_type}. Must be one of: {valid}"}), 400
+    if not reason:
+        return jsonify({"error": "A rationale is required for epistemic steering actions."}), 400
+
+    existing = _find_pending_steering_intent(target_type, target_id, action, reason=reason, value=value)
+    if existing:
+        return jsonify({
+            "ok": True,
+            "queued": True,
+            "duplicate": True,
+            "target_type": target_type,
+            "target_id": target_id,
+            "chat_id": existing.get("id"),
+        }), 200
+
+    from dashboard_db import add_chat
+
+    intent_text = _build_steering_intent_text(
+        target_type,
+        target_id,
+        action,
+        label=label,
+        reference=reference,
+        reason=reason,
+        value=None if value is None else str(value),
+    )
+    chat_id = add_chat("user", intent_text)
+    _log_operator_action(
+        target_id,
+        f"steering:{action}",
+        reason=reason,
+        value=value,
+        target_type=target_type,
+        label=label,
+        reference=reference,
+        resulting_state="queued",
+        apply="next-dispatch",
+    )
+    return jsonify({
+        "ok": True,
+        "queued": True,
+        "duplicate": False,
+        "target_type": target_type,
+        "target_id": target_id,
+        "chat_id": chat_id,
+        "dispatch_mode": "next-dispatch",
+        "resulting_state": "queued",
     }), 200

--- a/blog/api_dashboard.py
+++ b/blog/api_dashboard.py
@@ -9,7 +9,7 @@ from blog.services import (
     load_claims_dashboard, load_lineage_dashboard, load_proposals_dashboard,
     load_autonomy_summary, load_current_dispatch_state, load_primitive_runtime_summary,
     load_recent_dispatch_cycles, load_skill_evidence_summary, load_strategy_dashboard,
-    load_task_interventions,
+    load_task_interventions, load_epistemic_steering,
 )
 
 dashboard_bp = Blueprint("dashboard", __name__)
@@ -453,11 +453,16 @@ def partial_runtime():
 
 def _build_epistemic_data():
     """Build context dict for epistemic and steering surfaces."""
+    steering = load_epistemic_steering(limit_actions=8)
     return {
         "ep_claims": load_claims_dashboard(limit=6),
         "ep_strategy": load_strategy_dashboard(limit_topics=5, limit_objectives=5),
         "ep_proposals": load_proposals_dashboard(limit=5),
         "ep_lineage": load_lineage_dashboard(limit=6),
+        "ep_queued_steering": steering["queued"],
+        "ep_queued_steering_count": steering["queued_count"],
+        "ep_steering_trace": steering["trace"],
+        "ep_steering_trace_count": steering["trace_count"],
     }
 
 

--- a/blog/services.py
+++ b/blog/services.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 import sys
 from datetime import date, datetime, timezone
+from hashlib import sha1
 from pathlib import Path
 
 import markdown
@@ -89,6 +90,22 @@ def _short_ts(value):
     if not value:
         return ""
     return str(value).replace("T", " ")[:16]
+
+
+def _claim_id(artifact_filename, text):
+    seed = f"{artifact_filename}:{text}".encode("utf-8", errors="ignore")
+    return f"claim-{sha1(seed).hexdigest()[:12]}"
+
+
+def _surface_href(target_type, reference=None):
+    reference = str(reference or "").strip()
+    if not target_type or not reference:
+        return None
+    if target_type == "claim" and reference.endswith(".md"):
+        return f"/blog/entries/{reference}"
+    if target_type in {"objective", "thread"}:
+        return f"/thread/{reference}"
+    return None
 
 
 def _find_shadow_markers(*markers):
@@ -548,9 +565,18 @@ def load_operator_actions(limit=8):
         action = str(entry.get("action") or "").strip()
         if not target_id or not action:
             continue
+        target_type = str(entry.get("target_type") or "").strip() or None
+        reference = str(entry.get("reference") or "").strip() or None
         actions.append({
             "target_id": target_id,
             "action": action,
+            "display_action": action.split(":", 1)[1] if ":" in action else action,
+            "target_type": target_type,
+            "label": entry.get("label") or target_id,
+            "reference": reference,
+            "href": entry.get("href") or _surface_href(target_type, reference=reference),
+            "resulting_state": entry.get("resulting_state"),
+            "apply": entry.get("apply"),
             "reason": entry.get("reason"),
             "value": entry.get("value"),
             "ts": entry.get("ts"),
@@ -591,11 +617,12 @@ def load_queued_task_intents(limit=8):
     """Read queued task interventions from the async chat inbox."""
     try:
         from dashboard_db import get_chats
+        messages = get_chats(unprocessed_only=True, limit=200)
     except Exception:
         return []
 
     intents = []
-    for message in get_chats(unprocessed_only=True, limit=200):
+    for message in messages:
         if message.get("author") != "user":
             continue
         parsed = _parse_task_intent_message(message.get("text", ""))
@@ -612,6 +639,82 @@ def load_queued_task_intents(limit=8):
         if len(intents) >= limit:
             break
     return intents
+
+
+def _parse_steering_intent_message(text):
+    if not text or not str(text).startswith("[steering-intent]"):
+        return None
+    payload = {}
+    for line in str(text).splitlines()[1:]:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip().lower()
+        value = value.strip()
+        if key:
+            payload[key] = value
+    target_type = payload.get("target_type")
+    target_id = payload.get("target_id")
+    action = payload.get("action")
+    if not target_type or not target_id or not action:
+        return None
+    reference = payload.get("reference")
+    return {
+        "target_type": target_type,
+        "target_id": target_id,
+        "action": action,
+        "label": payload.get("label") or target_id,
+        "reference": reference,
+        "href": _surface_href(target_type, reference=reference),
+        "resulting_state": payload.get("resulting_state"),
+        "apply": payload.get("apply"),
+        "reason": payload.get("reason"),
+        "value": payload.get("value"),
+        "note": payload.get("note"),
+    }
+
+
+def load_queued_steering_intents(limit=8):
+    """Read queued epistemic steering intents from the async chat inbox."""
+    try:
+        from dashboard_db import get_chats
+        messages = get_chats(unprocessed_only=True, limit=200)
+    except Exception:
+        return []
+
+    intents = []
+    for message in messages:
+        if message.get("author") != "user":
+            continue
+        parsed = _parse_steering_intent_message(message.get("text", ""))
+        if not parsed:
+            continue
+        intents.append({
+            **parsed,
+            "chat_id": message.get("id"),
+            "processed": bool(message.get("processed")),
+            "pinned": bool(message.get("pinned")),
+            "ts": message.get("ts"),
+            "ts_short": _short_ts(message.get("ts")),
+        })
+        if len(intents) >= limit:
+            break
+    return intents
+
+
+def load_epistemic_steering(limit_actions=8):
+    """Build queued steering and steering trace read models."""
+    queued = load_queued_steering_intents(limit=limit_actions)
+    trace = [
+        item for item in load_operator_actions(limit=200)
+        if item["action"].startswith("steering:")
+    ][:limit_actions]
+    return {
+        "queued": queued,
+        "queued_count": len(queued),
+        "trace": trace,
+        "trace_count": len(trace),
+    }
 
 
 def load_task_interventions(limit_tasks=6, limit_actions=8):
@@ -671,11 +774,8 @@ def _entry_records():
     return records
 
 
-def load_claims_dashboard(limit=6):
-    """Summarize claim state from entry frontmatter."""
-    verified_total = 0
-    open_total = 0
-    recent = []
+def _claim_records():
+    records = []
     for entry in _entry_records():
         for raw_claim in entry["claims"]:
             text = raw_claim.get("claim", "") if isinstance(raw_claim, dict) else str(raw_claim)
@@ -684,25 +784,32 @@ def load_claims_dashboard(limit=6):
             clean_text = str(text).lstrip("! ").strip()
             if not clean_text:
                 continue
-            if is_gap:
-                open_total += 1
-            else:
-                verified_total += 1
-            if len(recent) < limit:
-                recent.append({
-                    "text": clean_text,
-                    "kind": "gap" if is_gap else "verified",
-                    "kind_color": "red" if is_gap else "green",
-                    "artifact_title": entry["title"],
-                    "artifact_filename": entry["filename"],
-                    "threads": entry["threads"],
-                    "date": entry["date"],
-                })
+            records.append({
+                "claim_id": _claim_id(entry["filename"], clean_text),
+                "text": clean_text,
+                "kind": "gap" if is_gap else "verified",
+                "kind_color": "red" if is_gap else "green",
+                "artifact_title": entry["title"],
+                "artifact_filename": entry["filename"],
+                "artifact_href": f"/blog/entries/{entry['filename']}",
+                "threads": entry["threads"],
+                "reference": entry["filename"],
+                "report": entry["report"],
+                "date": entry["date"],
+            })
+    return records
+
+
+def load_claims_dashboard(limit=6):
+    """Summarize claim state from entry frontmatter."""
+    claims = _claim_records()
+    verified_total = len([item for item in claims if item["kind"] == "verified"])
+    open_total = len([item for item in claims if item["kind"] == "gap"])
     return {
         "total": verified_total + open_total,
         "verified_total": verified_total,
         "open_total": open_total,
-        "recent": recent,
+        "recent": claims[:limit],
     }
 
 
@@ -729,7 +836,12 @@ def load_strategy_dashboard(limit_topics=5, limit_objectives=5):
             try:
                 raw = fp.read_text(encoding="utf-8", errors="replace")
                 heading = next((line.lstrip("# ").strip() for line in raw.splitlines() if line.startswith("# ")), fp.stem)
-                topics.append({"name": fp.stem, "title": heading})
+                topics.append({
+                    "id": fp.stem,
+                    "name": fp.stem,
+                    "title": heading,
+                    "reference": fp.name,
+                })
             except Exception:
                 continue
 
@@ -739,15 +851,20 @@ def load_strategy_dashboard(limit_topics=5, limit_objectives=5):
         if thread.get("status") not in {"active", "proposed"}:
             continue
         objectives.append({
+            "id": thread["id"],
             "thread_id": thread["id"],
             "title": thread["title"],
             "goal": thread.get("goal") or thread["title"],
             "status": thread.get("status"),
             "next_step": thread.get("next_step"),
+            "reference": thread["id"],
+            "href": f"/thread/{thread['id']}",
         })
 
     return {
         "available": STRATEGY_FILE.exists(),
+        "strategy_id": "global",
+        "strategy_reference": "config/strategy.md",
         "summary": " ".join(summary_lines[:2]).strip(),
         "priorities": priorities[:4],
         "topics": topics[:limit_topics],
@@ -768,6 +885,8 @@ def load_proposals_dashboard(limit=5):
             "type": proposal.get("type", "proposal"),
             "updated_short": _short_ts(proposal.get("updated") or proposal.get("created")),
             "evidence_count": len(proposal.get("evidence", []) or []),
+            "evidence_preview": list(proposal.get("evidence", []) or [])[:2],
+            "reference": (proposal.get("evidence", []) or [None])[0],
             "cost": proposal.get("cost"),
         })
     active.sort(key=lambda item: item.get("updated_short", ""), reverse=True)
@@ -795,26 +914,21 @@ def load_proposals_dashboard(limit=5):
 def load_lineage_dashboard(limit=6):
     """Build recent claim -> thread -> artifact lineage rows."""
     lineage = []
-    for entry in _entry_records():
-        for raw_claim in entry["claims"]:
-            text = raw_claim.get("claim", "") if isinstance(raw_claim, dict) else str(raw_claim)
-            status = raw_claim.get("status") if isinstance(raw_claim, dict) else None
-            clean_text = str(text).lstrip("! ").strip()
-            if not clean_text:
-                continue
-            is_gap = str(text).startswith("!") or status in {"open", "disputed", "stale"}
-            lineage.append({
-                "claim": clean_text,
-                "claim_status": "gap" if is_gap else "verified",
-                "claim_color": "red" if is_gap else "green",
-                "threads": entry["threads"],
-                "artifact_title": entry["title"],
-                "artifact_filename": entry["filename"],
-                "report": entry["report"],
-                "date": entry["date"],
-            })
-            if len(lineage) >= limit:
-                return lineage
+    for item in _claim_records():
+        lineage.append({
+            "claim_id": item["claim_id"],
+            "claim": item["text"],
+            "claim_status": item["kind"],
+            "claim_color": item["kind_color"],
+            "threads": item["threads"],
+            "artifact_title": item["artifact_title"],
+            "artifact_filename": item["artifact_filename"],
+            "artifact_href": item["artifact_href"],
+            "report": item["report"],
+            "date": item["date"],
+        })
+        if len(lineage) >= limit:
+            return lineage
     return lineage
 
 

--- a/blog/templates/dashboard.html
+++ b/blog/templates/dashboard.html
@@ -28,7 +28,7 @@
   </div>
 
   <!-- Epistemic + steering (claims/strategy/proposals/lineage) -->
-  <div hx-get="/partials/epistemics" hx-trigger="every 120s" hx-swap="innerHTML">
+  <div id="dashboard-epistemics" hx-get="/partials/epistemics" hx-trigger="every 120s" hx-swap="innerHTML">
     {% include 'partials/epistemics.html' %}
   </div>
 
@@ -140,6 +140,14 @@ function refreshDashboardInterventions() {
   }
 }
 
+function refreshDashboardEpistemics() {
+  if (window.htmx) {
+    htmx.ajax('GET', '/partials/epistemics', {target: '#dashboard-epistemics', swap: 'innerHTML'});
+  } else {
+    location.reload();
+  }
+}
+
 function taskAction(taskId, action, btn) {
   if (!action) return;
 
@@ -165,6 +173,43 @@ function taskAction(taskId, action, btn) {
       refreshDashboardInterventions();
     } else {
       r.json().then(function(d) { alert(d.error || 'Task action failed'); });
+    }
+  }).catch(function() {
+    alert('Network error');
+  }).finally(function() {
+    if (btn) btn.disabled = false;
+  });
+}
+
+function steeringAction(targetType, targetId, action, label, reference, btn, valuePrompt) {
+  if (!targetType || !targetId || !action) return;
+
+  var reason = window.prompt('rationale for ' + action + ' on ' + label + '?');
+  if (reason === null || !reason.trim()) return;
+
+  var payload = {
+    action: action,
+    reason: reason.trim(),
+    label: label,
+    reference: reference || ''
+  };
+
+  if (valuePrompt) {
+    var value = window.prompt(valuePrompt);
+    if (value === null) return;
+    if (value.trim()) payload.value = value.trim();
+  }
+
+  if (btn) btn.disabled = true;
+  fetch('/api/steering/' + encodeURIComponent(targetType) + '/' + encodeURIComponent(targetId) + '/action', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  }).then(function(r) {
+    if (r.ok) {
+      refreshDashboardEpistemics();
+    } else {
+      r.json().then(function(d) { alert(d.error || 'Steering action failed'); });
     }
   }).catch(function() {
     alert('Network error');

--- a/blog/templates/partials/epistemics.html
+++ b/blog/templates/partials/epistemics.html
@@ -1,5 +1,6 @@
 <div class="dash-section">
   <h2 class="dash-section-title">epistemic & steering</h2>
+  <div class="runtime-note">operator steering is queued for the next dispatch; the cards below remain the current read model until dispatch applies the intent.</div>
 
   <div class="runtime-grid">
     <div class="runtime-card">
@@ -21,7 +22,13 @@
             <strong>{{ item.text }}</strong>
             <span class="runtime-pill runtime-pill-{{ item.kind_color }}">{{ item.kind }}</span>
           </div>
-          <div class="runtime-meta"><a href="/blog/entries/{{ item.artifact_filename }}" style="color:inherit">{{ item.artifact_title }}</a>{% if item.threads %} · {{ item.threads|join(', ') }}{% endif %}</div>
+          <div class="runtime-meta"><a href="{{ item.artifact_href }}" style="color:inherit">{{ item.artifact_title }}</a>{% if item.threads %} · {{ item.threads|join(', ') }}{% endif %}</div>
+          <div class="dash-task-actions">
+            <button class="action-btn" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "promote", {{ item.text|tojson }}, {{ item.reference|tojson }}, this)'>promote</button>
+            <button class="action-btn action-start" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "verified", {{ item.text|tojson }}, {{ item.reference|tojson }}, this)'>verified</button>
+            <button class="action-btn action-blocked" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "disputed", {{ item.text|tojson }}, {{ item.reference|tojson }}, this)'>disputed</button>
+            <button class="action-btn" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "stale", {{ item.text|tojson }}, {{ item.reference|tojson }}, this)'>stale</button>
+          </div>
         </div>
         {% endfor %}
       </div>
@@ -34,6 +41,12 @@
       <div class="runtime-card-title">strategy, topics, objectives</div>
       {% if ep_strategy.available %}
       <div class="runtime-note">{{ ep_strategy.summary or 'strategy file present but no summary text extracted yet' }}</div>
+      <div class="dash-task-actions">
+        <button class="action-btn action-start" onclick='steeringAction("strategy", {{ ep_strategy.strategy_id|tojson }}, "align", "strategy", {{ ep_strategy.strategy_reference|tojson }}, this, "alignment note for the next dispatch?")'>align</button>
+        <button class="action-btn" onclick='steeringAction("strategy", {{ ep_strategy.strategy_id|tojson }}, "reprioritize", "strategy", {{ ep_strategy.strategy_reference|tojson }}, this, "what should be reprioritized on the next dispatch?")'>reprioritize</button>
+        <button class="action-btn action-blocked" onclick='steeringAction("strategy", {{ ep_strategy.strategy_id|tojson }}, "redirect", "strategy", {{ ep_strategy.strategy_reference|tojson }}, this, "what redirect should the next dispatch follow?")'>redirect</button>
+        <button class="action-btn" onclick='steeringAction("strategy", {{ ep_strategy.strategy_id|tojson }}, "review-drift", "strategy", {{ ep_strategy.strategy_reference|tojson }}, this, "what drift should be reviewed on the next dispatch?")'>review drift</button>
+      </div>
       {% if ep_strategy.priorities %}
       <div class="runtime-subtitle">priorities</div>
       <div class="runtime-list">
@@ -55,6 +68,11 @@
             <strong>{{ topic.name }}</strong>
           </div>
           <div class="runtime-meta">{{ topic.title }}</div>
+          <div class="dash-task-actions">
+            <button class="action-btn action-start" onclick='steeringAction("topic", {{ topic.id|tojson }}, "promote", {{ topic.title|tojson }}, {{ topic.reference|tojson }}, this)'>promote</button>
+            <button class="action-btn" onclick='steeringAction("topic", {{ topic.id|tojson }}, "prioritize", {{ topic.title|tojson }}, {{ topic.reference|tojson }}, this)'>prioritize</button>
+            <button class="action-btn action-blocked" onclick='steeringAction("topic", {{ topic.id|tojson }}, "defer", {{ topic.title|tojson }}, {{ topic.reference|tojson }}, this)'>defer</button>
+          </div>
         </div>
         {% endfor %}
       </div>
@@ -68,13 +86,18 @@
         {% for objective in ep_strategy.objectives %}
         <div class="runtime-list-item">
           <div class="runtime-row">
-            <strong><a href="/thread/{{ objective.thread_id }}" style="color:inherit">{{ objective.title }}</a></strong>
+            <strong><a href="{{ objective.href }}" style="color:inherit">{{ objective.title }}</a></strong>
             <span class="runtime-meta">{{ objective.status }}</span>
           </div>
           <div class="runtime-meta">{{ objective.goal }}</div>
           {% if objective.next_step %}
           <div class="runtime-meta">next: {{ objective.next_step }}</div>
           {% endif %}
+          <div class="dash-task-actions">
+            <button class="action-btn action-start" onclick='steeringAction("objective", {{ objective.id|tojson }}, "attach", {{ objective.title|tojson }}, {{ objective.reference|tojson }}, this)'>attach</button>
+            <button class="action-btn" onclick='steeringAction("objective", {{ objective.id|tojson }}, "defer", {{ objective.title|tojson }}, {{ objective.reference|tojson }}, this)'>defer</button>
+            <button class="action-btn action-blocked" onclick='steeringAction("objective", {{ objective.id|tojson }}, "retire", {{ objective.title|tojson }}, {{ objective.reference|tojson }}, this)'>retire</button>
+          </div>
         </div>
         {% endfor %}
       </div>
@@ -98,6 +121,15 @@
             <span class="runtime-meta">{{ proposal.type }}</span>
           </div>
           <div class="runtime-meta">{{ proposal.updated_short }} · evidence {{ proposal.evidence_count }}{% if proposal.cost %} · {{ proposal.cost }}{% endif %}</div>
+          {% if proposal.evidence_preview %}
+          <div class="runtime-note">{{ proposal.evidence_preview|join(' · ') }}</div>
+          {% endif %}
+          <div class="dash-task-actions">
+            <button class="action-btn action-start" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "approve", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this)'>approve</button>
+            <button class="action-btn action-blocked" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "reject", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this)'>reject</button>
+            <button class="action-btn" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "defer", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this)'>defer</button>
+            <button class="action-btn" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "request-revision", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this, "what revision should be requested on the next dispatch?")'>revision</button>
+          </div>
         </div>
         {% endfor %}
       </div>
@@ -114,6 +146,72 @@
       </div>
       {% else %}
       <div class="runtime-empty">no decision log entries yet</div>
+      {% endif %}
+    </div>
+
+    <div class="runtime-card">
+      <div class="runtime-card-title">queued for next dispatch</div>
+      <div class="runtime-row">
+        <span>pending steering intents</span>
+        <span class="runtime-meta">{{ ep_queued_steering_count }}</span>
+      </div>
+
+      {% if ep_queued_steering %}
+      <div class="runtime-list">
+        {% for item in ep_queued_steering %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{% if item.href %}<a href="{{ item.href }}" style="color:inherit">{{ item.label }}</a>{% else %}{{ item.label }}{% endif %}</strong>
+            <span class="runtime-pill runtime-pill-muted">{{ item.target_type }}</span>
+          </div>
+          <div class="runtime-meta">{{ item.action }} · {{ item.ts_short }}{% if item.apply %} · {{ item.apply }}{% endif %}</div>
+          {% if item.reference %}
+          <div class="runtime-meta">ref: {{ item.reference }}</div>
+          {% endif %}
+          {% if item.reason %}
+          <div class="runtime-note">{{ item.reason }}</div>
+          {% endif %}
+          {% if item.value %}
+          <div class="runtime-note">{{ item.value }}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no queued steering intents</div>
+      {% endif %}
+    </div>
+
+    <div class="runtime-card">
+      <div class="runtime-card-title">steering trace</div>
+      <div class="runtime-row">
+        <span>recent steering decisions</span>
+        <span class="runtime-meta">{{ ep_steering_trace_count }}</span>
+      </div>
+
+      {% if ep_steering_trace %}
+      <div class="runtime-list">
+        {% for item in ep_steering_trace %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{% if item.href %}<a href="{{ item.href }}" style="color:inherit">{{ item.label }}</a>{% else %}{{ item.label }}{% endif %}</strong>
+            <span class="runtime-pill runtime-pill-muted">{{ item.display_action }}</span>
+          </div>
+          <div class="runtime-meta">{{ item.target_type or 'surface' }} · {{ item.ts_short }}{% if item.resulting_state %} · {{ item.resulting_state }}{% endif %}</div>
+          {% if item.reference %}
+          <div class="runtime-meta">ref: {{ item.reference }}</div>
+          {% endif %}
+          {% if item.reason %}
+          <div class="runtime-note">{{ item.reason }}</div>
+          {% endif %}
+          {% if item.value %}
+          <div class="runtime-note">{{ item.value }}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no steering trace yet</div>
       {% endif %}
     </div>
 
@@ -135,7 +233,7 @@
             {% else %}
               no thread
             {% endif %}
-            → <a href="/blog/entries/{{ item.artifact_filename }}" style="color:inherit">{{ item.artifact_title }}</a>
+            → <a href="{{ item.artifact_href }}" style="color:inherit">{{ item.artifact_title }}</a>
             {% if item.report %} · <a href="/reports/{{ item.report }}" style="color:inherit">report</a>{% endif %}
           </div>
         </div>

--- a/tests/test_dashboard_steering.sh
+++ b/tests/test_dashboard_steering.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VENV_PY="${EDGE_BLOG_VENV:-$EDGE_DIR/blog/.venv/bin/python3}"
+if [ ! -x "$VENV_PY" ]; then
+    echo "Missing blog venv python: $VENV_PY" >&2
+    echo "Set EDGE_BLOG_VENV=/path/to/blog/.venv/bin/python3 when running from a clean worktree." >&2
+    exit 2
+fi
+
+TMP_BASE="$(mktemp -d /tmp/edge-dashboard-steering-XXXXXX)"
+TMP_STATE="$TMP_BASE/state-root"
+TMP_HOME="$TMP_BASE/home"
+STRATEGY_FILE="$EDGE_DIR/config/strategy.md"
+STRATEGY_BACKUP="$TMP_BASE/strategy.md.bak"
+
+cleanup() {
+    if [ -f "$STRATEGY_BACKUP" ]; then
+        mv "$STRATEGY_BACKUP" "$STRATEGY_FILE"
+    else
+        rm -f "$STRATEGY_FILE"
+    fi
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE/blog/entries" "$TMP_STATE/state/signals" "$TMP_STATE/threads" "$TMP_STATE/logs" "$TMP_STATE/search" "$TMP_HOME/.claude/projects/test-project/memory/topics"
+
+if [ -f "$STRATEGY_FILE" ]; then cp "$STRATEGY_FILE" "$STRATEGY_BACKUP"; fi
+
+cat >"$STRATEGY_FILE" <<'MD'
+# Strategy
+
+Make epistemic steering explicit and operator-visible.
+
+- keep steering decisions queued for the next dispatch
+- show claim and proposal direction without hidden markdown edits
+- tie runtime visibility to explicit operator direction
+MD
+
+cat >"$TMP_HOME/.claude/projects/test-project/memory/topics/dispatch.md" <<'MD'
+# Dispatch transparency
+MD
+
+cat >"$TMP_HOME/.claude/projects/test-project/memory/topics/epistemics.md" <<'MD'
+# Epistemic steering
+MD
+
+cat >"$TMP_STATE/blog/entries/2026-04-20-claims-a.md" <<'MD'
+---
+title: "Dispatch evidence review"
+date: "2026-04-20"
+claims:
+  - "Dispatch cycles need explicit close evidence"
+  - "!Pre-skill is still not instrumented"
+threads:
+  - runtime-transparency
+report: dispatch-evidence.html
+---
+body
+MD
+
+cat >"$TMP_STATE/threads/runtime-transparency.md" <<'MD'
+---
+id: runtime-transparency
+title: "Runtime transparency"
+status: active
+owner: ed
+goal: "Expose dispatch and evidence state to the operator"
+---
+## Next
+Ship the runtime dashboard section.
+MD
+
+cat >"$TMP_STATE/state/proposals.json" <<'JSON'
+[
+  {
+    "id": "prop-1",
+    "title": "Surface lineage in dashboard",
+    "type": "execution",
+    "status": "active",
+    "created": "2026-04-20T20:00:00+00:00",
+    "updated": "2026-04-20T20:10:00+00:00",
+    "evidence": ["Dispatch evidence review", "Dispatch cycles need explicit close evidence"],
+    "cost": "medium"
+  }
+]
+JSON
+
+cat >"$TMP_STATE/state/signals/decision.md" <<'MD'
+- Approved dashboard lineage slice
+MD
+
+HOME="$TMP_HOME" MEMORY_PROJECT_DIR="test-project" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$VENV_PY" - <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+edge_dir = os.environ["EDGE_REPO_DIR"]
+state_dir = Path(os.environ["EDGE_STATE_DIR"])
+sys.path.insert(0, edge_dir)
+sys.path.insert(0, os.path.join(edge_dir, "blog"))
+os.chdir(os.path.join(edge_dir, "blog"))
+
+from app import app
+
+client = app.test_client()
+
+seed = client.get("/api/dashboard/epistemics")
+assert seed.status_code == 200, seed.status_code
+seed_data = seed.get_json()
+
+claim_id = seed_data["ep_claims"]["recent"][0]["claim_id"]
+claim_label = seed_data["ep_claims"]["recent"][0]["text"]
+proposal_id = seed_data["ep_proposals"]["active"][0]["id"]
+proposal_label = seed_data["ep_proposals"]["active"][0]["title"]
+topic_id = seed_data["ep_strategy"]["topics"][0]["id"]
+topic_label = seed_data["ep_strategy"]["topics"][0]["title"]
+objective_id = seed_data["ep_strategy"]["objectives"][0]["id"]
+objective_label = seed_data["ep_strategy"]["objectives"][0]["title"]
+
+proposal = client.post(
+    f"/api/steering/proposal/{proposal_id}/action",
+    json={
+        "action": "approve",
+        "reason": "evidence is already aligned with operator intent",
+        "label": proposal_label,
+        "reference": "Dispatch evidence review",
+    },
+)
+assert proposal.status_code == 200, proposal.status_code
+assert proposal.get_json()["queued"] is True
+assert proposal.get_json()["dispatch_mode"] == "next-dispatch"
+
+proposal_dup = client.post(
+    f"/api/steering/proposal/{proposal_id}/action",
+    json={
+        "action": "approve",
+        "reason": "evidence is already aligned with operator intent",
+        "label": proposal_label,
+        "reference": "Dispatch evidence review",
+    },
+)
+assert proposal_dup.status_code == 200, proposal_dup.status_code
+assert proposal_dup.get_json()["duplicate"] is True
+
+claim = client.post(
+    f"/api/steering/claim/{claim_id}/action",
+    json={
+        "action": "disputed",
+        "reason": "pre-skill evidence is still incomplete",
+        "label": claim_label,
+        "reference": "2026-04-20-claims-a.md",
+    },
+)
+assert claim.status_code == 200, claim.status_code
+
+topic = client.post(
+    f"/api/steering/topic/{topic_id}/action",
+    json={
+        "action": "prioritize",
+        "reason": "dispatch transparency should stay ahead of other topics",
+        "label": topic_label,
+        "reference": "dispatch.md",
+    },
+)
+assert topic.status_code == 200, topic.status_code
+
+objective = client.post(
+    f"/api/steering/objective/{objective_id}/action",
+    json={
+        "action": "attach",
+        "reason": "the next dispatch should bind this objective explicitly",
+        "label": objective_label,
+        "reference": objective_id,
+    },
+)
+assert objective.status_code == 200, objective.status_code
+
+strategy = client.post(
+    "/api/steering/strategy/global/action",
+    json={
+        "action": "redirect",
+        "reason": "runtime evidence needs tighter operator focus",
+        "value": "focus runtime evidence over prose cleanup on the next dispatch",
+        "label": "strategy",
+        "reference": "config/strategy.md",
+    },
+)
+assert strategy.status_code == 200, strategy.status_code
+strategy_data = strategy.get_json()
+assert strategy_data["queued"] is True
+assert strategy_data["resulting_state"] == "queued"
+
+messages = client.get("/api/chat?unprocessed=1").get_json()["messages"]
+intents = [m for m in messages if m["author"] == "user" and m["text"].startswith("[steering-intent]")]
+assert len(intents) == 5
+assert any("target_type: proposal" in m["text"] for m in intents)
+assert any("target_type: claim" in m["text"] for m in intents)
+assert any("target_type: topic" in m["text"] for m in intents)
+assert any("target_type: objective" in m["text"] for m in intents)
+assert any("target_type: strategy" in m["text"] for m in intents)
+assert any("focus runtime evidence over prose cleanup on the next dispatch" in m["text"] for m in intents)
+
+operator_log = [
+    json.loads(line)
+    for line in (state_dir / "logs" / "operator-actions.jsonl").read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+assert operator_log[-1]["action"] == "steering:redirect"
+assert operator_log[-1]["target_type"] == "strategy"
+assert operator_log[-1]["resulting_state"] == "queued"
+assert operator_log[-1]["apply"] == "next-dispatch"
+
+resp = client.get("/api/dashboard/epistemics")
+assert resp.status_code == 200, resp.status_code
+data = resp.get_json()
+assert data["ep_queued_steering_count"] == 5
+assert {item["target_type"] for item in data["ep_queued_steering"]} == {"proposal", "claim", "topic", "objective", "strategy"}
+assert data["ep_steering_trace_count"] == 5
+assert {item["action"] for item in data["ep_steering_trace"]} == {
+    "steering:approve",
+    "steering:disputed",
+    "steering:prioritize",
+    "steering:attach",
+    "steering:redirect",
+}
+
+partial = client.get("/partials/epistemics")
+assert partial.status_code == 200, partial.status_code
+text = partial.get_data(as_text=True)
+assert "queued for next dispatch" in text
+assert "steering trace" in text
+assert "Surface lineage in dashboard" in text
+assert "Dispatch cycles need explicit close evidence" in text
+assert "focus runtime evidence over prose cleanup on the next dispatch" in text
+print("ok")
+PY

--- a/tests/test_ops_console.sh
+++ b/tests/test_ops_console.sh
@@ -120,6 +120,11 @@ r = client.post("/api/tasks/TASK-20260309-001/action",
                 content_type="application/json")
 check("POST /api/tasks/TASK-20260309-001/action", r)
 
+r = client.post("/api/steering/strategy/global/action",
+                json={"action": "align", "reason": "integration steering smoke test", "label": "strategy", "reference": "config/strategy.md"},
+                content_type="application/json")
+check("POST /api/steering/strategy/global/action", r)
+
 r = client.post("/api/heartbeat/trigger", content_type="application/json")
 ok = r.status_code in (200, 429)
 mark = "PASS" if ok else "FAIL"


### PR DESCRIPTION
Closes #273

## What changed

This turns the dashboard's epistemic surfaces into queued operator steering surfaces instead of read-only cards.

- adds `POST /api/steering/<target_type>/<target_id>/action`
- queues proposal, claim, topic, objective, and strategy steering intents into the async chat inbox for the next dispatch
- records a durable steering trace in `logs/operator-actions.jsonl`
- gives claims, proposals, topics, objectives, and strategy explicit dashboard actions
- adds queued steering and steering trace cards to the epistemics dashboard
- adds stable claim ids and richer read-model metadata so queued intents can cross-link cleanly to the affected surfaces
- adds `tests/test_dashboard_steering.sh`
- extends `tests/test_ops_console.sh` with a steering smoke check

## Why

The operator should not mutate runtime or epistemic state directly from the dashboard. Steering needs to be explicit, durable, and deferred to the next dispatch, matching the async chat model instead of hidden markdown edits or immediate side effects.

## Validation

- `python3 -m py_compile blog/app.py blog/api_actions.py blog/api_dashboard.py blog/services.py`
- `tests/test_dashboard_steering.sh`
- `tests/test_dashboard_epistemics.sh`
- `tests/test_dashboard_interventions.sh`
- `tests/test_dashboard_runtime.sh`
- `tests/test_ops_console.sh`
