### PR TITLE
[codex] implement proposals decision console

### DIFF
--- a/blog/api_dashboard.py
+++ b/blog/api_dashboard.py
@@ -465,7 +465,7 @@ def _build_epistemic_data():
     return {
         "ep_claims": load_claims_dashboard(limit=6),
         "ep_strategy": load_strategy_dashboard(limit_topics=5, limit_objectives=5),
-        "ep_proposals": load_proposals_dashboard(limit=5),
+        "ep_proposals": load_proposals_dashboard(limit=8),
         "ep_lineage": load_lineage_dashboard(limit=6),
         "ep_queued_steering": steering["queued"],
         "ep_queued_steering_count": steering["queued_count"],

--- a/blog/app.py
+++ b/blog/app.py
@@ -1162,6 +1162,29 @@ def thread_page(thread_id):
     return render_template("thread_detail.html", thread=detail)
 
 
+@app.route("/api/proposals/<proposal_id>/detail")
+def api_proposal_detail(proposal_id):
+    """Full proposal detail: evidence, linked surfaces, and steering history."""
+    try:
+        from blog.services import load_proposal_detail
+        detail = load_proposal_detail(proposal_id)
+        if detail is None:
+            return jsonify({"error": f"Proposal '{proposal_id}' not found"}), 404
+        return jsonify(detail)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/proposal/<proposal_id>")
+def proposal_page(proposal_id):
+    """Render proposal detail page."""
+    from blog.services import load_proposal_detail
+    detail = load_proposal_detail(proposal_id)
+    if detail is None:
+        abort(404)
+    return render_template("proposal_detail.html", proposal=detail)
+
+
 @app.route("/api/thread-candidates")
 def api_thread_candidates():
     """Detect recurring tags that could become threads."""

--- a/blog/services.py
+++ b/blog/services.py
@@ -108,14 +108,20 @@ def _surface_id(prefix, *parts):
     return f"{prefix}-{sha1(seed.encode('utf-8', errors='ignore')).hexdigest()[:12]}"
 
 
-def _surface_href(target_type, reference=None):
+def _surface_href(target_type, reference=None, target_id=None):
     reference = str(reference or "").strip()
+    target_id = str(target_id or "").strip()
     if not target_type or not reference:
+        if target_type == "proposal" and target_id:
+            return f"/proposal/{target_id}"
         return None
     if target_type == "claim" and reference.endswith(".md"):
         return f"/blog/entries/{reference}"
     if target_type in {"objective", "thread"}:
         return f"/thread/{reference}"
+    if target_type == "proposal":
+        proposal_id = target_id or reference
+        return f"/proposal/{proposal_id}" if proposal_id else None
     return None
 
 
@@ -661,7 +667,7 @@ def load_operator_actions(limit=8):
             "target_type": target_type,
             "label": entry.get("label") or target_id,
             "reference": reference,
-            "href": entry.get("href") or _surface_href(target_type, reference=reference),
+            "href": entry.get("href") or _surface_href(target_type, reference=reference, target_id=target_id),
             "resulting_state": entry.get("resulting_state"),
             "apply": entry.get("apply"),
             "reason": entry.get("reason"),
@@ -752,7 +758,7 @@ def _parse_steering_intent_message(text):
         "action": action,
         "label": payload.get("label") or target_id,
         "reference": reference,
-        "href": _surface_href(target_type, reference=reference),
+        "href": _surface_href(target_type, reference=reference, target_id=target_id),
         "resulting_state": payload.get("resulting_state"),
         "apply": payload.get("apply"),
         "reason": payload.get("reason"),
@@ -828,7 +834,7 @@ def _parse_runtime_intent_message(text):
         "action": action,
         "label": payload.get("label") or target_id,
         "reference": reference,
-        "href": _surface_href(target_type, reference=reference),
+        "href": _surface_href(target_type, reference=reference, target_id=target_id),
         "resulting_state": payload.get("resulting_state"),
         "apply": payload.get("apply"),
         "reason": payload.get("reason"),
@@ -1325,24 +1331,56 @@ def load_strategy_dashboard(limit_topics=5, limit_objectives=5):
     }
 
 
-def load_proposals_dashboard(limit=5):
-    """Summarize active proposals and recent decisions."""
-    active = []
-    for proposal in load_json_safe(PROPOSALS_FILE, []):
-        if proposal.get("status") != "active":
-            continue
-        active.append({
-            "id": proposal.get("id"),
-            "title": proposal.get("title", "untitled"),
-            "type": proposal.get("type", "proposal"),
-            "updated_short": _short_ts(proposal.get("updated") or proposal.get("created")),
-            "evidence_count": len(proposal.get("evidence", []) or []),
-            "evidence_preview": list(proposal.get("evidence", []) or [])[:2],
-            "reference": (proposal.get("evidence", []) or [None])[0],
-            "cost": proposal.get("cost"),
-        })
-    active.sort(key=lambda item: item.get("updated_short", ""), reverse=True)
+PROPOSAL_STALE_DAYS = 14
 
