### PR TITLE
[codex] implement claims workbench

### DIFF
--- a/blog/app.py
+++ b/blog/app.py
@@ -1106,6 +1106,39 @@ def api_threads():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route("/api/claims")
+def api_claims():
+    """Aggregated claims workbench for epistemic triage."""
+    try:
+        from blog.services import load_claims_dashboard
+        return jsonify(load_claims_dashboard(limit=12))
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/claims/<claim_id>/detail")
+def api_claim_detail(claim_id):
+    """Full claim detail: support, threads, reports, and steering history."""
+    try:
+        from blog.services import load_claim_detail
+        detail = load_claim_detail(claim_id)
+        if detail is None:
+            return jsonify({"error": f"Claim '{claim_id}' not found"}), 404
+        return jsonify(detail)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/claim/<claim_id>")
+def claim_page(claim_id):
+    """Render claim detail page."""
+    from blog.services import load_claim_detail
+    detail = load_claim_detail(claim_id)
+    if detail is None:
+        abort(404)
+    return render_template("claim_detail.html", claim=detail)
+
+
 @app.route("/api/threads/<thread_id>/detail")
 def api_thread_detail(thread_id):
     """Full thread detail: metadata, body, linked entries, reports, claims."""

--- a/blog/services.py
+++ b/blog/services.py
@@ -1,6 +1,7 @@
 """Shared service helpers for dashboard and action blueprints."""
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -96,6 +97,10 @@ def _short_ts(value):
 def _claim_id(artifact_filename, text):
     seed = f"{artifact_filename}:{text}".encode("utf-8", errors="ignore")
     return f"claim-{sha1(seed).hexdigest()[:12]}"
+
+
+def _claim_surface_id(text):
+    return _surface_id("claim", str(text or "").strip().lower())
 
 
 def _surface_id(prefix, *parts):
@@ -1007,7 +1012,38 @@ def _entry_records():
     return records
 
 
-def _claim_records():
+CLAIM_STALE_DAYS = 14
+
+
+def _build_claim_operator_action_index(limit_per_claim=6):
+    rollup = {}
+    for item in load_operator_actions(limit=200):
+        if item.get("target_type") != "claim":
+            continue
+        claim_id = str(item.get("target_id") or "").strip()
+        if not claim_id:
+            continue
+        bucket = rollup.setdefault(claim_id, [])
+        if len(bucket) < limit_per_claim:
+            bucket.append(item)
+    return rollup
+
+
+def _build_claim_queued_intent_index(limit_per_claim=6):
+    rollup = {}
+    for item in load_queued_steering_intents(limit=200):
+        if item.get("target_type") != "claim":
+            continue
+        claim_id = str(item.get("target_id") or "").strip()
+        if not claim_id:
+            continue
+        bucket = rollup.setdefault(claim_id, [])
+        if len(bucket) < limit_per_claim:
+            bucket.append(item)
+    return rollup
+
+
+def _claim_occurrence_records():
     records = []
     for entry in _entry_records():
         for raw_claim in entry["claims"]:
@@ -1018,7 +1054,8 @@ def _claim_records():
             if not clean_text:
                 continue
             records.append({
-                "claim_id": _claim_id(entry["filename"], clean_text),
+                "claim_id": _claim_surface_id(clean_text),
+                "claim_occurrence_id": _claim_id(entry["filename"], clean_text),
                 "text": clean_text,
                 "kind": "gap" if is_gap else "verified",
                 "kind_color": "red" if is_gap else "green",
@@ -1029,21 +1066,202 @@ def _claim_records():
                 "reference": entry["filename"],
                 "report": entry["report"],
                 "date": entry["date"],
+                "_sort_ts": _parse_ts_value(entry["date"]),
             })
     return records
 
 
