### PR TITLE
[codex] improve dashboard navigation and claim context

### DIFF
--- a/blog/app.py
+++ b/blog/app.py
@@ -1412,40 +1412,53 @@ def get_health_data(entries):
 @app.route("/dashboard/")
 def dashboard_page():
     """Operational dashboard — 30-second health check for operator."""
-    entries = get_entries()
-    health = get_health_data(entries)
-    knowledge_clusters = load_knowledge_clusters()
-    kc_summary = [{k: v for k, v in c.items() if k != "content"} for c in knowledge_clusters]
+    dashboard_sections = [
+        {"id": "overview", "label": "overview"},
+        {"id": "runtime", "label": "runtime"},
+        {"id": "work", "label": "work"},
+        {"id": "epistemics", "label": "epistemics"},
+        {"id": "threads", "label": "threads"},
+        {"id": "knowledge", "label": "knowledge"},
+    ]
+    section_lookup = {item["id"]: item["label"] for item in dashboard_sections}
+    dashboard_section = str(request.args.get("section") or "overview").strip().lower()
+    if dashboard_section not in section_lookup:
+        dashboard_section = "overview"
 
     status_strip = _build_status_strip_data()
-    alerts = _build_alerts_data()
-    pipeline = _build_pipeline_data()
-    hotspots_data = _build_hotspots_data()
-    corpus_data = _build_corpus_data()
-    briefing_data = _build_briefing_data()
-    epistemic_data = _build_epistemic_data()
-    interventions_data = _build_interventions_data()
-    runtime_data = _build_runtime_data()
-    threads_data = _build_threads_data()
+    dashboard_context = {}
+
+    if dashboard_section == "overview":
+        dashboard_context["alerts"] = _build_alerts_data()
+        dashboard_context.update(_build_pipeline_data())
+        dashboard_context.update(_build_hotspots_data())
+        dashboard_context.update(_build_corpus_data())
+        dashboard_context.update(_build_briefing_data())
+    elif dashboard_section == "runtime":
+        dashboard_context.update(_build_runtime_data())
+    elif dashboard_section == "work":
+        dashboard_context.update(_build_interventions_data())
+    elif dashboard_section == "epistemics":
+        dashboard_context.update(_build_epistemic_data())
+    elif dashboard_section == "threads":
+        dashboard_context.update(_build_threads_data())
+    elif dashboard_section == "knowledge":
+        knowledge_clusters = load_knowledge_clusters()
+        dashboard_context["knowledge_clusters"] = [
+            {k: v for k, v in item.items() if k != "content"}
+            for item in knowledge_clusters
+        ]
 
     return render_template(
         "dashboard.html",
         tab="dashboard",
-        page_title="edge_of_chaos — dashboard",
-        header_sub="dashboard",
+        page_title=f"edge_of_chaos — dashboard / {section_lookup[dashboard_section]}",
+        header_sub=f"dashboard / {section_lookup[dashboard_section]}",
         stats=get_stats_data(),
-        health=health,
-        knowledge_clusters=kc_summary,
-        alerts=alerts,
+        dashboard_sections=dashboard_sections,
+        dashboard_section=dashboard_section,
         **status_strip,
-        **pipeline,
-        **hotspots_data,
-        **corpus_data,
-        **briefing_data,
-        **epistemic_data,
-        **interventions_data,
-        **runtime_data,
-        **threads_data,
+        **dashboard_context,
     )
 
 

--- a/blog/services.py
+++ b/blog/services.py
@@ -1019,6 +1019,120 @@ def _entry_records():
 
 
 CLAIM_STALE_DAYS = 14