+
+def _build_proposal_operator_action_index(limit_per_proposal=6):
+    rollup = {}
+    for item in load_operator_actions(limit=200):
+        if item.get("target_type") != "proposal":
+            continue
+        proposal_id = str(item.get("target_id") or "").strip()
+        if not proposal_id:
+            continue
+        bucket = rollup.setdefault(proposal_id, [])
+        if len(bucket) < limit_per_proposal:
+            bucket.append(item)
+    return rollup
+
+
+def _build_proposal_queued_intent_index(limit_per_proposal=6):
+    rollup = {}
+    for item in load_queued_steering_intents(limit=200):
+        if item.get("target_type") != "proposal":
+            continue
+        proposal_id = str(item.get("target_id") or "").strip()
+        if not proposal_id:
+            continue
+        bucket = rollup.setdefault(proposal_id, [])
+        if len(bucket) < limit_per_proposal:
+            bucket.append(item)
+    return rollup
+
+
+def _normalize_claim_text(raw_claim):
+    text = raw_claim.get("claim", "") if isinstance(raw_claim, dict) else str(raw_claim)
+    return str(text).lstrip("! ").strip()
+
+
+def _proposal_revisions_count(value):
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, list):
+        return len(value)
+    try:
+        return max(0, int(str(value).strip()))
+    except Exception:
+        return 0
+
+
+def _proposal_decision_log(limit=8):
     decisions = []
     decision_path = SIGNALS_DIR / "decision.md"
     if decision_path.exists():
@@ -1355,11 +1393,356 @@ def load_proposals_dashboard(limit=5):
                     break
         except Exception:
             pass
