### PR TITLE
[codex] fix blog-publish fallback when branding codename is missing

### DIFF
--- a/config/branding.py
+++ b/config/branding.py
@@ -28,6 +28,7 @@ _DEFAULTS = {
     },
     "edge_dir": "",
     "memory_project_dir": "",
+    "codename": "",
     "skill_prefix": "agent",
 }
 

--- a/config/branding.yaml.tpl
+++ b/config/branding.yaml.tpl
@@ -29,4 +29,5 @@ blog:
 # Paths
 edge_dir: ""  # empty = auto-detect from script location
 memory_project_dir: "{{MEMORY_PROJECT_DIR}}"
+codename: "{{CODENAME}}"  # optional at runtime; falls back to skill_prefix when omitted
 skill_prefix: "{{SKILL_PREFIX}}"

--- a/config/paths.sh
+++ b/config/paths.sh
@@ -13,15 +13,22 @@ EDGE_DIR="$EDGE_REPO_DIR"   # Legacy alias kept during migration.
 
 # --- Load branding.yaml from genotype root ---
 BRANDING_FILE="$EDGE_REPO_DIR/config/branding.yaml"
+
+branding_value() {
+  local pattern="$1"
+  local file="$2"
+  grep "$pattern" "$file" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"' || true
+}
+
 if [ -f "$BRANDING_FILE" ]; then