+CLAIM_ACTION_COPY = {
+    "promote": {
+        "label": "Turn into proposal",
+        "detail": "Escalate this claim into explicit work for the next dispatch.",
+    },
+    "verified": {
+        "label": "Mark supported",
+        "detail": "Treat the claim as sufficiently supported by current evidence.",
+    },
+    "disputed": {
+        "label": "Mark contested",
+        "detail": "Keep the claim explicitly contested until evidence improves.",
+    },
+    "stale": {
+        "label": "Needs fresh evidence",
+        "detail": "Ask the next dispatch to refresh or strengthen the evidence.",
+    },
+}
+
+
+def _claim_action_copy(action):
+    action = str(action or "").strip().lower()
+    meta = CLAIM_ACTION_COPY.get(action)
+    if meta:
+        return dict(meta)
+    label = action.replace("-", " ").strip() or "take action"
+    return {
+        "label": label.capitalize(),
+        "detail": "Queue a steering action for the next dispatch.",
+    }
+
+
+def _decorate_claim_action(item, action_key):
+    if not item:
+        return None
+    meta = _claim_action_copy(action_key)
+    return {
+        **item,
+        "action_label": meta["label"],
+        "action_detail": meta["detail"],
+    }
+
+
+def _claim_evidence_strength(support_count, reports_count, single_source):
+    if support_count >= 3 or (support_count >= 2 and reports_count >= 1):
+        return {
+            "label": "grounded",
+            "detail": "Multiple artifacts and at least some published evidence support this claim.",
+        }
+    if support_count >= 2 or reports_count >= 1:
+        return {
+            "label": "moderate",
+            "detail": "There is more than one signal, but the support still has visible gaps.",
+        }
+    if single_source:
+        return {
+            "label": "thin",
+            "detail": "This claim currently hangs on a single artifact.",
+        }
+    return {
+        "label": "unknown",
+        "detail": "No reliable support strength could be derived.",
+    }
+
+
+def _claim_linked_work_summary(thread_links):
+    if not thread_links:
+        return "No linked thread yet."
+    titles = [item["title"] for item in thread_links[:2]]
+    summary = ", ".join(titles)
+    remaining = len(thread_links) - len(titles)
+    if remaining > 0:
+        summary += f" +{remaining} more"
+    return summary
+
+
+def _claim_why_now(kind, no_thread, no_report, stale, stale_days):
+    reasons = []
+    if kind == "gap":
+        reasons.append("This claim is still an open evidence gap.")
+    if no_thread:
+        reasons.append("No thread currently owns it.")
+    if no_report:
+        reasons.append("There is no published report backing it yet.")
+    if stale:
+        days = stale_days if stale_days is not None else "?"
+        reasons.append(f"The latest evidence is {days}d old.")
+    if reasons:
+        return " ".join(reasons)
+    return "This claim is supported, linked, and not asking for immediate intervention."
+
+
+def _claim_recommended_action(kind, no_thread, no_report, stale, single_source, queued_steering):
+    if queued_steering:
+        return None
+    if no_thread:
+        return {
+            "action": "promote",
+            "label": CLAIM_ACTION_COPY["promote"]["label"],
+            "reason": "No continuity surface owns this claim yet, so it should become explicit work.",
+        }
+    if kind == "gap":
+        return {
+            "action": "disputed",
+            "label": CLAIM_ACTION_COPY["disputed"]["label"],
+            "reason": "Keep it explicitly contested until the supporting evidence becomes stronger.",
+        }
+    if stale or no_report or single_source:
+        return {
+            "action": "stale",
+            "label": CLAIM_ACTION_COPY["stale"]["label"],
+            "reason": "The evidence is too thin, too old, or insufficiently published to leave untouched.",
+        }
+    return None
 
 
 def _build_claim_operator_action_index(limit_per_claim=6):
@@ -1031,7 +1145,7 @@ def _build_claim_operator_action_index(limit_per_claim=6):
             continue
         bucket = rollup.setdefault(claim_id, [])
         if len(bucket) < limit_per_claim:
-            bucket.append(item)
+            bucket.append(_decorate_claim_action(item, item.get("display_action")))
     return rollup
 
 
@@ -1045,7 +1159,7 @@ def _build_claim_queued_intent_index(limit_per_claim=6):
             continue
         bucket = rollup.setdefault(claim_id, [])
         if len(bucket) < limit_per_claim:
-            bucket.append(item)
+            bucket.append(_decorate_claim_action(item, item.get("action")))
     return rollup
 
 
@@ -1081,6 +1195,10 @@ def _claim_records():
     claims = {}
     operator_index = _build_claim_operator_action_index()
     queued_index = _build_claim_queued_intent_index()
+    thread_index = {
+        item["id"]: item
+        for item in load_threads_enriched().get("threads", [])
+    }
     today = date.today()
 
     for item in _claim_occurrence_records():
@@ -1121,6 +1239,21 @@ def _claim_records():
         no_thread = len(bucket["threads"]) == 0
         no_report = len(bucket["report_files"]) == 0
         single_source = len(bucket["artifact_files"]) == 1
+        reports_count = len(bucket["report_files"])
+        thread_links = [
+            {
+                "id": tid,
+                "title": thread_index.get(tid, {}).get("title", tid),
+                "status": thread_index.get(tid, {}).get("status"),
+                "href": f"/thread/{tid}",
+            }
+            for tid in sorted(bucket["threads"])
+        ]
+        evidence_strength = _claim_evidence_strength(
+            support_count=len(bucket["artifact_files"]),
+            reports_count=reports_count,
+            single_source=single_source,
+        )
         flags = []
         attention_score = 0
         if kind == "gap":
@@ -1141,17 +1274,48 @@ def _claim_records():
 
         recent_operator_action = (operator_index.get(claim_id) or [None])[0]
         queued_steering = (queued_index.get(claim_id) or [None])[0]