+    return decisions
+
+
+def _proposal_records():
+    proposals_raw = load_json_safe(PROPOSALS_FILE, [])
+    if not isinstance(proposals_raw, list):
+        proposals_raw = []
+
+    thread_items = {
+        item["id"]: item
+        for item in load_threads_enriched().get("threads", [])
+    }
+    thread_lookup = {}
+    for thread_id, thread in thread_items.items():
+        for key in {thread_id.lower(), str(thread.get("title") or "").strip().lower()}:
+            if key:
+                thread_lookup[key] = thread_id
+
+    claim_items = _claim_records()
+    claim_by_text = {}
+    claim_by_id = {}
+    for claim in claim_items:
+        claim_by_id[claim["claim_id"]] = claim
+        claim_by_text[claim["text"].strip().lower()] = claim
+
+    entry_lookup = {}
+    for entry in _entry_records():
+        keys = {
+            entry["filename"].strip().lower(),
+            entry["slug"].strip().lower(),
+            str(entry.get("title") or "").strip().lower(),
+        }
+        for key in keys:
+            if key:
+                entry_lookup[key] = entry
+
+    operator_index = _build_proposal_operator_action_index(limit_per_proposal=12)
+    queued_index = _build_proposal_queued_intent_index(limit_per_proposal=12)
+    today = date.today()
+    records = []
+
+    for proposal in proposals_raw:
+        if not isinstance(proposal, dict):
+            continue
+        proposal_id = str(proposal.get("id") or "").strip()
+        if not proposal_id:
+            continue
+
+        title = str(proposal.get("title") or "untitled").strip()
+        status = str(proposal.get("status") or "active").strip().lower()
+        proposal_type = str(proposal.get("type") or "proposal").strip() or "proposal"
+        created = str(proposal.get("created") or "").strip() or None
+        updated = str(proposal.get("updated") or created or "").strip() or None
+        rationale = str(
+            proposal.get("rationale")
+            or proposal.get("hypothesis")
+            or proposal.get("summary")
+            or proposal.get("why")
+            or ""
+        ).strip() or None
+        action_text = str(
+            proposal.get("action")
+            or proposal.get("scope")
+            or proposal.get("next_step")
+            or ""
+        ).strip() or None
+        impact = str(
+            proposal.get("impact")
+            or proposal.get("expected_value")
+            or proposal.get("expected_impact")
+            or ""
+        ).strip() or None
+        risk = str(
+            proposal.get("risk")
+            or proposal.get("risks")
+            or proposal.get("operational_risk")
+            or ""
+        ).strip() or None
+        cost = str(proposal.get("cost") or "").strip() or None
+        revisions_count = _proposal_revisions_count(proposal.get("revisions"))
+
+        evidence_items = _normalize_string_list(proposal.get("evidence") or [])
+        evidence_links = []
+        linked_threads = {}
+        linked_claims = {}
+        report_files = set()
+
+        explicit_threads = _normalize_string_list(proposal.get("threads") or proposal.get("thread"))
+        for raw_thread in explicit_threads:
+            thread_id = thread_lookup.get(raw_thread.lower(), raw_thread)
+            thread = thread_items.get(thread_id)
+            if thread:
+                linked_threads[thread_id] = {
+                    "id": thread_id,
+                    "title": thread.get("title", thread_id),
+                    "status": thread.get("status"),
+                    "href": f"/thread/{thread_id}",
+                }
+            else:
+                linked_threads[thread_id] = {
+                    "id": thread_id,
+                    "title": raw_thread,
+                    "status": None,
+                    "href": f"/thread/{thread_id}",
+                }
+
+        explicit_claims = _normalize_string_list(proposal.get("claims") or proposal.get("claim"))
+        for raw_claim in explicit_claims:
+            claim = claim_by_id.get(raw_claim) or claim_by_text.get(raw_claim.lstrip("! ").strip().lower())
+            if claim:
+                linked_claims[claim["claim_id"]] = {
+                    "claim_id": claim["claim_id"],
+                    "text": claim["text"],
+                    "kind": claim["kind"],
+                    "href": f"/claim/{claim['claim_id']}",
+                }
+
+        for evidence in evidence_items:
+            key = evidence.strip().lower()
+            entry = entry_lookup.get(key)
+            claim = claim_by_text.get(evidence.lstrip("! ").strip().lower())
+
+            if entry:
+                evidence_links.append({
+                    "label": entry["title"],
+                    "href": f"/blog/entries/{entry['filename']}",
+                    "kind": "artifact",
+                })
+                if entry.get("report"):
+                    report_files.add(entry["report"])
+                for thread_id in entry.get("threads", []):
+                    thread = thread_items.get(thread_id)
+                    linked_threads[thread_id] = {
+                        "id": thread_id,
+                        "title": thread.get("title", thread_id) if thread else thread_id,
+                        "status": thread.get("status") if thread else None,
+                        "href": f"/thread/{thread_id}",
+                    }
+                for raw_claim in entry.get("claims", []):
+                    clean_claim = _normalize_claim_text(raw_claim)
+                    if not clean_claim:
+                        continue
+                    matched_claim = claim_by_text.get(clean_claim.lower())
+                    if matched_claim:
+                        linked_claims[matched_claim["claim_id"]] = {
+                            "claim_id": matched_claim["claim_id"],
+                            "text": matched_claim["text"],
+                            "kind": matched_claim["kind"],
+                            "href": f"/claim/{matched_claim['claim_id']}",
+                        }
+            elif claim:
+                evidence_links.append({
+                    "label": claim["text"],
+                    "href": f"/claim/{claim['claim_id']}",
+                    "kind": "claim",
+                })
+                linked_claims[claim["claim_id"]] = {
+                    "claim_id": claim["claim_id"],
+                    "text": claim["text"],
+                    "kind": claim["kind"],
+                    "href": f"/claim/{claim['claim_id']}",
+                }
+                for thread_id in claim.get("threads", []):
+                    thread = thread_items.get(thread_id)
+                    linked_threads[thread_id] = {
+                        "id": thread_id,
+                        "title": thread.get("title", thread_id) if thread else thread_id,
+                        "status": thread.get("status") if thread else None,
+                        "href": f"/thread/{thread_id}",
+                    }
+            else:
+                evidence_links.append({
+                    "label": evidence,
+                    "href": None,
+                    "kind": "note",
+                })
+
+        operator_actions = operator_index.get(proposal_id, [])
+        queued_steering = queued_index.get(proposal_id, [])
+        recent_operator_action = operator_actions[0] if operator_actions else None
+        queued_action = queued_steering[0]["action"] if queued_steering else None
+        recent_action = recent_operator_action["display_action"] if recent_operator_action else None
+
+        updated_ts = _parse_ts_value(updated)
+        updated_date = updated_ts.date() if updated_ts else _parse_date_value(updated)
+        stale_days = (today - updated_date).days if updated_date else None
+        stale = stale_days is not None and stale_days >= PROPOSAL_STALE_DAYS
+        low_evidence = len(evidence_items) <= 1
+        no_links = not linked_threads and not linked_claims
+        needs_revision = status in {"needs_revision", "needs-revision", "revision", "revision-requested"} or queued_action == "request-revision" or recent_action == "request-revision"
+        approved_waiting = status == "approved" or queued_action == "approve"
+        deferred = status in {"deferred", "parked", "on-hold"} or queued_action == "defer"
+        decided_recently = status in {"rejected", "rejected_recent", "done"} or queued_action == "reject" or recent_action == "reject"
+        needs_decision = status == "active" and not needs_revision and not approved_waiting and not deferred and not decided_recently
+
+        flags = []
+        attention_score = 0
+        if needs_revision:
+            flags.append({"kind": "warn", "label": "needs revision", "detail": "proposal is blocked on a revision request"})
+            attention_score += 5
+        if low_evidence:
+            flags.append({"kind": "warn", "label": "low evidence", "detail": "proposal has one or zero explicit evidence items"})
+            attention_score += 3
+        if no_links:
+            flags.append({"kind": "muted", "label": "unlinked", "detail": "proposal is not linked to any claim or thread"})
+            attention_score += 2
+        if stale:
+            flags.append({"kind": "warn", "label": "stale", "detail": f"{stale_days}d since last update"})
+            attention_score += 2
+        if approved_waiting:
+            flags.append({"kind": "ok", "label": "queued", "detail": "proposal is approved or queued for the next dispatch"})
+        if deferred:
+            flags.append({"kind": "muted", "label": "deferred", "detail": "proposal is explicitly parked"})
+
+        if needs_revision:
+            lane = "needs_revision"
+            status_badge = "needs-revision"
+            status_label = "needs revision"
+        elif approved_waiting:
+            lane = "approved_waiting"
+            status_badge = "approved"
+            status_label = "approved"
+        elif deferred:
+            lane = "deferred"
+            status_badge = "deferred"
+            status_label = "deferred"
+        elif decided_recently:
+            lane = "recently_decided"
+            status_badge = "decided"
+            status_label = "decided"
+        else:
+            lane = "needs_decision"
+            status_badge = "needs-decision"
+            status_label = "needs decision"
+
+        records.append({
+            "id": proposal_id,
+            "title": title,
+            "type": proposal_type,
+            "status": status,
+            "status_label": status_label,
+            "status_badge": status_badge,
+            "lane": lane,
+            "href": f"/proposal/{proposal_id}",
+            "created": created,
+            "created_short": _short_ts(created),
+            "updated": updated,
+            "updated_short": _short_ts(updated),
+            "_sort_ts": updated_ts.timestamp() if updated_ts else 0,
+            "reference": evidence_items[0] if evidence_items else proposal_id,
+            "rationale": rationale,
+            "action_text": action_text,
+            "impact": impact,
+            "risk": risk,
+            "cost": cost,
+            "revisions_count": revisions_count,
+            "evidence_count": len(evidence_items),
+            "evidence_preview": evidence_items[:2],
+            "evidence_links": evidence_links,
+            "linked_threads": list(linked_threads.values())[:6],
+            "linked_threads_count": len(linked_threads),
+            "linked_claims": list(linked_claims.values())[:6],
+            "linked_claims_count": len(linked_claims),
+            "reports_count": len(report_files),
+            "reports": sorted(report_files),
+            "flags": flags,
+            "low_evidence": low_evidence,
+            "no_links": no_links,
+            "stale": stale,
+            "stale_days": stale_days,
+            "needs_attention": bool(needs_decision or needs_revision or low_evidence or stale or no_links),
+            "attention_score": attention_score,
+            "needs_decision": needs_decision,
+            "needs_revision": needs_revision,
+            "approved_waiting": approved_waiting,
+            "deferred": deferred,
+            "decided_recently": decided_recently,
+            "recent_operator_action": recent_operator_action,
+            "queued_steering": queued_steering[0] if queued_steering else None,
+            "operator_actions": operator_actions[:8],
+            "queued_steering_items": queued_steering[:8],
+        })
+
+    records.sort(
+        key=lambda item: (
+            {
+                "needs_revision": 0,
+                "needs_decision": 1,
+                "approved_waiting": 2,
+                "deferred": 3,
+                "recently_decided": 4,
+            }.get(item["lane"], 5),
+            -int(item.get("attention_score") or 0),
+            -(item.get("_sort_ts") or 0),
+            item.get("title") or "",
+        ),
+        reverse=False,
+    )
+    for item in records:
+        item.pop("_sort_ts", None)
+    return records
+
+
+def load_proposals_dashboard(limit=5):
+    """Summarize proposals into a decision console read model."""
+    proposals = _proposal_records()
+    active = sorted(
+        [item for item in proposals if item["status"] == "active"],
+        key=lambda item: item.get("updated") or "",
+        reverse=True,
+    )
+    needs_decision = [item for item in proposals if item["lane"] == "needs_decision"]
+    needs_revision = [item for item in proposals if item["lane"] == "needs_revision"]
+    approved_waiting = [item for item in proposals if item["lane"] == "approved_waiting"]
+    deferred = [item for item in proposals if item["lane"] == "deferred"]
+    recently_decided = [item for item in proposals if item["lane"] == "recently_decided"]
+    return {
+        "total": len(proposals),
+        "active_count": len(active),
+        "queued_count": len([item for item in proposals if item.get("queued_steering")]),
+        "low_evidence_count": len([item for item in proposals if item["low_evidence"]]),
+        "needs_decision_count": len(needs_decision),
+        "needs_revision_count": len(needs_revision),
+        "approved_waiting_count": len(approved_waiting),
+        "deferred_count": len(deferred),
+        "active": active[:limit],
+        "needs_decision": needs_decision[:limit],
+        "needs_revision": needs_revision[:limit],
+        "approved_waiting_execution": approved_waiting[:limit],
+        "deferred": deferred[:limit],
+        "recently_decided": recently_decided[:limit],
+        "decisions": _proposal_decision_log(limit=limit),
+    }
+
+
+def load_proposal_detail(proposal_id):
+    """Load a single proposal with linked evidence and steering history."""
+    proposal = next((item for item in _proposal_records() if item["id"] == proposal_id), None)
+    if not proposal:
+        return None
+
+    decision_hits = []
+    title_needle = proposal["title"].strip().lower()
+    for item in _proposal_decision_log(limit=50):
+        if title_needle and title_needle in item.lower():
+            decision_hits.append(item)
 
     return {
-        "active_count": len(active),
-        "active": active[:limit],
-        "decisions": decisions,
+        **proposal,
+        "decision_log": decision_hits,
     }
 
 

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -1850,6 +1850,11 @@
   .status-done { background: var(--accent-soft); color: var(--accent); }
   .status-proposed { background: rgba(99, 179, 237, 0.12); color: var(--accent); }
   .status-candidate { background: rgba(255, 255, 255, 0.08); color: var(--text-muted); }
