### PR TITLE
[dispatch] Consume async inbox at skill level

### DIFF
--- a/search/dashboard_db.py
+++ b/search/dashboard_db.py
@@ -64,7 +64,7 @@ def get_chats(unprocessed_only: bool = False, pinned_only: bool = False,
             clauses.append("pinned=1")
         if clauses:
             sql += " WHERE " + " AND ".join(clauses)
-        sql += " ORDER BY ts ASC LIMIT ?"
+        sql += " ORDER BY ts ASC, id ASC LIMIT ?"
         return [dict(r) for r in conn.execute(sql, (limit,)).fetchall()]
     finally:
         if own: conn.close()

--- a/skills/_shared/state-protocol.md
+++ b/skills/_shared/state-protocol.md
@@ -64,6 +64,39 @@ Any change to these files is monitored by `edge-state-audit`:
 
 ---
 
+## Async Inbox (MANDATORY, before execution)
+
+**User interaction is priority.** The async blog chat is the canonical operator
+input channel, but skills must consume it through the structured inbox
+contract rather than scraping `/api/chat` directly.
+
+Before meaningful execution, read the inbox:
+
+```bash
+edge-skill-inbox read --skill <skill> | tee /tmp/edge-skill-inbox.json
+```
+
+Rules:
+- `edge-skill-inbox read` returns the **captured dispatch snapshot** when the
+  skill was already dispatched. This is the deterministic contract for the
+  current cycle (`request.async_inbox` in `state/current-dispatch.json`).
+- If there is no active dispatched cycle yet, the tool falls back to a live
+  view. Use that only for lightweight routing/bootstrap. The real contract is
+  captured at `edge-dispatch dispatch --skill <skill>`.
+- Inspect all buckets: `direct_messages`, `task_intents`, `steering_intents`,
+  `runtime_intents`, and `pinned_messages`.
+- If the inbox reports `priority: high`, address it before generic exploration,
+  rotation, or opportunistic work.
+- `task_intents`, `steering_intents`, and `runtime_intents` are operator
+  instructions queued for the **next dispatch**, not immediate mutations.
+- Do **not** mark chat messages as processed manually inside the skill. The
+  captured `message_ids` are consumed by `edge-close` only after successful
+  completion of the cycle.
+- The shared protocol is the genotype of this rule. `pre-skill` is its
+  phenotype. They must agree: user interaction outranks generic exploration.
+
+---
+
 ## Workflow Lookup (MANDATORY, before execution)
 
 Before starting any skill, look up relevant workflows and save the results:

--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -244,19 +244,27 @@ This creates a `workflow` entry (operator authority = instant approval) that ent
 
 **If unable to extract content, record the technical reason in debugging.md. DO NOT skip silently.**
 
-### 1b: Read async chat (single channel)
+### 1b: Check async inbox priority (routing only)
 
 ```bash
-curl -s 'http://localhost:8766/api/chat?unprocessed=true' | python3 -c "
+edge-skill-inbox read 2>/dev/null | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
-for m in data.get('messages', []):
-    if m.get('author') == 'user' and not m.get('processed'):
-        print(f'CHAT ID: {m[\"id\"]} | TEXT: {m[\"text\"]}')
+print(f'priority={data.get(\"priority\", \"normal\")}')
+print(f'unprocessed_total={data.get(\"unprocessed_total\", 0)}')
+print(f'pinned_total={data.get(\"pinned_total\", 0)}')
+print(f'direct_messages={len(data.get(\"direct_messages\", []))}')
+print(f'task_intents={len(data.get(\"task_intents\", []))}')
+print(f'steering_intents={len(data.get(\"steering_intents\", []))}')
+print(f'runtime_intents={len(data.get(\"runtime_intents\", []))}')
 "
 ```
 
-Chat is the async channel. Blog comments exist as a feature (annotate, save) but the heartbeat does not process them.
+The async blog chat is the operator channel, but heartbeat should use it only
+for routing pressure and priority. The actual skill-level contract is captured
+at `edge-dispatch dispatch --skill <skill>` and delivered as
+`request.async_inbox`. Do not treat heartbeat as the place that consumes the
+chat payload.
 
 ### 1c: Read previous beats (avoid repetition)
 
@@ -428,7 +436,7 @@ skill, dispatch it, and continue. Only `/ed-execute` may stop for human sign-off
 
 ### Decision tree (simple)
 
-1. **User asked for something?** (message in chat/comment with direction) → Address it. If it's an internal change → do it. If it's a project → note it, reply that it needs /ed-execute.
+1. **Async inbox has operator input?** (`priority: high`, direct message, or queued intent) → This outranks exploration and rotation. Choose the internal skill best suited to handle it, then let that dispatched skill read `request.async_inbox`.
 
 2. **Dispatch queue has pending items?** → Check `state/dispatch-queue.json` for queued dispatches from reflection or other skills:
 
@@ -591,14 +599,11 @@ Respond WITH FOLLOW-UP — what the beat did, how it connects with the request.
 curl -s -X POST http://localhost:8766/api/chat \
   -H "Content-Type: application/json" \
   -d '{"author":"claude","text":"RESPONSE"}'
-
-# Mark user message as processed
-curl -s -X POST http://localhost:8766/api/chat \
-  -H "Content-Type: application/json" \
-  -d '{"action":"mark_processed","id":CHAT_ID}'
 ```
 
-**RULE:** Every response MUST be followed by mark_processed on the user's message. No exceptions.
+**RULE:** Do **not** mark chat messages as processed manually here. The
+captured async inbox is consumed by `edge-close` only after successful
+completion of the cycle.
 
 ### 3b: Capture errors in debugging.md
 

--- a/skills/loader/SKILL.md
+++ b/skills/loader/SKILL.md
@@ -54,18 +54,23 @@ Only read these if the briefing indicates something that needs detail:
 
 DO NOT read by default: working-state.md (replaced by briefing), debugging.md (active errors are already in briefing), breaks-active.md (beats are already in briefing).
 
-### Step 2: Read pending chat
+### Step 2: Read async inbox
 
 ```bash
-curl -s 'http://localhost:8766/api/chat?unprocessed=true' 2>/dev/null | python3 -c "
+edge-skill-inbox read --skill loader 2>/dev/null | python3 -c "
 import json, sys
 try:
     data = json.load(sys.stdin)
-    msgs = [m for m in data.get('messages', []) if m.get('author') == 'user' and not m.get('processed')]
-    for m in msgs:
-        print(f'[{m.get(\"id\")}] {m.get(\"text\", \"\")[:200]}')
-    if not msgs: print('(none)')
-except: print('(chat inaccessible)')
+    printed = 0
+    for bucket in ('direct_messages', 'task_intents', 'steering_intents', 'runtime_intents'):
+        for item in data.get(bucket, [])[:3]:
+            preview = item.get('preview') or item.get('text') or item.get('action') or ''
+            print(f'[{bucket}] {preview[:200]}')
+            printed += 1
+    if not printed:
+        print('(none)')
+except Exception:
+    print('(inbox inaccessible)')
 "
 ```
 
@@ -88,11 +93,11 @@ DO NOT dump file contents. ABSORB and produce a short synthesis:
 
 **Synthesis priority:** threads with overdue resurface appear FIRST — they are what needs attention today. Dormant and done threads do not appear in the synthesis (only on explicit request).
 
-### Step 5: Respond to pending chat (if any)
+### Step 5: Respond to pending inbox (if any)
 
-If there are unprocessed chat messages:
-1. Show them to the user
-2. Ask if they want me to respond now or later
+If there are pending async inbox items:
+1. Show the relevant direct messages/intents to the user
+2. Ask if they want me to act now or later
 
 ---
 

--- a/skills/reflection/SKILL.md
+++ b/skills/reflection/SKILL.md
@@ -184,21 +184,29 @@ Cross-reference with findings from HN-1 and HN-2:
 # Pending feedback in ~/work/CLAUDE.md
 grep -c "PROCESSED" ~/work/CLAUDE.md 2>/dev/null || echo "0"
 
-# Async chat
-curl -s "http://localhost:8766/api/chat?unprocessed=true" 2>/dev/null | python3 -c "
+# Structured async inbox
+edge-skill-inbox read --skill reflection 2>/dev/null | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
-msgs = [m for m in data.get('messages', []) if m.get('author') == 'user' and not m.get('processed')]
-print(f'{len(msgs)} pending messages')
-for m in msgs[:3]:
-    print(f'  - {m[\"text\"][:80]}')
+counts = {
+    'direct_messages': len(data.get('direct_messages', [])),
+    'task_intents': len(data.get('task_intents', [])),
+    'steering_intents': len(data.get('steering_intents', [])),
+    'runtime_intents': len(data.get('runtime_intents', [])),
+}
+print(f'priority={data.get(\"priority\", \"normal\")}')
+print('counts=' + json.dumps(counts, ensure_ascii=False))
+for bucket in ('direct_messages', 'task_intents', 'steering_intents', 'runtime_intents'):
+    for item in data.get(bucket, [])[:2]:
+        preview = item.get('preview') or item.get('text') or item.get('action') or ''
+        print(f'  [{bucket}] {preview[:80]}')
 " 2>/dev/null || echo "Chat unavailable"
 ```
 
-Classify each message:
-- **Frustrations** → HN-3 (debugging.md candidate)
-- **Questions** → pending (don't answer yet)
-- **Directions/directives** → record. If the message contains an operational directive (patterns: "always", "from now on", "whenever", "never do X", "make sure to", "every time"), create an approved workflow:
+Classify each inbox item:
+- **Frustrations** in `direct_messages` → HN-3 (debugging.md candidate)
+- **Questions** in `direct_messages` → pending (don't answer yet)
+- **Directions/directives** in `direct_messages` or pinned guidance → record. If the message contains an operational directive (patterns: "always", "from now on", "whenever", "never do X", "make sure to", "every time"), create an approved workflow:
 
 ```bash
 # Operator directive detected — create approved workflow (no draft stage)
@@ -206,8 +214,13 @@ edge-crystallize --from-operator "the directive text here"
 ```
 
 This creates a `workflow` entry immediately (operator authority = approval). The workflow enters `edge-search --type workflow` recall so skills follow it from the next beat.
+- **Task / steering / runtime intents** are already structured next-dispatch
+  inputs. Review them as operator priority, but do not apply them immediately
+  from reflection unless reflection itself is the dispatched skill responsible
+  for that action.
 
-**DO NOT respond, DO NOT mark as processed** — the heartbeat handles responses (Step 3a).
+**DO NOT mark as processed manually** — `edge-close` consumes the captured
+message ids only after the cycle completes successfully.
 
 ### HN-5: State drift check + skill step completion
 

--- a/tests/test_skill_inbox.sh
+++ b/tests/test_skill_inbox.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-skill-inbox-XXXXXX)"
+TMP_EDGE="$TMP_BASE/edge"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_EDGE/state" "$TMP_EDGE/logs" "$TMP_EDGE/search"
+
+export EDGE_REPO_DIR="$EDGE_DIR"
+export EDGE_STATE_DIR="$TMP_EDGE"
+export EDGE_CODENAME="test-agent"
+
+DISPATCH_TOOL="$EDGE_DIR/tools/edge-dispatch"
+CLOSE_TOOL="$EDGE_DIR/tools/edge-close"
+STEP_TOOL="$EDGE_DIR/tools/edge-skill-step"
+INBOX_TOOL="$EDGE_DIR/tools/edge-skill-inbox"
+
+echo "=== edge-skill-inbox Smoke Test ==="
+echo "Temp state: $TMP_EDGE"
+echo ""
+
+echo "--- Test 1: dispatch captures a deterministic async inbox snapshot ---"
+SEED_OUTPUT=$(python3 - <<'PY' "$EDGE_DIR"
+import json
+import sys
+
+edge_dir = sys.argv[1]
+sys.path.insert(0, edge_dir + "/search")
+from dashboard_db import add_chat, pin_chat
+
+direct_id = add_chat("user", "Prioritize operator feedback before exploration.")
+task_id = add_chat("user", "\n".join([
+    "[task-intent]",
+    "task: TASK-001",
+    "action: prioritize",
+    "apply: next-dispatch",
+    "reason: user interaction always wins",
+]))
+steering_id = add_chat("user", "\n".join([
+    "[steering-intent]",
+    "target_type: topic",
+    "target_id: operator-feedback",
+    "action: prioritize",
+    "label: operator feedback",
+    "apply: next-dispatch",
+]))
+runtime_id = add_chat("user", "\n".join([
+    "[runtime-intent]",
+    "target_type: primitive",
+    "target_id: primitives-status",
+    "action: stable",
+    "label: primitives status cli",
+    "apply: next-dispatch",
+]))
+pinned_id = add_chat("user", "User interaction is priority.")
+pin_chat(pinned_id)
+
+print(json.dumps({
+    "captured_ids": [direct_id, task_id, steering_id, runtime_id, pinned_id],
+    "pinned_id": pinned_id,
+}))
+PY
+)
+
+"$DISPATCH_TOOL" open \
+    --trigger heartbeat \
+    --cycle-id cycle-skill-inbox \
+    --postflight-profile none >/dev/null
+"$DISPATCH_TOOL" dispatch --skill research >/dev/null
+
+LATE_OUTPUT=$(python3 - <<'PY' "$EDGE_DIR"
+import json
+import sys
+
+edge_dir = sys.argv[1]
+sys.path.insert(0, edge_dir + "/search")
+from dashboard_db import add_chat
+
+late_id = add_chat("user", "This message arrived after dispatch and should wait for the next cycle.")
+print(json.dumps({"late_id": late_id}))
+PY
+)
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$SEED_OUTPUT" "$LATE_OUTPUT"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+seed = json.loads(sys.argv[2])
+late = json.loads(sys.argv[3])
+inbox = dispatch["request"]["async_inbox"]
+
+assert inbox["priority"] == "high"
+assert inbox["priority_reason"] == "user_async_input"
+assert inbox["dispatch_guidance"].startswith("user interaction is priority")
+assert inbox["skill"] == "research"
+assert inbox["unprocessed_total"] == 5
+assert inbox["pinned_total"] == 1
+assert inbox["message_ids"] == seed["captured_ids"]
+assert len(inbox["direct_messages"]) == 2
+assert len(inbox["task_intents"]) == 1
+assert len(inbox["steering_intents"]) == 1
+assert len(inbox["runtime_intents"]) == 1
+assert seed["pinned_id"] in [item["chat_id"] for item in inbox["pinned_messages"]]
+assert late["late_id"] not in inbox["message_ids"]
+PY
+then
+    pass "dispatch captures operator-priority inbox without late arrivals"
+else
+    fail "dispatch captures operator-priority inbox without late arrivals"
+fi
+
+echo "--- Test 2: edge-skill-inbox read returns the captured dispatch snapshot ---"
+if python3 - <<'PY' "$("$INBOX_TOOL" read --skill research)" "$SEED_OUTPUT" "$LATE_OUTPUT"
+import json
+import sys
+
+snapshot = json.loads(sys.argv[1])
+seed = json.loads(sys.argv[2])
+late = json.loads(sys.argv[3])
+
+assert snapshot["message_ids"] == seed["captured_ids"]
+assert snapshot["unprocessed_total"] == 5
+assert late["late_id"] not in snapshot["message_ids"]
+assert snapshot["priority"] == "high"
+PY
+then
+    pass "edge-skill-inbox read is deterministic during an active cycle"
+else
+    fail "edge-skill-inbox read is deterministic during an active cycle"
+fi
+
+echo "--- Test 3: successful close consumes only the captured inbox ---"
+EDGE_CYCLE_ID=cycle-skill-inbox "$STEP_TOOL" research start >/dev/null
+EDGE_CYCLE_ID=cycle-skill-inbox "$STEP_TOOL" research end >/dev/null
+"$CLOSE_TOOL" --status completed >/dev/null
+
+if python3 - <<'PY' "$EDGE_DIR" "$SEED_OUTPUT" "$LATE_OUTPUT" "$TMP_EDGE/state/current-dispatch.json"
+import json
+import sys
+
+edge_dir = sys.argv[1]
+seed = json.loads(sys.argv[2])
+late = json.loads(sys.argv[3])
+dispatch = json.load(open(sys.argv[4], encoding="utf-8"))
+
+sys.path.insert(0, edge_dir + "/search")
+from dashboard_db import get_chats
+
+messages = {int(item["id"]): item for item in get_chats(limit=20)}
+for chat_id in seed["captured_ids"]:
+    assert messages[chat_id]["processed"] == 1
+assert messages[seed["pinned_id"]]["pinned"] == 1
+assert messages[late["late_id"]]["processed"] == 0
+
+inbox = dispatch["request"]["async_inbox"]
+assert dispatch["state"]["close_status"] == "completed"
+assert inbox["processed_count"] == 5
+assert inbox["processed_message_ids"] == seed["captured_ids"]
+assert "processed_at" in inbox
+PY
+then
+    pass "edge-close consumes captured ids and leaves late input for the next cycle"
+else
+    fail "edge-close consumes captured ids and leaves late input for the next cycle"
+fi
+
+echo "--- Test 4: after close, read falls back to the live inbox ---"
+if python3 - <<'PY' "$("$INBOX_TOOL" read --skill research)" "$LATE_OUTPUT"
+import json
+import sys
+
+snapshot = json.loads(sys.argv[1])
+late = json.loads(sys.argv[2])
+
+assert snapshot["message_ids"] == [late["late_id"]]
+assert snapshot["unprocessed_total"] == 1
+assert snapshot["priority"] == "high"
+PY
+then
+    pass "edge-skill-inbox read falls back to live inbox when the cycle is inactive"
+else
+    fail "edge-skill-inbox read falls back to live inbox when the cycle is inactive"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tools/_shared/skill_inbox.py
+++ b/tools/_shared/skill_inbox.py
@@ -1,0 +1,273 @@
+"""Structured async inbox for skills.
+
+Converts the blog chat's async channel into a deterministic contract that
+skills can inspect without scraping raw `/api/chat` output.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "search"))
+
+
+def _load_dashboard_chat_api():
+    try:
+        from dashboard_db import get_chats, mark_chat_processed  # type: ignore
+    except Exception:
+        return None, None
+    return get_chats, mark_chat_processed
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _preview(text: str, *, limit: int = 180) -> str:
+    blob = " ".join(str(text or "").split())
+    if len(blob) <= limit:
+        return blob
+    return blob[: limit - 1] + "…"
+
+
+def _parse_kv_block(prefix: str, text: str) -> dict[str, str] | None:
+    raw = str(text or "")
+    if not raw.startswith(prefix):
+        return None
+    payload: dict[str, str] = {}
+    for line in raw.splitlines()[1:]:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip().lower()
+        value = value.strip()
+        if key:
+            payload[key] = value
+    return payload
+
+
+def parse_task_intent(text: str) -> dict[str, Any] | None:
+    payload = _parse_kv_block("[task-intent]", text)
+    if not payload:
+        return None
+    task_id = payload.get("task")
+    action = payload.get("action")
+    if not task_id or not action:
+        return None
+    return {
+        "target_type": "task",
+        "target_id": task_id,
+        "action": action,
+        "reason": payload.get("reason"),
+        "value": payload.get("value"),
+        "apply": payload.get("apply"),
+        "note": payload.get("note"),
+    }
+
+
+def parse_steering_intent(text: str) -> dict[str, Any] | None:
+    payload = _parse_kv_block("[steering-intent]", text)
+    if not payload:
+        return None
+    target_type = payload.get("target_type")
+    target_id = payload.get("target_id")
+    action = payload.get("action")
+    if not target_type or not target_id or not action:
+        return None
+    return {
+        "target_type": target_type,
+        "target_id": target_id,
+        "action": action,
+        "label": payload.get("label") or target_id,
+        "reference": payload.get("reference"),
+        "reason": payload.get("reason"),
+        "value": payload.get("value"),
+        "apply": payload.get("apply"),
+        "resulting_state": payload.get("resulting_state"),
+        "note": payload.get("note"),
+    }
+
+
+def parse_runtime_intent(text: str) -> dict[str, Any] | None:
+    payload = _parse_kv_block("[runtime-intent]", text)
+    if not payload:
+        return None
+    target_type = payload.get("target_type")
+    target_id = payload.get("target_id")
+    action = payload.get("action")
+    if not target_type or not target_id or not action:
+        return None
+    return {
+        "target_type": target_type,
+        "target_id": target_id,
+        "action": action,
+        "label": payload.get("label") or target_id,
+        "reference": payload.get("reference"),
+        "reason": payload.get("reason"),
+        "value": payload.get("value"),
+        "apply": payload.get("apply"),
+        "resulting_state": payload.get("resulting_state"),
+        "note": payload.get("note"),
+    }
+
+
+def classify_message(message: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    text = str(message.get("text") or "")
+    base = {
+        "chat_id": message.get("id"),
+        "author": message.get("author"),
+        "ts": message.get("ts"),
+        "text": text,
+        "preview": _preview(text),
+        "priority": "operator",
+    }
+
+    parsed = parse_task_intent(text)
+    if parsed:
+        return "task_intents", {**base, **parsed}
+
+    parsed = parse_steering_intent(text)
+    if parsed:
+        return "steering_intents", {**base, **parsed}
+
+    parsed = parse_runtime_intent(text)
+    if parsed:
+        return "runtime_intents", {**base, **parsed}
+
+    return "direct_messages", {
+        **base,
+        "kind": "direct_message",
+    }
+
+
+def build_async_inbox_snapshot(*, skill: str | None = None, limit: int = 200) -> dict[str, Any]:
+    """Return the structured async inbox contract for the next skill."""
+    get_chats, _ = _load_dashboard_chat_api()
+    if get_chats is None:
+        unprocessed = []
+        pinned = []
+    else:
+        try:
+            unprocessed = get_chats(unprocessed_only=True, limit=limit)
+        except Exception:
+            unprocessed = []
+        try:
+            pinned = get_chats(pinned_only=True, limit=min(limit, 50))
+        except Exception:
+            pinned = []
+
+    snapshot: dict[str, Any] = {
+        "captured_at": now_iso(),
+        "skill": skill,
+        "source": "blog-chat",
+        "priority": "normal",
+        "priority_reason": None,
+        "dispatch_guidance": "continue normal routing",
+        "unprocessed_total": 0,
+        "pinned_total": 0,
+        "message_ids": [],
+        "direct_messages": [],
+        "task_intents": [],
+        "steering_intents": [],
+        "runtime_intents": [],
+        "pinned_messages": [],
+    }
+
+    for message in unprocessed:
+        if message.get("author") != "user":
+            continue
+        bucket, item = classify_message(message)
+        snapshot[bucket].append(item)
+        if message.get("id") is not None:
+            snapshot["message_ids"].append(int(message["id"]))
+
+    seen_pins: set[int] = set()
+    for message in pinned:
+        if message.get("author") != "user":
+            continue
+        chat_id = message.get("id")
+        if chat_id is None:
+            continue
+        chat_id = int(chat_id)
+        if chat_id in seen_pins:
+            continue
+        seen_pins.add(chat_id)
+        snapshot["pinned_messages"].append({
+            "chat_id": chat_id,
+            "author": message.get("author"),
+            "ts": message.get("ts"),
+            "text": str(message.get("text") or ""),
+            "preview": _preview(message.get("text") or ""),
+        })
+
+    snapshot["unprocessed_total"] = len(snapshot["message_ids"])
+    snapshot["pinned_total"] = len(snapshot["pinned_messages"])
+    if snapshot["unprocessed_total"] > 0:
+        snapshot["priority"] = "high"
+        snapshot["priority_reason"] = "user_async_input"
+        snapshot["dispatch_guidance"] = "user interaction is priority; address async inbox before exploration or rotation"
+    elif snapshot["pinned_total"] > 0:
+        snapshot["priority"] = "high"
+        snapshot["priority_reason"] = "pinned_user_direction"
+        snapshot["dispatch_guidance"] = "standing user direction is active; honor pinned guidance before generic exploration"
+    return snapshot
+
+
+def attach_snapshot_to_dispatch(state: dict[str, Any], *, skill: str | None = None, limit: int = 200) -> dict[str, Any]:
+    """Attach an async inbox snapshot to a dispatch state dict."""
+    request = state.setdefault("request", {})
+    state_block = state.setdefault("state", {})
+    snapshot = build_async_inbox_snapshot(skill=skill or request.get("skill"), limit=limit)
+    request["async_inbox"] = snapshot
+    state_block["inbox_captured_at"] = snapshot["captured_at"]
+    return snapshot
+
+
+def get_dispatch_snapshot(state: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the active cycle's captured async inbox, if present."""
+    state_block = state.get("state", {}) or {}
+    if not state_block.get("active"):
+        return None
+    request = state.get("request", {}) or {}
+    snapshot = request.get("async_inbox")
+    if isinstance(snapshot, dict) and snapshot:
+        return snapshot
+    return None
+
+
+def consume_captured_inbox(state: dict[str, Any]) -> dict[str, Any]:
+    """Mark captured async inbox messages as processed after a successful skill run."""
+    request = state.setdefault("request", {})
+    snapshot = request.get("async_inbox") or {}
+    ids = [int(item) for item in snapshot.get("message_ids", []) if str(item).strip()]
+    processed_ids: list[int] = []
+    _, mark_chat_processed = _load_dashboard_chat_api()
+    if mark_chat_processed is None:
+        return {
+            "processed_ids": processed_ids,
+            "processed_count": 0,
+            "captured_total": len(ids),
+        }
+    for chat_id in ids:
+        try:
+            mark_chat_processed(chat_id)
+            processed_ids.append(chat_id)
+        except Exception:
+            continue
+
+    if snapshot:
+        snapshot["processed_at"] = now_iso()
+        snapshot["processed_message_ids"] = processed_ids
+        snapshot["processed_count"] = len(processed_ids)
+        request["async_inbox"] = snapshot
+
+    return {
+        "processed_ids": processed_ids,
+        "processed_count": len(processed_ids),
+        "captured_total": len(ids),
+    }

--- a/tools/edge-close
+++ b/tools/edge-close
@@ -20,6 +20,7 @@ sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import CURRENT_DISPATCH_FILE, EDGE_REPO_DIR, LOGS_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
 from _shared.telemetry import current_actor, emit_shadow_event, log_event  # noqa: E402
+from _shared.skill_inbox import consume_captured_inbox  # noqa: E402
 
 POST_SKILL_LOG = LOGS_DIR / "post-skill.log"
 
@@ -259,6 +260,44 @@ def main() -> int:
         )
 
     _, payload = close_dispatch(effective_status, effective_reason)
+    if effective_status == "completed":
+        try:
+            consumed = consume_captured_inbox(payload)
+            write_state(payload)
+            emit_shadow_event(
+                "AsyncInboxConsumed",
+                actor="edge-close",
+                cycle_id=payload.get("cycle_id"),
+                payload={
+                    "processed_count": consumed.get("processed_count", 0),
+                    "captured_total": consumed.get("captured_total", 0),
+                    "processed_ids": consumed.get("processed_ids", []),
+                },
+            )
+            log_event(
+                "async_inbox",
+                actor="edge-close",
+                action="consumed",
+                cycle_id=payload.get("cycle_id"),
+                skill=(payload.get("request", {}) or {}).get("skill", ""),
+                processed_count=consumed.get("processed_count", 0),
+                captured_total=consumed.get("captured_total", 0),
+            )
+        except Exception as exc:
+            emit_shadow_event(
+                "AsyncInboxConsumeFailed",
+                actor="edge-close",
+                cycle_id=payload.get("cycle_id"),
+                payload={"error": str(exc)},
+            )
+            log_event(
+                "async_inbox",
+                actor="edge-close",
+                action="consume_failed",
+                cycle_id=payload.get("cycle_id"),
+                skill=(payload.get("request", {}) or {}).get("skill", ""),
+                error=str(exc),
+            )
     print(json.dumps(payload, indent=2, ensure_ascii=False))
     return exit_code
 

--- a/tools/edge-dispatch
+++ b/tools/edge-dispatch
@@ -23,6 +23,7 @@ sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import CURRENT_BEAT_FILE, CURRENT_DISPATCH_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
 from _shared.telemetry import current_actor, emit_shadow_event, log_event  # noqa: E402
+from _shared.skill_inbox import attach_snapshot_to_dispatch  # noqa: E402
 
 
 def now_iso() -> str:
@@ -232,9 +233,28 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     state_block["skill_status"] = "running"
     state_block["dispatched_at"] = timestamp
     state_block["updated_at"] = timestamp
+    inbox = attach_snapshot_to_dispatch(state, skill=requested_skill)
 
     write_json(CURRENT_DISPATCH_FILE, state)
     mirror_heartbeat_guard(state)
+
+    emit_shadow_event(
+        "AsyncInboxCaptured",
+        actor="edge-dispatch",
+        cycle_id=state["cycle_id"],
+        payload={
+            "skill": request.get("skill"),
+            "priority": inbox.get("priority"),
+            "priority_reason": inbox.get("priority_reason"),
+            "unprocessed_total": inbox.get("unprocessed_total", 0),
+            "pinned_total": inbox.get("pinned_total", 0),
+            "direct_messages": len(inbox.get("direct_messages", [])),
+            "task_intents": len(inbox.get("task_intents", [])),
+            "steering_intents": len(inbox.get("steering_intents", [])),
+            "runtime_intents": len(inbox.get("runtime_intents", [])),
+            "message_ids": inbox.get("message_ids", []),
+        },
+    )
 
     emit_shadow_event(
         "SkillDispatched",
@@ -246,6 +266,16 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             "dispatch_mode": args.dispatch_mode,
             "policy": request.get("policy"),
             "args": request.get("args", {}),
+            "async_inbox": {
+                "priority": inbox.get("priority"),
+                "priority_reason": inbox.get("priority_reason"),
+                "unprocessed_total": inbox.get("unprocessed_total", 0),
+                "pinned_total": inbox.get("pinned_total", 0),
+                "direct_messages": len(inbox.get("direct_messages", [])),
+                "task_intents": len(inbox.get("task_intents", [])),
+                "steering_intents": len(inbox.get("steering_intents", [])),
+                "runtime_intents": len(inbox.get("runtime_intents", [])),
+            },
         },
     )
     log_event(
@@ -255,6 +285,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         trigger=request.get("trigger"),
         skill=request.get("skill"),
         dispatch_mode=args.dispatch_mode,
+        async_inbox_priority=inbox.get("priority"),
+        async_inbox_unprocessed=inbox.get("unprocessed_total", 0),
     )
     print_json(state)
     return 0

