### PR TITLE
[dashboard] Queue runtime and autonomy interventions for next dispatch

### DIFF
--- a/blog/api_actions.py
+++ b/blog/api_actions.py
@@ -1,4 +1,4 @@
-"""Action endpoints for heartbeat, threads, and queued task interventions."""
+"""Action endpoints for heartbeat, threads, and queued operator interventions."""
 
 import json
 from datetime import datetime, timezone
@@ -135,6 +135,20 @@ VALID_STEERING_ACTIONS = {
     "topic": {"promote", "prioritize", "defer"},
     "objective": {"attach", "retire", "defer"},
     "strategy": {"align", "reprioritize", "redirect", "review-drift"},
+}
+VALID_RUNTIME_ACTIONS = {
+    "dispatch": {"require-review", "retry", "halt", "safe-to-continue"},
+    "evidence": {"confirm", "dispute", "incomplete", "needs-instrumentation"},
+    "primitive": {"confirm-failure", "needs-guardrail", "stable", "defer"},
+    "autonomy": {
+        "accept-delta",
+        "dispute-delta",
+        "confirm-unstable",
+        "codify-accepted",
+        "codify-deferred",
+        "promote-proposal",
+        "promote-task",
+    },
 }
 
 
@@ -325,6 +339,142 @@ def steering_action(target_type, target_id):
     _log_operator_action(
         target_id,
         f"steering:{action}",
+        reason=reason,
+        value=value,
+        target_type=target_type,
+        label=label,
+        reference=reference,
+        resulting_state="queued",
+        apply="next-dispatch",
+    )
+    return jsonify({
+        "ok": True,
+        "queued": True,
+        "duplicate": False,
+        "target_type": target_type,
+        "target_id": target_id,
+        "chat_id": chat_id,
+        "dispatch_mode": "next-dispatch",
+        "resulting_state": "queued",
+    }), 200
+
+
+def _build_runtime_intent_text(target_type, target_id, action, label=None, reference=None, reason=None, value=None):
+    lines = [
+        "[runtime-intent]",
+        f"target_type: {target_type}",
+        f"target_id: {target_id}",
+        f"action: {action}",
+        "apply: next-dispatch",
+        "resulting_state: queued",
+    ]
+    if label:
+        lines.append(f"label: {label}")
+    if reference:
+        lines.append(f"reference: {reference}")
+    if reason:
+        lines.append(f"reason: {reason}")
+    if value is not None:
+        lines.append(f"value: {value}")
+    lines.append("note: queue this operator runtime/autonomy intervention for the next dispatch; do not apply it immediately")
+    return "\n".join(lines)
+
+
+def _parse_runtime_intent_text(text):
+    if not text or not str(text).startswith("[runtime-intent]"):
+        return None
+    data = {}
+    for line in str(text).splitlines()[1:]:
+        if ":" not in line:
+            continue
+        key, raw_value = line.split(":", 1)
+        key = key.strip().lower()
+        value = raw_value.strip()
+        if key:
+            data[key] = value
+    target_type = data.get("target_type")
+    target_id = data.get("target_id")
+    action = data.get("action")
+    if not target_type or not target_id or not action:
+        return None
+    return {
+        "target_type": target_type,
+        "target_id": target_id,
+        "action": action,
+        "label": data.get("label"),
+        "reference": data.get("reference"),
+        "reason": data.get("reason"),
+        "value": data.get("value"),
+        "apply": data.get("apply"),
+        "resulting_state": data.get("resulting_state"),
+        "note": data.get("note"),
+    }
+
+
+def _find_pending_runtime_intent(target_type, target_id, action, reason=None, value=None):
+    from dashboard_db import get_chats
+
+    for message in get_chats(unprocessed_only=True, limit=200):
+        if message.get("author") != "user":
+            continue
+        parsed = _parse_runtime_intent_text(message.get("text", ""))
+        if not parsed:
+            continue
+        if parsed["target_type"] != target_type or parsed["target_id"] != target_id or parsed["action"] != action:
+            continue
+        if (parsed.get("reason") or None) != reason:
+            continue
+        if (parsed.get("value") or None) != (None if value is None else str(value)):
+            continue
+        return message
+    return None
+
+
+@actions_bp.route('/api/runtime/<target_type>/<path:target_id>/action', methods=['POST'])
+def runtime_action(target_type, target_id):
+    target_type = str(target_type or "").strip().lower()
+    if target_type not in VALID_RUNTIME_ACTIONS:
+        return jsonify({"error": f"Invalid target_type. Must be one of: {', '.join(sorted(VALID_RUNTIME_ACTIONS))}"}), 400
+
+    data = request.get_json(silent=True) or {}
+    action = str(data.get("action") or "").strip().lower()
+    reason = str(data.get("reason") or "").strip() or None
+    value = data.get("value")
+    label = str(data.get("label") or "").strip() or target_id
+    reference = str(data.get("reference") or "").strip() or None
+
+    if action not in VALID_RUNTIME_ACTIONS[target_type]:
+        valid = ", ".join(sorted(VALID_RUNTIME_ACTIONS[target_type]))
+        return jsonify({"error": f"Invalid action for {target_type}. Must be one of: {valid}"}), 400
+    if not reason:
+        return jsonify({"error": "A rationale is required for runtime/autonomy interventions."}), 400
+
+    existing = _find_pending_runtime_intent(target_type, target_id, action, reason=reason, value=value)
+    if existing:
+        return jsonify({
+            "ok": True,
+            "queued": True,
+            "duplicate": True,
+            "target_type": target_type,
+            "target_id": target_id,
+            "chat_id": existing.get("id"),
+        }), 200
+
+    from dashboard_db import add_chat
+
+    intent_text = _build_runtime_intent_text(
+        target_type,
+        target_id,
+        action,
+        label=label,
+        reference=reference,
+        reason=reason,
+        value=None if value is None else str(value),
+    )
+    chat_id = add_chat("user", intent_text)
+    _log_operator_action(
+        target_id,
+        f"runtime:{action}",
         reason=reason,
         value=value,
         target_type=target_type,

--- a/blog/api_dashboard.py
+++ b/blog/api_dashboard.py
@@ -9,7 +9,7 @@ from blog.services import (
     load_claims_dashboard, load_lineage_dashboard, load_proposals_dashboard,
     load_autonomy_summary, load_current_dispatch_state, load_primitive_runtime_summary,
     load_recent_dispatch_cycles, load_skill_evidence_summary, load_strategy_dashboard,
-    load_task_interventions, load_epistemic_steering,
+    load_task_interventions, load_epistemic_steering, load_runtime_interventions,
 )
 
 dashboard_bp = Blueprint("dashboard", __name__)
@@ -429,12 +429,19 @@ def partial_briefing():
 
 def _build_runtime_data():
     """Build context dict for runtime transparency surfaces."""
+    interventions = load_runtime_interventions(limit_actions=8)
     return {
         "runtime_current_cycle": load_current_dispatch_state(),
         "runtime_recent_cycles": load_recent_dispatch_cycles(limit=6),
         "runtime_skill_evidence": load_skill_evidence_summary(limit=5),
         "runtime_primitives": load_primitive_runtime_summary(limit=5),
         "runtime_autonomy": load_autonomy_summary(),
+        "runtime_queued_interventions": interventions["queued"],
+        "runtime_queued_count": interventions["queued_count"],
+        "runtime_intervention_trace": interventions["trace"],
+        "runtime_intervention_trace_count": interventions["trace_count"],
+        "runtime_intervention_lineage": interventions["lineage"],
+        "runtime_intervention_lineage_count": interventions["lineage_count"],
     }
 
 

--- a/blog/services.py
+++ b/blog/services.py
@@ -97,6 +97,11 @@ def _claim_id(artifact_filename, text):
     return f"claim-{sha1(seed).hexdigest()[:12]}"
 
 
+def _surface_id(prefix, *parts):
+    seed = "||".join(str(part).strip() for part in parts if str(part).strip())
+    return f"{prefix}-{sha1(seed.encode('utf-8', errors='ignore')).hexdigest()[:12]}"
+
+
 def _surface_href(target_type, reference=None):
     reference = str(reference or "").strip()
     if not target_type or not reference:
@@ -106,6 +111,21 @@ def _surface_href(target_type, reference=None):
     if target_type in {"objective", "thread"}:
         return f"/thread/{reference}"
     return None
+
+
+def _parse_ts_value(value):
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except Exception:
+        return None
 
 
 def _find_shadow_markers(*markers):
@@ -286,16 +306,20 @@ def load_skill_evidence_summary(limit=5):
     current = load_current_dispatch_state()
     return {
         "pre_skill": {
+            "id": "pre-skill",
             "status": "observed" if pre_events else "gap",
             "color": "green" if pre_events else "red",
             "detail": f"{len(pre_events)} explicit pre-skill events" if pre_events else "no explicit pre-skill runtime evidence in shadow log yet",
             "protocol_status": current.get("preflight_status", "unknown"),
+            "reference": current.get("cycle_id"),
         },
         "post_skill": {
+            "id": "post-skill",
             "status": "observed" if post_events else "gap",
             "color": "green" if post_events else "red",
             "detail": f"{len(post_events)} explicit post-skill events" if post_events else "no explicit post-skill runtime evidence in shadow log yet",
             "protocol_status": current.get("postflight_status", "unknown"),
+            "reference": current.get("cycle_id"),
         },
         "skill_runs": runs,
         "skill_runs_total": len(runs),
@@ -323,6 +347,15 @@ def load_primitive_runtime_summary(limit=5):
     if payload and isinstance(payload, dict) and isinstance(payload.get("summary"), dict):
         summary = payload["summary"]
         sources = payload.get("sources", []) if isinstance(payload.get("sources"), list) else []
+        sources = [
+            {
+                **item,
+                "id": item.get("name"),
+                "reference": item.get("name"),
+            }
+            for item in sources
+            if isinstance(item, dict)
+        ]
         top_used = sorted(sources, key=lambda item: (-int(item.get("usage_30d", 0) or 0), item.get("name", "")))
         return {
             "available": True,
@@ -422,6 +455,8 @@ def load_autonomy_summary():
                 "total": 0,
                 "gaps": [],
                 "next_steps": [],
+                "recovered": [],
+                "codify_now": [],
             }
         content = AUTONOMY_CAPABILITIES_FILE.read_text(encoding="utf-8")
         rows = re.findall(r'^\|\s*\d+\s*\|([^|]+)\|\s*(\d+)\s*\|', content, re.MULTILINE)
@@ -432,21 +467,65 @@ def load_autonomy_summary():
                 "total": 0,
                 "gaps": [],
                 "next_steps": [],
+                "recovered": [],
+                "codify_now": [],
             }
-        caps = [{"name": row[0].strip(), "level": int(row[1])} for row in rows]
+        caps = [{
+            "id": _surface_id("cap", row[0].strip()),
+            "name": row[0].strip(),
+            "level": int(row[1]),
+            "reference": row[0].strip(),
+        } for row in rows]
         avg = round(sum(cap["level"] for cap in caps) / len(caps), 1)
         gaps = sorted(caps, key=lambda cap: cap["level"])[:3]
         next_steps = []
         if FRONTIER_FILE.exists():
             frontier = FRONTIER_FILE.read_text(encoding="utf-8")
             for match in re.finditer(r'### (?!~~)(GAP-\d+): (.+)', frontier):
-                next_steps.append({"id": match.group(1), "title": match.group(2)})
+                next_steps.append({
+                    "id": match.group(1),
+                    "title": match.group(2),
+                    "reference": match.group(1),
+                })
+        hotspots = load_hotspots()
+        recovered = []
+        for item in hotspots.get("recovered_but_unstable", [])[:3]:
+            if not isinstance(item, dict):
+                continue
+            signature = str(item.get("signature") or "").strip()
+            if not signature:
+                continue
+            recovered.append({
+                "id": _surface_id("recovered", signature),
+                "signature": signature,
+                "count": int(item.get("count", 0) or 0),
+                "last_seen": item.get("last_seen"),
+                "last_seen_short": _short_ts(item.get("last_seen")),
+                "reference": signature,
+            })
+        codify_now = []
+        for item in hotspots.get("codify_now", [])[:3]:
+            if not isinstance(item, dict):
+                continue
+            signature = str(item.get("signature") or "").strip()
+            if not signature:
+                continue
+            codify_now.append({
+                "id": _surface_id("codify", signature),
+                "signature": signature,
+                "count": int(item.get("count", 0) or 0),
+                "last_seen": item.get("last_seen"),
+                "last_seen_short": _short_ts(item.get("last_seen")),
+                "reference": signature,
+            })
         return {
             "available": True,
             "avg": avg,
             "total": len(caps),
             "gaps": gaps,
             "next_steps": next_steps[:4],
+            "recovered": recovered,
+            "codify_now": codify_now,
         }
     except Exception:
         return {
@@ -455,6 +534,8 @@ def load_autonomy_summary():
             "total": 0,
             "gaps": [],
             "next_steps": [],
+            "recovered": [],
+            "codify_now": [],
         }
 
 
@@ -714,6 +795,157 @@ def load_epistemic_steering(limit_actions=8):
         "queued_count": len(queued),
         "trace": trace,
         "trace_count": len(trace),
+    }
+
+
+def _parse_runtime_intent_message(text):
+    if not text or not str(text).startswith("[runtime-intent]"):
+        return None
+    payload = {}
+    for line in str(text).splitlines()[1:]:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip().lower()
+        value = value.strip()
+        if key:
+            payload[key] = value
+    target_type = payload.get("target_type")
+    target_id = payload.get("target_id")
+    action = payload.get("action")
+    if not target_type or not target_id or not action:
+        return None
+    reference = payload.get("reference")
+    return {
+        "target_type": target_type,
+        "target_id": target_id,
+        "action": action,
+        "label": payload.get("label") or target_id,
+        "reference": reference,
+        "href": _surface_href(target_type, reference=reference),
+        "resulting_state": payload.get("resulting_state"),
+        "apply": payload.get("apply"),
+        "reason": payload.get("reason"),
+        "value": payload.get("value"),
+        "note": payload.get("note"),
+    }
+
+
+def load_queued_runtime_intents(limit=8):
+    """Read queued runtime/autonomy interventions from the async chat inbox."""
+    try:
+        from dashboard_db import get_chats
+        messages = get_chats(unprocessed_only=True, limit=200)
+    except Exception:
+        return []
+
+    intents = []
+    for message in messages:
+        if message.get("author") != "user":
+            continue
+        parsed = _parse_runtime_intent_message(message.get("text", ""))
+        if not parsed:
+            continue
+        intents.append({
+            **parsed,
+            "chat_id": message.get("id"),
+            "processed": bool(message.get("processed")),
+            "pinned": bool(message.get("pinned")),
+            "ts": message.get("ts"),
+            "ts_short": _short_ts(message.get("ts")),
+        })
+        if len(intents) >= limit:
+            break
+    return intents
+
+
+def _match_followup_task(value):
+    needle = str(value or "").strip().lower()
+    if not needle:
+        return None
+    for task in load_tasks_snapshot()["tasks"]:
+        hay = " ".join([task["id"], task["title"]]).lower()
+        if needle in hay or task["id"].lower() == needle:
+            return {
+                "type": "task",
+                "id": task["id"],
+                "label": task["title"],
+                "href": "/dashboard",
+            }
+    return None
+
+
+def _match_followup_proposal(value):
+    needle = str(value or "").strip().lower()
+    if not needle:
+        return None
+    for proposal in load_json_safe(PROPOSALS_FILE, []):
+        if not isinstance(proposal, dict):
+            continue
+        title = str(proposal.get("title") or "").strip()
+        proposal_id = str(proposal.get("id") or "").strip()
+        hay = " ".join([proposal_id, title]).lower()
+        if needle in hay or proposal_id.lower() == needle:
+            return {
+                "type": "proposal",
+                "id": proposal_id or needle,
+                "label": title or proposal_id or needle,
+                "href": "/dashboard",
+            }
+    return None
+
+
+def _find_downstream_cycles(after_ts, exclude_cycle_id=None, limit=2):
+    after_dt = _parse_ts_value(after_ts)
+    if not after_dt:
+        return []
+    matches = []
+    for cycle in load_recent_dispatch_cycles(limit=24):
+        cycle_id = cycle.get("cycle_id")
+        if exclude_cycle_id and cycle_id == exclude_cycle_id:
+            continue
+        cycle_ts = _parse_ts_value(cycle.get("opened_at")) or _parse_ts_value(cycle.get("last_ts"))
+        if not cycle_ts or cycle_ts <= after_dt:
+            continue
+        matches.append({
+            "cycle_id": cycle_id,
+            "skill": cycle.get("skill"),
+            "trigger": cycle.get("trigger"),
+            "last_ts_short": cycle.get("last_ts_short"),
+        })
+        if len(matches) >= limit:
+            break
+    return matches
+
+
+def load_runtime_interventions(limit_actions=8):
+    """Build queued runtime interventions and a lineage-oriented trace."""
+    queued = load_queued_runtime_intents(limit=limit_actions)
+    trace = [
+        item for item in load_operator_actions(limit=200)
+        if item["action"].startswith("runtime:")
+    ][:limit_actions]
+
+    lineage = []
+    for item in trace:
+        followup = None
+        if item["display_action"] == "promote-task":
+            followup = _match_followup_task(item.get("value"))
+        elif item["display_action"] == "promote-proposal":
+            followup = _match_followup_proposal(item.get("value"))
+        lineage.append({
+            **item,
+            "downstream_cycles": _find_downstream_cycles(item.get("ts"), exclude_cycle_id=item.get("reference") or item.get("target_id")),
+            "downstream_target": followup,
+        })
+
+    return {
+        "queued": queued,
+        "queued_count": len(queued),
+        "trace": trace,
+        "trace_count": len(trace),
+        "lineage": lineage,
+        "lineage_count": len(lineage),
     }
 
 