+  .status-needs-decision { background: rgba(251, 191, 36, 0.18); color: #fbd38d; }
+  .status-needs-revision { background: rgba(237, 137, 54, 0.18); color: #f6ad55; }
+  .status-approved { background: rgba(72, 187, 120, 0.18); color: #9ae6b4; }
+  .status-deferred { background: rgba(160, 174, 192, 0.14); color: var(--text-muted); }
+  .status-decided { background: rgba(99, 179, 237, 0.14); color: var(--accent); }
 
   .dash-thread-name { flex: 1; }
   .dash-thread-owner { font-size: 0.65rem; color: var(--text-muted); font-family: 'IBM Plex Mono', monospace; }

--- a/blog/templates/partials/epistemics.html
+++ b/blog/templates/partials/epistemics.html
@@ -1,3 +1,92 @@
+{% macro proposal_card(proposal) %}
+<div class="thread-console-card{{ ' thread-console-card-attention' if proposal.needs_attention else '' }}">
+  <div class="thread-console-head">
+    <div class="thread-console-title-row">
+      <span class="dash-thread-status status-{{ proposal.status_badge }}">{{ proposal.status_label }}</span>
+      <a href="{{ proposal.href }}" class="thread-console-title">{{ proposal.title }}</a>
+      <span class="thread-console-chip">{{ proposal.type }}</span>
+      {% if proposal.cost %}<span class="thread-console-chip">{{ proposal.cost }}</span>{% endif %}
+      {% if proposal.revisions_count %}<span class="thread-console-chip">v{{ proposal.revisions_count + 1 }}</span>{% endif %}
+    </div>
+    <div class="thread-console-meta-row">
+      {% if proposal.updated_short %}<span>updated {{ proposal.updated_short }}</span>{% endif %}
+      {% if proposal.created_short %}<span>created {{ proposal.created_short }}</span>{% endif %}
+      {% if proposal.queued_steering %}<span>queued {{ proposal.queued_steering.action }}</span>{% endif %}
+    </div>
+  </div>
+
+  {% if proposal.rationale %}
+  <div class="thread-console-summary-text">{{ proposal.rationale }}</div>
+  {% elif proposal.action_text %}
+  <div class="thread-console-summary-text">{{ proposal.action_text }}</div>
+  {% endif %}
+
+  <div class="thread-console-grid">
+    <div class="thread-console-column">
+      {% if proposal.action_text %}
+      <div class="thread-console-line"><strong>next</strong><span>{{ proposal.action_text }}</span></div>
+      {% endif %}
+      {% if proposal.impact %}
+      <div class="thread-console-line"><strong>impact</strong><span>{{ proposal.impact }}</span></div>
+      {% endif %}
+      {% if proposal.risk %}
+      <div class="thread-console-line"><strong>risk</strong><span>{{ proposal.risk }}</span></div>
+      {% endif %}
+    </div>
+
+    <div class="thread-console-column">
+      {% if proposal.evidence_count %}
+      <div class="thread-console-line"><strong>evidence</strong><span>{{ proposal.evidence_count }} linked items</span></div>
+      {% else %}
+      <div class="thread-console-line thread-console-line-warn"><strong>evidence</strong><span>none linked yet</span></div>
+      {% endif %}
+      <div class="thread-console-line"><strong>surfaces</strong><span>{{ proposal.linked_claims_count }} claims · {{ proposal.linked_threads_count }} threads · {{ proposal.reports_count }} reports</span></div>
+      {% if proposal.queued_steering %}
+      <div class="thread-console-line"><strong>queued</strong><span>{{ proposal.queued_steering.action }}{% if proposal.queued_steering.ts_short %} · {{ proposal.queued_steering.ts_short }}{% endif %}</span></div>
+      {% elif proposal.recent_operator_action %}
+      <div class="thread-console-line"><strong>decision</strong><span>{{ proposal.recent_operator_action.display_action }}{% if proposal.recent_operator_action.ts_short %} · {{ proposal.recent_operator_action.ts_short }}{% endif %}</span></div>
+      {% endif %}
+    </div>
+  </div>
+
+  {% if proposal.evidence_preview %}
+  <div class="runtime-note">{{ proposal.evidence_preview|join(' · ') }}</div>
+  {% endif %}
+
+  {% if proposal.linked_threads %}
+  <div class="runtime-meta">
+    threads:
+    {% for item in proposal.linked_threads[:3] %}
+      <a href="{{ item.href }}" style="color:inherit">{{ item.title }}</a>{% if not loop.last %}, {% endif %}
+    {% endfor %}
+  </div>
+  {% endif %}
+  {% if proposal.linked_claims %}
+  <div class="runtime-meta">
+    claims:
+    {% for item in proposal.linked_claims[:3] %}
+      <a href="{{ item.href }}" style="color:inherit">{{ item.text }}</a>{% if not loop.last %}, {% endif %}
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if proposal.flags %}
+  <div class="thread-console-flags">
+    {% for flag in proposal.flags %}
+    <span class="thread-flag thread-flag-{{ flag.kind }}" title="{{ flag.detail }}">{{ flag.label }}</span>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div class="thread-console-actions">
+    <button class="action-btn action-start" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "approve", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this)'>approve</button>
+    <button class="action-btn action-blocked" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "reject", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this)'>reject</button>
+    <button class="action-btn" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "defer", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this)'>defer</button>
+    <button class="action-btn" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "request-revision", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this, "what revision should be requested on the next dispatch?")'>revision</button>
+  </div>
+</div>
+{% endmacro %}
+
 <div class="dash-section">
   <h2 class="dash-section-title">epistemic & steering</h2>
   <div class="runtime-note">operator steering is queued for the next dispatch; the cards below remain the current read model until dispatch applies the intent.</div>