+        why_now = _claim_why_now(
+            kind=kind,
+            no_thread=no_thread,
+            no_report=no_report,
+            stale=stale,
+            stale_days=stale_days,
+        )
+        best_evidence = {
+            "label": latest.get("artifact_title") if latest else None,
+            "href": latest.get("artifact_href") if latest else None,
+            "date_short": _short_ts(latest.get("date")) if latest else "",
+            "report": latest.get("report") if latest else None,
+        } if latest else None
+        recommended_action = _claim_recommended_action(
+            kind=kind,
+            no_thread=no_thread,
+            no_report=no_report,
+            stale=stale,
+            single_source=single_source,
+            queued_steering=queued_steering,
+        )
+        support_summary_parts = [
+            f"{len(bucket['artifact_files'])} artifact{'s' if len(bucket['artifact_files']) != 1 else ''}",
+            f"{reports_count} report{'s' if reports_count != 1 else ''}",
+        ]
+        if thread_links:
+            support_summary_parts.append(_claim_linked_work_summary(thread_links))
+        else:
+            support_summary_parts.append("no linked thread")
 
         records.append({
             "claim_id": claim_id,
             "text": bucket["text"],
             "kind": kind,
             "kind_color": kind_color,
+            "judgment_label": "needs support" if kind == "gap" else "supported",
             "verified_occurrences": bucket["verified_occurrences"],
             "gap_occurrences": bucket["gap_occurrences"],
             "support_count": len(bucket["artifact_files"]),
-            "reports_count": len(bucket["report_files"]),
+            "reports_count": reports_count,
             "threads": sorted(bucket["threads"]),
+            "thread_links": thread_links,
             "reference": latest.get("artifact_filename") if latest else None,
             "artifact_title": latest.get("artifact_title") if latest else None,
             "artifact_filename": latest.get("artifact_filename") if latest else None,
@@ -1163,6 +1327,13 @@ def _claim_records():
             "latest_artifact_href": latest.get("artifact_href") if latest else None,
             "latest_artifact_filename": latest.get("artifact_filename") if latest else None,
             "latest_report": latest.get("report") if latest else None,
+            "best_evidence": best_evidence,
+            "why_now": why_now,
+            "support_summary": " · ".join(support_summary_parts),
+            "linked_work_summary": _claim_linked_work_summary(thread_links),
+            "evidence_strength_label": evidence_strength["label"],
+            "evidence_strength_detail": evidence_strength["detail"],
+            "recommended_action": recommended_action,
             "flags": flags,
             "no_thread": no_thread,
             "no_report": no_report,
@@ -1249,7 +1420,7 @@ def load_claim_detail(claim_id):
         **{key: value for key, value in claim.items() if key != "occurrences"},
         "occurrences": occurrences,
         "reports": reports,
-        "thread_links": [
+        "thread_links": claim.get("thread_links") or [
             {
                 "id": tid,
                 "title": thread_index.get(tid, {}).get("title", tid),

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -1321,6 +1321,38 @@
     gap: 1.5rem;
   }
 
+  .dashboard-subnav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.35rem 0 0.1rem 0;
+  }
+
+  .dashboard-subtab {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    text-decoration: none;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    border-radius: 999px;
+    padding: 0.28rem 0.7rem;
+    transition: border-color 0.15s, color 0.15s, background 0.15s;
+  }
+
+  .dashboard-subtab:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .dashboard-subtab.active {
+    color: var(--text);
+    border-color: var(--accent);
+    background: rgba(99, 179, 237, 0.12);
+  }
+
   .dash-health {
     display: flex;
     flex-wrap: wrap;
@@ -2278,6 +2310,7 @@
   .dash-task-actions {
     display: flex;
     gap: 0.3rem;
+    flex-wrap: wrap;
     margin-top: 0.3rem;
     padding-top: 0.3rem;
     border-top: 1px solid var(--border);

--- a/blog/templates/claim_detail.html
+++ b/blog/templates/claim_detail.html
@@ -38,25 +38,39 @@
   <div class="claim-header">
     <h1 class="claim-title">{{ claim.text }}</h1>
     <div class="claim-meta">
-      <span>{{ claim.kind }}</span>
+      <span>{{ claim.judgment_label }}</span>
+      <span>{{ claim.evidence_strength_label }}</span>
       <span>{{ claim.support_count }} artifacts</span>
       <span>{{ claim.reports_count }} reports</span>
       <span>{{ claim.verified_occurrences }} verified</span>
       <span>{{ claim.gap_occurrences }} gap</span>
       {% if claim.date_short %}<span>last seen: {{ claim.date_short }}</span>{% endif %}
     </div>
+    <p style="color:#a0aec0;margin:.5rem 0 0;"><strong>Why this is here:</strong> {{ claim.why_now }}</p>
   </div>
 
   <div class="claim-grid">
     <div class="claim-card">
-      <h2>Claim Snapshot</h2>
-      <div class="claim-line"><strong>status</strong><span>{{ claim.kind }}</span></div>
-      <div class="claim-line"><strong>support</strong><span>{{ claim.support_count }} supporting artifacts</span></div>
-      <div class="claim-line"><strong>threads</strong><span>{{ claim.threads|length }}</span></div>
-      <div class="claim-line"><strong>reports</strong><span>{{ claim.reports_count }}</span></div>
-      {% if claim.latest_artifact_href %}
-      <div class="claim-line"><strong>latest artifact</strong><span><a class="artifact-link" href="{{ claim.latest_artifact_href }}">{{ claim.latest_artifact_title }}</a></span></div>
+      <h2>Current Judgment</h2>
+      <div class="claim-line"><strong>status</strong><span>{{ claim.judgment_label }}</span></div>
+      <div class="claim-line"><strong>support</strong><span>{{ claim.support_summary }}</span></div>
+      <div class="claim-line"><strong>strength</strong><span>{{ claim.evidence_strength_label }} · {{ claim.evidence_strength_detail }}</span></div>
+      {% if claim.best_evidence and claim.best_evidence.href %}
+      <div class="claim-line"><strong>best evidence</strong><span><a class="artifact-link" href="{{ claim.best_evidence.href }}">{{ claim.best_evidence.label }}</a>{% if claim.best_evidence.date_short %} · {{ claim.best_evidence.date_short }}{% endif %}</span></div>
+      {% elif claim.best_evidence and claim.best_evidence.label %}
+      <div class="claim-line"><strong>best evidence</strong><span>{{ claim.best_evidence.label }}{% if claim.best_evidence.date_short %} · {{ claim.best_evidence.date_short }}{% endif %}</span></div>
       {% endif %}
+      <div class="claim-line"><strong>linked work</strong><span>{{ claim.linked_work_summary }}</span></div>
+      <div class="claim-line">
+        <strong>next action</strong>
+        <span>
+          {% if claim.recommended_action %}
+          {{ claim.recommended_action.label }} · {{ claim.recommended_action.reason }}
+          {% else %}
+          no immediate action needed
+          {% endif %}
+        </span>
+      </div>
       {% if claim.flags %}
       <div class="claim-flags">
         {% for flag in claim.flags %}
@@ -67,7 +81,7 @@
     </div>
 
     <div class="claim-card">
-      <h2>Threads & Reports</h2>
+      <h2>Linked Work & Reports</h2>
       {% if claim.thread_links %}
       <ul class="thread-list">
         {% for item in claim.thread_links %}
@@ -91,16 +105,22 @@
         {% endfor %}
       </ul>
       {% endif %}
+
+      {% if claim.queued_steering %}
+      <div class="claim-line"><strong>queued</strong><span>{{ claim.queued_steering[0].action_label }}{% if claim.queued_steering[0].reason %} · {{ claim.queued_steering[0].reason }}{% endif %}</span></div>
+      {% elif claim.operator_actions %}
+      <div class="claim-line"><strong>last decision</strong><span>{{ claim.operator_actions[0].action_label }}{% if claim.operator_actions[0].reason %} · {{ claim.operator_actions[0].reason }}{% endif %}</span></div>
+      {% endif %}
     </div>
   </div>
 
   {% if claim.queued_steering %}
-  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Queued Steering</h2>
+  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Queued Decision</h2>
   <ul class="timeline">
     {% for item in claim.queued_steering %}
     <li>
       <div class="timeline-head">
-        <strong>{{ item.action }}</strong>
+        <strong>{{ item.action_label }}</strong>
         <span class="timeline-meta">{{ item.ts_short }}</span>
       </div>
       <div class="timeline-meta">{{ item.reason }}{% if item.value %} · {{ item.value }}{% endif %}</div>
@@ -110,12 +130,12 @@
   {% endif %}
 
   {% if claim.operator_actions %}
-  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Steering History</h2>
+  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Decision History</h2>
   <ul class="timeline">
     {% for item in claim.operator_actions %}
     <li>
       <div class="timeline-head">
-        <strong>{{ item.display_action }}</strong>
+        <strong>{{ item.action_label }}</strong>
         <span class="timeline-meta">{{ item.ts_short }}</span>
       </div>
       <div class="timeline-meta">{{ item.reason }}{% if item.resulting_state %} · {{ item.resulting_state }}{% endif %}</div>
@@ -124,7 +144,7 @@
   </ul>
   {% endif %}
 
-  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Supporting Artifacts</h2>
+  <h2 style="font-size:1.05rem;color:#e2e8f0;margin:1.4rem 0 .7rem;">Evidence Timeline</h2>
   {% if claim.occurrences %}
   <ul class="timeline">
     {% for item in claim.occurrences %}

--- a/blog/templates/dashboard.html
+++ b/blog/templates/dashboard.html
@@ -2,80 +2,82 @@
 {% block content %}
 <div class="dashboard">
 
+  <div class="dashboard-subnav">
+    {% for item in dashboard_sections %}
+    <a class="dashboard-subtab {{ 'active' if dashboard_section == item.id }}" href="/dashboard?section={{ item.id }}">{{ item.label }}</a>
+    {% endfor %}
+  </div>
+
   <!-- Status Strip (auto-refreshes every 60s via HTMX) -->
   <div id="dashboard-status-strip" hx-get="/partials/status-strip" hx-trigger="every 60s" hx-swap="innerHTML">
     {% include 'partials/status_strip.html' %}
   </div>
 
-  <!-- Attention Panel (auto-refreshes every 120s via HTMX) -->
-  <div hx-get="/partials/alerts" hx-trigger="every 120s" hx-swap="innerHTML">
-    {% include 'partials/alerts.html' %}
-  </div>
+  {% if dashboard_section == 'overview' %}
+    <div hx-get="/partials/alerts" hx-trigger="every 120s" hx-swap="innerHTML">
+      {% include 'partials/alerts.html' %}
+    </div>
 
-  <!-- State Commit Pipeline (collapsible) -->
-  <div hx-get="/partials/pipeline" hx-trigger="every 120s" hx-swap="innerHTML">
-    {% include 'partials/pipeline.html' %}
-  </div>
+    <div hx-get="/partials/pipeline" hx-trigger="every 120s" hx-swap="innerHTML">
+      {% include 'partials/pipeline.html' %}
+    </div>
 
-  <!-- Runtime transparency (dispatch/evidence/primitives/autonomy) -->
-  <div id="dashboard-runtime" hx-get="/partials/runtime" hx-trigger="every 120s" hx-swap="innerHTML">
-    {% include 'partials/runtime.html' %}
-  </div>
+    <div hx-get="/partials/hotspots" hx-trigger="every 120s" hx-swap="innerHTML">
+      {% include 'partials/hotspots.html' %}
+    </div>
 
-  <!-- Task interventions + operator action feed -->
-  <div id="dashboard-interventions" hx-get="/partials/interventions" hx-trigger="every 120s" hx-swap="innerHTML">
-    {% include 'partials/interventions.html' %}
-  </div>
+    <div hx-get="/partials/corpus" hx-trigger="every 120s" hx-swap="innerHTML">
+      {% include 'partials/corpus.html' %}
+    </div>
 
-  <!-- Epistemic + steering (claims/strategy/proposals/lineage) -->
-  <div id="dashboard-epistemics" hx-get="/partials/epistemics" hx-trigger="every 120s" hx-swap="innerHTML">
-    {% include 'partials/epistemics.html' %}
-  </div>
+    <div hx-get="/partials/briefing" hx-trigger="every 300s" hx-swap="innerHTML">
+      {% include 'partials/briefing.html' %}
+    </div>
+  {% elif dashboard_section == 'runtime' %}
+    <div id="dashboard-runtime" hx-get="/partials/runtime" hx-trigger="every 120s" hx-swap="innerHTML">
+      {% include 'partials/runtime.html' %}
+    </div>
+  {% elif dashboard_section == 'work' %}
+    <div id="dashboard-interventions" hx-get="/partials/interventions" hx-trigger="every 120s" hx-swap="innerHTML">
+      {% include 'partials/interventions.html' %}
+    </div>
 
-  <!-- Operational Hotspots (collapsible) -->
-  <div hx-get="/partials/hotspots" hx-trigger="every 120s" hx-swap="innerHTML">
-    {% include 'partials/hotspots.html' %}
-  </div>
-
-  <!-- Corpus Health (collapsible) -->
-  <div hx-get="/partials/corpus" hx-trigger="every 120s" hx-swap="innerHTML">
-    {% include 'partials/corpus.html' %}
-  </div>
-
-  <!-- Daily Briefing (collapsible, collapsed by default) -->
-  <div hx-get="/partials/briefing" hx-trigger="every 300s" hx-swap="innerHTML">
-    {% include 'partials/briefing.html' %}
-  </div>
-
-  <!-- Threads (auto-refreshes every 120s via HTMX) -->
-  <div id="dashboard-threads" hx-get="/partials/threads" hx-trigger="every 120s" hx-swap="innerHTML">
-    {% include 'partials/threads.html' %}
-  </div>
-
-  <!-- Knowledge clusters -->
-  {% if knowledge_clusters %}
-  <div class="dash-section">
-    <h2 class="dash-section-title">knowledge clusters <a href="/knowledge" style="float:right;font-size:0.65rem;color:var(--accent);text-decoration:none">ver tudo &rarr;</a></h2>
-    <div class="dash-threads">
-      {% for c in knowledge_clusters %}
-      <div class="dash-thread">
-        <span class="dash-thread-status {{ 'status-active' if c.type == 'core' else ('status-waiting' if c.type == 'misses') }}">{{ c.type }}</span>
-        <span class="dash-thread-name">{{ c.name }}</span>
-        <span class="dash-thread-owner">{{ c.rules }}r</span>
+    <div class="dash-chat">
+      <div class="dash-chat-row">
+        <textarea class="dash-chat-input" id="dash-chat-input" rows="1" placeholder="message to agent..."></textarea>
+        <button class="action-btn action-send" onclick="sendDashChat()">send</button>
       </div>
-      {% endfor %}
+      <span class="dash-chat-confirm" id="dash-chat-confirm"></span>
     </div>
-  </div>
+  {% elif dashboard_section == 'epistemics' %}
+    <div id="dashboard-epistemics" hx-get="/partials/epistemics" hx-trigger="every 120s" hx-swap="innerHTML">
+      {% include 'partials/epistemics.html' %}
+    </div>
+  {% elif dashboard_section == 'threads' %}
+    <div id="dashboard-threads" hx-get="/partials/threads" hx-trigger="every 120s" hx-swap="innerHTML">
+      {% include 'partials/threads.html' %}
+    </div>
+  {% elif dashboard_section == 'knowledge' %}
+    {% if knowledge_clusters %}
+    <div class="dash-section">
+      <h2 class="dash-section-title">knowledge clusters <a href="/knowledge" style="float:right;font-size:0.65rem;color:var(--accent);text-decoration:none">ver tudo &rarr;</a></h2>
+      <div class="dash-threads">
+        {% for c in knowledge_clusters %}
+        <div class="dash-thread">
+          <span class="dash-thread-status {{ 'status-active' if c.type == 'core' else ('status-waiting' if c.type == 'misses') }}">{{ c.type }}</span>
+          <span class="dash-thread-name">{{ c.name }}</span>
+          <span class="dash-thread-owner">{{ c.rules }}r</span>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% else %}
+    <div class="dash-section">
+      <h2 class="dash-section-title">knowledge clusters</h2>
+      <div class="runtime-empty">no knowledge clusters indexed yet</div>
+    </div>
+    {% endif %}
   {% endif %}
-
-  <!-- Chat input -->
-  <div class="dash-chat">
-    <div class="dash-chat-row">
-      <textarea class="dash-chat-input" id="dash-chat-input" rows="1" placeholder="message to agent..."></textarea>
-      <button class="action-btn action-send" onclick="sendDashChat()">send</button>
-    </div>
-    <span class="dash-chat-confirm" id="dash-chat-confirm"></span>
-  </div>
 
 </div>
 
@@ -209,10 +211,11 @@ function taskAction(taskId, action, btn) {
   });
 }
 
-function steeringAction(targetType, targetId, action, label, reference, btn, valuePrompt) {
+function steeringAction(targetType, targetId, action, label, reference, btn, valuePrompt, actionLabel) {
   if (!targetType || !targetId || !action) return;
 
-  var reason = window.prompt('rationale for ' + action + ' on ' + label + '?');
+  var promptAction = actionLabel || action.replace(/-/g, ' ');
+  var reason = window.prompt('why "' + promptAction.toLowerCase() + '" for ' + label + '?');
   if (reason === null || !reason.trim()) return;
 
   var payload = {

--- a/blog/templates/partials/epistemics.html
+++ b/blog/templates/partials/epistemics.html
@@ -1,3 +1,94 @@
+{% macro claim_card(item, include_actions=true) %}
+<div class="thread-console-card{{ ' thread-console-card-attention' if item.needs_attention else '' }}">
+  <div class="thread-console-head">
+    <div class="thread-console-title-row">
+      <span class="runtime-pill runtime-pill-{{ item.kind_color }}">{{ item.judgment_label }}</span>
+      <a href="/claim/{{ item.claim_id }}" class="thread-console-title">{{ item.text }}</a>
+      <span class="thread-console-chip">{{ item.evidence_strength_label }}</span>
+    </div>
+    <div class="thread-console-meta-row">
+      {% if item.date_short %}<span>last seen {{ item.date_short }}</span>{% endif %}
+      <span>{{ item.support_count }} artifacts</span>
+      <span>{{ item.reports_count }} reports</span>
+    </div>
+  </div>
+
+  <div class="thread-console-summary-text">{{ item.why_now }}</div>
+
+  <div class="thread-console-grid">
+    <div class="thread-console-column">
+      <div class="thread-console-line">
+        <strong>best evidence</strong>
+        <span>
+          {% if item.best_evidence and item.best_evidence.href %}
+          <a href="{{ item.best_evidence.href }}">{{ item.best_evidence.label }}</a>
+          {% elif item.best_evidence and item.best_evidence.label %}
+          {{ item.best_evidence.label }}
+          {% else %}
+          none linked yet
+          {% endif %}
+          {% if item.best_evidence and item.best_evidence.date_short %} · {{ item.best_evidence.date_short }}{% endif %}
+          {% if item.latest_report %} · <a href="/reports/{{ item.latest_report }}">report</a>{% endif %}
+        </span>
+      </div>
+      <div class="thread-console-line">
+        <strong>linked work</strong>
+        <span>
+          {% if item.thread_links %}
+            {% for thread in item.thread_links[:2] %}
+              <a href="{{ thread.href }}">{{ thread.title }}</a>{% if not loop.last %}, {% endif %}
+            {% endfor %}
+            {% if item.thread_links|length > 2 %} +{{ item.thread_links|length - 2 }} more{% endif %}
+          {% else %}
+          no linked thread yet
+          {% endif %}
+        </span>
+      </div>
+    </div>
+
+    <div class="thread-console-column">
+      <div class="thread-console-line"><strong>support</strong><span>{{ item.support_summary }}</span></div>
+      <div class="thread-console-line">
+        <strong>next action</strong>
+        <span>
+          {% if item.recommended_action %}
+          {{ item.recommended_action.label }}
+          {% else %}
+          no immediate action needed
+          {% endif %}
+        </span>
+      </div>
+      {% if item.recommended_action %}
+      <div class="runtime-note">{{ item.recommended_action.reason }}</div>
+      {% endif %}
+    </div>
+  </div>
+
+  {% if item.flags %}
+  <div class="claim-card-flags">
+    {% for flag in item.flags %}
+    <span class="thread-flag thread-flag-{{ flag.kind }}" title="{{ flag.detail }}">{{ flag.label }}</span>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if item.queued_steering %}
+  <div class="runtime-note">Queued for next dispatch: {{ item.queued_steering.action_label }}{% if item.queued_steering.reason %} — {{ item.queued_steering.reason }}{% endif %}</div>
+  {% elif item.recent_operator_action %}
+  <div class="runtime-note">Last operator decision: {{ item.recent_operator_action.action_label }}{% if item.recent_operator_action.reason %} — {{ item.recent_operator_action.reason }}{% endif %}</div>
+  {% endif %}
+
+  {% if include_actions %}
+  <div class="dash-task-actions">
+    <button class="action-btn" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "promote", {{ item.text|tojson }}, {{ item.reference|tojson }}, this, null, "Turn into proposal")'>turn into proposal</button>
+    <button class="action-btn action-start" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "verified", {{ item.text|tojson }}, {{ item.reference|tojson }}, this, null, "Mark supported")'>mark supported</button>
+    <button class="action-btn action-blocked" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "disputed", {{ item.text|tojson }}, {{ item.reference|tojson }}, this, null, "Mark contested")'>mark contested</button>
+    <button class="action-btn" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "stale", {{ item.text|tojson }}, {{ item.reference|tojson }}, this, null, "Needs fresh evidence")'>needs fresh evidence</button>
+  </div>
+  {% endif %}
+</div>
+{% endmacro %}
+
 {% macro proposal_card(proposal) %}
 <div class="thread-console-card{{ ' thread-console-card-attention' if proposal.needs_attention else '' }}">
   <div class="thread-console-head">