--- a/blog/templates/dashboard.html
+++ b/blog/templates/dashboard.html
@@ -18,7 +18,7 @@
   </div>
 
   <!-- Runtime transparency (dispatch/evidence/primitives/autonomy) -->
-  <div hx-get="/partials/runtime" hx-trigger="every 120s" hx-swap="innerHTML">
+  <div id="dashboard-runtime" hx-get="/partials/runtime" hx-trigger="every 120s" hx-swap="innerHTML">
     {% include 'partials/runtime.html' %}
   </div>
 
@@ -148,6 +148,14 @@ function refreshDashboardEpistemics() {
   }
 }
 
+function refreshDashboardRuntime() {
+  if (window.htmx) {
+    htmx.ajax('GET', '/partials/runtime', {target: '#dashboard-runtime', swap: 'innerHTML'});
+  } else {
+    location.reload();
+  }
+}
+
 function taskAction(taskId, action, btn) {
   if (!action) return;
 
@@ -210,6 +218,43 @@ function steeringAction(targetType, targetId, action, label, reference, btn, val
       refreshDashboardEpistemics();
     } else {
       r.json().then(function(d) { alert(d.error || 'Steering action failed'); });
+    }
+  }).catch(function() {
+    alert('Network error');
+  }).finally(function() {
+    if (btn) btn.disabled = false;
+  });
+}
+
+function runtimeAction(targetType, targetId, action, label, reference, btn, valuePrompt) {
+  if (!targetType || !targetId || !action) return;
+
+  var reason = window.prompt('rationale for ' + action + ' on ' + label + '?');
+  if (reason === null || !reason.trim()) return;
+
+  var payload = {
+    action: action,
+    reason: reason.trim(),
+    label: label,
+    reference: reference || ''
+  };
+
+  if (valuePrompt) {
+    var value = window.prompt(valuePrompt);
+    if (value === null) return;
+    if (value.trim()) payload.value = value.trim();
+  }
+
+  if (btn) btn.disabled = true;
+  fetch('/api/runtime/' + encodeURIComponent(targetType) + '/' + encodeURIComponent(targetId) + '/action', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  }).then(function(r) {
+    if (r.ok) {
+      refreshDashboardRuntime();
+    } else {
+      r.json().then(function(d) { alert(d.error || 'Runtime action failed'); });
     }
   }).catch(function() {
     alert('Network error');

--- a/blog/templates/partials/runtime.html
+++ b/blog/templates/partials/runtime.html
@@ -1,5 +1,6 @@
 <div class="dash-section">
   <h2 class="dash-section-title">runtime transparency</h2>
+  <div class="runtime-note">runtime and autonomy controls are queued for the next dispatch; they do not mutate the live cycle directly from the dashboard.</div>
 
   <div class="runtime-grid">
     <div class="runtime-card">
@@ -17,6 +18,12 @@
       {% if runtime_current_cycle.opened_at_short %}
       <div class="runtime-note">opened {{ runtime_current_cycle.opened_at_short }}{% if runtime_current_cycle.dispatched_at_short %} · dispatched {{ runtime_current_cycle.dispatched_at_short }}{% endif %}{% if runtime_current_cycle.closed_at_short %} · closed {{ runtime_current_cycle.closed_at_short }}{% endif %}</div>
       {% endif %}
+      <div class="dash-task-actions">
+        <button class="action-btn action-blocked" onclick='runtimeAction("dispatch", {{ runtime_current_cycle.cycle_id|tojson }}, "require-review", {{ (runtime_current_cycle.skill or runtime_current_cycle.cycle_id)|tojson }}, {{ runtime_current_cycle.cycle_id|tojson }}, this)'>require review</button>
+        <button class="action-btn" onclick='runtimeAction("dispatch", {{ runtime_current_cycle.cycle_id|tojson }}, "retry", {{ (runtime_current_cycle.skill or runtime_current_cycle.cycle_id)|tojson }}, {{ runtime_current_cycle.cycle_id|tojson }}, this)'>retry</button>
+        <button class="action-btn action-blocked" onclick='runtimeAction("dispatch", {{ runtime_current_cycle.cycle_id|tojson }}, "halt", {{ (runtime_current_cycle.skill or runtime_current_cycle.cycle_id)|tojson }}, {{ runtime_current_cycle.cycle_id|tojson }}, this)'>halt</button>
+        <button class="action-btn action-start" onclick='runtimeAction("dispatch", {{ runtime_current_cycle.cycle_id|tojson }}, "safe-to-continue", {{ (runtime_current_cycle.skill or runtime_current_cycle.cycle_id)|tojson }}, {{ runtime_current_cycle.cycle_id|tojson }}, this)'>safe</button>
+      </div>
       {% else %}
       <div class="runtime-empty">no current dispatch file</div>
       {% endif %}
@@ -32,6 +39,11 @@
           </div>
           <div class="runtime-meta">{{ cycle.trigger or '?' }} · {{ cycle.cycle_id }}</div>
           <div class="runtime-meta">{{ cycle.last_ts_short }}</div>
+          <div class="dash-task-actions">
+            <button class="action-btn action-blocked" onclick='runtimeAction("dispatch", {{ cycle.cycle_id|tojson }}, "require-review", {{ (cycle.skill or cycle.cycle_id)|tojson }}, {{ cycle.cycle_id|tojson }}, this)'>review</button>
+            <button class="action-btn" onclick='runtimeAction("dispatch", {{ cycle.cycle_id|tojson }}, "retry", {{ (cycle.skill or cycle.cycle_id)|tojson }}, {{ cycle.cycle_id|tojson }}, this)'>retry</button>
+            <button class="action-btn action-blocked" onclick='runtimeAction("dispatch", {{ cycle.cycle_id|tojson }}, "halt", {{ (cycle.skill or cycle.cycle_id)|tojson }}, {{ cycle.cycle_id|tojson }}, this)'>halt</button>
+          </div>
         </div>
         {% endfor %}
       </div>
@@ -45,11 +57,24 @@
         <span class="runtime-pill runtime-pill-{{ runtime_skill_evidence.pre_skill.color }}">{{ runtime_skill_evidence.pre_skill.status }}</span>
       </div>
       <div class="runtime-note">{{ runtime_skill_evidence.pre_skill.detail }} · protocol={{ runtime_skill_evidence.pre_skill.protocol_status }}</div>
+      <div class="dash-task-actions">
+        <button class="action-btn action-start" onclick='runtimeAction("evidence", {{ runtime_skill_evidence.pre_skill.id|tojson }}, "confirm", "pre-skill evidence", {{ (runtime_skill_evidence.pre_skill.reference or runtime_skill_evidence.pre_skill.id)|tojson }}, this)'>confirm</button>
+        <button class="action-btn action-blocked" onclick='runtimeAction("evidence", {{ runtime_skill_evidence.pre_skill.id|tojson }}, "dispute", "pre-skill evidence", {{ (runtime_skill_evidence.pre_skill.reference or runtime_skill_evidence.pre_skill.id)|tojson }}, this)'>dispute</button>
+        <button class="action-btn" onclick='runtimeAction("evidence", {{ runtime_skill_evidence.pre_skill.id|tojson }}, "incomplete", "pre-skill evidence", {{ (runtime_skill_evidence.pre_skill.reference or runtime_skill_evidence.pre_skill.id)|tojson }}, this)'>incomplete</button>
+        <button class="action-btn" onclick='runtimeAction("evidence", {{ runtime_skill_evidence.pre_skill.id|tojson }}, "needs-instrumentation", "pre-skill evidence", {{ (runtime_skill_evidence.pre_skill.reference or runtime_skill_evidence.pre_skill.id)|tojson }}, this)'>instrument</button>
+      </div>
+
       <div class="runtime-row">
         <strong>post-skill</strong>
         <span class="runtime-pill runtime-pill-{{ runtime_skill_evidence.post_skill.color }}">{{ runtime_skill_evidence.post_skill.status }}</span>
       </div>
       <div class="runtime-note">{{ runtime_skill_evidence.post_skill.detail }} · protocol={{ runtime_skill_evidence.post_skill.protocol_status }}</div>
+      <div class="dash-task-actions">
+        <button class="action-btn action-start" onclick='runtimeAction("evidence", {{ runtime_skill_evidence.post_skill.id|tojson }}, "confirm", "post-skill evidence", {{ (runtime_skill_evidence.post_skill.reference or runtime_skill_evidence.post_skill.id)|tojson }}, this)'>confirm</button>
+        <button class="action-btn action-blocked" onclick='runtimeAction("evidence", {{ runtime_skill_evidence.post_skill.id|tojson }}, "dispute", "post-skill evidence", {{ (runtime_skill_evidence.post_skill.reference or runtime_skill_evidence.post_skill.id)|tojson }}, this)'>dispute</button>
+        <button class="action-btn" onclick='runtimeAction("evidence", {{ runtime_skill_evidence.post_skill.id|tojson }}, "incomplete", "post-skill evidence", {{ (runtime_skill_evidence.post_skill.reference or runtime_skill_evidence.post_skill.id)|tojson }}, this)'>incomplete</button>
+        <button class="action-btn" onclick='runtimeAction("evidence", {{ runtime_skill_evidence.post_skill.id|tojson }}, "needs-instrumentation", "post-skill evidence", {{ (runtime_skill_evidence.post_skill.reference or runtime_skill_evidence.post_skill.id)|tojson }}, this)'>instrument</button>
+      </div>
 
       <div class="runtime-subtitle">skill-step runs</div>
       <div class="runtime-row">
@@ -125,6 +150,11 @@
           {% if item.problems %}
           <div class="runtime-note">{{ item.problems | join(' · ') }}</div>
           {% endif %}
+          <div class="dash-task-actions">
+            <button class="action-btn action-blocked" onclick='runtimeAction("primitive", {{ item.id|tojson }}, "confirm-failure", {{ item.name|tojson }}, {{ item.reference|tojson }}, this)'>confirm fail</button>
+            <button class="action-btn" onclick='runtimeAction("primitive", {{ item.id|tojson }}, "needs-guardrail", {{ item.name|tojson }}, {{ item.reference|tojson }}, this)'>guardrail</button>
+            <button class="action-btn" onclick='runtimeAction("primitive", {{ item.id|tojson }}, "defer", {{ item.name|tojson }}, {{ item.reference|tojson }}, this)'>defer</button>
+          </div>
         </div>
         {% endfor %}
       </div>
@@ -162,6 +192,10 @@
             <strong>{{ gap.name }}</strong>
             <span class="runtime-meta">{{ gap.level }}/10</span>
           </div>
+          <div class="dash-task-actions">
+            <button class="action-btn action-start" onclick='runtimeAction("autonomy", {{ gap.id|tojson }}, "accept-delta", {{ gap.name|tojson }}, {{ gap.reference|tojson }}, this)'>accept delta</button>
+            <button class="action-btn action-blocked" onclick='runtimeAction("autonomy", {{ gap.id|tojson }}, "dispute-delta", {{ gap.name|tojson }}, {{ gap.reference|tojson }}, this)'>dispute delta</button>
+          </div>
         </div>
         {% endfor %}
       </div>
@@ -175,12 +209,128 @@
             <strong>{{ step.id }}</strong>
           </div>
           <div class="runtime-meta">{{ step.title }}</div>
+          <div class="dash-task-actions">
+            <button class="action-btn" onclick='runtimeAction("autonomy", {{ step.id|tojson }}, "promote-proposal", {{ step.title|tojson }}, {{ step.reference|tojson }}, this, "proposal title to carry into the next dispatch?")'>promote proposal</button>
+            <button class="action-btn" onclick='runtimeAction("autonomy", {{ step.id|tojson }}, "promote-task", {{ step.title|tojson }}, {{ step.reference|tojson }}, this, "task title to carry into the next dispatch?")'>promote task</button>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% if runtime_autonomy.recovered %}
+      <div class="runtime-subtitle">recovered but unstable</div>
+      <div class="runtime-list">
+        {% for item in runtime_autonomy.recovered %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ item.signature }}</strong>
+            <span class="runtime-meta">{{ item.count }}</span>
+          </div>
+          <div class="runtime-meta">{{ item.last_seen_short }}</div>
+          <div class="dash-task-actions">
+            <button class="action-btn action-blocked" onclick='runtimeAction("autonomy", {{ item.id|tojson }}, "confirm-unstable", {{ item.signature|tojson }}, {{ item.reference|tojson }}, this)'>confirm unstable</button>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% if runtime_autonomy.codify_now %}
+      <div class="runtime-subtitle">codify now</div>
+      <div class="runtime-list">
+        {% for item in runtime_autonomy.codify_now %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ item.signature }}</strong>
+            <span class="runtime-meta">{{ item.count }}</span>
+          </div>
+          <div class="runtime-meta">{{ item.last_seen_short }}</div>
+          <div class="dash-task-actions">
+            <button class="action-btn action-start" onclick='runtimeAction("autonomy", {{ item.id|tojson }}, "codify-accepted", {{ item.signature|tojson }}, {{ item.reference|tojson }}, this)'>accept</button>
+            <button class="action-btn action-blocked" onclick='runtimeAction("autonomy", {{ item.id|tojson }}, "codify-deferred", {{ item.signature|tojson }}, {{ item.reference|tojson }}, this)'>defer</button>
+            <button class="action-btn" onclick='runtimeAction("autonomy", {{ item.id|tojson }}, "promote-task", {{ item.signature|tojson }}, {{ item.reference|tojson }}, this, "task title to carry into the next dispatch?")'>promote task</button>
+          </div>
         </div>
         {% endfor %}
       </div>
       {% endif %}
       {% else %}
       <div class="runtime-empty">no autonomy capability file yet</div>