@@ -164,34 +253,63 @@
     </div>
 
     <div class="runtime-card">
-      <div class="runtime-card-title">proposals & decisions</div>
-      <div class="runtime-row">
-        <strong>active proposals</strong>
-        <span class="runtime-meta">{{ ep_proposals.active_count }}</span>
+      <div class="runtime-card-title">proposals console</div>
+      <div class="thread-console-summary-bar">
+        <span><strong>{{ ep_proposals.needs_decision_count }}</strong> needs decision</span>
+        <span><strong>{{ ep_proposals.needs_revision_count }}</strong> needs revision</span>
+        <span><strong>{{ ep_proposals.approved_waiting_count }}</strong> approved / queued</span>
+        <span><strong>{{ ep_proposals.deferred_count }}</strong> deferred</span>
+        <span><strong>{{ ep_proposals.queued_count }}</strong> queued steering</span>
+        <span><strong>{{ ep_proposals.low_evidence_count }}</strong> low evidence</span>
       </div>
-      {% if ep_proposals.active %}
-      <div class="runtime-list">
-        {% for proposal in ep_proposals.active %}
-        <div class="runtime-list-item">
-          <div class="runtime-row">
-            <strong>{{ proposal.title }}</strong>
-            <span class="runtime-meta">{{ proposal.type }}</span>
-          </div>
-          <div class="runtime-meta">{{ proposal.updated_short }} · evidence {{ proposal.evidence_count }}{% if proposal.cost %} · {{ proposal.cost }}{% endif %}</div>
-          {% if proposal.evidence_preview %}
-          <div class="runtime-note">{{ proposal.evidence_preview|join(' · ') }}</div>
-          {% endif %}
-          <div class="dash-task-actions">
-            <button class="action-btn action-start" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "approve", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this)'>approve</button>
-            <button class="action-btn action-blocked" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "reject", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this)'>reject</button>
-            <button class="action-btn" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "defer", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this)'>defer</button>
-            <button class="action-btn" onclick='steeringAction("proposal", {{ proposal.id|tojson }}, "request-revision", {{ proposal.title|tojson }}, {{ (proposal.reference or "")|tojson }}, this, "what revision should be requested on the next dispatch?")'>revision</button>
-          </div>
-        </div>
+
+      {% if ep_proposals.total == 0 %}
+      <div class="runtime-empty">no proposals captured yet</div>
+      {% endif %}
+
+      {% if ep_proposals.needs_decision %}
+      <div class="runtime-subtitle">needs decision</div>
+      <div class="thread-console-list">
+        {% for proposal in ep_proposals.needs_decision %}
+          {{ proposal_card(proposal) }}
         {% endfor %}
       </div>