+def _claim_records():
+    claims = {}
+    operator_index = _build_claim_operator_action_index()
+    queued_index = _build_claim_queued_intent_index()
+    today = date.today()
+
+    for item in _claim_occurrence_records():
+        claim_id = item["claim_id"]
+        bucket = claims.setdefault(claim_id, {
+            "claim_id": claim_id,
+            "text": item["text"],
+            "occurrences": [],
+            "threads": set(),
+            "report_files": set(),
+            "artifact_files": set(),
+            "verified_occurrences": 0,
+            "gap_occurrences": 0,
+            "latest_occurrence": None,
+        })
+        bucket["occurrences"].append(item)
+        bucket["threads"].update(item.get("threads") or [])
+        if item.get("report"):
+            bucket["report_files"].add(item["report"])
+        bucket["artifact_files"].add(item["artifact_filename"])
+        if item["kind"] == "gap":
+            bucket["gap_occurrences"] += 1
+        else:
+            bucket["verified_occurrences"] += 1
+        bucket["latest_occurrence"] = _latest_item(bucket["latest_occurrence"], dict(item))
+
+    records = []
+    for claim_id, bucket in claims.items():
+        occurrences = bucket["occurrences"]
+        occurrences.sort(key=lambda row: row.get("_sort_ts") or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
+        latest = bucket["latest_occurrence"] or (occurrences[0] if occurrences else None)
+        kind = "gap" if bucket["gap_occurrences"] > 0 else "verified"
+        kind_color = "red" if kind == "gap" else "green"
+        latest_ts = _parse_ts_value(latest.get("date")) if latest else None
+        latest_date = latest_ts.date() if latest_ts else _parse_date_value(latest.get("date") if latest else None)
+        stale_days = (today - latest_date).days if latest_date else None
+        stale = stale_days is not None and stale_days >= CLAIM_STALE_DAYS
+        no_thread = len(bucket["threads"]) == 0
+        no_report = len(bucket["report_files"]) == 0
+        single_source = len(bucket["artifact_files"]) == 1
+        flags = []
+        attention_score = 0
+        if kind == "gap":
+            flags.append({"kind": "warn", "label": "open gap", "detail": "claim is still open, disputed, or stale"})
+            attention_score += 5
+        if no_thread:
+            flags.append({"kind": "warn", "label": "no thread", "detail": "claim is not linked to any continuity surface"})
+            attention_score += 3
+        if no_report:
+            flags.append({"kind": "warn", "label": "no report", "detail": "claim has no published report evidence"})
+            attention_score += 2
+        if single_source:
+            flags.append({"kind": "muted", "label": "single source", "detail": "claim appears in only one artifact"})
+            attention_score += 1
+        if stale:
+            flags.append({"kind": "warn", "label": "stale", "detail": f"{stale_days}d since last supporting artifact"})
+            attention_score += 2
+
+        recent_operator_action = (operator_index.get(claim_id) or [None])[0]
+        queued_steering = (queued_index.get(claim_id) or [None])[0]
+
+        records.append({
+            "claim_id": claim_id,
+            "text": bucket["text"],
+            "kind": kind,
+            "kind_color": kind_color,
+            "verified_occurrences": bucket["verified_occurrences"],
+            "gap_occurrences": bucket["gap_occurrences"],
+            "support_count": len(bucket["artifact_files"]),
+            "reports_count": len(bucket["report_files"]),
+            "threads": sorted(bucket["threads"]),
+            "reference": latest.get("artifact_filename") if latest else None,
+            "artifact_title": latest.get("artifact_title") if latest else None,
+            "artifact_filename": latest.get("artifact_filename") if latest else None,
+            "artifact_href": latest.get("artifact_href") if latest else None,
+            "report": latest.get("report") if latest else None,
+            "date": latest.get("date") if latest else None,
+            "date_short": _short_ts(latest.get("date")) if latest else "",
+            "latest_artifact_title": latest.get("artifact_title") if latest else None,
+            "latest_artifact_href": latest.get("artifact_href") if latest else None,
+            "latest_artifact_filename": latest.get("artifact_filename") if latest else None,
+            "latest_report": latest.get("report") if latest else None,
+            "flags": flags,
+            "no_thread": no_thread,
+            "no_report": no_report,
+            "single_source": single_source,
+            "stale": stale,
+            "stale_days": stale_days,
+            "needs_attention": bool(kind == "gap" or no_thread or no_report or stale),
+            "attention_score": attention_score,
+            "recent_operator_action": recent_operator_action,
+            "queued_steering": queued_steering,
+            "occurrences": occurrences,
+        })
+
+    records.sort(
+        key=lambda item: (
+            not item.get("needs_attention"),
+            -(item.get("attention_score") or 0),
+            item.get("date") or "",
+            item.get("text") or "",
+        ),
+        reverse=False,
+    )
+    return records
+
+
 def load_claims_dashboard(limit=6):
-    """Summarize claim state from entry frontmatter."""
+    """Summarize claims into an operator-facing dashboard workbench."""
     claims = _claim_records()
     verified_total = len([item for item in claims if item["kind"] == "verified"])
     open_total = len([item for item in claims if item["kind"] == "gap"])
+    attention = [item for item in claims if item["needs_attention"]]
+    verified_recent = [item for item in claims if item["kind"] == "verified" and not item["needs_attention"]]
+    queued_count = len([item for item in claims if item.get("queued_steering")])
     return {
         "total": verified_total + open_total,
         "verified_total": verified_total,
         "open_total": open_total,
+        "attention_count": len(attention),
+        "unthreaded_count": len([item for item in claims if item["no_thread"]]),
+        "no_report_count": len([item for item in claims if item["no_report"]]),
+        "queued_count": queued_count,
+        "attention": attention[:limit],
+        "verified_recent": verified_recent[:limit],
         "recent": claims[:limit],
     }
+
+
+def load_claim_detail(claim_id):
+    """Load a single aggregated claim surface with support and steering history."""
+    claim = next((item for item in _claim_records() if item["claim_id"] == claim_id), None)
+    if not claim:
+        return None
+
+    thread_index = {
+        item["id"]: item
+        for item in load_threads_enriched().get("threads", [])
+    }
+
+    reports = []
+    for report in sorted({row.get("report") for row in claim["occurrences"] if row.get("report")}):
+        report_path = REPORTS_DIR / report
+        reports.append({
+            "filename": report,
+            "exists": report_path.exists(),
+            "url": f"/reports/{report}" if report_path.exists() else None,
+        })
+
+    occurrences = []
+    for row in claim["occurrences"]:
+        occurrences.append({
+            "claim_occurrence_id": row["claim_occurrence_id"],
+            "artifact_title": row["artifact_title"],
+            "artifact_filename": row["artifact_filename"],
+            "artifact_href": row["artifact_href"],
+            "report": row.get("report"),
+            "threads": row.get("threads", []),
+            "date": row.get("date"),
+            "date_short": _short_ts(row.get("date")),
+            "kind": row.get("kind"),
+            "kind_color": row.get("kind_color"),
+        })
+
+    return {
+        **{key: value for key, value in claim.items() if key != "occurrences"},
+        "occurrences": occurrences,
+        "reports": reports,
+        "thread_links": [
+            {
+                "id": tid,
+                "title": thread_index.get(tid, {}).get("title", tid),
+                "status": thread_index.get(tid, {}).get("status"),
+                "href": f"/thread/{tid}",
+            }
+            for tid in claim.get("threads", [])
+        ],
+        "operator_actions": _build_claim_operator_action_index(limit_per_claim=12).get(claim_id, []),
+        "queued_steering": _build_claim_queued_intent_index(limit_per_claim=12).get(claim_id, []),
+    }
+
+
+def _current_topics_dir():
+    memory_project_dir = str(os.environ.get("MEMORY_PROJECT_DIR") or "").strip()
+    if memory_project_dir:
+        return Path.home() / ".claude" / "projects" / memory_project_dir / "memory" / "topics"
+    return TOPICS_DIR
 
 
 def load_strategy_dashboard(limit_topics=5, limit_objectives=5):
@@ -1064,8 +1282,9 @@ def load_strategy_dashboard(limit_topics=5, limit_objectives=5):
             pass
 
     topics = []
-    if TOPICS_DIR.exists():
-        for fp in sorted(TOPICS_DIR.glob("*.md")):
+    topics_dir = _current_topics_dir()
+    if topics_dir.exists():
+        for fp in sorted(topics_dir.glob("*.md")):
             try:
                 raw = fp.read_text(encoding="utf-8", errors="replace")
                 heading = next((line.lstrip("# ").strip() for line in raw.splitlines() if line.startswith("# ")), fp.stem)
@@ -1147,7 +1366,7 @@ def load_proposals_dashboard(limit=5):
 def load_lineage_dashboard(limit=6):
     """Build recent claim -> thread -> artifact lineage rows."""
     lineage = []
-    for item in _claim_records():
+    for item in _claim_occurrence_records():
         lineage.append({
             "claim_id": item["claim_id"],
             "claim": item["text"],

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -1998,6 +1998,13 @@
     border-top: 1px solid var(--border);
   }
 
+  .claim-card-flags {
+    display: flex;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+    margin-top: 0.45rem;
+  }
+
   /* Summary bar */
   .dash-summary {
     text-align: center;

--- a/blog/templates/claim_detail.html
+++ b/blog/templates/claim_detail.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ claim.text }} — edge_of_chaos</title>
+<link rel="icon" type="image/png" href="/static/avatar.png">
+<link rel="stylesheet" href="/static/style.css">
+<style>
+  .claim-page { max-width: 920px; margin: 0 auto; padding: 1rem; }
+  .claim-header { margin-bottom: 1.5rem; }
+  .claim-title { font-size: 1.45rem; margin: 0 0 .6rem; color: #e2e8f0; }
+  .claim-meta { display: flex; gap: .8rem; flex-wrap: wrap; font-size: .82rem; color: #a0aec0; margin-bottom: .8rem; }
+  .claim-meta span { background: #2d3748; padding: .15rem .5rem; border-radius: 4px; }
+  .claim-back { color: #63b3ed; text-decoration: none; font-size: .9rem; }
+  .claim-back:hover { text-decoration: underline; }
+  .claim-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+  .claim-card { background: #2d3748; border: 1px solid #4a5568; border-radius: 6px; padding: .9rem 1rem; }
+  .claim-card h2 { margin: 0 0 .7rem; font-size: 1rem; color: #e2e8f0; }
+  .claim-line { display: flex; gap: .5rem; margin-bottom: .45rem; font-size: .9rem; color: #cbd5e0; }
+  .claim-line strong { min-width: 110px; color: #a0aec0; font-size: .75rem; text-transform: uppercase; letter-spacing: .04em; }
+  .claim-flags { display: flex; gap: .35rem; flex-wrap: wrap; margin-top: .7rem; }
+  .timeline { list-style: none; padding: 0; }
+  .timeline li { background: #2d3748; border-radius: 4px; padding: .7rem .8rem; margin-bottom: .45rem; border-left: 3px solid #4a5568; }
+  .timeline-head { display: flex; justify-content: space-between; gap: .5rem; flex-wrap: wrap; margin-bottom: .25rem; }
+  .timeline-meta { font-size: .82rem; color: #a0aec0; }
+  .report-list, .thread-list { list-style: none; padding: 0; }
+  .report-list li, .thread-list li { margin-bottom: .35rem; }
+  .report-list a, .thread-list a, .artifact-link { color: #63b3ed; text-decoration: none; }
+  .report-list a:hover, .thread-list a:hover, .artifact-link:hover { text-decoration: underline; }
+  .empty { color: #718096; font-style: italic; font-size: .9rem; }
+</style>
+</head>
+<body style="background:#1a202c;color:#e2e8f0;">
+<div class="claim-page">
+  <a href="/dashboard" class="claim-back">&larr; dashboard</a>
+
+  <div class="claim-header">
+    <h1 class="claim-title">{{ claim.text }}</h1>
+    <div class="claim-meta">
+      <span>{{ claim.kind }}</span>
+      <span>{{ claim.support_count }} artifacts</span>
+      <span>{{ claim.reports_count }} reports</span>
+      <span>{{ claim.verified_occurrences }} verified</span>
+      <span>{{ claim.gap_occurrences }} gap</span>
+      {% if claim.date_short %}<span>last seen: {{ claim.date_short }}</span>{% endif %}
+    </div>
+  </div>
+
+  <div class="claim-grid">
+    <div class="claim-card">
+      <h2>Claim Snapshot</h2>
+      <div class="claim-line"><strong>status</strong><span>{{ claim.kind }}</span></div>
+      <div class="claim-line"><strong>support</strong><span>{{ claim.support_count }} supporting artifacts</span></div>
+      <div class="claim-line"><strong>threads</strong><span>{{ claim.threads|length }}</span></div>
+      <div class="claim-line"><strong>reports</strong><span>{{ claim.reports_count }}</span></div>
+      {% if claim.latest_artifact_href %}
+      <div class="claim-line"><strong>latest artifact</strong><span><a class="artifact-link" href="{{ claim.latest_artifact_href }}">{{ claim.latest_artifact_title }}</a></span></div>
+      {% endif %}
+      {% if claim.flags %}
+      <div class="claim-flags">
+        {% for flag in claim.flags %}
+        <span class="thread-flag thread-flag-{{ flag.kind }}" title="{{ flag.detail }}">{{ flag.label }}</span>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+
+    <div class="claim-card">
+      <h2>Threads & Reports</h2>
+      {% if claim.thread_links %}
+      <ul class="thread-list">
+        {% for item in claim.thread_links %}
+        <li><a href="{{ item.href }}">{{ item.title }}</a>{% if item.status %} · {{ item.status }}{% endif %}</li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="empty">No linked threads.</p>
+      {% endif %}
+
+      {% if claim.reports %}
+      <ul class="report-list">
+        {% for item in claim.reports %}
+        <li>
+          {% if item.exists %}
+          <a href="{{ item.url }}">{{ item.filename }}</a>
+          {% else %}
+          <span style="color:#718096;">{{ item.filename }} (missing)</span>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+  </div>
+
+  {% if claim.queued_steering %}
+  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Queued Steering</h2>
+  <ul class="timeline">
+    {% for item in claim.queued_steering %}
+    <li>
+      <div class="timeline-head">
+        <strong>{{ item.action }}</strong>
+        <span class="timeline-meta">{{ item.ts_short }}</span>
+      </div>
+      <div class="timeline-meta">{{ item.reason }}{% if item.value %} · {{ item.value }}{% endif %}</div>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+  {% if claim.operator_actions %}
+  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Steering History</h2>
+  <ul class="timeline">
+    {% for item in claim.operator_actions %}
+    <li>
+      <div class="timeline-head">
+        <strong>{{ item.display_action }}</strong>
+        <span class="timeline-meta">{{ item.ts_short }}</span>
+      </div>
+      <div class="timeline-meta">{{ item.reason }}{% if item.resulting_state %} · {{ item.resulting_state }}{% endif %}</div>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Supporting Artifacts</h2>
+  {% if claim.occurrences %}
+  <ul class="timeline">
+    {% for item in claim.occurrences %}
+    <li>
+      <div class="timeline-head">
+        <strong><a class="artifact-link" href="{{ item.artifact_href }}">{{ item.artifact_title }}</a></strong>
+        <span class="timeline-meta">{{ item.date_short }}</span>
+      </div>
+      <div class="timeline-meta">{{ item.kind }}{% if item.report %} · <a class="artifact-link" href="/reports/{{ item.report }}">report</a>{% endif %}</div>
+      <div class="timeline-meta">
+        {% if item.threads %}
+          {% for tid in item.threads %}
+            <a class="artifact-link" href="/thread/{{ tid }}">{{ tid }}</a>{% if not loop.last %}, {% endif %}
+          {% endfor %}
+        {% else %}
+          no thread
+        {% endif %}
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p class="empty">No supporting artifacts recorded.</p>
+  {% endif %}
+</div>
+</body>
+</html>

--- a/blog/templates/partials/epistemics.html
+++ b/blog/templates/partials/epistemics.html
@@ -4,7 +4,7 @@
 
   <div class="runtime-grid">
     <div class="runtime-card">
-      <div class="runtime-card-title">claims</div>
+      <div class="runtime-card-title">claims workbench</div>
       <div class="runtime-row">
         <strong>verified</strong>
         <span class="runtime-meta">{{ ep_claims.verified_total }}</span>
@@ -13,16 +13,55 @@
         <strong>open / disputed</strong>
         <span class="runtime-meta">{{ ep_claims.open_total }}</span>
       </div>
-      {% if ep_claims.recent %}
-      <div class="runtime-subtitle">recent claims</div>
+      <div class="runtime-row">
+        <strong>need attention</strong>
+        <span class="runtime-meta">{{ ep_claims.attention_count }}</span>
+      </div>
+      <div class="runtime-row">
+        <strong>unthreaded</strong>
+        <span class="runtime-meta">{{ ep_claims.unthreaded_count }}</span>
+      </div>
+      <div class="runtime-row">
+        <strong>no report</strong>
+        <span class="runtime-meta">{{ ep_claims.no_report_count }}</span>
+      </div>
+      <div class="runtime-row">
+        <strong>queued steering</strong>
+        <span class="runtime-meta">{{ ep_claims.queued_count }}</span>
+      </div>
+      {% if ep_claims.attention %}
+      <div class="runtime-subtitle">needs attention</div>
       <div class="runtime-list">
-        {% for item in ep_claims.recent %}
+        {% for item in ep_claims.attention %}
         <div class="runtime-list-item">
           <div class="runtime-row">
-            <strong>{{ item.text }}</strong>
+            <strong><a href="/claim/{{ item.claim_id }}" style="color:inherit">{{ item.text }}</a></strong>
             <span class="runtime-pill runtime-pill-{{ item.kind_color }}">{{ item.kind }}</span>
           </div>
-          <div class="runtime-meta"><a href="{{ item.artifact_href }}" style="color:inherit">{{ item.artifact_title }}</a>{% if item.threads %} · {{ item.threads|join(', ') }}{% endif %}</div>
+          <div class="runtime-meta">{{ item.support_count }} artifacts · {{ item.reports_count }} reports{% if item.date_short %} · {{ item.date_short }}{% endif %}</div>
+          <div class="runtime-meta">
+            {% if item.threads %}
+              {% for tid in item.threads %}
+                <a href="/thread/{{ tid }}" style="color:inherit">{{ tid }}</a>{% if not loop.last %}, {% endif %}
+              {% endfor %}
+            {% else %}
+              no thread
+            {% endif %}
+            {% if item.latest_artifact_href %} · <a href="{{ item.latest_artifact_href }}" style="color:inherit">{{ item.latest_artifact_title }}</a>{% endif %}
+            {% if item.latest_report %} · <a href="/reports/{{ item.latest_report }}" style="color:inherit">report</a>{% endif %}
+          </div>
+          {% if item.flags %}
+          <div class="claim-card-flags">
+            {% for flag in item.flags %}
+            <span class="thread-flag thread-flag-{{ flag.kind }}" title="{{ flag.detail }}">{{ flag.label }}</span>
+            {% endfor %}
+          </div>
+          {% endif %}
+          {% if item.queued_steering %}
+          <div class="runtime-note">queued: {{ item.queued_steering.action }} · {{ item.queued_steering.ts_short }}</div>
+          {% elif item.recent_operator_action %}
+          <div class="runtime-note">last steering: {{ item.recent_operator_action.display_action }} · {{ item.recent_operator_action.ts_short }}</div>
+          {% endif %}
           <div class="dash-task-actions">
             <button class="action-btn" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "promote", {{ item.text|tojson }}, {{ item.reference|tojson }}, this)'>promote</button>
             <button class="action-btn action-start" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "verified", {{ item.text|tojson }}, {{ item.reference|tojson }}, this)'>verified</button>
@@ -34,6 +73,24 @@
       </div>
       {% else %}
       <div class="runtime-empty">no claims indexed from entries yet</div>
+      {% endif %}
+
+      {% if ep_claims.verified_recent %}
+      <div class="runtime-subtitle">stable recently</div>
+      <div class="runtime-list">
+        {% for item in ep_claims.verified_recent %}
+        <div class="runtime-list-item">
+          <div class="runtime-row">
+            <strong><a href="/claim/{{ item.claim_id }}" style="color:inherit">{{ item.text }}</a></strong>
+            <span class="runtime-pill runtime-pill-{{ item.kind_color }}">{{ item.kind }}</span>
+          </div>
+          <div class="runtime-meta">{{ item.support_count }} artifacts · {{ item.reports_count }} reports{% if item.threads %} · {{ item.threads|join(', ') }}{% endif %}</div>
+          {% if item.latest_artifact_href %}
+          <div class="runtime-meta"><a href="{{ item.latest_artifact_href }}" style="color:inherit">{{ item.latest_artifact_title }}</a>{% if item.latest_report %} · <a href="/reports/{{ item.latest_report }}" style="color:inherit">report</a>{% endif %}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
       {% endif %}
     </div>
 

--- a/tests/test_dashboard_claims.sh
+++ b/tests/test_dashboard_claims.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VENV_PY="${EDGE_BLOG_VENV:-$EDGE_DIR/blog/.venv/bin/python3}"
+if [ ! -x "$VENV_PY" ]; then
+    echo "Missing blog venv python: $VENV_PY" >&2
+    echo "Set EDGE_BLOG_VENV=/path/to/blog/.venv/bin/python3 when running from a clean worktree." >&2
+    exit 2
+fi
+
+TMP_BASE="$(mktemp -d /tmp/edge-dashboard-claims-XXXXXX)"
+TMP_STATE="$TMP_BASE/state-root"
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p \
+    "$TMP_STATE/blog/entries" \
+    "$TMP_STATE/threads" \
+    "$TMP_STATE/reports" \
+    "$TMP_STATE/logs" \
+    "$TMP_STATE/state/signals" \
+    "$TMP_STATE/state/events" \
+    "$TMP_STATE/search"
+
+cat >"$TMP_STATE/blog/entries/2026-04-20-claim-gap.md" <<'MD'
+---
+title: "Queue close audit"
+date: "2026-04-20"
+claims:
+  - "!Queue close evidence is still missing"
+---
+body
+MD
+
+cat >"$TMP_STATE/blog/entries/2026-04-20-claim-verified-a.md" <<'MD'
+---
+title: "Operator visibility note"
+date: "2026-04-20"
+claims:
+  - "Operator notes should land in visible tasks"
+threads:
+  - ops-visibility
+report: ops-visible.html
+---
+body
+MD
+
+cat >"$TMP_STATE/blog/entries/2026-04-21-claim-verified-b.md" <<'MD'
+---
+title: "Follow-up on visible tasks"
+date: "2026-04-21"
+claims:
+  - "Operator notes should land in visible tasks"
+threads:
+  - ops-visibility
+---
+body
+MD
+
+cat >"$TMP_STATE/threads/ops-visibility.md" <<'MD'
+---
+id: ops-visibility
+title: "Ops visibility"
+status: active
+owner: ed
+goal: "Make queued operator work visible"
+---
+## Next
+Review the next dispatch output.
+MD
+
+cat >"$TMP_STATE/reports/ops-visible.html" <<'HTML'
+<html><body>report</body></html>
+HTML
+
+EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$VENV_PY" - <<'PY'
+import os
+import sys
+
+edge_dir = os.environ["EDGE_REPO_DIR"]
+sys.path.insert(0, edge_dir)
+sys.path.insert(0, os.path.join(edge_dir, "blog"))
+os.chdir(os.path.join(edge_dir, "blog"))
+
+from app import app
+
+client = app.test_client()
+
+resp = client.get("/api/dashboard/epistemics")
+assert resp.status_code == 200, resp.status_code
+data = resp.get_json()
+
+claims = data["ep_claims"]
+assert claims["verified_total"] == 1
+assert claims["open_total"] == 1
+assert claims["attention_count"] == 1
+assert claims["unthreaded_count"] == 1
+assert claims["no_report_count"] == 1
+assert claims["verified_recent"][0]["support_count"] == 2
+
+attention_claim = claims["attention"][0]
+assert attention_claim["text"] == "Queue close evidence is still missing"
+assert attention_claim["no_thread"] is True
+assert attention_claim["no_report"] is True
+
+detail = client.get(f"/claim/{attention_claim['claim_id']}")
+assert detail.status_code == 200, detail.status_code
+detail_html = detail.get_data(as_text=True)
+assert "Claim Snapshot" in detail_html
+assert "Supporting Artifacts" in detail_html
+assert "Queue close audit" in detail_html
+
+steer = client.post(
+    f"/api/steering/claim/{attention_claim['claim_id']}/action",
+    json={
+        "action": "disputed",
+        "reason": "close evidence still has a blind spot",
+        "label": attention_claim["text"],
+        "reference": attention_claim["reference"],
+    },
+)
+assert steer.status_code == 200, steer.status_code
+
+partial = client.get("/partials/epistemics")
+assert partial.status_code == 200, partial.status_code
+text = partial.get_data(as_text=True)
+assert "claims workbench" in text
+assert "needs attention" in text
+assert "stable recently" in text
+assert "Operator notes should land in visible tasks" in text
+assert "queued: disputed" in text
+print("ok")
+PY


### PR DESCRIPTION
## Summary
- turn the claims slice into a claims workbench with attention-first triage inside the epistemics dashboard
- aggregate support across artifacts, threads, reports, and steering state for each claim
- add a dedicated claim detail page plus coverage for the new workbench and the existing epistemics fixtures

## Why
The old claims card only showed raw recent claim occurrences. It did not tell the operator which claims lacked continuity, which had weak evidence, or what steering was already queued against a claim.

## Validation
- `python3 -m py_compile blog/app.py blog/services.py blog/api_dashboard.py blog/api_actions.py`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_claims.sh`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_epistemics.sh`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_steering.sh`
- `git diff --check`