@@ -120,44 +211,9 @@
       </div>
       {% if ep_claims.attention %}
       <div class="runtime-subtitle">needs attention</div>
-      <div class="runtime-list">
+      <div class="thread-console-list">
         {% for item in ep_claims.attention %}
-        <div class="runtime-list-item">
-          <div class="runtime-row">
-            <strong><a href="/claim/{{ item.claim_id }}" style="color:inherit">{{ item.text }}</a></strong>
-            <span class="runtime-pill runtime-pill-{{ item.kind_color }}">{{ item.kind }}</span>
-          </div>
-          <div class="runtime-meta">{{ item.support_count }} artifacts · {{ item.reports_count }} reports{% if item.date_short %} · {{ item.date_short }}{% endif %}</div>
-          <div class="runtime-meta">
-            {% if item.threads %}
-              {% for tid in item.threads %}
-                <a href="/thread/{{ tid }}" style="color:inherit">{{ tid }}</a>{% if not loop.last %}, {% endif %}
-              {% endfor %}
-            {% else %}
-              no thread
-            {% endif %}
-            {% if item.latest_artifact_href %} · <a href="{{ item.latest_artifact_href }}" style="color:inherit">{{ item.latest_artifact_title }}</a>{% endif %}
-            {% if item.latest_report %} · <a href="/reports/{{ item.latest_report }}" style="color:inherit">report</a>{% endif %}
-          </div>
-          {% if item.flags %}
-          <div class="claim-card-flags">
-            {% for flag in item.flags %}
-            <span class="thread-flag thread-flag-{{ flag.kind }}" title="{{ flag.detail }}">{{ flag.label }}</span>
-            {% endfor %}
-          </div>
-          {% endif %}
-          {% if item.queued_steering %}
-          <div class="runtime-note">queued: {{ item.queued_steering.action }} · {{ item.queued_steering.ts_short }}</div>
-          {% elif item.recent_operator_action %}
-          <div class="runtime-note">last steering: {{ item.recent_operator_action.display_action }} · {{ item.recent_operator_action.ts_short }}</div>
-          {% endif %}
-          <div class="dash-task-actions">
-            <button class="action-btn" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "promote", {{ item.text|tojson }}, {{ item.reference|tojson }}, this)'>promote</button>
-            <button class="action-btn action-start" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "verified", {{ item.text|tojson }}, {{ item.reference|tojson }}, this)'>verified</button>
-            <button class="action-btn action-blocked" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "disputed", {{ item.text|tojson }}, {{ item.reference|tojson }}, this)'>disputed</button>
-            <button class="action-btn" onclick='steeringAction("claim", {{ item.claim_id|tojson }}, "stale", {{ item.text|tojson }}, {{ item.reference|tojson }}, this)'>stale</button>
-          </div>
-        </div>
+          {{ claim_card(item, true) }}
         {% endfor %}
       </div>
       {% else %}