-      {% else %}
-      <div class="runtime-empty">no active proposals</div>
+      {% endif %}
+
+      {% if ep_proposals.needs_revision %}
+      <div class="runtime-subtitle">needs revision</div>
+      <div class="thread-console-list">
+        {% for proposal in ep_proposals.needs_revision %}
+          {{ proposal_card(proposal) }}
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      {% if ep_proposals.approved_waiting_execution %}
+      <div class="runtime-subtitle">approved / waiting execution</div>
+      <div class="thread-console-list">
+        {% for proposal in ep_proposals.approved_waiting_execution %}
+          {{ proposal_card(proposal) }}
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      {% if ep_proposals.deferred %}
+      <div class="runtime-subtitle">deferred / parked</div>
+      <div class="thread-console-list">
+        {% for proposal in ep_proposals.deferred %}
+          {{ proposal_card(proposal) }}
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      {% if ep_proposals.recently_decided %}
+      <div class="runtime-subtitle">decided recently</div>
+      <div class="thread-console-list">
+        {% for proposal in ep_proposals.recently_decided %}
+          {{ proposal_card(proposal) }}
+        {% endfor %}
+      </div>
       {% endif %}
 
       <div class="runtime-subtitle">recent decisions</div>

--- a/blog/templates/proposal_detail.html
+++ b/blog/templates/proposal_detail.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ proposal.title }} — edge_of_chaos</title>
+<link rel="icon" type="image/png" href="/static/avatar.png">
+<link rel="stylesheet" href="/static/style.css">
+<style>
+  .proposal-page { max-width: 940px; margin: 0 auto; padding: 1rem; }
+  .proposal-header { margin-bottom: 1.5rem; }
+  .proposal-title { font-size: 1.45rem; margin: 0 0 .6rem; color: #e2e8f0; }
+  .proposal-meta { display: flex; gap: .8rem; flex-wrap: wrap; font-size: .82rem; color: #a0aec0; margin-bottom: .8rem; }
+  .proposal-meta span { background: #2d3748; padding: .15rem .5rem; border-radius: 4px; }
+  .proposal-back { color: #63b3ed; text-decoration: none; font-size: .9rem; }
+  .proposal-back:hover { text-decoration: underline; }
+  .proposal-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+  .proposal-card { background: #2d3748; border: 1px solid #4a5568; border-radius: 6px; padding: .9rem 1rem; }
+  .proposal-card h2 { margin: 0 0 .7rem; font-size: 1rem; color: #e2e8f0; }
+  .proposal-line { display: flex; gap: .5rem; margin-bottom: .45rem; font-size: .9rem; color: #cbd5e0; }
+  .proposal-line strong { min-width: 115px; color: #a0aec0; font-size: .75rem; text-transform: uppercase; letter-spacing: .04em; }
+  .proposal-flags { display: flex; gap: .35rem; flex-wrap: wrap; margin-top: .7rem; }
+  .timeline { list-style: none; padding: 0; }
+  .timeline li { background: #2d3748; border-radius: 4px; padding: .7rem .8rem; margin-bottom: .45rem; border-left: 3px solid #4a5568; }
+  .timeline-head { display: flex; justify-content: space-between; gap: .5rem; flex-wrap: wrap; margin-bottom: .25rem; }
+  .timeline-meta { font-size: .82rem; color: #a0aec0; }
+  .link-list { list-style: none; padding: 0; }
+  .link-list li { margin-bottom: .35rem; }
+  .link-list a, .proposal-link { color: #63b3ed; text-decoration: none; }
+  .link-list a:hover, .proposal-link:hover { text-decoration: underline; }
+  .empty { color: #718096; font-style: italic; font-size: .9rem; }
+</style>
+</head>
+<body style="background:#1a202c;color:#e2e8f0;">
+<div class="proposal-page">
+  <a href="/dashboard" class="proposal-back">&larr; dashboard</a>
+
+  <div class="proposal-header">
+    <h1 class="proposal-title">{{ proposal.title }}</h1>
+    <div class="proposal-meta">
+      <span>{{ proposal.status_label }}</span>
+      <span>{{ proposal.type }}</span>
+      <span>{{ proposal.evidence_count }} evidence</span>
+      <span>{{ proposal.linked_claims_count }} claims</span>
+      <span>{{ proposal.linked_threads_count }} threads</span>
+      {% if proposal.cost %}<span>cost: {{ proposal.cost }}</span>{% endif %}
+      {% if proposal.updated_short %}<span>updated: {{ proposal.updated_short }}</span>{% endif %}
+    </div>
+    {% if proposal.rationale %}
+    <p style="color:#a0aec0;margin:.5rem 0 0;"><strong>Why:</strong> {{ proposal.rationale }}</p>
+    {% endif %}
+  </div>
+
+  <div class="proposal-grid">
+    <div class="proposal-card">
+      <h2>Proposal Snapshot</h2>
+      <div class="proposal-line"><strong>status</strong><span>{{ proposal.status_label }}</span></div>
+      {% if proposal.action_text %}
+      <div class="proposal-line"><strong>next</strong><span>{{ proposal.action_text }}</span></div>
+      {% endif %}
+      {% if proposal.impact %}
+      <div class="proposal-line"><strong>impact</strong><span>{{ proposal.impact }}</span></div>
+      {% endif %}
+      {% if proposal.risk %}
+      <div class="proposal-line"><strong>risk</strong><span>{{ proposal.risk }}</span></div>
+      {% endif %}
+      <div class="proposal-line"><strong>surfaces</strong><span>{{ proposal.linked_claims_count }} claims · {{ proposal.linked_threads_count }} threads · {{ proposal.reports_count }} reports</span></div>
+      {% if proposal.flags %}
+      <div class="proposal-flags">
+        {% for flag in proposal.flags %}
+        <span class="thread-flag thread-flag-{{ flag.kind }}" title="{{ flag.detail }}">{{ flag.label }}</span>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+
+    <div class="proposal-card">
+      <h2>Linked Surfaces</h2>
+      {% if proposal.linked_threads %}
+      <ul class="link-list">
+        {% for item in proposal.linked_threads %}
+        <li><a href="{{ item.href }}">{{ item.title }}</a>{% if item.status %} · {{ item.status }}{% endif %}</li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="empty">No linked threads.</p>
+      {% endif %}
+
+      {% if proposal.linked_claims %}
+      <ul class="link-list">
+        {% for item in proposal.linked_claims %}
+        <li><a href="{{ item.href }}">{{ item.text }}</a>{% if item.kind %} · {{ item.kind }}{% endif %}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+  </div>
+
+  {% if proposal.queued_steering_items %}
+  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Queued Steering</h2>
+  <ul class="timeline">
+    {% for item in proposal.queued_steering_items %}
+    <li>
+      <div class="timeline-head">
+        <strong>{{ item.action }}</strong>
+        <span class="timeline-meta">{{ item.ts_short }}</span>
+      </div>
+      <div class="timeline-meta">{{ item.reason }}{% if item.value %} · {{ item.value }}{% endif %}</div>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+  {% if proposal.operator_actions %}
+  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Decision History</h2>
+  <ul class="timeline">
+    {% for item in proposal.operator_actions %}
+    <li>
+      <div class="timeline-head">
+        <strong>{{ item.display_action }}</strong>
+        <span class="timeline-meta">{{ item.ts_short }}</span>
+      </div>
+      <div class="timeline-meta">{{ item.reason }}{% if item.resulting_state %} · {{ item.resulting_state }}{% endif %}</div>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Evidence</h2>
+  {% if proposal.evidence_links %}
+  <ul class="timeline">
+    {% for item in proposal.evidence_links %}
+    <li>
+      <div class="timeline-head">
+        <strong>{% if item.href %}<a class="proposal-link" href="{{ item.href }}">{{ item.label }}</a>{% else %}{{ item.label }}{% endif %}</strong>
+        <span class="timeline-meta">{{ item.kind }}</span>
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p class="empty">No evidence linked yet.</p>
+  {% endif %}
+
+  {% if proposal.decision_log %}
+  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Decision Log Matches</h2>
+  <ul class="timeline">
+    {% for item in proposal.decision_log %}
+    <li><div class="timeline-meta">{{ item }}</div></li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</div>
+</body>
+</html>

--- a/tests/test_dashboard_proposals.sh
+++ b/tests/test_dashboard_proposals.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VENV_PY="${EDGE_BLOG_VENV:-$EDGE_DIR/blog/.venv/bin/python3}"
+if [ ! -x "$VENV_PY" ]; then
+    echo "Missing blog venv python: $VENV_PY" >&2
+    echo "Set EDGE_BLOG_VENV=/path/to/blog/.venv/bin/python3 when running from a clean worktree." >&2
+    exit 2
+fi
+
+TMP_BASE="$(mktemp -d /tmp/edge-dashboard-proposals-XXXXXX)"
+TMP_STATE="$TMP_BASE/state-root"
+TMP_HOME="$TMP_BASE/home"
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p \
+    "$TMP_STATE/blog/entries" \
+    "$TMP_STATE/threads" \
+    "$TMP_STATE/reports" \
+    "$TMP_STATE/logs" \
+    "$TMP_STATE/state/signals" \
+    "$TMP_STATE/search" \
+    "$TMP_HOME/.claude/projects/test-project/memory/topics"
+
+cat >"$TMP_HOME/.claude/projects/test-project/memory/topics/dispatch.md" <<'MD'
+# Dispatch transparency
+MD
+
+cat >"$TMP_STATE/blog/entries/2026-04-20-dispatch.md" <<'MD'
+---
+title: "Dispatch evidence review"
+date: "2026-04-20"
+claims:
+  - "Dispatch cycles need explicit close evidence"
+threads:
+  - runtime-transparency
+report: dispatch-evidence.html
+---
+body
+MD
+
+cat >"$TMP_STATE/blog/entries/2026-04-20-gap.md" <<'MD'
+---
+title: "Gap tracking note"
+date: "2026-04-20"
+claims:
+  - "!Pre-skill is still not instrumented"
+threads:
+  - runtime-transparency
+---
+body
+MD
+
+cat >"$TMP_STATE/threads/runtime-transparency.md" <<'MD'
+---
+id: runtime-transparency
+title: "Runtime transparency"
+status: active
+owner: ed
+goal: "Expose dispatch and evidence state to the operator"
+---
+## Next
+Ship the runtime dashboard section.
+MD
+
+cat >"$TMP_STATE/reports/dispatch-evidence.html" <<'HTML'
+<html><body>report</body></html>
+HTML
+
+cat >"$TMP_STATE/state/proposals.json" <<'JSON'
+[
+  {
+    "id": "prop-1",
+    "title": "Surface lineage in dashboard",
+    "type": "execution",
+    "status": "active",
+    "created": "2026-04-20T20:00:00+00:00",
+    "updated": "2026-04-20T20:10:00+00:00",
+    "hypothesis": "Operators need decision-ready proposals instead of a flat ideas list.",
+    "action": "Put lineage and downstream state next to the proposal itself.",
+    "impact": "Cuts decision latency in the dashboard.",
+    "risk": "Could surface weak evidence too aggressively.",
+    "evidence": ["Dispatch evidence review", "Dispatch cycles need explicit close evidence"],
+    "cost": "medium"
+  },
+  {
+    "id": "prop-2",
+    "title": "Promote claim gap tracker",
+    "type": "experiment",
+    "status": "active",
+    "created": "2026-04-20T20:05:00+00:00",
+    "updated": "2026-04-20T20:12:00+00:00",
+    "hypothesis": "Gap claims should ask for revision instead of silently aging.",
+    "action": "Turn gap claims into revision queues.",
+    "evidence": ["Pre-skill is still not instrumented"],
+    "cost": "low"
+  },
+  {
+    "id": "prop-3",
+    "title": "Queue operator-visible evidence",
+    "type": "execution",
+    "status": "approved",
+    "created": "2026-04-19T12:00:00+00:00",
+    "updated": "2026-04-20T19:00:00+00:00",
+    "evidence": ["Dispatch evidence review"],
+    "cost": "low"
+  },
+  {
+    "id": "prop-4",
+    "title": "Archive old workflow board",
+    "type": "execution",
+    "status": "deferred",
+    "created": "2026-04-18T12:00:00+00:00",
+    "updated": "2026-04-18T13:00:00+00:00",
+    "evidence": []
+  }
+]
+JSON
+
+cat >"$TMP_STATE/state/signals/decision.md" <<'MD'
+- Approved dashboard lineage slice
+- Deferred workflow board cleanup
+MD
+
+HOME="$TMP_HOME" MEMORY_PROJECT_DIR="test-project" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$VENV_PY" - <<'PY'
+import os
+import sys
+
+edge_dir = os.environ["EDGE_REPO_DIR"]
+sys.path.insert(0, edge_dir)
+sys.path.insert(0, os.path.join(edge_dir, "blog"))
+os.chdir(os.path.join(edge_dir, "blog"))
+
+from app import app
+
+client = app.test_client()
+
+resp = client.get("/api/dashboard/epistemics")
+assert resp.status_code == 200, resp.status_code
+data = resp.get_json()
+proposals = data["ep_proposals"]
+
+assert proposals["total"] == 4
+assert proposals["needs_decision_count"] == 2
+assert proposals["approved_waiting_count"] == 1
+assert proposals["deferred_count"] == 1
+assert proposals["low_evidence_count"] == 3
+
+prop_1 = next(item for item in proposals["needs_decision"] if item["id"] == "prop-1")
+assert prop_1["linked_claims_count"] >= 1
+assert prop_1["linked_threads_count"] >= 1
+
+revision = client.post(
+    "/api/steering/proposal/prop-2/action",
+    json={
+        "action": "request-revision",
+        "reason": "the evidence is still too thin for a direct approval",
+        "label": "Promote claim gap tracker",
+        "reference": "Pre-skill is still not instrumented",
+    },
+)
+assert revision.status_code == 200, revision.status_code
+assert revision.get_json()["queued"] is True
+
+resp = client.get("/api/dashboard/epistemics")
+assert resp.status_code == 200, resp.status_code
+data = resp.get_json()
+proposals = data["ep_proposals"]
+assert proposals["needs_revision_count"] == 1
+assert proposals["queued_count"] == 1
+
+detail = client.get("/proposal/prop-2")
+assert detail.status_code == 200, detail.status_code
+detail_html = detail.get_data(as_text=True)
+assert "Proposal Snapshot" in detail_html
+assert "Queued Steering" in detail_html
+assert "Pre-skill is still not instrumented" in detail_html
+
+partial = client.get("/partials/epistemics")
+assert partial.status_code == 200, partial.status_code
+text = partial.get_data(as_text=True)
+assert "proposals console" in text
+assert "needs decision" in text
+assert "needs revision" in text
+assert "approved / waiting execution" in text
+assert "deferred / parked" in text
+assert "Surface lineage in dashboard" in text
+assert "Queue operator-visible evidence" in text
+print("ok")
+PY


### PR DESCRIPTION
## What changed
- turn the proposals area in the epistemics dashboard into a decision console with explicit lanes for `needs decision`, `needs revision`, `approved / waiting execution`, `deferred / parked`, and `decided recently`
- enrich the proposals read model with linked claims, linked threads, evidence rollups, flags, queued steering state, and recent operator actions
- add `/proposal/<id>` and `/api/proposals/<id>/detail` so each proposal has an auditable detail surface
- add coverage for the new proposals console in `tests/test_dashboard_proposals.sh`

## Why
The previous proposals surface only listed active items and recent decisions. It did not tell the operator what required a decision now, what was low-evidence, what was already queued, or what downstream surfaces were linked.

## Impact
- the dashboard now supports proposal triage as a first-class operational surface
- queued steering and recent decisions are visible at the proposal level
- operators can inspect proposal evidence and lineage without leaving the dashboard flow

## Validation
- `python3 -m py_compile blog/app.py blog/api_dashboard.py blog/services.py`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_proposals.sh`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_epistemics.sh`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_steering.sh`
- `git diff --check`