+      {% endif %}
+    </div>
+
+    <div class="runtime-card">
+      <div class="runtime-card-title">queued for next dispatch</div>
+      <div class="runtime-row">
+        <span>pending runtime intents</span>
+        <span class="runtime-meta">{{ runtime_queued_count }}</span>
+      </div>
+
+      {% if runtime_queued_interventions %}
+      <div class="runtime-list">
+        {% for item in runtime_queued_interventions %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ item.label }}</strong>
+            <span class="runtime-pill runtime-pill-muted">{{ item.target_type }}</span>
+          </div>
+          <div class="runtime-meta">{{ item.action }} · {{ item.ts_short }}{% if item.apply %} · {{ item.apply }}{% endif %}</div>
+          {% if item.reference %}
+          <div class="runtime-meta">ref: {{ item.reference }}</div>
+          {% endif %}
+          {% if item.reason %}
+          <div class="runtime-note">{{ item.reason }}</div>
+          {% endif %}
+          {% if item.value %}
+          <div class="runtime-note">{{ item.value }}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no queued runtime interventions</div>
+      {% endif %}
+    </div>
+
+    <div class="runtime-card">
+      <div class="runtime-card-title">intervention lineage</div>
+      <div class="runtime-row">
+        <span>logged interventions</span>
+        <span class="runtime-meta">{{ runtime_intervention_lineage_count }}</span>
+      </div>
+
+      {% if runtime_intervention_lineage %}
+      <div class="runtime-list">
+        {% for item in runtime_intervention_lineage %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong>{{ item.label }}</strong>
+            <span class="runtime-pill runtime-pill-muted">{{ item.display_action }}</span>
+          </div>
+          <div class="runtime-meta">{{ item.target_type }} · {{ item.ts_short }}{% if item.resulting_state %} · {{ item.resulting_state }}{% endif %}</div>
+          {% if item.reference %}
+          <div class="runtime-meta">ref: {{ item.reference }}</div>
+          {% endif %}
+          {% if item.reason %}
+          <div class="runtime-note">{{ item.reason }}</div>
+          {% endif %}
+          {% if item.value %}
+          <div class="runtime-note">{{ item.value }}</div>
+          {% endif %}
+          {% if item.downstream_target %}
+          <div class="runtime-meta">downstream {{ item.downstream_target.type }}: {% if item.downstream_target.href %}<a href="{{ item.downstream_target.href }}" style="color:inherit">{{ item.downstream_target.label }}</a>{% else %}{{ item.downstream_target.label }}{% endif %}</div>
+          {% endif %}
+          {% if item.downstream_cycles %}
+          <div class="runtime-meta">later cycles:
+            {% for cycle in item.downstream_cycles %}
+              {{ cycle.cycle_id }}{% if cycle.skill %} ({{ cycle.skill }}){% endif %}{% if not loop.last %}, {% endif %}
+            {% endfor %}
+          </div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="runtime-empty">no runtime intervention lineage yet</div>
       {% endif %}
     </div>
   </div>

--- a/tests/test_dashboard_runtime_interventions.sh
+++ b/tests/test_dashboard_runtime_interventions.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VENV_PY="${EDGE_BLOG_VENV:-$EDGE_DIR/blog/.venv/bin/python3}"
+if [ ! -x "$VENV_PY" ]; then
+    echo "Missing blog venv python: $VENV_PY" >&2
+    echo "Set EDGE_BLOG_VENV=/path/to/blog/.venv/bin/python3 when running from a clean worktree." >&2
+    exit 2
+fi
+
+TMP_BASE="$(mktemp -d /tmp/edge-dashboard-runtime-interventions-XXXXXX)"
+TMP_STATE="$TMP_BASE/state-root"
+AUTONOMY_DIR="$EDGE_DIR/autonomy"
+CAP_FILE="$AUTONOMY_DIR/capabilities.md"
+FRONTIER_FILE="$AUTONOMY_DIR/frontier.md"
+CAP_BACKUP="$TMP_BASE/capabilities.md.bak"
+FRONTIER_BACKUP="$TMP_BASE/frontier.md.bak"
+
+cleanup() {
+    if [ -f "$CAP_BACKUP" ]; then
+        mv "$CAP_BACKUP" "$CAP_FILE"
+    else
+        rm -f "$CAP_FILE"
+    fi
+    if [ -f "$FRONTIER_BACKUP" ]; then
+        mv "$FRONTIER_BACKUP" "$FRONTIER_FILE"
+    else
+        rm -f "$FRONTIER_FILE"
+    fi
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE/state/events" "$TMP_STATE/logs" "$TMP_STATE/blog/entries" "$TMP_STATE/state/signals" "$TMP_STATE/search" "$AUTONOMY_DIR"
+
+if [ -f "$CAP_FILE" ]; then cp "$CAP_FILE" "$CAP_BACKUP"; fi
+if [ -f "$FRONTIER_FILE" ]; then cp "$FRONTIER_FILE" "$FRONTIER_BACKUP"; fi
+
+cat >"$TMP_STATE/state/current-dispatch.json" <<'JSON'
+{
+  "version": 1,
+  "cycle_id": "cycle-20260420T220000Z-runtime",
+  "request": {
+    "trigger": "heartbeat",
+    "skill": "reflection",
+    "policy": "autonomous"
+  },
+  "state": {
+    "active": true,
+    "phase": "skill_dispatched",
+    "skill_dispatched": true,
+    "preflight_status": "completed",
+    "skill_status": "running",
+    "postflight_status": "pending",
+    "opened_at": "2026-04-20T22:00:00+00:00",
+    "dispatched_at": "2026-04-20T22:01:00+00:00",
+    "updated_at": "2026-04-20T22:01:30+00:00"
+  }
+}
+JSON
+
+cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
+{"ts":"2026-04-20T21:00:00+00:00","type":"CycleStarted","cycle_id":"cycle-a","payload":{"trigger":"heartbeat"}}
+{"ts":"2026-04-20T21:01:00+00:00","type":"SkillDispatched","cycle_id":"cycle-a","payload":{"trigger":"heartbeat","skill":"planner","dispatch_mode":"normal"}}
+{"ts":"2026-04-20T21:20:00+00:00","type":"CycleClosed","cycle_id":"cycle-a","payload":{"trigger":"heartbeat","skill":"planner","close_status":"completed"}}
+{"ts":"2026-04-21T01:00:00+00:00","type":"CycleStarted","cycle_id":"cycle-followup","payload":{"trigger":"operator"}}
+{"ts":"2026-04-21T01:01:00+00:00","type":"SkillDispatched","cycle_id":"cycle-followup","payload":{"trigger":"operator","skill":"repair","dispatch_mode":"normal"}}
+{"ts":"2026-04-21T01:15:00+00:00","type":"CycleClosed","cycle_id":"cycle-followup","payload":{"trigger":"operator","skill":"repair","close_status":"completed"}}
+JSONL
+
+cat >"$TMP_STATE/logs/skill-steps.jsonl" <<'JSONL'
+{"skill":"reflection","event":"end","expected":5,"done":4,"explicit_skips":1,"silent_skips":["crossref"],"completion_pct":80,"ts":"2026-04-20T22:02:00"}
+JSONL
+
+cat >"$TMP_STATE/state/primitives-status.json" <<'JSON'
+{
+  "generated_at": "2026-04-20T22:10:00+00:00",
+  "summary": {
+    "window_days": 30,
+    "declared_total": 2,
+    "contract_only_total": 0,
+    "active_total": 1,
+    "probed_total": 0,
+    "broken_total": 1,
+    "drifted_total": 0,
+    "usage_30d_total": 12,
+    "counts_by_effective_status": {
+      "broken": 1,
+      "active": 1
+    },
+    "health_status": "fail"
+  },
+  "sources": [
+    {
+      "name": "exa",
+      "effective_status": "broken",
+      "probe_status": "fail",
+      "usage_30d": 10,
+      "manifest_status": "active",
+      "problems": ["last_probe_failed"]
+    },
+    {
+      "name": "grok",
+      "effective_status": "active",
+      "probe_status": "unknown",
+      "usage_30d": 2,
+      "manifest_status": "active",
+      "problems": []
+    }
+  ]
+}
+JSON
+
+cat >"$TMP_STATE/state/ops-hotspots.json" <<'JSON'
+{
+  "generated_at": "2026-04-20T22:12:00+00:00",
+  "window": "48h",
+  "incidents": [],
+  "top_pain": [],
+  "recovered_but_unstable": [
+    {
+      "signature": "exa timeout on retry",
+      "count": 3,
+      "last_seen": "2026-04-20T22:05:00+00:00"
+    }
+  ],
+  "codify_now": [
+    {
+      "signature": "missing pre-skill evidence guardrail",
+      "count": 4,
+      "last_seen": "2026-04-20T22:06:00+00:00"
+    }
+  ]
+}
+JSON
+
+cat >"$TMP_STATE/state/proposals.json" <<'JSON'
+[
+  {
+    "id": "prop-runtime-1",
+    "title": "Instrument explicit pre-skill evidence",
+    "type": "runtime",
+    "status": "active",
+    "created": "2026-04-20T22:12:00+00:00",
+    "updated": "2026-04-20T22:12:00+00:00",
+    "evidence": ["GAP-101"]
+  }
+]
+JSON
+
+cat >"$TMP_STATE/state/tasks.snapshot.json" <<'JSON'
+{
+  "version": 1,
+  "tasks": [
+    {
+      "id": "TASK-RUNTIME-001",
+      "title": "Investigate exa guardrail",
+      "status": "todo",
+      "priority": "P1",
+      "owner": "ed",
+      "blocked": false
+    }
+  ]
+}
+JSON
+
+cat >"$CAP_FILE" <<'MD'
+| # | Name | Sheridan |
+|---|------|----------|
+| 1 | Safe execution | 8 |
+| 2 | Runtime transparency | 4 |
+| 3 | Primitive stewardship | 3 |
+MD
+
+cat >"$FRONTIER_FILE" <<'MD'
+### GAP-101: instrument explicit pre-skill evidence
+MD
+
+EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$VENV_PY" - <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+edge_dir = os.environ["EDGE_REPO_DIR"]
+state_dir = Path(os.environ["EDGE_STATE_DIR"])
+sys.path.insert(0, edge_dir)
+sys.path.insert(0, os.path.join(edge_dir, "blog"))
+os.chdir(os.path.join(edge_dir, "blog"))
+
+from app import app
+
+client = app.test_client()
+
+seed = client.get("/api/dashboard/runtime")
+assert seed.status_code == 200, seed.status_code
+seed_data = seed.get_json()
+
+cycle_id = seed_data["runtime_current_cycle"]["cycle_id"]
+primitive_id = seed_data["runtime_primitives"]["top_sources"][0]["id"]
+frontier_id = seed_data["runtime_autonomy"]["next_steps"][0]["id"]
+codify_id = seed_data["runtime_autonomy"]["codify_now"][0]["id"]
+
+dispatch = client.post(
+    f"/api/runtime/dispatch/{cycle_id}/action",
+    json={
+        "action": "require-review",
+        "reason": "cycle needs explicit human review before continuation",
+        "label": "reflection",
+        "reference": cycle_id,
+    },
+)
+assert dispatch.status_code == 200, dispatch.status_code
+assert dispatch.get_json()["queued"] is True
+assert dispatch.get_json()["dispatch_mode"] == "next-dispatch"
+
+evidence = client.post(
+    "/api/runtime/evidence/pre-skill/action",
+    json={
+        "action": "incomplete",
+        "reason": "pre-skill evidence is still missing operator-grade detail",
+        "label": "pre-skill evidence",
+        "reference": cycle_id,
+    },
+)
+assert evidence.status_code == 200, evidence.status_code
+
+primitive = client.post(
+    f"/api/runtime/primitive/{primitive_id}/action",
+    json={
+        "action": "confirm-failure",
+        "reason": "probe failure is reproducible and should not be ignored",
+        "label": "exa",
+        "reference": "exa",
+    },
+)
+assert primitive.status_code == 200, primitive.status_code
+
+proposal = client.post(
+    f"/api/runtime/autonomy/{frontier_id}/action",
+    json={
+        "action": "promote-proposal",
+        "reason": "frontier gap should become an explicit proposal",
+        "value": "Instrument explicit pre-skill evidence",
+        "label": "instrument explicit pre-skill evidence",
+        "reference": frontier_id,
+    },
+)
+assert proposal.status_code == 200, proposal.status_code
+
+task = client.post(
+    f"/api/runtime/autonomy/{codify_id}/action",
+    json={
+        "action": "promote-task",
+        "reason": "codify-now incident needs a concrete operator-visible task",
+        "value": "Investigate exa guardrail",
+        "label": "missing pre-skill evidence guardrail",
+        "reference": "missing pre-skill evidence guardrail",
+    },
+)
+assert task.status_code == 200, task.status_code
+assert task.get_json()["resulting_state"] == "queued"
+
+messages = client.get("/api/chat?unprocessed=1").get_json()["messages"]
+intents = [m for m in messages if m["author"] == "user" and m["text"].startswith("[runtime-intent]")]
+assert len(intents) == 5
+assert any("target_type: dispatch" in m["text"] for m in intents)
+assert any("target_type: evidence" in m["text"] for m in intents)
+assert any("target_type: primitive" in m["text"] for m in intents)
+assert any("target_type: autonomy" in m["text"] for m in intents)
+assert any("Instrument explicit pre-skill evidence" in m["text"] for m in intents)
+assert any("Investigate exa guardrail" in m["text"] for m in intents)
+
+operator_log = [
+    json.loads(line)
+    for line in (state_dir / "logs" / "operator-actions.jsonl").read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+assert operator_log[-1]["action"] == "runtime:promote-task"
+assert operator_log[-1]["target_type"] == "autonomy"
+assert operator_log[-1]["resulting_state"] == "queued"
+
+runtime = client.get("/api/dashboard/runtime")
+assert runtime.status_code == 200, runtime.status_code
+data = runtime.get_json()
+assert data["runtime_queued_count"] == 5
+assert data["runtime_intervention_trace_count"] == 5
+assert data["runtime_intervention_lineage_count"] == 5
+assert {item["action"] for item in data["runtime_intervention_trace"]} == {
+    "runtime:require-review",
+    "runtime:incomplete",
+    "runtime:confirm-failure",
+    "runtime:promote-proposal",
+    "runtime:promote-task",
+}
+
+proposal_lineage = next(item for item in data["runtime_intervention_lineage"] if item["display_action"] == "promote-proposal")
+assert proposal_lineage["downstream_target"]["type"] == "proposal"
+assert proposal_lineage["downstream_target"]["label"] == "Instrument explicit pre-skill evidence"
+
+task_lineage = next(item for item in data["runtime_intervention_lineage"] if item["display_action"] == "promote-task")
+assert task_lineage["downstream_target"]["type"] == "task"
+assert task_lineage["downstream_target"]["label"] == "Investigate exa guardrail"
+
+dispatch_lineage = next(item for item in data["runtime_intervention_lineage"] if item["display_action"] == "require-review")
+assert dispatch_lineage["reference"] == cycle_id
+assert dispatch_lineage["downstream_cycles"][0]["cycle_id"] == "cycle-followup"
+
+partial = client.get("/partials/runtime")
+assert partial.status_code == 200, partial.status_code
+text = partial.get_data(as_text=True)
+assert "queued for next dispatch" in text
+assert "intervention lineage" in text
+assert "require review" in text
+assert "Instrument explicit pre-skill evidence" in text
+assert "Investigate exa guardrail" in text
+print("ok")
+PY

--- a/tests/test_ops_console.sh
+++ b/tests/test_ops_console.sh
@@ -125,6 +125,11 @@ r = client.post("/api/steering/strategy/global/action",
                 content_type="application/json")
 check("POST /api/steering/strategy/global/action", r)
 
+r = client.post("/api/runtime/dispatch/integration-cycle/action",
+                json={"action": "require-review", "reason": "integration runtime smoke test", "label": "integration cycle", "reference": "integration-cycle"},
+                content_type="application/json")
+check("POST /api/runtime/dispatch/integration-cycle/action", r)
+
 r = client.post("/api/heartbeat/trigger", content_type="application/json")
 ok = r.status_code in (200, 429)
 mark = "PASS" if ok else "FAIL"


### PR DESCRIPTION
Closes #274

## What changed

This adds queued runtime and autonomy interventions to the dashboard instead of direct operator-side mutations.

- adds `POST /api/runtime/<target_type>/<target_id>/action`
- queues dispatch, evidence, primitive, and autonomy interventions into the async chat inbox for the next dispatch
- adds dispatch controls on current and recent cycles
- adds operator feedback controls for pre/post-skill evidence and primitive failures
- adds autonomy interventions for capability deltas, recovered-but-unstable incidents, codify-now incidents, and promote-to-proposal/task flows
- adds queued runtime interventions and intervention lineage cards to the runtime dashboard
- extends runtime read models with the metadata needed to trace later cycles and proposal/task followups
- adds `tests/test_dashboard_runtime_interventions.sh`
- extends `tests/test_ops_console.sh` with a runtime intervention smoke check

## Why

Runtime state was visible but still not governable from the operator surface. These controls need to follow the same async pattern as dashboard chat and steering: queue explicit human judgment for the next dispatch instead of letting the operator mutate live execution directly.

## Validation

- `python3 -m py_compile blog/app.py blog/api_actions.py blog/api_dashboard.py blog/services.py`
- `tests/test_dashboard_runtime_interventions.sh`
- `tests/test_dashboard_runtime.sh`
- `tests/test_dashboard_epistemics.sh`
- `tests/test_dashboard_interventions.sh`
- `tests/test_ops_console.sh`