@@ -165,19 +221,10 @@
       {% endif %}
 
       {% if ep_claims.verified_recent %}
-      <div class="runtime-subtitle">stable recently</div>
-      <div class="runtime-list">
+      <div class="runtime-subtitle">supported and linked</div>
+      <div class="thread-console-list">
         {% for item in ep_claims.verified_recent %}
-        <div class="runtime-list-item">
-          <div class="runtime-row">
-            <strong><a href="/claim/{{ item.claim_id }}" style="color:inherit">{{ item.text }}</a></strong>
-            <span class="runtime-pill runtime-pill-{{ item.kind_color }}">{{ item.kind }}</span>
-          </div>
-          <div class="runtime-meta">{{ item.support_count }} artifacts · {{ item.reports_count }} reports{% if item.threads %} · {{ item.threads|join(', ') }}{% endif %}</div>
-          {% if item.latest_artifact_href %}
-          <div class="runtime-meta"><a href="{{ item.latest_artifact_href }}" style="color:inherit">{{ item.latest_artifact_title }}</a>{% if item.latest_report %} · <a href="/reports/{{ item.latest_report }}" style="color:inherit">report</a>{% endif %}</div>
-          {% endif %}
-        </div>
+          {{ claim_card(item, false) }}
         {% endfor %}
       </div>
       {% endif %}