--- a/tools/edge-skill-inbox
+++ b/tools/edge-skill-inbox
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""edge-skill-inbox — structured async inbox for skill-level execution.
+
+Usage:
+  edge-skill-inbox read
+  edge-skill-inbox capture --skill research
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import CURRENT_DISPATCH_FILE  # noqa: E402
+sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.skill_inbox import attach_snapshot_to_dispatch, build_async_inbox_snapshot, get_dispatch_snapshot  # noqa: E402
+from _shared.telemetry import current_cycle_id, emit_shadow_event, log_event  # noqa: E402
+
+
+def read_state() -> dict:
+    if not CURRENT_DISPATCH_FILE.exists():
+        raise FileNotFoundError(f"{CURRENT_DISPATCH_FILE} not found")
+    return json.loads(CURRENT_DISPATCH_FILE.read_text(encoding="utf-8"))
+
+
+def write_state(state: dict) -> None:
+    CURRENT_DISPATCH_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = CURRENT_DISPATCH_FILE.with_suffix(CURRENT_DISPATCH_FILE.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp.replace(CURRENT_DISPATCH_FILE)
+
+
+def emit_capture_events(snapshot: dict, *, skill: str | None = None) -> None:
+    cycle_id = current_cycle_id()
+    payload = {
+        "skill": skill or snapshot.get("skill"),
+        "priority": snapshot.get("priority"),
+        "priority_reason": snapshot.get("priority_reason"),
+        "unprocessed_total": snapshot.get("unprocessed_total", 0),
+        "pinned_total": snapshot.get("pinned_total", 0),
+        "direct_messages": len(snapshot.get("direct_messages", [])),
+        "task_intents": len(snapshot.get("task_intents", [])),
+        "steering_intents": len(snapshot.get("steering_intents", [])),
+        "runtime_intents": len(snapshot.get("runtime_intents", [])),
+        "message_ids": snapshot.get("message_ids", []),
+    }
+    emit_shadow_event(
+        "AsyncInboxCaptured",
+        actor="edge-skill-inbox",
+        cycle_id=cycle_id,
+        payload=payload,
+    )
+    log_event(
+        "async_inbox",
+        actor="edge-skill-inbox",
+        action="captured",
+        cycle_id=cycle_id,
+        skill=skill or snapshot.get("skill") or "",
+        priority=snapshot.get("priority"),
+        priority_reason=snapshot.get("priority_reason") or "",
+        unprocessed_total=snapshot.get("unprocessed_total", 0),
+        pinned_total=snapshot.get("pinned_total", 0),
+    )
+
+
+def cmd_read(args: argparse.Namespace) -> int:
+    snapshot = None
+    try:
+        state = read_state()
+    except FileNotFoundError:
+        state = {}
+    snapshot = get_dispatch_snapshot(state)
+    if snapshot is None:
+        snapshot = build_async_inbox_snapshot(skill=args.skill, limit=args.limit)
+    print(json.dumps(snapshot, indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_capture(args: argparse.Namespace) -> int:
+    state = read_state()
+    snapshot = attach_snapshot_to_dispatch(state, skill=args.skill, limit=args.limit)
+    write_state(state)
+    emit_capture_events(snapshot, skill=args.skill)
+    print(json.dumps(snapshot, indent=2, ensure_ascii=False))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Structured async inbox for skills")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_read = sub.add_parser("read", help="Print the current structured inbox snapshot")
+    p_read.add_argument("--skill", help="Optional target skill label")
+    p_read.add_argument("--limit", type=int, default=200)
+
+    p_capture = sub.add_parser("capture", help="Attach the structured inbox snapshot to the active dispatch")
+    p_capture.add_argument("--skill", help="Target skill label")
+    p_capture.add_argument("--limit", type=int, default=200)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.cmd == "read":
+        return cmd_read(args)
+    if args.cmd == "capture":
+        return cmd_capture(args)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- capture the structured async inbox when `edge-dispatch dispatch --skill <skill>` runs
- expose a deterministic skill-level inbox contract via `edge-skill-inbox`
- consume captured inbox messages only after a successful `edge-close`
- document that user interaction is priority and that skills must use the structured inbox instead of scraping raw `/api/chat`

## Why
The dashboard now queues `task-intent`, `steering-intent`, and `runtime-intent` for the next dispatch. This PR closes the loop by making the dispatched skill receive the same async channel as explicit input, at skill level rather than heartbeat level.

## Validation
- `python3 -m py_compile tools/_shared/skill_inbox.py tools/edge-dispatch tools/edge-close tools/edge-skill-inbox`
- `bash tests/test_skill_inbox.sh`
- `bash tests/test_edge_dispatch.sh`
- `bash tests/test_edge_close.sh`

## Notes
- `edge-skill-inbox read` returns the captured dispatch snapshot during an active cycle and falls back to the live inbox when no active cycle exists
- `edge-close` now swallows inbox-consumption failures and records telemetry instead of breaking cycle finalization