### PR TITLE
[codex] fix genotype runtime path leaks and tools deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ threads/*.md
 !threads/.gitkeep
 state/*.md
 state/*.json
+state/events/
 state/signals/
 !state/.gitkeep
 autonomy/*.md

--- a/bin/check-content.sh
+++ b/bin/check-content.sh
@@ -5,8 +5,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/survival-lib.sh"
 
-ENTRIES_DIR=$(read_yaml_key blog_entries_dir 2>/dev/null || echo "$HOME/edge/blog/entries")
-THREADS_DIR=$(read_yaml_key threads_dir 2>/dev/null || echo "$HOME/edge/threads")
+ENTRIES_DIR="${ENTRIES_DIR:-$(read_yaml_key blog_entries_dir 2>/dev/null || echo "$HOME/edge/blog/entries")}"
+THREADS_DIR="${THREADS_DIR:-$(read_yaml_key threads_dir 2>/dev/null || echo "$HOME/edge/threads")}"
 
 stale_files=()
 remediation=()

--- a/bin/check-infra.sh
+++ b/bin/check-infra.sh
@@ -7,8 +7,8 @@ source "$SCRIPT_DIR/survival-lib.sh"
 
 BLOG_PORT=$(read_yaml_key blog_port 2>/dev/null || echo 8766)
 BLOG_SERVICE=$(read_yaml_key blog_service 2>/dev/null || echo blog-server.service)
-SQLITE_DB=$(read_yaml_key sqlite_db 2>/dev/null || echo "$HOME/edge/edge-memory.db")
-REPO_ROOT=$(read_yaml_key repo_root 2>/dev/null || echo "$HOME/edge")
+SQLITE_DB="${SQLITE_DB:-$(read_yaml_key sqlite_db 2>/dev/null || echo "${SEARCH_DB_FILE:-$HOME/edge/edge-memory.db}")}"
+REPO_ROOT="${REPO_ROOT:-$(read_yaml_key repo_root 2>/dev/null || echo "${EDGE_REPO_DIR:-$HOME/edge}")}"
 
 # --- disk ---
 check_disk() {
@@ -119,7 +119,7 @@ check_index() {
 # --- consolidate-state ---
 check_consolidate() {
   local latest
-  latest=$(find "$REPO_ROOT/meta-reports" -name '*meta*' -type f -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
+  latest=$(find "$META_DIR" -name '*meta*' -type f -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
   if [[ -z "$latest" ]]; then
     emit_component consolidate unknown "no meta-reports found"
     return

--- a/bin/check-quality.sh
+++ b/bin/check-quality.sh
@@ -5,9 +5,9 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/survival-lib.sh"
 
-ENTRIES_DIR=$(read_yaml_key blog_entries_dir 2>/dev/null || echo "$HOME/edge/blog/entries")
-META_DIR=$(read_yaml_key meta_reports_dir 2>/dev/null || echo "$HOME/edge/meta-reports")
-SECRETS_DIR=$(read_yaml_key secrets_dir 2>/dev/null || echo "$HOME/edge/secrets")
+ENTRIES_DIR="${ENTRIES_DIR:-$(read_yaml_key blog_entries_dir 2>/dev/null || echo "$HOME/edge/blog/entries")}"
+META_DIR="${META_DIR:-$(read_yaml_key meta_reports_dir 2>/dev/null || echo "$HOME/edge/meta-reports")}"
+SECRETS_DIR="${SECRETS_DIR:-$(read_yaml_key secrets_dir 2>/dev/null || echo "$HOME/edge/secrets")}"
 
 # --- Adversarial rate (last 7 days) ---
 adversarial_rate=0

--- a/bin/edge-repair.sh
+++ b/bin/edge-repair.sh
@@ -9,7 +9,7 @@ REPAIR_STATE="$HEALTH_DIR/repair-state.json"
 REPAIR_LOG="$HEALTH_DIR/repair.log"
 BLOG_SERVICE=$(read_yaml_key blog_service 2>/dev/null || echo blog-server.service)
 BLOG_PORT=$(read_yaml_key blog_port 2>/dev/null || echo 8766)
-SQLITE_DB=$(read_yaml_key sqlite_db 2>/dev/null || echo "$HOME/edge/edge-memory.db")
+SQLITE_DB="${SQLITE_DB:-$(read_yaml_key sqlite_db 2>/dev/null || echo "${SEARCH_DB_FILE:-$HOME/edge/edge-memory.db}")}"
 
 # Initialize repair state if missing
 if [[ ! -f "$REPAIR_STATE" ]]; then
@@ -124,7 +124,7 @@ if [[ "$index_status" == "fail" || "$index_status" == "unknown" ]]; then
     repair_log "Index: in cooldown, skipping"
   else
     repair_log "Index: attempting reindex"
-    if safe_timeout 60 edge-index "$HOME/edge/blog/entries/" "$HOME/edge/reports/" "$HOME/edge/notes/" 2>/dev/null; then
+    if safe_timeout 60 edge-index "$ENTRIES_DIR/" "$REPORTS_DIR/" "$NOTES_DIR/" 2>/dev/null; then
       repair_log "Index: reindex SUCCESS"
       update_repair_state index true
       jq -n --arg ts "$(ts_now)" '{ts:$ts, source:"repair"}' > "$HEALTH_DIR/last_success/index.ok"

--- a/bin/survival-lib.sh
+++ b/bin/survival-lib.sh
@@ -2,6 +2,13 @@
 # survival-lib.sh — shared functions for health checks
 # Part of: Instinto de Sobrevivência (edge_of_chaos)
 
+_SURVIVAL_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_PATHS_SH="${_SURVIVAL_LIB_DIR}/../config/paths.sh"
+if [[ -f "$_PATHS_SH" ]]; then
+  # shellcheck source=../config/paths.sh
+  source "$_PATHS_SH"
+fi
+
 HEALTH_DIR="${HEALTH_DIR:-$HOME/edge/health}"
 CONFIG_FILE="${CONFIG_FILE:-$HEALTH_DIR/config.yaml}"
 RAW_DIR="$HEALTH_DIR/raw"

--- a/tests/test_edge_apply_tools_recursive.sh
+++ b/tests/test_edge_apply_tools_recursive.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-tools-recursive-XXXXXX)"
+TMP_HOME="$TMP_BASE/home"
+TMP_EDGE="$TMP_BASE/agent"
+TMP_CONFIG="$TMP_BASE/agent.yaml"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME" "$TMP_EDGE"
+
+cat >"$TMP_CONFIG" <<YAML
+name: Recursive Tools Test
+codename: recursive-tools
+skill_prefix: recursive-tools
+mission: Validate recursive tools copy
+voice: Direct and factual
+domain: testing
+edge_home: $TMP_EDGE
+blog_port: 8766
+onboarding_mode: true
+YAML
+
+echo "=== edge-apply recursive tools Smoke Test ==="
+
+export HOME="$TMP_HOME"
+export EDGE_REPO_DIR="$EDGE_DIR"
+export EDGE_STATE_DIR="$TMP_EDGE"
+export EDGE_CODENAME="recursive-tools"
+export EDGE_CYCLE_ID="install:test-recursive-tools"
+
+python3 - <<'PY' "$EDGE_DIR" "$TMP_CONFIG"
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+edge_dir, config_path = sys.argv[1:]
+
+loader = importlib.machinery.SourceFileLoader("edge_apply_mod", f"{edge_dir}/tools/edge-apply")
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+
+cfg = mod.load_config(Path(config_path))
+assert mod.phase_tools(cfg, dry_run=False) is True
+PY
+
+for path in \
+  "$TMP_EDGE/tools/_shared/telemetry.py" \
+  "$TMP_EDGE/tools/primitives/_shared/usage_log.py" \
+  "$TMP_EDGE/tools/assets/logo.svg"
+do
+  if [[ -f "$path" ]]; then
+    pass "$(realpath --relative-to="$TMP_EDGE" "$path") copied"
+  else
+    fail "$(realpath --relative-to="$TMP_EDGE" "$path") missing"
+  fi
+done
+
+if [[ -x "$TMP_HOME/.local/bin/edge-primitives" ]]; then
+  pass "top-level tool wrapper still linked"
+else
+  fail "top-level tool wrapper missing"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/tests/test_health_runtime_paths.sh
+++ b/tests/test_health_runtime_paths.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-health-paths-XXXXXX)"
+TMP_HOME="$TMP_BASE/home"
+TMP_STATE="$TMP_BASE/state"
+TMP_BIN="$TMP_BASE/bin"
+TMP_REPO="$TMP_BASE/heartbeat-repo"
+TMP_STATE_HEARTBEAT="$TMP_BASE/heartbeat-state"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME" "$TMP_STATE" "$TMP_BIN" "$TMP_REPO/config" "$TMP_REPO/tools" "$TMP_REPO/bin" "$TMP_STATE_HEARTBEAT"
+
+echo "=== health/heartbeat path split Smoke Test ==="
+
+echo "--- Test 1: survival-lib derives HEALTH_DIR from EDGE_STATE_DIR ---"
+if OUTPUT=$(env HOME="$TMP_HOME" EDGE_DIR="$EDGE_DIR" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" bash -lc 'source "$EDGE_DIR/bin/survival-lib.sh"; printf "%s\n%s\n%s\n" "$HEALTH_DIR" "$CONFIG_FILE" "$RAW_DIR"' 2>/dev/null); then
+  mapfile -t lines <<<"$OUTPUT"
+  if [[ "${lines[0]}" == "$TMP_STATE/health" ]] && [[ "${lines[1]}" == "$TMP_STATE/health/config.yaml" ]] && [[ "${lines[2]}" == "$TMP_STATE/health/raw" ]]; then
+    pass "survival-lib uses state-root health paths"
+  else
+    fail "survival-lib health paths wrong: ${OUTPUT//$'\n'/ | }"
+  fi
+else
+  fail "survival-lib could not be sourced"
+fi
+
+echo "--- Test 2: check-infra uses state sqlite/meta paths ---"
+mkdir -p "$TMP_STATE/health" "$TMP_STATE/meta-reports" "$TMP_STATE/search"
+printf 'meta\n' > "$TMP_STATE/meta-reports/test-meta.md"
+if command -v sqlite3 >/dev/null 2>&1; then
+  sqlite3 "$TMP_STATE/search/edge-memory.db" "create table if not exists t(x integer); insert into t values (1);" >/dev/null
+fi
+if env HOME="$TMP_HOME" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" bash "$EDGE_DIR/bin/check-infra.sh" >/dev/null 2>&1; then
+  consolidate_status=$(jq -r '.status' "$TMP_STATE/health/raw/consolidate.json" 2>/dev/null || echo "missing")
+  if [[ "$consolidate_status" == "ok" || "$consolidate_status" == "degraded" || "$consolidate_status" == "fail" ]]; then
+    pass "check-infra reads meta-reports from state root"
+  else
+    fail "check-infra consolidate status unexpected: $consolidate_status"
+  fi
+
+  if command -v sqlite3 >/dev/null 2>&1; then
+    sqlite_status=$(jq -r '.status' "$TMP_STATE/health/raw/sqlite.json" 2>/dev/null || echo "missing")
+    if [[ "$sqlite_status" == "ok" || "$sqlite_status" == "degraded" ]]; then
+      pass "check-infra reads sqlite db from state root"
+    else
+      fail "check-infra sqlite status unexpected: $sqlite_status"
+    fi
+  else
+    pass "sqlite3 unavailable; sqlite path assertion skipped"
+  fi
+else
+  fail "check-infra execution failed"
+fi
+
+echo "--- Test 3: edge-repair reindexes state paths ---"
+mkdir -p "$TMP_STATE/blog/entries" "$TMP_STATE/reports" "$TMP_STATE/notes"
+cat >"$TMP_STATE/health/current.json" <<'JSON'
+{
+  "infra": {
+    "blog": {"status": "ok"},
+    "sqlite": {"status": "ok"},
+    "index": {"status": "fail"},
+    "git": {"status": "ok"},
+    "mini_repos": {"status": "ok"}
+  }
+}
+JSON
+cat >"$TMP_BIN/edge-index" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" > "$TMP_BASE/edge-index.args"
+exit 0
+EOF
+chmod +x "$TMP_BIN/edge-index"
+
+if env PATH="$TMP_BIN:/usr/bin:/bin" HOME="$TMP_HOME" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" bash "$EDGE_DIR/bin/edge-repair.sh" >/dev/null 2>&1; then
+  expected="$TMP_STATE/blog/entries/ $TMP_STATE/reports/ $TMP_STATE/notes/"
+  actual="$(cat "$TMP_BASE/edge-index.args" 2>/dev/null || true)"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "edge-repair reindexes state-root content"
+  else
+    fail "edge-repair used wrong edge-index args: $actual"
+  fi
+else
+  fail "edge-repair execution failed"
+fi
+
+echo "--- Test 4: heartbeat-preflight reads health from state root ---"
+cp "$EDGE_DIR/tools/heartbeat-preflight.sh" "$TMP_REPO/tools/heartbeat-preflight.sh"
+cp "$EDGE_DIR/config/paths.sh" "$TMP_REPO/config/paths.sh"
+cat >"$TMP_REPO/bin/edge-check.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TMP_REPO/bin/edge-check.sh" "$TMP_REPO/tools/heartbeat-preflight.sh"
+cat >"$TMP_REPO/config/branding.yaml" <<YAML
+codename: hbtest
+skill_prefix: hbtest
+edge_state_dir: "$TMP_STATE_HEARTBEAT"
+blog:
+  port: 9
+  auth_enabled: false
+YAML
+mkdir -p "$TMP_STATE_HEARTBEAT/health" "$TMP_STATE_HEARTBEAT/blog/entries" "$TMP_STATE_HEARTBEAT/threads" "$TMP_STATE_HEARTBEAT/state" "$TMP_STATE_HEARTBEAT/libexec/hbtest"
+cat >"$TMP_STATE_HEARTBEAT/health/current.json" <<'JSON'
+{"status":"degraded","score":80}
+JSON
+
+if OUTPUT=$(env PATH="/usr/bin:/bin" HOME="$TMP_HOME" EDGE_REPO_DIR="$TMP_REPO" EDGE_STATE_DIR="$TMP_STATE_HEARTBEAT" bash "$TMP_REPO/tools/heartbeat-preflight.sh" 2>/dev/null); then
+  if grep -q 'HEALTH:DEGRADED score=80' <<<"$OUTPUT"; then
+    pass "heartbeat-preflight reads health snapshot from state root"
+  else
+    fail "heartbeat-preflight did not emit health signal from state root"
+  fi
+else
+  fail "heartbeat-preflight execution failed"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/tests/test_runtime_gitignore.sh
+++ b/tests/test_runtime_gitignore.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "=== runtime gitignore Smoke Test ==="
+
+if git -C "$EDGE_DIR" check-ignore -q state/events/log.jsonl; then
+  echo "PASS: state/events/log.jsonl is ignored"
+else
+  echo "FAIL: state/events/log.jsonl is not ignored"
+  exit 1
+fi

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -153,10 +153,11 @@ def _copy_tree(
     *,
     phase: str,
     dry_run: bool,
+    ignore=None,
 ) -> None:
     if dry_run:
         return
-    shutil.copytree(src, dst, dirs_exist_ok=True)
+    shutil.copytree(src, dst, dirs_exist_ok=True, ignore=ignore)
     _log_install_applied(
         dst,
         source_template=_repo_relative(src),
@@ -167,6 +168,27 @@ def _copy_tree(
         dry_run=False,
         recursive=True,
     )
+
+
+def _should_skip_tool_entry(path: Path) -> bool:
+    name = path.name
+    if name.startswith(".") or name.startswith("__"):
+        return True
+    if name in {".venv", "venv", "__pycache__", ".mypy_cache", ".pytest_cache"}:
+        return True
+    return False
+
+
+def _tool_tree_ignore(_src: str, names: list[str]) -> set[str]:
+    skipped = set()
+    for name in names:
+        if name.startswith(".") or name.startswith("__"):
+            skipped.add(name)
+        elif name in {".venv", "venv", "__pycache__", ".mypy_cache", ".pytest_cache"}:
+            skipped.add(name)
+        elif name.endswith((".pyc", ".pyo")):
+            skipped.add(name)
+    return skipped
 
 
 def _write_text(
@@ -823,20 +845,29 @@ def phase_tools(cfg, dry_run):
     count = 0
     if tools_src.resolve() != tools_dst.resolve():
         for tool in tools_src.iterdir():
-            if tool.name.startswith(".") or tool.name.startswith("__") or tool.is_dir():
+            if _should_skip_tool_entry(tool):
                 continue
             if not dry_run:
                 dst = tools_dst / tool.name
-                _copy_file(tool, dst, phase="tools", dry_run=False)
-                dst.chmod(0o755)
+                if tool.is_dir():
+                    _copy_tree(
+                        tool,
+                        dst,
+                        phase="tools",
+                        dry_run=False,
+                        ignore=_tool_tree_ignore,
+                    )
+                else:
+                    _copy_file(tool, dst, phase="tools", dry_run=False)
+                    dst.chmod(0o755)
             count += 1
         ok(f"{count} tools copied → {tools_dst}")
     else:
-        count = len([f for f in tools_src.iterdir() if f.is_file() and not f.name.startswith(".")])
+        count = len([f for f in tools_src.iterdir() if not _should_skip_tool_entry(f)])
         # Just ensure executable
         if not dry_run:
             for tool in tools_src.iterdir():
-                if tool.is_file() and not tool.name.startswith("."):
+                if tool.is_file() and not _should_skip_tool_entry(tool):
                     tool.chmod(0o755)
         ok(f"Tools: repo = edge_home (in-place, {count} tools)")
 

--- a/tools/heartbeat-preflight.sh
+++ b/tools/heartbeat-preflight.sh
@@ -15,7 +15,7 @@ source "$(dirname "$0")/../config/paths.sh"
 
 # 0. Health check (runs edge-check.sh, updates health/current.json)
 HEALTH_SCRIPT="$(dirname "$0")/../bin/edge-check.sh"
-HEALTH_FILE="$EDGE_DIR/health/current.json"
+HEALTH_FILE="$HEALTH_CURRENT_FILE"
 
 if [ -x "$HEALTH_SCRIPT" ]; then
   bash "$HEALTH_SCRIPT" >/dev/null 2>&1
@@ -49,10 +49,10 @@ if [ -x "$STATE_MONITOR_BIN" ]; then
 fi
 
 # 0b. Stub primitives — implement ALL before any beat runs (#191)
-LIBEXEC_DIR="$EDGE_DIR/libexec/${SKILL_PREFIX}"
-if [ -d "$LIBEXEC_DIR" ]; then
+PRIMITIVES_LIBEXEC_DIR="$LIBEXEC_DIR"
+if [ -d "$PRIMITIVES_LIBEXEC_DIR" ]; then
   STUBS=()
-  for prim in "$LIBEXEC_DIR"/*; do
+  for prim in "$PRIMITIVES_LIBEXEC_DIR"/*; do
     [ -f "$prim" ] || continue
     [[ "$prim" == *.meta.yaml ]] && continue
     if grep -q 'exit 127' "$prim" 2>/dev/null; then
@@ -65,8 +65,8 @@ if [ -d "$LIBEXEC_DIR" ]; then
     echo "PREFLIGHT_STUBS (${#STUBS[@]} unimplemented primitives)"
     echo "Implementing before heartbeat can start..."
     for stub_name in "${STUBS[@]}"; do
-      stub_path="$LIBEXEC_DIR/$stub_name"
-      meta_path="$LIBEXEC_DIR/${stub_name}.meta.yaml"
+      stub_path="$PRIMITIVES_LIBEXEC_DIR/$stub_name"
+      meta_path="$PRIMITIVES_LIBEXEC_DIR/${stub_name}.meta.yaml"
       desc=""
       if [ -f "$meta_path" ]; then
         desc=$(cat "$meta_path")
@@ -150,7 +150,7 @@ if [ -f "$debug_file" ]; then
 fi
 
 # 4. Corpus curation — run every beat, lightweight
-CURATION_FILE="$EDGE_DIR/state/procedure-curation.json"
+CURATION_FILE="$PROCEDURE_CURATION_FILE"
 if command -v edge-crystallize &>/dev/null; then
   # Regenerate curation if stale (>2h) or missing
   curation_stale=false
@@ -171,7 +171,7 @@ if command -v edge-crystallize &>/dev/null; then
 fi
 
 # 5. Source primitive usage — check last beat
-USAGE_LOG="$EDGE_DIR/state/source-usage.jsonl"
+USAGE_LOG="$SOURCE_USAGE_FILE"
 if [ -f "$USAGE_LOG" ]; then
   recent_usage=$(python3 -c "
 import json
@@ -194,7 +194,7 @@ else
 fi
 
 # 5b. Holding queue — artifacts BLOCKED awaiting drain (#206)
-HOLDING_INDEX="$EDGE_DIR/holding/index.json"
+HOLDING_INDEX="$STATE_DIR/holding/index.json"
 if [ -f "$HOLDING_INDEX" ]; then
   hold_summary=$(python3 -c "
 import json
@@ -214,7 +214,7 @@ except: pass
 fi
 
 # 5c. Missing primitives — exit 127 was recorded (#206 + #191)
-MISSING_FLAG="$EDGE_DIR/state/missing-primitives.json"
+MISSING_FLAG="$STATE_DIR/missing-primitives.json"
 if [ -f "$MISSING_FLAG" ]; then
   missing_names=$(python3 -c "
 import json


### PR DESCRIPTION
## Summary

Fixes three concrete genotype/runtime bugs in one pass:

- closes #255 by making `edge-apply` copy nested `tools/` modules and assets when `repo != edge_home`
- closes #256 by finishing the remaining state-root path migration in the health/heartbeat stack
- closes #257 by ignoring `state/events/log.jsonl` so normal runtime append-only facts do not keep fleet worktrees permanently dirty

## What changed

- `edge-apply` now copies nested `tools/` directories recursively with cache/venv exclusions instead of only top-level files.
- `survival-lib` now sources `config/paths.sh`, so direct health scripts inherit `EDGE_STATE_DIR` correctly.
- `check-content`, `check-quality`, `check-infra`, `edge-repair`, and `heartbeat-preflight` now prefer canonical state-aware paths instead of falling back to repo-root/runtime-singleton paths.
- `.gitignore` now ignores `state/events/log.jsonl` via `state/events/`.
- Added focused smokes for:
  - runtime gitignore coverage
  - recursive `edge-apply` tools deploy
  - health/heartbeat state-root path behavior

## Why

These bugs were making deploys and fleet state noisier than they should be:

- nested `tools/_shared` code could stay stale after a deploy even when top-level tools updated
- health and heartbeat still leaked reads/writes back into the repo checkout after `EDGE_STATE_DIR` split
- normal event-log appends could keep agent repos permanently dirty

## Validation

- `python3 -m py_compile tools/edge-apply`
- `bash -n bin/survival-lib.sh bin/check-content.sh bin/check-quality.sh bin/check-infra.sh bin/edge-repair.sh tools/heartbeat-preflight.sh tests/test_runtime_gitignore.sh tests/test_edge_apply_tools_recursive.sh tests/test_health_runtime_paths.sh`
- `bash tests/test_runtime_gitignore.sh`
- `bash tests/test_edge_apply_tools_recursive.sh`
- `bash tests/test_health_runtime_paths.sh`
- `bash tests/test_install_telemetry.sh`
- `bash tests/test_heartbeat_entrypoints.sh`

## Impact

This is intentionally scoped to deterministic bug fixes, not new architecture. It reduces rollout drift and keeps the repo/state split cleaner while the larger dispatch/event-sourced work continues.