--- a/tests/test_dashboard_claims.sh
+++ b/tests/test_dashboard_claims.sh
@@ -110,8 +110,9 @@ assert attention_claim["no_report"] is True
 detail = client.get(f"/claim/{attention_claim['claim_id']}")
 assert detail.status_code == 200, detail.status_code
 detail_html = detail.get_data(as_text=True)
-assert "Claim Snapshot" in detail_html
-assert "Supporting Artifacts" in detail_html
+assert "Current Judgment" in detail_html
+assert "Evidence Timeline" in detail_html
+assert "Why this is here" in detail_html
 assert "Queue close audit" in detail_html
 
 steer = client.post(
@@ -130,8 +131,10 @@ assert partial.status_code == 200, partial.status_code
 text = partial.get_data(as_text=True)
 assert "claims workbench" in text
 assert "needs attention" in text
-assert "stable recently" in text
+assert "supported and linked" in text
 assert "Operator notes should land in visible tasks" in text
-assert "queued: disputed" in text
+assert "Queued for next dispatch: Mark contested" in text
+assert "Turn into proposal" in text
+assert "Needs fresh evidence" in text
 print("ok")
 PY

--- a/tests/test_dashboard_submenu.sh
+++ b/tests/test_dashboard_submenu.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VENV_PY="${EDGE_BLOG_VENV:-$EDGE_DIR/blog/.venv/bin/python3}"
+if [ ! -x "$VENV_PY" ]; then
+    echo "Missing blog venv python: $VENV_PY" >&2
+    echo "Set EDGE_BLOG_VENV=/path/to/blog/.venv/bin/python3 when running from a clean worktree." >&2
+    exit 2
+fi
+
+TMP_BASE="$(mktemp -d /tmp/edge-dashboard-submenu-XXXXXX)"
+TMP_STATE="$TMP_BASE/state-root"
+TMP_HOME="$TMP_BASE/home"
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p \
+    "$TMP_STATE/blog/entries" \
+    "$TMP_STATE/state/signals" \
+    "$TMP_STATE/threads" \
+    "$TMP_STATE/reports" \
+    "$TMP_STATE/logs" \
+    "$TMP_STATE/search" \
+    "$TMP_HOME/.claude/projects/test-project/memory/topics"
+
+cat >"$TMP_STATE/blog/entries/2026-04-21-dashboard.md" <<'MD'
+---
+title: "Dashboard shakedown"
+date: "2026-04-21"
+claims:
+  - "Dashboard sections should load independently"
+threads:
+  - dashboard-split
+report: dashboard-shakedown.html
+---
+body
+MD
+
+cat >"$TMP_STATE/threads/dashboard-split.md" <<'MD'
+---
+id: dashboard-split
+title: "Dashboard split"
+status: active
+owner: ed
+goal: "Keep the dashboard readable and fast"
+---
+## Next
+Split the dashboard into focused sections.
+MD
+
+cat >"$TMP_STATE/reports/dashboard-shakedown.html" <<'HTML'
+<html><body>report</body></html>
+HTML
+
+cat >"$TMP_STATE/state/proposals.json" <<'JSON'
+[
+  {
+    "id": "prop-dashboard-split",
+    "title": "Split dashboard by section",
+    "type": "execution",
+    "status": "active",
+    "created": "2026-04-21T02:00:00+00:00",
+    "updated": "2026-04-21T02:05:00+00:00",
+    "evidence": ["Dashboard shakedown"]
+  }
+]
+JSON
+
+HOME="$TMP_HOME" MEMORY_PROJECT_DIR="test-project" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$VENV_PY" - <<'PY'
+import os
+import sys
+
+edge_dir = os.environ["EDGE_REPO_DIR"]
+sys.path.insert(0, edge_dir)
+sys.path.insert(0, os.path.join(edge_dir, "blog"))
+os.chdir(os.path.join(edge_dir, "blog"))
+
+from app import app
+
+client = app.test_client()
+
+overview = client.get("/dashboard")
+assert overview.status_code == 200, overview.status_code
+overview_html = overview.get_data(as_text=True)
+assert "dashboard-subnav" in overview_html
+assert 'hx-get="/partials/alerts"' in overview_html
+assert 'hx-get="/partials/pipeline"' in overview_html
+assert "proposals console" not in overview_html
+assert "task interventions" not in overview_html
+
+runtime = client.get("/dashboard?section=runtime")
+assert runtime.status_code == 200, runtime.status_code
+runtime_html = runtime.get_data(as_text=True)
+assert "runtime transparency" in runtime_html
+assert 'hx-get="/partials/alerts"' not in runtime_html
+
+work = client.get("/dashboard?section=work")
+assert work.status_code == 200, work.status_code
+work_html = work.get_data(as_text=True)
+assert "task interventions" in work_html
+assert "runtime transparency" not in work_html
+
+epistemics = client.get("/dashboard?section=epistemics")
+assert epistemics.status_code == 200, epistemics.status_code
+epistemics_html = epistemics.get_data(as_text=True)
+assert "epistemic & steering" in epistemics_html
+assert "proposals console" in epistemics_html
+assert "attention required" not in epistemics_html
+
+threads = client.get("/dashboard?section=threads")
+assert threads.status_code == 200, threads.status_code
+threads_html = threads.get_data(as_text=True)
+assert '<h2 class="dash-section-title">threads</h2>' in threads_html
+assert "proposals console" not in threads_html
+
+knowledge = client.get("/dashboard?section=knowledge")
+assert knowledge.status_code == 200, knowledge.status_code
+knowledge_html = knowledge.get_data(as_text=True)
+assert "knowledge clusters" in knowledge_html
+assert "epistemic & steering" not in knowledge_html
+
+fallback = client.get("/dashboard?section=unknown")
+assert fallback.status_code == 200, fallback.status_code
+fallback_html = fallback.get_data(as_text=True)
+assert 'hx-get="/partials/alerts"' in fallback_html
+print("ok")
+PY


### PR DESCRIPTION
## What changed
- split the dashboard into submenu sections so `/dashboard` stops rendering every panel at once
- improve claim cards and claim detail views with contextual summaries, best evidence, linked work, and human-readable next actions
- replace cryptic claim action labels with operator-facing language and add dashboard submenu test coverage

## Why
The dashboard had become too dense for one initial render, and the claims workbench exposed internal state without enough context for an operator to understand what each claim needed.

## Impact
- faster, clearer dashboard entry point with section navigation
- claims are easier to triage because each card explains why it appears, what evidence exists, and what action is recommended
- claim decision prompts and history read more like operator actions than raw internal flags

## Validation
- `python3 -m py_compile blog/app.py blog/services.py blog/api_dashboard.py`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_claims.sh`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_epistemics.sh`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_proposals.sh`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_submenu.sh`
- `EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_ops_console.sh`