-  BLOG_PORT=$(grep '^  port:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}')
-  BLOG_AUTH_ENABLED=$(grep '^  auth_enabled:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}')
-  BLOG_AUTH_USER=$(grep '^  auth_user:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
-  BLOG_AUTH_PASS=$(grep '^  auth_pass:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
-  MEMORY_PROJECT_DIR=$(grep '^memory_project_dir:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
-  SKILL_PREFIX=$(grep '^skill_prefix:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
-  EDGE_INSTANCE_FROM_BRANDING=$(grep '^codename:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
-  EDGE_STATE_DIR_FROM_BRANDING=$(grep '^edge_state_dir:' "$BRANDING_FILE" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
+  BLOG_PORT=$(branding_value '^  port:' "$BRANDING_FILE")
+  BLOG_AUTH_ENABLED=$(branding_value '^  auth_enabled:' "$BRANDING_FILE")
+  BLOG_AUTH_USER=$(branding_value '^  auth_user:' "$BRANDING_FILE")
+  BLOG_AUTH_PASS=$(branding_value '^  auth_pass:' "$BRANDING_FILE")
+  MEMORY_PROJECT_DIR=$(branding_value '^memory_project_dir:' "$BRANDING_FILE")
+  SKILL_PREFIX=$(branding_value '^skill_prefix:' "$BRANDING_FILE")
+  EDGE_INSTANCE_FROM_BRANDING=$(branding_value '^codename:' "$BRANDING_FILE")
+  EDGE_STATE_DIR_FROM_BRANDING=$(branding_value '^edge_state_dir:' "$BRANDING_FILE")
 else
   BLOG_PORT=8766
   BLOG_AUTH_ENABLED=false
@@ -33,7 +40,7 @@ else
   EDGE_STATE_DIR_FROM_BRANDING=""
 fi
 
-EDGE_INSTANCE="${EDGE_INSTANCE:-${EDGE_CODENAME:-${EDGE_INSTANCE_FROM_BRANDING:-}}}"
+EDGE_INSTANCE="${EDGE_INSTANCE:-${EDGE_CODENAME:-${EDGE_INSTANCE_FROM_BRANDING:-${SKILL_PREFIX:-agent}}}}"
 EDGE_STATE_DIR="${EDGE_STATE_DIR:-${EDGE_STATE_DIR_FROM_BRANDING:-${EDGE_REPO_DIR}}}"
 EDGE_HOME="$EDGE_STATE_DIR"  # Legacy mutable-root alias used by some tools.
 
@@ -53,7 +60,11 @@ if [ -n "$MEMORY_PROJECT_DIR" ]; then
   MEMORY_BASE="$HOME/.claude/projects/${MEMORY_PROJECT_DIR}/memory"
   PROJECT_DIR="$HOME/.claude/projects/${MEMORY_PROJECT_DIR}"
 else
-  _first_proj=$(ls "$HOME/.claude/projects/" 2>/dev/null | head -1)
+  if [ -d "$HOME/.claude/projects" ]; then
+    _first_proj=$(find "$HOME/.claude/projects" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | head -1 || true)
+  else
+    _first_proj=""
+  fi
   MEMORY_BASE="$HOME/.claude/projects/${_first_proj}/memory"
   PROJECT_DIR="$HOME/.claude/projects/${_first_proj}"
 fi

--- a/tests/test_blog_publish_branding.sh
+++ b/tests/test_blog_publish_branding.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-blog-publish-XXXXXX)"
+TMP_RUNTIME="$TMP_BASE/runtime"
+TMP_HOME="$TMP_BASE/home"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_RUNTIME/config" "$TMP_RUNTIME/blog" "$TMP_RUNTIME/logs" "$TMP_RUNTIME/state" "$TMP_HOME"
+
+cat >"$TMP_RUNTIME/config/branding.yaml" <<'YAML'
+agent_name: "drucker"
+agent_bio: "test agent"
+org_name: "OpenAI"
+org_short: "OA"
+logo_filename: "logo.svg"
+css_var_prefix: "brand"
+colors:
+  primary: "#2b6cb0"
+blog:
+  port: 8766
+  host: "127.0.0.1"
+  auth_enabled: false
+  auth_user: ""
+  auth_pass: ""
+edge_dir: ""
+memory_project_dir: ""
+skill_prefix: "dru"
+YAML
+
+echo "=== blog-publish Missing Codename Smoke Test ==="
+echo "Temp runtime: $TMP_RUNTIME"
+echo ""
+
+echo "--- Test 1: paths.sh survives missing codename under pipefail ---"
+if OUTPUT=$(env -u EDGE_STATE_DIR -u EDGE_HOME -u EDGE_CODENAME -u EDGE_INSTANCE HOME="$TMP_HOME" EDGE_REPO_DIR="$TMP_RUNTIME" bash -lc "set -euo pipefail; source \"$EDGE_DIR/config/paths.sh\"; printf '%s\n%s\n' \"\$EDGE_INSTANCE\" \"\$LIBEXEC_DIR\"" 2>&1); then
+    if python3 - <<'PY' "$OUTPUT" "$TMP_RUNTIME"
+import pathlib
+import sys
+
+lines = sys.argv[1].splitlines()
+runtime = pathlib.Path(sys.argv[2])
+
+assert lines[0] == "dru"
+assert lines[1] == str(runtime / "libexec" / "dru")
+PY
+    then
+        pass "paths.sh falls back to skill_prefix when codename is absent"
+    else
+        fail "paths.sh falls back to skill_prefix when codename is absent"
+    fi
+else
+    fail "paths.sh falls back to skill_prefix when codename is absent"
+fi
+
+echo "--- Test 2: blog-publish no longer aborts silently without codename ---"
+ENTRY_PATH="$TMP_BASE/issue-302-smoke.md"
+cat >"$ENTRY_PATH" <<'EOF'
+---
+title: "Issue 302 Smoke"
+date: 2026-04-22
+tags: [note]
+claims:
+  - "blog publish should tolerate missing codename in branding"
+threads: [issue-302]
+keywords: [blog-publish, branding, codename]
+report: reports/issue-302.html
+---
+
+This smoke test entry exists only to prove that publication reaches the
+regular pipeline instead of exiting silently while sourcing config/paths.sh.
+EOF
+
+set +e
+OUTPUT=$(env -u EDGE_STATE_DIR -u EDGE_HOME -u EDGE_CODENAME -u EDGE_INSTANCE HOME="$TMP_HOME" EDGE_REPO_DIR="$TMP_RUNTIME" CALLED_FROM_CONSOLIDAR_ESTADO=1 bash "$EDGE_DIR/blog/blog-publish.sh" "$ENTRY_PATH" 2>&1)
+STATUS=$?
+set -e
+
+if python3 - <<'PY' "$STATUS" "$OUTPUT" "$TMP_RUNTIME/blog/changelog.md"
+import pathlib
+import sys
+
+status = int(sys.argv[1])
+output = sys.argv[2]
+changelog = pathlib.Path(sys.argv[3])
+
+assert status == 0
+assert "=== blog-publish: issue-302-smoke ===" in output
+assert "[3/5] Updating changelog..." in output
+assert changelog.exists()
+assert "Issue 302 Smoke" in changelog.read_text(encoding="utf-8")
+PY
+then
+    pass "blog-publish reaches the normal publish flow without codename"
+else
+    echo "$OUTPUT"
+    fail "blog-publish reaches the normal publish flow without codename"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- make `config/paths.sh` safe to source under `set -euo pipefail` when branding keys are absent
- fall back to `skill_prefix` when `codename:` is omitted so shell path resolution matches `paths.py`
- add `codename` back to the branding template and a smoke test that reproduces the `blog-publish.sh` failure mode

Fixes #302

## Testing
- `bash tests/test_blog_publish_branding.sh`
- `bash -n config/paths.sh blog/blog-publish.sh tests/test_blog_publish_branding.sh`
- `python3 -m py_compile config/branding.py`