### PR TITLE
[codex] implement thread triage console

### DIFF
--- a/blog/api_actions.py
+++ b/blog/api_actions.py
@@ -128,7 +128,7 @@ def heartbeat_trigger():
     return jsonify({"ok": True, "triggered_at": now_str}), 200
 
 
-VALID_THREAD_ACTIONS = {"active", "dormant", "done"}
+VALID_THREAD_ACTIONS = {"active", "waiting", "dormant", "done"}
 VALID_STEERING_ACTIONS = {
     "proposal": {"approve", "reject", "defer", "request-revision"},
     "claim": {"promote", "verified", "disputed", "stale"},
@@ -175,7 +175,15 @@ def thread_action(thread_id):
     fm["updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     new_fm = yaml.dump(fm, default_flow_style=False, allow_unicode=True).rstrip("\n")
     thread_path.write_text(f"---\n{new_fm}\n---{parts[2]}", encoding="utf-8")
-    _log_operator_action(thread_id, f"thread:{action}", reason=reason)
+    _log_operator_action(
+        thread_id,
+        f"thread:{action}",
+        reason=reason,
+        target_type="thread",
+        label=fm.get("title") or thread_id,
+        reference=thread_id,
+        resulting_state="applied",
+    )
     return jsonify({"ok": True, "thread_id": thread_id, "old_status": old_status, "new_status": action}), 200
 
 

--- a/blog/api_dashboard.py
+++ b/blog/api_dashboard.py
@@ -397,6 +397,7 @@ def _build_status_strip_data():
         "claims_total": claims.get("total_learned", 0),
         "claims_open": claims.get("total_gaps", 0),
         "threads_active_count": thread_stats.get("active", 0),
+        "threads_waiting_count": thread_stats.get("waiting", 0),
         "threads_proposed_count": thread_stats.get("proposed", 0),
         "threads_dormant_count": thread_stats.get("dormant", 0),
         "threads_resurface_due": thread_stats.get("resurface_due", 0),

--- a/blog/app.py
+++ b/blog/app.py
@@ -1180,6 +1180,8 @@ Thread criado a partir de candidate (tag '{tag}').
 def api_thread_snooze(thread_id):
     """Snooze: update resurface +7d."""
     from datetime import timedelta
+    from blog.api_actions import _log_operator_action
+
     thread_path = THREADS_DIR / f"{thread_id}.md"
     if not thread_path.exists():
         return jsonify({"error": f"Thread {thread_id} not found"}), 404
@@ -1196,6 +1198,15 @@ def api_thread_snooze(thread_id):
         fm["updated"] = today
     new_fm = yaml.dump(fm, default_flow_style=False, allow_unicode=True).rstrip("\n")
     thread_path.write_text(f"---\n{new_fm}\n---{parts[2]}", encoding="utf-8")
+    _log_operator_action(
+        thread_id,
+        f"thread:{mode}",
+        value=fm["resurface"],
+        target_type="thread",
+        label=fm.get("title") or thread_id,
+        reference=thread_id,
+        resulting_state="applied",
+    )
     return jsonify({"ok": True, "resurface": fm["resurface"]})
 
 
@@ -1241,13 +1252,36 @@ def _build_threads_data():
     from blog.services import load_threads_enriched, compute_thread_candidates
     data = load_threads_enriched()
     threads = data["threads"]
+    threads_attention = [
+        t for t in threads
+        if t["status"] in {"active", "waiting"} and t.get("needs_attention")
+    ]
+    threads_waiting = [
+        t for t in threads
+        if t["status"] == "waiting" and not t.get("needs_attention")
+    ]
+    threads_active_healthy = [
+        t for t in threads
+        if t["status"] == "active" and not t.get("needs_attention")
+    ]
+    threads_proposed = [t for t in threads if t["status"] == "proposed"]
+    threads_backlog = [t for t in threads if t["status"] in {"dormant", "done"}]
+
     return {
-        "threads_due": [t for t in threads if t["resurface_due"] and t["status"] == "active"],
-        "threads_active": [t for t in threads if not t["resurface_due"] and t["status"] == "active"],
-        "threads_proposed": [t for t in threads if t["status"] == "proposed"],
-        "threads_dormant": [t for t in threads if t["status"] == "dormant"],
+        "threads_attention": threads_attention,
+        "threads_waiting": threads_waiting,
+        "threads_active_healthy": threads_active_healthy,
+        "threads_proposed": threads_proposed,
+        "threads_backlog": threads_backlog,
         "thread_candidates": compute_thread_candidates(),
         "thread_stats": data["stats"],
+        "thread_summary": {
+            "attention": len(threads_attention),
+            "waiting": len(threads_waiting),
+            "healthy": len(threads_active_healthy),
+            "proposed": len(threads_proposed),
+            "backlog": len(threads_backlog),
+        },
     }
 
 

--- a/blog/services.py
+++ b/blog/services.py
@@ -20,6 +20,7 @@ from paths import (  # noqa: E402
     CURADORIA_CANDIDATES_FILE as CURADORIA_CANDIDATES,
     EDGE_REPO_DIR,
     ENTRIES_DIR,
+    EVENTS_FILE,
     EXECUTION_LEDGER_FILE as EXECUTION_LEDGER,
     FRONTIER_FILE,
     GIT_SIGNALS_FILE as GIT_SIGNALS,
@@ -1330,37 +1331,32 @@ def get_heartbeat_status():
 
 # ─── Threads ───
 
-def _build_entries_thread_index():
-    """Build {thread_id: count} from entry frontmatter."""
-    index = {}
-    if not ENTRIES_DIR.exists():
-        return index
-    for fp in ENTRIES_DIR.glob("*.md"):
-        try:
-            raw = fp.read_text(encoding="utf-8", errors="replace")
-            parts = raw.split("---", 2)
-            if len(parts) < 3:
-                continue
-            fm = yaml.safe_load(parts[1])
-            if not fm:
-                continue
-            threads = fm.get("threads", [])
-            if isinstance(threads, str):
-                threads = [t.strip() for t in threads.split(",")]
-            if not isinstance(threads, list):
-                continue
-            for tid in threads:
-                tid = str(tid).strip()
-                if tid:
-                    index[tid] = index.get(tid, 0) + 1
-        except Exception:
-            continue
-    return index
+THREAD_EVIDENCE_STALE_DAYS = 7
+THREAD_HISTORY_LIMIT = 8
+THREAD_DETAIL_HISTORY_LIMIT = 20
+THREAD_NEXT_STEP_PLACEHOLDERS = {
+    "[definir]",
+    "[define]",
+    "definir",
+    "todo",
+    "tbd",
+    "pending",
+}
 
 
-def _parse_next_step(raw_body):
-    """Extract first non-empty line after ## Próximo passo or ## Next."""
-    match = re.search(r"^##\s+(?:Próximo passo|Next)\s*$", raw_body, re.MULTILINE | re.IGNORECASE)
+def _normalize_string_list(value):
+    if isinstance(value, str):
+        items = [part.strip() for part in value.split(",")]
+    elif isinstance(value, list):
+        items = [str(part).strip() for part in value]
+    else:
+        return []
+    return [item for item in items if item]
+
+
+def _extract_section_first_line(raw_body, heading_patterns):
+    pattern = r"^##\s+(?:" + "|".join(heading_patterns) + r")\s*$"
+    match = re.search(pattern, raw_body, re.MULTILINE | re.IGNORECASE)
     if not match:
         return None
     after = raw_body[match.end():]
@@ -1371,15 +1367,230 @@ def _parse_next_step(raw_body):
     return None
 
 
-def load_threads_enriched(status_filter=None):
-    """Load threads with enriched metadata (entries_count, resurface_due, next_step)."""
-    if not THREADS_DIR.exists():
-        return {"threads": [], "stats": {"total": 0, "active": 0, "dormant": 0, "done": 0, "proposed": 0, "resurface_due": 0}}
+def _extract_thread_summary(raw_body):
+    for line in raw_body.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith(("```", "-", "*")):
+            continue
+        return stripped
+    return None
 
-    entries_index = _build_entries_thread_index()
+
+def _parse_date_value(value):
+    parsed = _parse_ts_value(value)
+    return parsed.date() if parsed else None
+
+
+def _latest_item(current, candidate):
+    if not candidate:
+        return current
+    if not current:
+        return candidate
+
+    candidate_ts = candidate.get("_sort_ts")
+    current_ts = current.get("_sort_ts")
+    if candidate_ts and current_ts:
+        return candidate if candidate_ts > current_ts else current
+    if candidate_ts and not current_ts:
+        return candidate
+    return current
+
+
+def _build_thread_entry_rollup():
+    rollup = {}
+    if not ENTRIES_DIR.exists():
+        return rollup
+
+    for fp in ENTRIES_DIR.glob("*.md"):
+        try:
+            raw = fp.read_text(encoding="utf-8", errors="replace")
+            parts = raw.split("---", 2)
+            if len(parts) < 3:
+                continue
+            fm = yaml.safe_load(parts[1]) or {}
+            thread_ids = _normalize_string_list(fm.get("threads", []))
+            if not thread_ids:
+                continue
+
+            claims = _normalize_string_list(fm.get("claims", []))
+            verified_count = sum(1 for claim in claims if not str(claim).startswith("!"))
+            gaps_count = len(claims) - verified_count
+            report_file = str(fm.get("report") or "").strip() or None
+            note_file = str(fm.get("note") or "").strip() or None
+            entry_date = str(fm.get("date") or "").strip() or None
+            entry_sort_ts = _parse_ts_value(entry_date) or _parse_ts_value(fm.get("updated"))
+            evidence = {
+                "kind": "entry",
+                "label": str(fm.get("title") or fp.stem),
+                "slug": fp.stem,
+                "href": f"/entry/{fp.stem}",
+                "ts": entry_date,
+                "report": report_file,
+                "note": note_file,
+                "_sort_ts": entry_sort_ts,
+            }
+
+            for thread_id in thread_ids:
+                bucket = rollup.setdefault(thread_id, {
+                    "entries_count": 0,
+                    "claims_count": 0,
+                    "verified_count": 0,
+                    "gaps_count": 0,
+                    "report_files": set(),
+                    "last_evidence": None,
+                })
+                bucket["entries_count"] += 1
+                bucket["claims_count"] += len(claims)
+                bucket["verified_count"] += verified_count
+                bucket["gaps_count"] += gaps_count
+                if report_file:
+                    bucket["report_files"].add(report_file)
+                bucket["last_evidence"] = _latest_item(bucket["last_evidence"], dict(evidence))
+        except Exception:
+            continue
+
+    for bucket in rollup.values():
+        bucket["reports_count"] = len(bucket.pop("report_files", set()))
+        if bucket.get("last_evidence"):
+            bucket["last_evidence"]["ts_short"] = _short_ts(bucket["last_evidence"].get("ts"))
+            bucket["last_evidence"].pop("_sort_ts", None)
+    return rollup
+
+
+def _normalize_thread_event(row):
+    payload = row.get("payload") if isinstance(row.get("payload"), dict) else {}
+    thread_id = str(row.get("thread_id") or payload.get("thread_id") or "").strip()
+    if not thread_id:
+        return None
+
+    ts = row.get("timestamp") or row.get("ts")
+    event_type = str(row.get("type") or "").strip()
+    skill = str(row.get("skill") or payload.get("skill") or "").strip() or None
+    cycle_id = str(row.get("cycle_id") or payload.get("cycle_id") or "").strip() or None
+    artifacts = row.get("artifacts") or payload.get("artifacts") or payload.get("artifact") or []
+    if isinstance(artifacts, str):
+        artifacts = [artifacts]
+    elif isinstance(artifacts, list):
+        artifacts = [str(item).strip() for item in artifacts if str(item).strip()]
+    else:
+        artifacts = []
+
+    summary = str(row.get("summary") or payload.get("summary") or "").strip()
+    normalized_type = re.sub(r"[^a-z0-9]+", "", event_type.lower())
+    if not summary:
+        if normalized_type == "skilldispatched" and skill:
+            summary = f"Dispatched /{skill}"
+        elif normalized_type in {"artifactpublished", "artifactcreated"} and artifacts:
+            summary = f"Published {artifacts[0]}"
+        elif normalized_type == "threadupdated":
+            summary = "Thread updated"
+        else:
+            summary = event_type or "event"
+
+    return {
+        "thread_id": thread_id,
+        "ts": ts,
+        "ts_short": _short_ts(ts),
+        "type": event_type,
+        "summary": summary,
+        "skill": skill,
+        "cycle_id": cycle_id,
+        "artifacts": artifacts,
+        "_sort_ts": _parse_ts_value(ts),
+        "_normalized_type": normalized_type,
+    }
+
+
+def _build_thread_event_rollup(limit_history=THREAD_HISTORY_LIMIT):
+    rollup = {}
+    seen = set()
+
+    for path in (STATE_EVENTS_FILE, EVENTS_FILE):
+        for row in _iter_jsonl(path):
+            event = _normalize_thread_event(row)
+            if not event:
+                continue
+            dedupe_key = (
+                event["thread_id"],
+                event.get("ts"),
+                event.get("_normalized_type"),
+                event.get("summary"),
+                event.get("skill"),
+                tuple(event.get("artifacts") or []),
+            )
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            rollup.setdefault(event["thread_id"], {"history": []})["history"].append(event)
+
+    min_ts = datetime.min.replace(tzinfo=timezone.utc)
+    for bucket in rollup.values():
+        bucket["history"].sort(key=lambda item: item.get("_sort_ts") or min_ts, reverse=True)
+        bucket["history"] = bucket["history"][:limit_history]
+        for item in bucket["history"]:
+            item.pop("_sort_ts", None)
+            item.pop("_normalized_type", None)
+        bucket["last_event"] = bucket["history"][0] if bucket["history"] else None
+        bucket["last_dispatch"] = next(
+            (
+                item for item in bucket["history"]
+                if item.get("skill") or re.sub(r"[^a-z0-9]+", "", str(item.get("type") or "").lower()) == "skilldispatched"
+            ),
+            None,
+        )
+    return rollup
+
+
+def _build_thread_operator_action_index(limit_per_thread=6):
+    rollup = {}
+    for item in load_operator_actions(limit=200):
+        action = str(item.get("action") or "").strip()
+        thread_id = str(item.get("target_id") or "").strip()
+        if not thread_id or not action.startswith("thread:"):
+            continue
+        bucket = rollup.setdefault(thread_id, [])
+        if len(bucket) < limit_per_thread:
+            bucket.append(item)
+    return rollup
+
+
+def _parse_next_step(raw_body):
+    """Extract first non-empty line after a next-step heading."""
+    return _extract_section_first_line(
+        raw_body,
+        [
+            r"Próximo passo",
+            r"Next",
+            r"Next step",
+            r"Refined next step",
+        ],
+    )
+
+
+def load_threads_enriched(status_filter=None):
+    """Load threads with operational metadata for dashboard triage."""
+    if not THREADS_DIR.exists():
+        return {
+            "threads": [],
+            "stats": {
+                "total": 0,
+                "active": 0,
+                "waiting": 0,
+                "dormant": 0,
+                "done": 0,
+                "proposed": 0,
+                "resurface_due": 0,
+            },
+        }
+
+    entry_rollup = _build_thread_entry_rollup()
+    event_rollup = _build_thread_event_rollup()
+    operator_rollup = _build_thread_operator_action_index()
     today = date.today()
     threads = []
-    stats = {"total": 0, "active": 0, "dormant": 0, "done": 0, "proposed": 0, "resurface_due": 0}
+    stats = {"total": 0, "active": 0, "waiting": 0, "dormant": 0, "done": 0, "proposed": 0, "resurface_due": 0}
 
     for fp in sorted(THREADS_DIR.glob("*.md")):
         try:
@@ -1393,23 +1604,102 @@ def load_threads_enriched(status_filter=None):
 
             thread_id = fm.get("id", fp.stem)
             status = fm.get("status", "active")
-            entries_count = entries_index.get(thread_id, 0) or entries_index.get(fp.stem, 0)
-            next_step = _parse_next_step(parts[2])
+            body = parts[2]
+            next_step = _parse_next_step(body)
+            thread_summary = fm.get("goal") or _extract_thread_summary(body)
+            entry_data = entry_rollup.get(thread_id) or entry_rollup.get(fp.stem, {})
+            event_data = event_rollup.get(thread_id) or event_rollup.get(fp.stem, {})
+            operator_actions = operator_rollup.get(thread_id) or operator_rollup.get(fp.stem, [])
+            waiting_reason = next(
+                (
+                    item.get("reason")
+                    for item in operator_actions
+                    if item.get("action") == "thread:waiting" and item.get("reason")
+                ),
+                None,
+            )
 
             # Resurface check
             resurface_str = fm.get("resurface")
             resurface_due = False
+            resurface_days_overdue = None
             if resurface_str:
                 try:
                     rd = date.fromisoformat(str(resurface_str))
                     resurface_due = rd <= today
+                    if rd <= today:
+                        resurface_days_overdue = max(0, (today - rd).days)
                 except (ValueError, TypeError):
                     pass
+
+            next_step_normalized = (next_step or "").strip().lower()
+            no_next_step = status in {"active", "waiting"} and (
+                not next_step or next_step_normalized in THREAD_NEXT_STEP_PLACEHOLDERS
+            )
+            last_evidence = entry_data.get("last_evidence")
+            last_dispatch = event_data.get("last_dispatch")
+            last_dispatch_ts = _parse_ts_value(last_dispatch.get("ts")) if last_dispatch else None
+            last_evidence_ts = _parse_ts_value(last_evidence.get("ts")) if last_evidence else None
+            last_touched_candidates = [
+                _parse_ts_value(fm.get("updated")),
+                last_evidence_ts,
+                last_dispatch_ts,
+                _parse_ts_value(operator_actions[0].get("ts")) if operator_actions else None,
+            ]
+            last_touched_candidates = [item for item in last_touched_candidates if item]
+            last_touched = max(last_touched_candidates) if last_touched_candidates else None
+
+            no_recent_evidence = False
+            days_since_evidence = None
+            if status in {"active", "waiting"}:
+                reference_ts = last_evidence_ts or last_dispatch_ts
+                if reference_ts is None:
+                    no_recent_evidence = True
+                else:
+                    days_since_evidence = max(0, (today - reference_ts.date()).days)
+                    no_recent_evidence = days_since_evidence >= THREAD_EVIDENCE_STALE_DAYS
+
+            closure_ready = (
+                status in {"active", "waiting"}
+                and bool(fm.get("done_when"))
+                and entry_data.get("reports_count", 0) > 0
+                and entry_data.get("gaps_count", 0) == 0
+                and not no_next_step
+            )
+
+            flags = []
+            attention_reasons = []
+            if resurface_due and status in {"active", "waiting"}:
+                label = "resurface due"
+                detail = f"{resurface_days_overdue}d overdue" if resurface_days_overdue else "due today"
+                flags.append({"kind": "warn", "label": label, "detail": detail})
+                attention_reasons.append(label)
+            if status == "waiting":
+                flags.append({"kind": "warn", "label": "waiting", "detail": waiting_reason or "awaiting follow-up"})
+            if no_next_step:
+                flags.append({"kind": "warn", "label": "no next step", "detail": "operator cannot tell what advances this thread"})
+                attention_reasons.append("no next step")
+            if no_recent_evidence:
+                detail = "no linked evidence yet" if days_since_evidence is None else f"{days_since_evidence}d since last evidence"
+                flags.append({"kind": "warn", "label": "no recent evidence", "detail": detail})
+                attention_reasons.append("no recent evidence")
+            if entry_data.get("gaps_count", 0) > 0:
+                flags.append({"kind": "muted", "label": f"{entry_data.get('gaps_count', 0)} open gaps", "detail": "claims still unresolved"})
+            if closure_ready:
+                flags.append({"kind": "ok", "label": "closure-ready", "detail": "done_when has support with no open gaps"})
+
+            attention_score = 0
+            if resurface_due:
+                attention_score += 5 + min(resurface_days_overdue or 0, 3)
+            if no_next_step:
+                attention_score += 4
+            if no_recent_evidence:
+                attention_score += 3
 
             stats["total"] += 1
             if status in stats:
                 stats[status] += 1
-            if resurface_due and status == "active":
+            if resurface_due and status in {"active", "waiting"}:
                 stats["resurface_due"] += 1
 
             threads.append({
@@ -1422,10 +1712,34 @@ def load_threads_enriched(status_filter=None):
                 "updated": str(fm.get("updated", "")),
                 "resurface": str(resurface_str) if resurface_str else None,
                 "goal": fm.get("goal"),
+                "summary": thread_summary,
                 "done_when": fm.get("done_when"),
-                "entries_count": entries_count,
+                "entries_count": entry_data.get("entries_count", 0),
+                "reports_count": entry_data.get("reports_count", 0),
+                "claims_count": entry_data.get("claims_count", 0),
+                "verified_count": entry_data.get("verified_count", 0),
+                "gaps_count": entry_data.get("gaps_count", 0),
                 "resurface_due": resurface_due,
+                "resurface_days_overdue": resurface_days_overdue,
                 "next_step": next_step,
+                "no_next_step": no_next_step,
+                "no_recent_evidence": no_recent_evidence,
+                "days_since_evidence": days_since_evidence,
+                "closure_ready": closure_ready,
+                "waiting_reason": waiting_reason,
+                "flags": flags,
+                "attention_reasons": attention_reasons,
+                "attention_summary": ", ".join(attention_reasons[:2]) if attention_reasons else None,
+                "attention_score": attention_score,
+                "needs_attention": status in {"active", "waiting"} and attention_score > 0,
+                "last_evidence": last_evidence,
+                "last_event": event_data.get("last_event"),
+                "last_dispatch": last_dispatch,
+                "last_skill": last_dispatch.get("skill") if last_dispatch else None,
+                "last_cycle_id": last_dispatch.get("cycle_id") if last_dispatch else None,
+                "recent_operator_action": operator_actions[0] if operator_actions else None,
+                "last_touched": last_touched.isoformat() if last_touched else None,
+                "last_touched_short": _short_ts(last_touched.isoformat()) if last_touched else None,
             })
         except Exception:
             continue
@@ -1433,14 +1747,34 @@ def load_threads_enriched(status_filter=None):
     if status_filter:
         threads = [t for t in threads if t["status"] == status_filter]
 
+    threads.sort(
+        key=lambda item: (
+            item.get("status") == "done",
+            item.get("status") == "dormant",
+            item.get("status") == "proposed",
+            item.get("status") != "waiting" and not item.get("needs_attention"),
+            -(item.get("attention_score") or 0),
+            item.get("resurface") or "",
+            item.get("updated") or "",
+        )
+    )
     return {"threads": threads, "stats": stats}
 
 
 def load_thread_detail(thread_id):
-    """Load full detail for a single thread: metadata, body, linked entries, reports, claims."""
+    """Load full detail for a single thread with evidence and operator history."""
     thread_path = THREADS_DIR / f"{thread_id}.md"
     if not thread_path.exists():
         return None
+
+    enriched_map = {item["id"]: item for item in load_threads_enriched().get("threads", [])}
+    enriched = enriched_map.get(thread_id, {})
+    event_history = (
+        _build_thread_event_rollup(limit_history=THREAD_DETAIL_HISTORY_LIMIT)
+        .get(thread_id, {})
+        .get("history", [])
+    )
+    operator_actions = _build_thread_operator_action_index(limit_per_thread=12).get(thread_id, [])
 
     raw = thread_path.read_text(encoding="utf-8", errors="replace")
     parts = raw.split("---", 2)
@@ -1518,6 +1852,16 @@ def load_thread_detail(thread_id):
         "resurface": str(fm.get("resurface", "")),
         "goal": fm.get("goal"),
         "done_when": fm.get("done_when"),
+        "summary": enriched.get("summary"),
+        "flags": enriched.get("flags", []),
+        "attention_summary": enriched.get("attention_summary"),
+        "next_step": enriched.get("next_step"),
+        "waiting_reason": enriched.get("waiting_reason"),
+        "last_evidence": enriched.get("last_evidence"),
+        "last_dispatch": enriched.get("last_dispatch"),
+        "last_skill": enriched.get("last_skill"),
+        "last_cycle_id": enriched.get("last_cycle_id"),
+        "recent_operator_action": enriched.get("recent_operator_action"),
         "body_html": body_html,
         "entries": entries,
         "entries_count": len(entries),
@@ -1528,6 +1872,8 @@ def load_thread_detail(thread_id):
         "claims_count": len(all_claims),
         "verified_count": len(verified),
         "gaps_count": len(gaps),
+        "event_history": event_history,
+        "operator_actions": operator_actions,
     }
 
 

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -1846,9 +1846,157 @@
 
   .status-active { background: var(--green); color: #000; }
   .status-waiting { background: var(--orange); color: #000; }
+  .status-dormant { background: var(--surface); color: var(--text-muted); }
+  .status-done { background: var(--accent-soft); color: var(--accent); }
+  .status-proposed { background: rgba(99, 179, 237, 0.12); color: var(--accent); }
+  .status-candidate { background: rgba(255, 255, 255, 0.08); color: var(--text-muted); }
 
   .dash-thread-name { flex: 1; }
   .dash-thread-owner { font-size: 0.65rem; color: var(--text-muted); font-family: 'IBM Plex Mono', monospace; }
+
+  .thread-console-summary-bar {
+    display: flex;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.68rem;
+    color: var(--text-muted);
+  }
+
+  .thread-console-summary-bar strong { color: var(--text); }
+  .thread-console-overcommit { margin-top: 0.7rem; }
+  .thread-console-empty { color: var(--text-muted); margin: 0; }
+  .thread-console-list { display: flex; flex-direction: column; gap: 0.7rem; }
+
+  .thread-console-card {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+  }
+
+  .thread-console-card-attention { border-color: var(--orange); }
+  .thread-console-card-candidate { border-style: dashed; }
+
+  .thread-console-head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  .thread-console-title-row,
+  .thread-console-meta-row {
+    display: flex;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .thread-console-title {
+    color: var(--text);
+    text-decoration: none;
+    font-size: 0.95rem;
+    font-weight: 600;
+    flex: 1;
+    min-width: 180px;
+  }
+
+  .thread-console-title:hover { color: var(--accent); }
+
+  .thread-console-chip {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.62rem;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.1rem 0.4rem;
+  }
+
+  .thread-console-meta-row {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.63rem;
+    color: var(--text-muted);
+  }
+
+  .thread-console-summary-text {
+    color: var(--text);
+    font-size: 0.84rem;
+    line-height: 1.45;
+  }
+
+  .thread-console-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 0.8rem;
+  }
+
+  .thread-console-column {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+
+  .thread-console-line {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+    font-size: 0.77rem;
+    line-height: 1.45;
+  }
+
+  .thread-console-line strong {
+    min-width: 84px;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .thread-console-line span { color: var(--text); }
+  .thread-console-line a { color: var(--accent); text-decoration: none; }
+  .thread-console-line a:hover { text-decoration: underline; }
+  .thread-console-line-warn span { color: var(--orange); }
+
+  .thread-console-stats {
+    display: flex;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.64rem;
+    color: var(--text-muted);
+  }
+
+  .thread-console-flags {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .thread-flag {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.62rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    padding: 0.12rem 0.45rem;
+    color: var(--text-muted);
+  }
+
+  .thread-flag-warn { border-color: var(--orange); color: var(--orange); }
+  .thread-flag-ok { border-color: var(--green); color: var(--green); }
+  .thread-flag-muted { border-color: var(--border); color: var(--text-muted); }
+
+  .thread-console-actions {
+    display: flex;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+    padding-top: 0.35rem;
+    border-top: 1px solid var(--border);
+  }
 
   /* Summary bar */
   .dash-summary {

--- a/blog/templates/dashboard.html
+++ b/blog/templates/dashboard.html
@@ -3,7 +3,7 @@
 <div class="dashboard">
 
   <!-- Status Strip (auto-refreshes every 60s via HTMX) -->
-  <div hx-get="/partials/status-strip" hx-trigger="every 60s" hx-swap="innerHTML">
+  <div id="dashboard-status-strip" hx-get="/partials/status-strip" hx-trigger="every 60s" hx-swap="innerHTML">
     {% include 'partials/status_strip.html' %}
   </div>
 
@@ -48,7 +48,7 @@
   </div>
 
   <!-- Threads (auto-refreshes every 120s via HTMX) -->
-  <div hx-get="/partials/threads" hx-trigger="every 120s" hx-swap="innerHTML">
+  <div id="dashboard-threads" hx-get="/partials/threads" hx-trigger="every 120s" hx-swap="innerHTML">
     {% include 'partials/threads.html' %}
   </div>
 
@@ -86,7 +86,7 @@ function threadSnooze(threadId, mode) {
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({mode: mode})
   }).then(function(r) {
-    if (r.ok) { location.reload(); }
+    if (r.ok) { refreshDashboardThreads(); refreshStatusStrip(); }
     else { r.json().then(function(d) { alert(d.error || 'Snooze failed'); }); }
   }).catch(function() { alert('Network error'); });
 }
@@ -96,7 +96,7 @@ function promoteCandidate(tag) {
     method: 'POST',
     headers: {'Content-Type': 'application/json'}
   }).then(function(r) {
-    if (r.ok) { location.reload(); }
+    if (r.ok) { refreshDashboardThreads(); refreshStatusStrip(); }
     else { r.json().then(function(d) { alert(d.error || 'Promote failed'); }); }
   }).catch(function() { alert('Network error'); });
 }
@@ -122,14 +122,34 @@ function triggerHeartbeat(btn) {
 
 function threadAction(threadId, action) {
   if (!action) return;
+  var payload = {action: action};
+  if (action === 'waiting') {
+    var reason = window.prompt('waiting on what for ' + threadId + '?');
+    if (reason === null) return;
+    if (reason.trim()) payload.reason = reason.trim();
+  }
   fetch('/api/threads/' + threadId + '/action', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({action: action})
+    body: JSON.stringify(payload)
   }).then(function(r) {
-    if (r.ok) { location.reload(); }
+    if (r.ok) { refreshDashboardThreads(); refreshStatusStrip(); }
     else { r.json().then(function(d) { alert(d.error || 'Action failed'); }); }
   }).catch(function() { alert('Network error'); });
+}
+
+function refreshStatusStrip() {
+  if (window.htmx) {
+    htmx.ajax('GET', '/partials/status-strip', {target: '#dashboard-status-strip', swap: 'innerHTML'});
+  }
+}
+
+function refreshDashboardThreads() {
+  if (window.htmx) {
+    htmx.ajax('GET', '/partials/threads', {target: '#dashboard-threads', swap: 'innerHTML'});
+  } else {
+    location.reload();
+  }
 }
 
 function refreshDashboardInterventions() {

--- a/blog/templates/partials/status_strip.html
+++ b/blog/templates/partials/status_strip.html
@@ -28,7 +28,7 @@
   <div class="status-strip-item {{ 'status-border-yellow' if threads_resurface_due > 0 else '' }}">
     <span class="dash-label">threads</span>
     <span class="dash-value">{{ threads_active_count }} <small>active</small></span>
-    <span class="status-strip-detail">{% if threads_resurface_due > 0 %}<span class="status-text-yellow">{{ threads_resurface_due }} resurface</span> · {% endif %}{% if threads_proposed_count > 0 %}{{ threads_proposed_count }} proposed · {% endif %}{{ threads_dormant_count }} dormant</span>
+    <span class="status-strip-detail">{% if threads_waiting_count > 0 %}{{ threads_waiting_count }} waiting · {% endif %}{% if threads_resurface_due > 0 %}<span class="status-text-yellow">{{ threads_resurface_due }} resurface</span> · {% endif %}{% if threads_proposed_count > 0 %}{{ threads_proposed_count }} proposed · {% endif %}{{ threads_dormant_count }} dormant</span>
   </div>
 
   <!-- Production -->

--- a/blog/templates/partials/threads.html
+++ b/blog/templates/partials/threads.html
@@ -1,105 +1,191 @@
-<!-- Overcommit warning -->
-{% if threads_active|length + threads_due|length > 7 %}
-<div class="dash-section">
-  <div class="dash-overcommit">{{ threads_active|length + threads_due|length }} threads ativos — considere arquivar ou pausar alguns</div>
-</div>
-{% endif %}
-
-<!-- Threads: Resurface due (prominent) -->
-{% if threads_due %}
-<div class="dash-section">
-  <h2 class="dash-section-title dash-warn">resurface</h2>
-  {% for th in threads_due %}
-  <div class="dash-thread-card dash-thread-due">
-    <div class="dash-thread-header">
+{% macro thread_card(th) %}
+<div class="thread-console-card{{ ' thread-console-card-attention' if th.needs_attention else '' }}">
+  <div class="thread-console-head">
+    <div class="thread-console-title-row">
       <span class="dash-thread-status status-{{ th.status }}">{{ th.status }}</span>
-      <a href="/thread/{{ th.id }}" class="dash-thread-name" style="color:inherit;text-decoration:none;" onclick="event.stopPropagation()">{{ th.title }}</a>
-      <span class="dash-thread-type">{{ th.type }}</span>
-      <span class="dash-thread-owner">{{ th.owner }}</span>
-      <span class="dash-thread-entries">{{ th.entries_count }} entries</span>
+      <a href="/thread/{{ th.id }}" class="thread-console-title">{{ th.title }}</a>
+      <span class="thread-console-chip">{{ th.type }}</span>
+      <span class="thread-console-chip">{{ th.owner }}</span>
     </div>
-    {% if th.goal %}
-    <div class="dash-thread-goal">{{ th.goal }}</div>
-    {% endif %}
-    {% if th.next_step %}
-    <div class="dash-thread-next">{{ th.next_step }}</div>
-    {% endif %}
-    <div class="dash-thread-actions">
-      <button class="action-btn action-worked" onclick="threadSnooze('{{ th.id }}', 'worked')">worked</button>
-      <button class="action-btn action-snooze" onclick="threadSnooze('{{ th.id }}', 'snooze')">snooze 7d</button>
-      <button class="action-btn action-dormant" onclick="threadAction('{{ th.id }}', 'dormant')">dormant</button>
+    <div class="thread-console-meta-row">
+      {% if th.resurface %}<span>resurface {{ th.resurface }}</span>{% endif %}
+      {% if th.last_touched_short %}<span>touched {{ th.last_touched_short }}</span>{% endif %}
+      {% if th.last_cycle_id %}<span>{{ th.last_cycle_id }}</span>{% endif %}
     </div>
   </div>
-  {% endfor %}
-</div>
-{% endif %}
 
-<!-- Threads: Active -->
-{% if threads_active %}
-<div class="dash-section">
-  <h2 class="dash-section-title">threads ativos</h2>
-  {% for th in threads_active %}
-  <div class="dash-thread-card" onclick="this.classList.toggle('expanded')">
-    <div class="dash-thread-header">
-      <span class="dash-thread-status status-{{ th.status }}">{{ th.status }}</span>
-      <a href="/thread/{{ th.id }}" class="dash-thread-name" style="color:inherit;text-decoration:none;" onclick="event.stopPropagation()">{{ th.title }}</a>
-      <span class="dash-thread-type">{{ th.type }}</span>
-      <span class="dash-thread-owner">{{ th.owner }}</span>
-      <span class="dash-thread-entries">{{ th.entries_count }} entries</span>
-      {% if th.resurface %}<span class="dash-thread-resurface">{{ th.resurface }}</span>{% endif %}
-    </div>
-    <div class="dash-thread-detail">
+  {% if th.summary %}
+  <div class="thread-console-summary-text">{{ th.summary }}</div>
+  {% endif %}
+
+  <div class="thread-console-grid">
+    <div class="thread-console-column">
       {% if th.goal %}
-      <div class="dash-thread-goal">{{ th.goal }}</div>
+      <div class="thread-console-line"><strong>goal</strong><span>{{ th.goal }}</span></div>
       {% endif %}
+
       {% if th.next_step %}
-      <div class="dash-thread-next">{{ th.next_step }}</div>
+      <div class="thread-console-line"><strong>next</strong><span>{{ th.next_step }}</span></div>
+      {% else %}
+      <div class="thread-console-line thread-console-line-warn"><strong>next</strong><span>missing</span></div>
       {% endif %}
+
       {% if th.done_when %}
-      <div class="dash-thread-done-when">done when: {{ th.done_when }}</div>
+      <div class="thread-console-line"><strong>done when</strong><span>{{ th.done_when }}</span></div>
       {% endif %}
-      <div class="dash-thread-actions">
-        <select class="thread-action-select" onclick="event.stopPropagation()" onchange="threadAction('{{ th.id }}', this.value); this.value='';">
-          <option value="" disabled selected>action</option>
-          {% if th.status != 'dormant' %}<option value="dormant">dormant</option>{% endif %}
-          {% if th.status != 'done' %}<option value="done">done</option>{% endif %}
-        </select>
+
+      {% if th.waiting_reason %}
+      <div class="thread-console-line"><strong>waiting on</strong><span>{{ th.waiting_reason }}</span></div>
+      {% endif %}
+    </div>
+
+    <div class="thread-console-column">
+      <div class="thread-console-stats">
+        <span>{{ th.entries_count }} entries</span>
+        <span>{{ th.reports_count }} reports</span>
+        <span>{{ th.verified_count }} verified</span>
+        <span>{{ th.gaps_count }} gaps</span>
       </div>
+
+      {% if th.last_evidence %}
+      <div class="thread-console-line">
+        <strong>last evidence</strong>
+        <span>
+          <a href="{{ th.last_evidence.href }}">{{ th.last_evidence.label }}</a>
+          {% if th.last_evidence.ts_short %} · {{ th.last_evidence.ts_short }}{% endif %}
+        </span>
+      </div>
+      {% else %}
+      <div class="thread-console-line thread-console-line-warn"><strong>last evidence</strong><span>none linked yet</span></div>
+      {% endif %}
+
+      {% if th.last_dispatch %}
+      <div class="thread-console-line">
+        <strong>last beat</strong>
+        <span>
+          {{ th.last_dispatch.summary }}
+          {% if th.last_skill %} · /{{ th.last_skill }}{% endif %}
+          {% if th.last_dispatch.ts_short %} · {{ th.last_dispatch.ts_short }}{% endif %}
+        </span>
+      </div>
+      {% endif %}
+
+      {% if th.recent_operator_action %}
+      <div class="thread-console-line">
+        <strong>operator</strong>
+        <span>
+          {{ th.recent_operator_action.display_action }}
+          {% if th.recent_operator_action.reason %} · {{ th.recent_operator_action.reason }}{% endif %}
+          {% if th.recent_operator_action.ts_short %} · {{ th.recent_operator_action.ts_short }}{% endif %}
+        </span>
+      </div>
+      {% endif %}
     </div>
   </div>
-  {% endfor %}
+
+  {% if th.flags %}
+  <div class="thread-console-flags">
+    {% for flag in th.flags %}
+    <span class="thread-flag thread-flag-{{ flag.kind }}" title="{{ flag.detail }}">{{ flag.label }}</span>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div class="thread-console-actions">
+    {% if th.status in ['active', 'waiting'] %}
+    <button class="action-btn action-worked" onclick="threadSnooze('{{ th.id }}', 'worked')">worked</button>
+    <button class="action-btn action-snooze" onclick="threadSnooze('{{ th.id }}', 'snooze')">snooze 7d</button>
+    {% endif %}
+    {% if th.status != 'active' %}<button class="action-btn action-start" onclick="threadAction('{{ th.id }}', 'active')">activate</button>{% endif %}
+    {% if th.status != 'waiting' %}<button class="action-btn" onclick="threadAction('{{ th.id }}', 'waiting')">waiting</button>{% endif %}
+    {% if th.status != 'dormant' %}<button class="action-btn action-dormant" onclick="threadAction('{{ th.id }}', 'dormant')">dormant</button>{% endif %}
+    {% if th.status != 'done' %}<button class="action-btn action-done" onclick="threadAction('{{ th.id }}', 'done')">done</button>{% endif %}
+  </div>
+</div>
+{% endmacro %}
+
+<div class="dash-section">
+  <h2 class="dash-section-title">threads</h2>
+
+  <div class="thread-console-summary-bar">
+    <span><strong>{{ thread_summary.attention }}</strong> need attention</span>
+    <span><strong>{{ thread_summary.healthy }}</strong> in progress</span>
+    <span><strong>{{ thread_summary.waiting }}</strong> waiting</span>
+    <span><strong>{{ thread_summary.proposed }}</strong> proposed</span>
+    <span><strong>{{ thread_summary.backlog }}</strong> dormant/done</span>
+    {% if thread_candidates %}
+    <span><strong>{{ thread_candidates|length }}</strong> candidates</span>
+    {% endif %}
+  </div>
+
+  {% if thread_stats.active + thread_stats.waiting > 7 %}
+  <div class="dash-overcommit thread-console-overcommit">{{ thread_stats.active + thread_stats.waiting }} threads em circulação ativa</div>
+  {% endif %}
+
+  {% if thread_stats.total == 0 %}
+  <p class="thread-console-empty">Nenhuma thread registrada ainda.</p>
+  {% endif %}
+</div>
+
+{% if threads_attention %}
+<div class="dash-section">
+  <h2 class="dash-section-title dash-warn">needs attention</h2>
+  <div class="thread-console-list">
+    {% for th in threads_attention %}
+      {{ thread_card(th) }}
+    {% endfor %}
+  </div>
 </div>
 {% endif %}
 
-<!-- Threads: Proposed (candidates promoted to thread) -->
+{% if threads_active_healthy %}
+<div class="dash-section">
+  <h2 class="dash-section-title">in progress</h2>
+  <div class="thread-console-list">
+    {% for th in threads_active_healthy %}
+      {{ thread_card(th) }}
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+
+{% if threads_waiting %}
+<div class="dash-section">
+  <h2 class="dash-section-title">waiting</h2>
+  <div class="thread-console-list">
+    {% for th in threads_waiting %}
+      {{ thread_card(th) }}
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+
 {% if threads_proposed %}
 <div class="dash-section">
-  <h2 class="dash-section-title dash-muted">propostos</h2>
-  {% for th in threads_proposed %}
-  <div class="dash-thread-card dash-thread-candidate">
-    <div class="dash-thread-header">
-      <span class="dash-thread-status status-proposed">proposed</span>
-      <a href="/thread/{{ th.id }}" class="dash-thread-name" style="color:inherit;text-decoration:none;" onclick="event.stopPropagation()">{{ th.title }}</a>
-      <span class="dash-thread-entries">{{ th.entries_count }} entries</span>
-      <button class="action-btn action-start" onclick="event.stopPropagation(); threadAction('{{ th.id }}', 'active')">activate</button>
-    </div>
+  <h2 class="dash-section-title dash-muted">proposed</h2>
+  <div class="thread-console-list">
+    {% for th in threads_proposed %}
+      {{ thread_card(th) }}
+    {% endfor %}
   </div>
-  {% endfor %}
 </div>
 {% endif %}
 
-<!-- Thread candidates (tags without threads yet) -->
 {% if thread_candidates %}
 <div class="dash-section">
-  <h2 class="dash-section-title dash-muted">sugestões</h2>
-  <div class="dash-threads">
+  <h2 class="dash-section-title dash-muted">candidates</h2>
+  <div class="thread-console-list">
     {% for c in thread_candidates[:5] %}
-    <div class="dash-thread-card dash-thread-candidate">
-      <div class="dash-thread-header">
-        <span class="dash-thread-status status-candidate">?</span>
-        <span class="dash-thread-name">{{ c.tag }}</span>
-        <span class="dash-thread-entries">{{ c.entry_count }} entries</span>
-        <button class="action-btn action-promote" onclick="promoteCandidate('{{ c.tag }}')">criar thread</button>
+    <div class="thread-console-card thread-console-card-candidate">
+      <div class="thread-console-head">
+        <div class="thread-console-title-row">
+          <span class="dash-thread-status status-candidate">candidate</span>
+          <span class="thread-console-title">{{ c.tag }}</span>
+          <span class="thread-console-chip">{{ c.entry_count }} entries</span>
+        </div>
+      </div>
+      <div class="thread-console-actions">
+        <button class="action-btn action-start" onclick="promoteCandidate('{{ c.tag }}')">create thread</button>
       </div>
     </div>
     {% endfor %}
@@ -107,20 +193,12 @@
 </div>
 {% endif %}
 
-<!-- Threads: Dormant (collapsed) -->
-{% if threads_dormant %}
+{% if threads_backlog %}
 <div class="dash-section collapsed" onclick="this.classList.toggle('collapsed')">
-  <h2 class="dash-section-title dash-muted">dormant ({{ threads_dormant|length }})</h2>
-  <div class="dash-section-body">
-    {% for th in threads_dormant %}
-    <div class="dash-thread-card dash-thread-dormant">
-      <div class="dash-thread-header">
-        <span class="dash-thread-status status-dormant">dormant</span>
-        <a href="/thread/{{ th.id }}" class="dash-thread-name" style="color:inherit;text-decoration:none;" onclick="event.stopPropagation()">{{ th.title }}</a>
-        <span class="dash-thread-entries">{{ th.entries_count }} entries</span>
-        <button class="action-btn action-start" onclick="event.stopPropagation(); threadAction('{{ th.id }}', 'active')">activate</button>
-      </div>
-    </div>
+  <h2 class="dash-section-title dash-muted">dormant / done ({{ threads_backlog|length }})</h2>
+  <div class="dash-section-body thread-console-list">
+    {% for th in threads_backlog %}
+      {{ thread_card(th) }}
     {% endfor %}
   </div>
 </div>

--- a/blog/templates/thread_detail.html
+++ b/blog/templates/thread_detail.html
@@ -46,6 +46,22 @@
   .back-link:hover { text-decoration: underline; }
   .stat-pill { display: inline-block; background: #4a5568; color: #e2e8f0; padding: .1rem .5rem; border-radius: 10px; font-size: .8rem; margin-right: .5rem; }
   .empty-state { color: #718096; font-style: italic; font-size: .9rem; }
+  .ops-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+  .ops-card { background: #2d3748; border: 1px solid #4a5568; border-radius: 6px; padding: .9rem 1rem; }
+  .ops-card h3 { margin: 0 0 .6rem; font-size: .95rem; color: #e2e8f0; }
+  .ops-line { display: flex; gap: .5rem; margin-bottom: .45rem; font-size: .9rem; color: #cbd5e0; }
+  .ops-line strong { min-width: 105px; color: #a0aec0; font-size: .75rem; text-transform: uppercase; letter-spacing: .04em; }
+  .thread-flag-list { display: flex; gap: .35rem; flex-wrap: wrap; margin-top: .7rem; }
+  .thread-flag { display: inline-block; padding: .15rem .5rem; border-radius: 999px; font-size: .72rem; border: 1px solid #4a5568; color: #e2e8f0; }
+  .thread-flag-warn { border-color: #ed8936; color: #fbd38d; }
+  .thread-flag-ok { border-color: #38a169; color: #9ae6b4; }
+  .thread-flag-muted { border-color: #718096; color: #cbd5e0; }
+  .timeline-list { list-style: none; padding: 0; }
+  .timeline-list li { background: #2d3748; padding: .7rem .8rem; margin-bottom: .45rem; border-radius: 4px; border-left: 3px solid #4a5568; }
+  .timeline-head { display: flex; justify-content: space-between; gap: .5rem; flex-wrap: wrap; margin-bottom: .25rem; }
+  .timeline-type { font-size: .72rem; color: #a0aec0; font-family: 'IBM Plex Mono', monospace; }
+  .timeline-summary { color: #e2e8f0; }
+  .timeline-meta { font-size: .8rem; color: #a0aec0; margin-top: .2rem; }
 </style>
 </head>
 <body style="background:#1a202c;color:#e2e8f0;">
@@ -74,11 +90,88 @@
     {% if thread.done_when %}
     <p style="color:#a0aec0;"><strong>Done when:</strong> {{ thread.done_when }}</p>
     {% endif %}
+    {% if thread.summary and not thread.goal %}
+    <p style="color:#a0aec0;"><strong>Summary:</strong> {{ thread.summary }}</p>
+    {% endif %}
+  </div>
+
+  <div class="ops-grid">
+    <div class="ops-card">
+      <h3>Operational Snapshot</h3>
+      {% if thread.next_step %}
+      <div class="ops-line"><strong>next</strong><span>{{ thread.next_step }}</span></div>
+      {% endif %}
+      {% if thread.waiting_reason %}
+      <div class="ops-line"><strong>waiting on</strong><span>{{ thread.waiting_reason }}</span></div>
+      {% endif %}
+      {% if thread.last_evidence %}
+      <div class="ops-line">
+        <strong>last evidence</strong>
+        <span>
+          <a class="entry-title-link" href="{{ thread.last_evidence.href }}">{{ thread.last_evidence.label }}</a>
+          {% if thread.last_evidence.ts_short %} · {{ thread.last_evidence.ts_short }}{% endif %}
+        </span>
+      </div>
+      {% endif %}
+      {% if thread.last_dispatch %}
+      <div class="ops-line">
+        <strong>last beat</strong>
+        <span>
+          {{ thread.last_dispatch.summary }}
+          {% if thread.last_skill %} · /{{ thread.last_skill }}{% endif %}
+          {% if thread.last_dispatch.ts_short %} · {{ thread.last_dispatch.ts_short }}{% endif %}
+        </span>
+      </div>
+      {% endif %}
+      {% if thread.flags %}
+      <div class="thread-flag-list">
+        {% for flag in thread.flags %}
+        <span class="thread-flag thread-flag-{{ flag.kind }}" title="{{ flag.detail }}">{{ flag.label }}</span>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+
+    {% if thread.operator_actions %}
+    <div class="ops-card">
+      <h3>Operator Actions</h3>
+      {% for action in thread.operator_actions[:6] %}
+      <div class="ops-line">
+        <strong>{{ action.ts_short }}</strong>
+        <span>
+          {{ action.display_action }}
+          {% if action.reason %} · {{ action.reason }}{% endif %}
+          {% if action.resulting_state %} · {{ action.resulting_state }}{% endif %}
+        </span>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
   </div>
 
   <div class="thread-body">
     {{ thread.body_html | safe }}
   </div>
+
+  {% if thread.event_history %}
+  <h2 class="section-title">Beat History ({{ thread.event_history|length }})</h2>
+  <ul class="timeline-list">
+    {% for item in thread.event_history %}
+    <li>
+      <div class="timeline-head">
+        <span class="timeline-summary">{{ item.summary }}</span>
+        <span class="timeline-type">{{ item.ts_short }}</span>
+      </div>
+      <div class="timeline-meta">
+        {{ item.type }}
+        {% if item.skill %} · /{{ item.skill }}{% endif %}
+        {% if item.cycle_id %} · {{ item.cycle_id }}{% endif %}
+        {% if item.artifacts %} · {{ item.artifacts|join(', ') }}{% endif %}
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
 
   {% if thread.entries %}
   <h2 class="section-title">Entries ({{ thread.entries_count }})</h2>

--- a/tests/test_dashboard_threads.sh
+++ b/tests/test_dashboard_threads.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VENV_PY="${EDGE_BLOG_VENV:-$EDGE_DIR/blog/.venv/bin/python3}"
+if [ ! -x "$VENV_PY" ]; then
+    echo "Missing blog venv python: $VENV_PY" >&2
+    echo "Set EDGE_BLOG_VENV=/path/to/blog/.venv/bin/python3 when running from a clean worktree." >&2
+    exit 2
+fi
+
+TMP_BASE="$(mktemp -d /tmp/edge-dashboard-threads-XXXXXX)"
+TMP_STATE="$TMP_BASE/state-root"
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p \
+    "$TMP_STATE/threads" \
+    "$TMP_STATE/blog/entries" \
+    "$TMP_STATE/logs" \
+    "$TMP_STATE/state/events" \
+    "$TMP_STATE/reports" \
+    "$TMP_STATE/notes" \
+    "$TMP_STATE/search"
+
+cat >"$TMP_STATE/threads/attention-thread.md" <<'MD'
+---
+id: attention-thread
+title: "Attention Thread"
+type: investigation
+status: active
+owner: ed
+created: 2026-04-18
+updated: 2026-04-18
+resurface: 2026-04-19
+goal: "Explain queue latency drift"
+done_when: "root cause and mitigation are documented"
+---
+
+## Context
+
+Latency is drifting and nobody can tell why.
+
+## Next step
+
+[definir]
+MD
+
+cat >"$TMP_STATE/threads/healthy-thread.md" <<'MD'
+---
+id: healthy-thread
+title: "Healthy Thread"
+type: execution
+status: active
+owner: ed
+created: 2026-04-19
+updated: 2026-04-20
+resurface: 2026-04-26
+goal: "Ship queue diagnostics"
+done_when: "report and benchmark are linked"
+---
+
+## Context
+
+The queue diagnostics slice is moving and has current evidence.
+
+## Next step
+
+Compare the new benchmark against the previous dispatch.
+MD
+
+cat >"$TMP_STATE/threads/waiting-thread.md" <<'MD'
+---
+id: waiting-thread
+title: "Waiting Thread"
+type: investigation
+status: waiting
+owner: roberto
+created: 2026-04-19
+updated: 2026-04-20
+resurface: 2026-04-25
+---
+
+## Context
+
+Waiting on an external benchmark before dispatching the next step.
+
+## Next step
+
+Re-run the benchmark once the external sample lands.
+MD
+
+cat >"$TMP_STATE/threads/proposed-thread.md" <<'MD'
+---
+id: proposed-thread
+title: "Proposed Thread"
+type: investigation
+status: proposed
+owner: ed
+created: 2026-04-20
+updated: 2026-04-20
+resurface: 2026-04-27
+---
+
+## Context
+
+This candidate has not been activated yet.
+MD
+
+cat >"$TMP_STATE/threads/done-thread.md" <<'MD'
+---
+id: done-thread
+title: "Done Thread"
+type: investigation
+status: done
+owner: ed
+created: 2026-04-15
+updated: 2026-04-20
+resurface: 2026-05-01
+---
+
+## Context
+
+This thread is already complete.
+MD
+
+cat >"$TMP_STATE/blog/entries/2026-04-20-healthy.md" <<'MD'
+---
+title: "Measured queue latency"
+date: 2026-04-20
+threads:
+  - healthy-thread
+claims:
+  - "Queue latency doubles under load"
+  - "!Need benchmark on smaller archive"
+report: healthy-report.html
+note: healthy-note.md
+---
+
+Benchmark run with the new queue diagnostics.
+MD
+
+cat >"$TMP_STATE/blog/entries/2026-04-20-waiting.md" <<'MD'
+---
+title: "Collected external sample"
+date: 2026-04-20
+threads:
+  - waiting-thread
+claims:
+  - "External sample is pending verification"
+---
+
+Waiting for the external benchmark to land.
+MD
+
+cat >"$TMP_STATE/reports/healthy-report.html" <<'HTML'
+<html><body>healthy report</body></html>
+HTML
+
+cat >"$TMP_STATE/notes/healthy-note.md" <<'MD'
+# healthy note
+MD
+
+cat >"$TMP_STATE/logs/events.jsonl" <<'JSONL'
+{"timestamp":"2026-04-20T21:00:00+00:00","type":"skill_dispatched","summary":"advanced synthesis","thread_id":"healthy-thread","skill":"research","artifacts":["healthy-report.html"]}
+{"timestamp":"2026-04-20T21:11:00+00:00","type":"thread_updated","summary":"waiting for external benchmark","thread_id":"waiting-thread","skill":"review"}
+JSONL
+
+cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
+{"ts":"2026-04-20T21:00:00+00:00","type":"SkillDispatched","cycle_id":"cycle-healthy","payload":{"thread_id":"healthy-thread","skill":"research","summary":"advanced synthesis","artifacts":["healthy-report.html"]}}
+{"ts":"2026-04-20T21:11:00+00:00","type":"ThreadUpdated","cycle_id":"cycle-waiting","payload":{"thread_id":"waiting-thread","summary":"waiting for external benchmark","skill":"review"}}
+JSONL
+
+cat >"$TMP_STATE/logs/operator-actions.jsonl" <<'JSONL'
+{"ts":"2026-04-20T21:05:00Z","actor":"operator","target_id":"healthy-thread","action":"thread:worked","target_type":"thread","label":"Healthy Thread","reference":"healthy-thread","resulting_state":"applied","value":"2026-04-27"}
+{"ts":"2026-04-20T21:12:00Z","actor":"operator","target_id":"waiting-thread","action":"thread:waiting","target_type":"thread","label":"Waiting Thread","reference":"waiting-thread","resulting_state":"applied","reason":"external benchmark"}
+JSONL
+
+EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$VENV_PY" - <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+edge_dir = os.environ["EDGE_REPO_DIR"]
+state_dir = Path(os.environ["EDGE_STATE_DIR"])
+sys.path.insert(0, edge_dir)
+sys.path.insert(0, os.path.join(edge_dir, "blog"))
+os.chdir(os.path.join(edge_dir, "blog"))
+
+from app import app
+
+client = app.test_client()
+
+threads_partial = client.get("/partials/threads")
+assert threads_partial.status_code == 200, threads_partial.status_code
+threads_html = threads_partial.get_data(as_text=True)
+assert "needs attention" in threads_html
+assert "in progress" in threads_html
+assert "waiting" in threads_html
+assert "Attention Thread" in threads_html
+assert "Healthy Thread" in threads_html
+assert "external benchmark" in threads_html
+assert "last evidence" in threads_html
+assert "last beat" in threads_html
+assert "no next step" in threads_html
+
+detail = client.get("/thread/healthy-thread")
+assert detail.status_code == 200, detail.status_code
+detail_html = detail.get_data(as_text=True)
+assert "Operational Snapshot" in detail_html
+assert "Beat History" in detail_html
+assert "advanced synthesis" in detail_html
+assert "cycle-healthy" in detail_html
+assert "Operator Actions" in detail_html
+
+status_strip = client.get("/partials/status-strip")
+assert status_strip.status_code == 200, status_strip.status_code
+strip_html = status_strip.get_data(as_text=True)
+assert "1 waiting" in strip_html
+
+waiting = client.post(
+    "/api/threads/proposed-thread/action",
+    json={"action": "waiting", "reason": "operator review"},
+)
+assert waiting.status_code == 200, waiting.status_code
+waiting_data = waiting.get_json()
+assert waiting_data["new_status"] == "waiting"
+
+updated_thread = (state_dir / "threads" / "proposed-thread.md").read_text(encoding="utf-8")
+assert "status: waiting" in updated_thread
+
+operator_log = [
+    json.loads(line)
+    for line in (state_dir / "logs" / "operator-actions.jsonl").read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+assert operator_log[-1]["action"] == "thread:waiting"
+assert operator_log[-1]["reason"] == "operator review"
+assert operator_log[-1]["target_type"] == "thread"
+print("ok")
+PY


### PR DESCRIPTION
## Summary
- turn the dashboard threads section into an attention-first triage console
- surface per-thread health, last evidence, last beat/skill, and operator action lineage
- add thread detail operational snapshot + beat history and cover the slice with a dashboard integration test

## Why
The old threads section mostly listed thread files. It did not tell the operator why a thread needed attention, what evidence supported its state, or whether the last beat actually moved it forward.

Closes #283

## Validation
- `python3 -m py_compile blog/app.py blog/api_actions.py blog/api_dashboard.py blog/services.py`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_threads.sh`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_ops_console.sh`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_runtime.sh`
- `git diff --check`