### PR TITLE
[codex] add event-backed health v2 runtime

### DIFF
--- a/bin/check-quality.sh
+++ b/bin/check-quality.sh
@@ -87,9 +87,9 @@ check_providers() {
   # Exa
   if [[ -f "$SECRETS_DIR/exa.env" ]]; then
     local exa_key
+    local code=000
     exa_key=$(grep -oP 'EXA_API_KEY=\K.*' "$SECRETS_DIR/exa.env" 2>/dev/null)
     if [[ -n "$exa_key" ]]; then
-      local code
       code=$(safe_timeout 5 curl -sS -o /dev/null -w '%{http_code}' \
         -H "x-api-key: $exa_key" \
         -H "Content-Type: application/json" \
@@ -101,14 +101,15 @@ check_providers() {
         exa_status="degraded"
       fi
     fi
+    emit_shadow_fact "ProviderProbeCompleted" "$(jq -cn --arg provider exa --arg status "$exa_status" --arg http_status "$code" '{provider:$provider, ok: ($status == "ok"), status:$status, http_status:$http_status, probe:"check-quality"}')" "check-quality"
   fi
 
   # OpenAI
   if [[ -f "$SECRETS_DIR/openai.env" ]]; then
     local oai_key
+    local code=000
     oai_key=$(grep -oP 'OPENAI_API_KEY=\K.*' "$SECRETS_DIR/openai.env" 2>/dev/null)
     if [[ -n "$oai_key" ]]; then
-      local code
       code=$(safe_timeout 5 curl -sS -o /dev/null -w '%{http_code}' \
         -H "Authorization: Bearer $oai_key" \
         "https://api.openai.com/v1/models" 2>/dev/null || echo 000)
@@ -118,6 +119,7 @@ check_providers() {
         openai_status="degraded"
       fi
     fi
+    emit_shadow_fact "ProviderProbeCompleted" "$(jq -cn --arg provider openai --arg status "$openai_status" --arg http_status "$code" '{provider:$provider, ok: ($status == "ok"), status:$status, http_status:$http_status, probe:"check-quality"}')" "check-quality"
   fi
 }
 

--- a/bin/edge-check.sh
+++ b/bin/edge-check.sh
@@ -12,70 +12,63 @@ log_health "edge-check starting"
 "$SCRIPT_DIR/check-content.sh" 2>&1 || log_health "WARN: check-content failed"
 "$SCRIPT_DIR/check-quality.sh" 2>&1 || log_health "WARN: check-quality failed"
 
-# Compute unified score
-score=$(compute_score)
-
-# Determine status
-status="healthy"
-if [[ "$score" -lt 85 ]]; then status="degraded"; fi
-if [[ "$score" -lt 70 ]]; then status="unhealthy"; fi
-if [[ "$score" -lt 40 ]]; then status="critical"; fi
-
-# Hard-fails override score
-hard_fail=false
-for comp in fs_rw disk sqlite; do
-  local_status=$(jq -r '.status' "$RAW_DIR/${comp}.json" 2>/dev/null || echo "unknown")
-  if [[ "$local_status" == "critical" ]]; then
-    status="critical"
-    hard_fail=true
+if ! python3 "$SCRIPT_DIR/../tools/rollup-health-v2.py" --write >/dev/null 2>&1; then
+  log_health "WARN: rollup-health-v2 failed, falling back to legacy score"
+  score=$(compute_score)
+  status="healthy"
+  if [[ "$score" -lt 85 ]]; then status="degraded"; fi
+  if [[ "$score" -lt 70 ]]; then status="unhealthy"; fi
+  if [[ "$score" -lt 40 ]]; then status="critical"; fi
+  hard_fail=false
+  for comp in fs_rw disk sqlite; do
+    local_status=$(jq -r '.status' "$RAW_DIR/${comp}.json" 2>/dev/null || echo "unknown")
+    if [[ "$local_status" == "critical" ]]; then
+      status="critical"
+      hard_fail=true
+    fi
+  done
+  ts=$(ts_now)
+  infra=$(jq -n '{}')
+  for comp in disk fs_rw sqlite blog index consolidate git heartbeat mini_repos primitives; do
+    if [[ -f "$RAW_DIR/${comp}.json" ]]; then
+      infra=$(echo "$infra" | jq --arg k "$comp" --slurpfile v "$RAW_DIR/${comp}.json" '.[$k] = {status: $v[0].status, detail: $v[0].detail}')
+    fi
+  done
+  content="{}"
+  if [[ -f "$RAW_DIR/content.json" ]]; then
+    content=$(jq '{status: .status, detail: .detail}' "$RAW_DIR/content.json")
   fi
-done
-
-# Build current.json
-ts=$(ts_now)
-
-# Collect infra components
-infra=$(jq -n '{}')
-for comp in disk fs_rw sqlite blog index consolidate git heartbeat mini_repos primitives; do
-  if [[ -f "$RAW_DIR/${comp}.json" ]]; then
-    infra=$(echo "$infra" | jq --arg k "$comp" --slurpfile v "$RAW_DIR/${comp}.json" '.[$k] = {status: $v[0].status, detail: $v[0].detail}')
+  quality="{}"
+  if [[ -f "$RAW_DIR/quality.json" ]]; then
+    quality=$(jq '{status: .status, detail: .detail}' "$RAW_DIR/quality.json")
   fi
-done
-
-# Content
-content="{}"
-if [[ -f "$RAW_DIR/content.json" ]]; then
-  content=$(jq '{status: .status, detail: .detail}' "$RAW_DIR/content.json")
+  remediation="[]"
+  for rfile in "$RAW_DIR"/content-remediation.json "$RAW_DIR"/quality-remediation.json; do
+    if [[ -f "$rfile" ]]; then
+      remediation=$(echo "$remediation" | jq --slurpfile r "$rfile" '. + $r[0]')
+    fi
+  done
+  remediation=$(echo "$remediation" | jq 'sort_by(.priority)')
+  jq -n \
+    --arg ts "$ts" \
+    --arg status "$status" \
+    --argjson score "$score" \
+    --argjson hard_fail "$hard_fail" \
+    --argjson infra "$infra" \
+    --argjson content "$content" \
+    --argjson quality "$quality" \
+    --argjson remediation "$remediation" \
+    '{schema_version:1, ts:$ts, status:$status, score:$score, hard_fail:$hard_fail, infra:$infra, content:$content, quality:$quality, remediation_queue:$remediation}' \
+    | atomic_write "$HEALTH_DIR/current.json"
 fi
 
-# Quality
-quality="{}"
-if [[ -f "$RAW_DIR/quality.json" ]]; then
-  quality=$(jq '{status: .status, detail: .detail}' "$RAW_DIR/quality.json")
+score=$(jq -r '.score // 0' "$HEALTH_DIR/current.json" 2>/dev/null || echo 0)
+status=$(jq -r '.status // "unknown"' "$HEALTH_DIR/current.json" 2>/dev/null || echo unknown)
+hard_fail=$(jq -r '.hard_fail // false' "$HEALTH_DIR/current.json" 2>/dev/null || echo false)
+ts=$(jq -r '.ts // empty' "$HEALTH_DIR/current.json" 2>/dev/null || true)
+if [[ -z "${ts:-}" ]]; then
+  ts=$(ts_now)
 fi
-
-# Merge remediation queues
-remediation="[]"
-for rfile in "$RAW_DIR"/content-remediation.json "$RAW_DIR"/quality-remediation.json; do
-  if [[ -f "$rfile" ]]; then
-    remediation=$(echo "$remediation" | jq --slurpfile r "$rfile" '. + $r[0]')
-  fi
-done
-# Sort by priority
-remediation=$(echo "$remediation" | jq 'sort_by(.priority)')
-
-# Write current.json
-jq -n \
-  --arg ts "$ts" \
-  --arg status "$status" \
-  --argjson score "$score" \
-  --argjson hard_fail "$hard_fail" \
-  --argjson infra "$infra" \
-  --argjson content "$content" \
-  --argjson quality "$quality" \
-  --argjson remediation "$remediation" \
-  '{ts:$ts, status:$status, score:$score, hard_fail:$hard_fail, infra:$infra, content:$content, quality:$quality, remediation_queue:$remediation}' \
-  | atomic_write "$HEALTH_DIR/current.json"
 
 # Append to history
 jq -c '.' "$HEALTH_DIR/current.json" >> "$HEALTH_DIR/history.jsonl"

--- a/bin/survival-lib.sh
+++ b/bin/survival-lib.sh
@@ -19,18 +19,66 @@ log_health() {
   echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >&2
 }
 
+emit_shadow_fact() {
+  local event_type="$1"
+  local payload_json="${2-}"
+  if [[ -z "$payload_json" ]]; then
+    payload_json='{}'
+  fi
+  local actor="${3:-edge-health}"
+  EDGE_HEALTH_PAYLOAD_JSON="$payload_json" python3 - "$event_type" "$actor" <<'PYEOF' 2>/dev/null || true
+import json
+import os
+import sys
+from pathlib import Path
+
+event_type, actor = sys.argv[1:3]
+payload_json = os.environ.get("EDGE_HEALTH_PAYLOAD_JSON", "")
+tools_dir = Path(
+    os.environ.get("TOOLS_DIR")
+    or (
+        Path(
+            os.environ.get(
+                "EDGE_REPO_DIR",
+                os.environ.get("EDGE_DIR", str(Path.home() / "edge")),
+            )
+        ).expanduser()
+        / "tools"
+    )
+)
+sys.path.insert(0, str(tools_dir))
+try:
+    from _shared.telemetry import emit_shadow_event
+except Exception:
+    sys.exit(0)
+
+try:
+    payload = json.loads(payload_json)
+except Exception:
+    payload = {"raw_payload": payload_json}
+
+emit_shadow_event(
+    event_type,
+    actor=actor,
+    cycle_id=os.environ.get("EDGE_CYCLE_ID"),
+    payload=payload,
+)
+PYEOF
+}
+
 emit_component() {
   local name="$1" status="$2" detail="$3"
   local ts
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   local json
-  json=$(jq -n \
+  json=$(jq -cn \
     --arg name "$name" \
     --arg status "$status" \
     --arg detail "$detail" \
     --arg ts "$ts" \
     '{name:$name, status:$status, detail:$detail, ts:$ts}')
   echo "$json" > "$RAW_DIR/${name}.json"
+  emit_shadow_fact "HealthComponentObserved" "$json" "edge-health"
 }
 
 compute_score() {

--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -894,6 +894,14 @@ def fail(msg): print(f"  {RED}FAIL{NC}: {msg}")
 FAILURES_FILE = Path(os.environ.get("PIPELINE_FAILURES_FILE", os.path.expanduser("~/edge/logs/pipeline-failures.jsonl")))
 FAILURES_FILE.parent.mkdir(parents=True, exist_ok=True)
 
+tools_dir = Path(os.environ.get("TOOLS_DIR", str(Path.home() / "edge" / "tools")))
+if str(tools_dir) not in sys.path:
+    sys.path.insert(0, str(tools_dir))
+try:
+    from _shared.telemetry import log_workflow_observed  # type: ignore
+except Exception:
+    log_workflow_observed = None
+
 def log_failure(phase, operation, error, tb=None):
     """Log pipeline failure to persistent JSONL for post-mortem analysis."""
     entry = {
@@ -989,6 +997,14 @@ try:
         citations[wslug]["used"] += 1
         citations[wslug]["last_cited"] = today
         updated = True
+        if log_workflow_observed is not None:
+            log_workflow_observed(
+                wslug,
+                mode="used",
+                artifact=f"blog/entries/{slug}.md",
+                cycle_id=os.environ.get("EDGE_CYCLE_ID"),
+                title=title,
+            )
 
     # Process workflows_broken (healing signal)
     for wslug in workflows_broken:
@@ -997,6 +1013,14 @@ try:
         citations[wslug]["broken"] += 1
         citations[wslug]["last_cited"] = today
         updated = True
+        if log_workflow_observed is not None:
+            log_workflow_observed(
+                wslug,
+                mode="broken",
+                artifact=f"blog/entries/{slug}.md",
+                cycle_id=os.environ.get("EDGE_CYCLE_ID"),
+                title=title,
+            )
 
     if updated:
         health["citations"] = citations
@@ -1093,7 +1117,6 @@ except Exception as e:
 
 # ── 4. Digest (gera briefing.md) ──
 try:
-    tools_dir = Path(os.environ.get("TOOLS_DIR", str(Path.home() / "edge" / "tools")))
     if str(tools_dir) not in sys.path:
         sys.path.insert(0, str(tools_dir))
     from _shared.continuity import process_publication_continuity  # type: ignore

--- a/memory/events.md
+++ b/memory/events.md
@@ -347,6 +347,135 @@ Represents the validation probe after contract or materialization.
 
 Represents the mutation of `state/sources-manifest.yaml`, which is the durable lifecycle index for materialized primitives.
 
+### `WorkflowRecommended`
+
+```json
+{
+  "type": "WorkflowRecommended",
+  "payload": {
+    "slug": "sources-research-consult-report",
+    "title": "Sources → Research → Consult → Report",
+    "source": "search_sidecar",
+    "score": 0.87,
+    "query": "claim continuity graph"
+  }
+}
+```
+
+Represents a workflow recommendation emitted by runtime preflight before the skill starts.
+
+### `WorkflowUsedObserved`
+
+```json
+{
+  "type": "WorkflowUsedObserved",
+  "artifact": "blog/entries/2026-04-23-example.md",
+  "payload": {
+    "slug": "sources-research-consult-report",
+    "mode": "used"
+  }
+}
+```
+
+Represents a workflow explicitly cited as having worked in a published artifact.
+
+### `WorkflowBrokenObserved`
+
+```json
+{
+  "type": "WorkflowBrokenObserved",
+  "artifact": "blog/entries/2026-04-23-example.md",
+  "payload": {
+    "slug": "stale-playwright-validation",
+    "mode": "broken"
+  }
+}
+```
+
+Represents a workflow explicitly cited as broken/outdated in a published artifact.
+
+### `WorkflowIgnoredObserved`
+
+```json
+{
+  "type": "WorkflowIgnoredObserved",
+  "payload": {
+    "slug": "sources-research-consult-report",
+    "reason": "recommended_not_cited"
+  }
+}
+```
+
+Represents a workflow recommendation that the cycle ignored instead of citing as used or broken.
+
+### `PrimitiveBypassObserved`
+
+```json
+{
+  "type": "PrimitiveBypassObserved",
+  "payload": {
+    "source": "arxiv",
+    "capability": "source.arxiv",
+    "reason": "primitive_used_without_capability_wrapper",
+    "primitive_invocations": 2,
+    "capability_invocations": 0
+  }
+}
+```
+
+Represents substrate discipline drift: a primitive was invoked directly when a capability wrapper existed.
+
+### `ProviderProbeCompleted`
+
+```json
+{
+  "type": "ProviderProbeCompleted",
+  "payload": {
+    "provider": "openai",
+    "ok": true,
+    "status": "ok",
+    "http_status": "200",
+    "probe": "check-quality"
+  }
+}
+```
+
+Represents a concrete provider/API availability probe executed by the runtime.
+
+### `HealthComponentObserved`
+
+```json
+{
+  "type": "HealthComponentObserved",
+  "payload": {
+    "name": "runtime_flow",
+    "status": "degraded",
+    "detail": "started=12 closed=10 dispatched=8"
+  }
+}
+```
+
+Represents one health component/check result written into `health/raw/*.json`.
+
+### `HealthSnapshotComputed`
+
+```json
+{
+  "type": "HealthSnapshotComputed",
+  "payload": {
+    "status": "degraded",
+    "score": 72,
+    "hard_fail": false,
+    "dimensions": {
+      "runtime_flow": {"status": "degraded", "score": 58},
+      "continuity": {"status": "degraded", "score": 54}
+    }
+  }
+}
+```
+
+Represents the final health v2 snapshot after all component checks and event-backed dimensions have been rolled up.
+
 ## Projection Inputs
 
 The first projections depend on this subset:

--- a/tests/test_health_events.sh
+++ b/tests/test_health_events.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-health-events-XXXXXX)"
+TMP_HOME="$TMP_BASE/home"
+TMP_STATE="$TMP_BASE/state"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME" "$TMP_STATE/state/events" "$TMP_STATE/health"
+
+echo "=== health events Smoke Test ==="
+
+echo "--- Test 1: emit_component also emits HealthComponentObserved ---"
+if env HOME="$TMP_HOME" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" EDGE_DIR="$EDGE_DIR" \
+  bash -lc 'source "'"$EDGE_DIR"'/bin/survival-lib.sh"; emit_component demo ok "works"' >/dev/null 2>&1; then
+  if grep -q '"type": "HealthComponentObserved"' "$TMP_STATE/state/events/log.jsonl" && grep -q '"name": "demo"' "$TMP_STATE/state/events/log.jsonl"; then
+    pass "HealthComponentObserved emitted from emit_component"
+  else
+    fail "HealthComponentObserved missing after emit_component"
+  fi
+else
+  fail "emit_component execution failed"
+fi
+
+cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
+{"ts":"2026-04-23T11:00:00+00:00","type":"PrimitiveInvocationObserved","cycle_id":"cycle-health-1","payload":{"source":"arxiv"}}
+{"ts":"2026-04-23T11:00:10+00:00","type":"CapabilityInvocationObserved","cycle_id":"cycle-health-1","payload":{"capability":"source.github","ok":true}}
+{"ts":"2026-04-23T11:00:20+00:00","type":"WorkflowUsedObserved","cycle_id":"cycle-health-1","payload":{"slug":"wf-used"}}
+JSONL
+
+echo "--- Test 2: observe_cycle_health_events emits workflow ignored and primitive bypass ---"
+if OUTPUT=$(env HOME="$TMP_HOME" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" python3 - <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+repo = Path(os.environ["EDGE_REPO_DIR"])
+sys.path.insert(0, str(repo / "tools"))
+from _shared.health_runtime import observe_cycle_health_events
+
+state = {
+    "cycle_id": "cycle-health-1",
+    "request": {
+        "skill": "research",
+        "corpus_query": "claim continuity graph",
+        "workflow_recommendations": [
+            {"slug": "wf-used", "source": "search_sidecar"},
+            {"slug": "wf-ignored", "source": "search_sidecar"},
+        ],
+    },
+}
+
+print(json.dumps(observe_cycle_health_events(state), ensure_ascii=False))
+PY
+); then
+  if [[ "$(jq -r '.workflow_ignored' <<<"$OUTPUT")" == "1" ]]; then
+    pass "workflow ignored observation count correct"
+  else
+    fail "workflow ignored observation count wrong: $OUTPUT"
+  fi
+  if [[ "$(jq -r '.primitive_bypass' <<<"$OUTPUT")" == "1" ]]; then
+    pass "primitive bypass observation count correct"
+  else
+    fail "primitive bypass observation count wrong: $OUTPUT"
+  fi
+  if grep -q '"type": "WorkflowIgnoredObserved"' "$TMP_STATE/state/events/log.jsonl" && grep -q '"slug": "wf-ignored"' "$TMP_STATE/state/events/log.jsonl"; then
+    pass "WorkflowIgnoredObserved emitted"
+  else
+    fail "WorkflowIgnoredObserved missing"
+  fi
+  if grep -q '"type": "PrimitiveBypassObserved"' "$TMP_STATE/state/events/log.jsonl" && grep -q '"source": "arxiv"' "$TMP_STATE/state/events/log.jsonl"; then
+    pass "PrimitiveBypassObserved emitted"
+  else
+    fail "PrimitiveBypassObserved missing"
+  fi
+else
+  fail "observe_cycle_health_events execution failed"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/tests/test_health_v2.sh
+++ b/tests/test_health_v2.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-health-v2-XXXXXX)"
+TMP_HOME="$TMP_BASE/home"
+TMP_STATE="$TMP_BASE/state"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME" "$TMP_STATE/health/raw" "$TMP_STATE/state/projections" "$TMP_STATE/state/events" \
+  "$TMP_STATE/blog/entries" "$TMP_STATE/threads"
+
+echo "=== health v2 Smoke Test ==="
+
+for comp in disk fs_rw sqlite blog index consolidate git heartbeat mini_repos primitives; do
+  cat >"$TMP_STATE/health/raw/${comp}.json" <<JSON
+{"name":"$comp","status":"ok","detail":"${comp}=ok","ts":"2026-04-23T12:00:00+00:00"}
+JSON
+done
+cat >"$TMP_STATE/health/raw/content.json" <<'JSON'
+{"name":"content","status":"degraded","detail":"stale=2/8 threads_overdue=1","ts":"2026-04-23T12:00:00+00:00"}
+JSON
+cat >"$TMP_STATE/health/raw/quality.json" <<'JSON'
+{"name":"quality","status":"degraded","detail":"adversarial=0% fontes=0% review_gate=false exa=ok openai=degraded","ts":"2026-04-23T12:00:00+00:00"}
+JSON
+
+cat >"$TMP_STATE/threads/alpha-thread.md" <<'MD'
+---
+title: Alpha Thread
+status: active
+updated: 2026-04-22
+resurface: 2026-04-22
+---
+MD
+cat >"$TMP_STATE/threads/beta-thread.md" <<'MD'
+---
+title: Beta Thread
+status: waiting
+updated: 2026-04-22
+resurface: 2026-04-24
+---
+MD
+
+cat >"$TMP_STATE/state/projections/claims-digest.json" <<'JSON'
+{
+  "open_total": 8,
+  "verified_total": 13,
+  "attention_count": 6,
+  "unthreaded_count": 3,
+  "stale_count": 4,
+  "opened_30d": 6,
+  "resolved_30d": 2,
+  "fanout_ratio": 3.0,
+  "hot_threads_by_open_claims": [{"thread_id":"alpha-thread","open_claims":5}]
+}
+JSON
+cat >"$TMP_STATE/state/projections/orphan-claims.json" <<'JSON'
+{
+  "orphan_total": 3,
+  "open_orphan_total": 2,
+  "stale_orphan_total": 1,
+  "candidate_clusters": [{"cluster_key":"alpha beta","score":6}]
+}
+JSON
+
+cat >"$TMP_STATE/state/primitives-status.json" <<'JSON'
+{
+  "summary": {
+    "health_status": "degraded",
+    "declared_total": 3,
+    "broken_total": 1,
+    "drifted_total": 1,
+    "usage_30d_total": 9
+  },
+  "sources": [
+    {"name":"arxiv","effective_status":"active","usage_30d":4},
+    {"name":"exa","effective_status":"broken","usage_30d":0},
+    {"name":"grafana","effective_status":"contract-only","usage_30d":0}
+  ]
+}
+JSON
+
+cat >"$TMP_STATE/state/capabilities-status.json" <<'JSON'
+{
+  "summary": {
+    "health_status": "degraded",
+    "capability_total": 4,
+    "available_total": 2,
+    "missing_total": 1,
+    "broken_total": 1,
+    "drifted_total": 0
+  },
+  "capabilities": [
+    {"name":"source.arxiv","effective_status":"available","invoke_30d":0},
+    {"name":"source.github","effective_status":"available","invoke_30d":2},
+    {"name":"search.corpus","effective_status":"broken","invoke_30d":1},
+    {"name":"storage.sync","effective_status":"missing","invoke_30d":0}
+  ]
+}
+JSON
+
+cat >"$TMP_STATE/blog/entries/2026-04-01-sources-research-consult-report.md" <<'MD'
+---
+title: Sources Research Consult Report
+date: 2026-04-01
+tags: [workflow]
+---
+MD
+cat >"$TMP_STATE/blog/entries/2026-04-01-stale-playwright-validation.md" <<'MD'
+---
+title: Stale Playwright Validation
+date: 2026-04-01
+tags: [workflow]
+---
+MD
+cat >"$TMP_STATE/state/workflow-health.json" <<'JSON'
+{
+  "citations": {
+    "2026-04-01-sources-research-consult-report": {"used": 2, "broken": 0, "last_cited": "2026-04-22T10:00:00+00:00"},
+    "2026-04-01-stale-playwright-validation": {"used": 1, "broken": 3, "last_cited": "2025-12-01T10:00:00+00:00"}
+  }
+}
+JSON
+
+cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
+{"ts":"2026-04-23T10:00:00+00:00","type":"CycleStarted","cycle_id":"cycle-1","payload":{}}
+{"ts":"2026-04-23T10:00:10+00:00","type":"SkillDispatched","cycle_id":"cycle-1","payload":{"skill":"research"}}
+{"ts":"2026-04-23T10:00:20+00:00","type":"SkillRunCompleted","cycle_id":"cycle-1","payload":{"skill":"research"}}
+{"ts":"2026-04-23T10:00:30+00:00","type":"PostflightCompleted","cycle_id":"cycle-1","payload":{}}
+{"ts":"2026-04-23T10:00:31+00:00","type":"CycleClosed","cycle_id":"cycle-1","payload":{}}
+{"ts":"2026-04-23T11:00:00+00:00","type":"CycleStarted","cycle_id":"cycle-2","payload":{}}
+{"ts":"2026-04-23T11:01:00+00:00","type":"HeartbeatDispatchTimedOut","cycle_id":"cycle-2","payload":{}}
+{"ts":"2026-04-23T11:02:00+00:00","type":"PostflightFailed","cycle_id":"cycle-2","payload":{}}
+{"ts":"2026-04-23T10:05:00+00:00","type":"ThreadTouched","payload":{"thread_id":"alpha-thread"}}
+{"ts":"2026-04-22T10:05:00+00:00","type":"ClaimPromotedToThread","payload":{"claim_id":"claim-x"}}
+{"ts":"2026-04-23T10:06:00+00:00","type":"WorkflowRecommended","payload":{"slug":"2026-04-01-sources-research-consult-report"}}
+{"ts":"2026-04-23T10:07:00+00:00","type":"WorkflowRecommended","payload":{"slug":"2026-04-01-stale-playwright-validation"}}
+{"ts":"2026-04-23T10:08:00+00:00","type":"WorkflowUsedObserved","payload":{"slug":"2026-04-01-sources-research-consult-report"}}
+{"ts":"2026-04-23T10:09:00+00:00","type":"WorkflowIgnoredObserved","payload":{"slug":"2026-04-01-stale-playwright-validation"}}
+{"ts":"2026-04-23T10:10:00+00:00","type":"PrimitiveManifestUpdated","payload":{"source":"grafana"}}
+{"ts":"2026-04-23T10:11:00+00:00","type":"PrimitiveMaterialized","payload":{"source":"grafana"}}
+{"ts":"2026-04-23T10:12:00+00:00","type":"PrimitiveProbeCompleted","payload":{"source":"grafana","ok":true}}
+{"ts":"2026-04-23T10:13:00+00:00","type":"PrimitiveBypassObserved","payload":{"source":"arxiv","capability":"source.arxiv"}}
+{"ts":"2026-04-23T10:14:00+00:00","type":"CapabilityInvocationObserved","payload":{"capability":"source.github","ok":true}}
+{"ts":"2026-04-23T10:15:00+00:00","type":"CapabilityProbeCompleted","payload":{"capability":"search.corpus","ok":false}}
+{"ts":"2026-04-23T10:16:00+00:00","type":"ProviderProbeCompleted","payload":{"provider":"exa","ok":true,"status":"ok","http_status":"200"}}
+{"ts":"2026-04-23T10:17:00+00:00","type":"ProviderProbeCompleted","payload":{"provider":"openai","ok":false,"status":"degraded","http_status":"401"}}
+JSONL
+
+echo "--- Test 1: rollup-health-v2 writes current.json with v2 dimensions ---"
+if env HOME="$TMP_HOME" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" python3 "$EDGE_DIR/tools/rollup-health-v2.py" --write >/dev/null 2>&1; then
+  if [[ "$(jq -r '.schema_version' "$TMP_STATE/health/current.json")" == "2" ]]; then
+    pass "health/current.json uses schema_version=2"
+  else
+    fail "schema_version was not 2"
+  fi
+  if jq -e '.dimensions.runtime_flow and .dimensions.continuity and .dimensions.capabilities and .dimensions.workflows and .dimensions.renewal and .dimensions.substrate_discipline and .dimensions.api_runtime' "$TMP_STATE/health/current.json" >/dev/null; then
+    pass "health v2 dimensions are present"
+  else
+    fail "health v2 dimensions missing"
+  fi
+  if [[ "$(jq -r '.dimensions.runtime_flow.metrics.heartbeat_dispatch_timeouts' "$TMP_STATE/health/current.json")" == "1" ]]; then
+    pass "runtime_flow captured heartbeat timeouts"
+  else
+    fail "runtime_flow did not capture heartbeat timeouts"
+  fi
+  if [[ "$(jq -r '.dimensions.workflows.metrics.ignored_30d' "$TMP_STATE/health/current.json")" == "1" ]]; then
+    pass "workflow dimension captured ignored recommendations"
+  else
+    fail "workflow ignored count wrong"
+  fi
+  if [[ "$(jq -r '.dimensions.substrate_discipline.metrics.primitive_bypass_30d' "$TMP_STATE/health/current.json")" == "1" ]]; then
+    pass "substrate discipline captured primitive bypass"
+  else
+    fail "primitive bypass count wrong"
+  fi
+  if grep -q '"type": "HealthSnapshotComputed"' "$TMP_STATE/state/events/log.jsonl"; then
+    pass "health snapshot emission wrote HealthSnapshotComputed"
+  else
+    fail "HealthSnapshotComputed event missing"
+  fi
+else
+  fail "rollup-health-v2 execution failed"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -32,7 +32,7 @@ from paths import (  # noqa: E402
 from .continuity import refresh_continuity_projections  # noqa: E402
 from .capability_runtime import build_capability_status  # noqa: E402
 from .skill_inbox import attach_snapshot_to_dispatch  # noqa: E402
-from .telemetry import emit_shadow_event, log_event, log_run_step  # noqa: E402
+from .telemetry import emit_shadow_event, log_event, log_run_step, log_workflow_recommended  # noqa: E402
 from .workflow_runtime import build_workflow_status, recommend_workflows  # noqa: E402
 
 REQUEST_SCHEMA_VERSION = 1
@@ -136,12 +136,21 @@ def _health_snapshot() -> dict[str, Any]:
     if not isinstance(payload, dict):
         payload = {}
     remediation = payload.get("remediation_queue") or []
+    dimensions = payload.get("dimensions") or {}
     return {
         "status": payload.get("status", "unknown"),
         "score": int(payload.get("score", 100) or 100),
         "hard_fail": bool(payload.get("hard_fail", False)),
         "updated_at": payload.get("ts") or payload.get("updated_at") or "",
         "remediation_count": len(remediation) if isinstance(remediation, list) else 0,
+        "dimensions": {
+            name: {
+                "status": dim.get("status"),
+                "score": dim.get("score"),
+            }
+            for name, dim in dimensions.items()
+            if isinstance(dim, dict)
+        },
     }
 
 
@@ -437,6 +446,21 @@ def enrich_dispatch_state(
             item for item in workflow_recommendations if item["slug"] not in {wf["slug"] for wf in corpus_workflows}
         ]
     request["workflow_recommendations"] = workflow_recommendations[:3]
+    for item in request["workflow_recommendations"]:
+        slug = str(item.get("slug") or "").strip()
+        if not slug:
+            continue
+        log_workflow_recommended(
+            slug,
+            title=str(item.get("title") or ""),
+            source=str(item.get("source") or ""),
+            score=float(item.get("score") or 0.0),
+            query=corpus_query or "",
+            cycle_id=state.get("cycle_id"),
+            stage=stage,
+            profile=state_block["preflight_profile"],
+            skill=skill or "",
+        )
     state_block["preflight_status"] = "completed"
     state_block["preflight_profile"] = profile or request.get("preflight_profile") or "standard"
     state_block["preflight_stage"] = stage

--- a/tools/_shared/health_runtime.py
+++ b/tools/_shared/health_runtime.py
@@ -1,0 +1,921 @@
+"""Health runtime — event-backed health v2 dimensions and cycle observations."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+import sys
+
+sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "config"))
+from paths import (  # noqa: E402
+    CAPABILITIES_STATUS_FILE,
+    CLAIMS_DIGEST_FILE,
+    HEALTH_CURRENT_FILE,
+    HEALTH_DIR,
+    ORPHAN_CLAIMS_FILE,
+    PRIMITIVES_STATUS_FILE,
+    STATE_EVENTS_FILE,
+    THREADS_DIR,
+    WORKFLOW_HEALTH_FILE,
+)
+from .capability_runtime import build_capability_status  # noqa: E402
+from .telemetry import emit_shadow_event  # noqa: E402
+from .workflow_runtime import build_workflow_status  # noqa: E402
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not value:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    try:
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        dt = datetime.fromisoformat(raw)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.exists():
+        return rows
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            rows.append(obj)
+    return rows
+
+
+def _iter_events(*paths: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in paths:
+        rows.extend(_read_jsonl(path))
+    return rows
+
+
+def _status_from_score(score: int, *, hard_fail: bool = False) -> str:
+    if hard_fail:
+        return "critical"
+    if score < 40:
+        return "critical"
+    if score < 70:
+        return "unhealthy"
+    if score < 85:
+        return "degraded"
+    return "healthy"
+
+
+def _dimension_status(score: int, *, hard_fail: bool = False) -> str:
+    if hard_fail or score < 25:
+        return "fail"
+    if score < 60:
+        return "degraded"
+    return "ok"
+
+
+def _component_score(status: str | None) -> int | None:
+    mapping = {
+        "ok": 100,
+        "healthy": 100,
+        "degraded": 60,
+        "warning": 60,
+        "fail": 0,
+        "critical": 0,
+        "unknown": None,
+    }
+    return mapping.get(str(status or "").strip().lower(), None)
+
+
+def _weighted_score(weights: dict[str, int], values: dict[str, str]) -> int:
+    total = 0
+    max_total = 0
+    for key, weight in weights.items():
+        score = _component_score(values.get(key))
+        if score is None:
+            continue
+        total += int(score * weight / 100)
+        max_total += weight
+    if max_total <= 0:
+        return 100
+    return max(0, min(100, round(total * 100 / max_total)))
+
+
+def _load_raw_components(health_dir: Path = HEALTH_DIR) -> dict[str, dict[str, Any]]:
+    raw_dir = health_dir / "raw"
+    payload: dict[str, dict[str, Any]] = {}
+    if not raw_dir.exists():
+        return payload
+    for path in sorted(raw_dir.glob("*.json")):
+        data = _read_json(path, {})
+        if isinstance(data, dict):
+            payload[path.stem] = data
+    return payload
+
+
+def _infra_dimension(raw: dict[str, dict[str, Any]]) -> tuple[dict[str, Any], bool]:
+    weights = {
+        "disk": 10,
+        "fs_rw": 15,
+        "sqlite": 15,
+        "blog": 10,
+        "index": 5,
+        "consolidate": 5,
+        "git": 5,
+        "heartbeat": 15,
+        "mini_repos": 5,
+        "primitives": 15,
+    }
+    values = {name: str((raw.get(name) or {}).get("status") or "unknown") for name in weights}
+    score = _weighted_score(weights, values)
+    hard_fail = any(str((raw.get(name) or {}).get("status")) == "critical" for name in {"disk", "fs_rw", "sqlite"})
+    detail_parts = [
+        f"{name}={values[name]}"
+        for name in ["disk", "fs_rw", "sqlite", "blog", "heartbeat", "primitives"]
+        if values.get(name) != "unknown"
+    ]
+    return (
+        {
+            "status": _dimension_status(score, hard_fail=hard_fail),
+            "score": score,
+            "detail": " ".join(detail_parts) if detail_parts else "no infra data",
+            "components": {
+                name: {
+                    "status": str((raw.get(name) or {}).get("status") or "unknown"),
+                    "detail": str((raw.get(name) or {}).get("detail") or ""),
+                }
+                for name in weights
+            },
+        },
+        hard_fail,
+    )
+
+
+def _cycle_window(events: list[dict[str, Any]], *, days: int = 7) -> list[dict[str, Any]]:
+    cutoff = _now() - timedelta(days=days)
+    return [row for row in events if (_parse_ts(row.get("ts") or row.get("timestamp")) or datetime.min.replace(tzinfo=timezone.utc)) >= cutoff]
+
+
+def _runtime_flow_dimension(events: list[dict[str, Any]]) -> dict[str, Any]:
+    rows = _cycle_window(events, days=7)
+    counts = Counter(row.get("type") for row in rows)
+    cycles_started = counts.get("CycleStarted", 0)
+    cycles_closed = counts.get("CycleClosed", 0)
+    dispatched = counts.get("SkillDispatched", 0)
+    skill_runs = counts.get("SkillRunCompleted", 0)
+    preflight_completed = counts.get("PreflightCompleted", 0)
+    preflight_failed = counts.get("PreflightFailed", 0)
+    postflight_completed = counts.get("PostflightCompleted", 0)
+    postflight_failed = counts.get("PostflightFailed", 0)
+    timeouts = counts.get("HeartbeatDispatchTimedOut", 0)
+
+    completion_rate = cycles_closed / cycles_started if cycles_started else 1.0
+    dispatch_rate = dispatched / cycles_started if cycles_started else 1.0
+    preflight_success_rate = preflight_completed / max(preflight_completed + preflight_failed, 1)
+    postflight_success_rate = postflight_completed / max(postflight_completed + postflight_failed, 1)
+    timeout_penalty = min(timeouts / max(cycles_started, 1), 1.0) if cycles_started else 0.0
+    if cycles_started == 0 and cycles_closed == 0 and dispatched == 0 and postflight_completed == 0 and postflight_failed == 0:
+        return {
+            "status": "unknown",
+            "score": 50,
+            "detail": "no recent cycle evidence",
+            "metrics": {
+                "window_days": 7,
+                "cycles_started": 0,
+                "cycles_closed": 0,
+                "skill_dispatched": 0,
+                "skill_runs_completed": 0,
+                "preflight_completed": preflight_completed,
+                "preflight_failed": preflight_failed,
+                "postflight_completed": 0,
+                "postflight_failed": 0,
+                "heartbeat_dispatch_timeouts": timeouts,
+                "completion_rate": 0.0,
+                "dispatch_rate": 0.0,
+                "preflight_success_rate": round(preflight_success_rate, 3),
+                "postflight_success_rate": 0.0,
+            },
+        }
+
+    score = round(
+        completion_rate * 35
+        + dispatch_rate * 20
+        + preflight_success_rate * 15
+        + postflight_success_rate * 20
+        + (1.0 - timeout_penalty) * 10
+    )
+    score = max(0, min(100, score))
+    return {
+        "status": _dimension_status(score),
+        "score": score,
+        "detail": (
+            f"started={cycles_started} closed={cycles_closed} dispatched={dispatched} "
+            f"skill_runs={skill_runs} postflight_fail={postflight_failed} timeouts={timeouts}"
+        ),
+        "metrics": {
+            "window_days": 7,
+            "cycles_started": cycles_started,
+            "cycles_closed": cycles_closed,
+            "skill_dispatched": dispatched,
+            "skill_runs_completed": skill_runs,
+            "preflight_completed": preflight_completed,
+            "preflight_failed": preflight_failed,
+            "postflight_completed": postflight_completed,
+            "postflight_failed": postflight_failed,
+            "heartbeat_dispatch_timeouts": timeouts,
+            "completion_rate": round(completion_rate, 3),
+            "dispatch_rate": round(dispatch_rate, 3),
+            "preflight_success_rate": round(preflight_success_rate, 3),
+            "postflight_success_rate": round(postflight_success_rate, 3),
+        },
+    }
+
+
+def _active_threads() -> tuple[int, int]:
+    active = 0
+    due = 0
+    today = _now().date().isoformat()
+    for path in THREADS_DIR.glob("*.md"):
+        fm = _read_frontmatter(path)
+        status = str(fm.get("status") or "").strip().lower()
+        if status not in {"active", "waiting"}:
+            continue
+        active += 1
+        resurface = str(fm.get("resurface") or "").strip()
+        if resurface and resurface <= today:
+            due += 1
+    return active, due
+
+
+def _read_frontmatter(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return {}
+    parts = raw.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    try:
+        data = yaml.safe_load(parts[1]) or {}
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _thread_touch_counts(events: list[dict[str, Any]], *, days: int = 7) -> tuple[int, list[str]]:
+    cutoff = _now() - timedelta(days=days)
+    touched: set[str] = set()
+    for row in events:
+        if row.get("type") != "ThreadTouched":
+            continue
+        dt = _parse_ts(row.get("ts"))
+        if not dt or dt < cutoff:
+            continue
+        payload = row.get("payload") or {}
+        thread_id = str(payload.get("thread_id") or "").strip()
+        if thread_id:
+            touched.add(thread_id)
+    return len(touched), sorted(touched)
+
+
+def _continuity_dimension(events: list[dict[str, Any]], claims_digest: dict[str, Any], orphan_claims: dict[str, Any]) -> dict[str, Any]:
+    active_threads, due_threads = _active_threads()
+    touched_7d, touched_threads = _thread_touch_counts(events, days=7)
+    renewal_rate = touched_7d / active_threads if active_threads else 1.0
+    open_total = int(claims_digest.get("open_total", 0) or 0)
+    orphan_total = int(orphan_claims.get("orphan_total", 0) or 0)
+    stale_total = int(claims_digest.get("stale_count", 0) or 0)
+    fanout_ratio = float(claims_digest.get("fanout_ratio", 0) or 0)
+    if active_threads == 0 and open_total == 0 and orphan_total == 0 and stale_total == 0:
+        return {
+            "status": "unknown",
+            "score": 50,
+            "detail": "no continuity evidence yet",
+            "metrics": {
+                "active_threads": 0,
+                "touched_threads_7d": touched_7d,
+                "touched_thread_ids_7d": [],
+                "renewal_rate_7d": 0.0,
+                "due_threads": 0,
+                "open_claims": 0,
+                "orphan_claims": 0,
+                "stale_claims": 0,
+                "fanout_ratio_30d": 0.0,
+                "resolved_30d": 0,
+                "opened_30d": 0,
+            },
+        }
+
+    score = 100
+    if fanout_ratio > 2.0:
+        score -= 25
+    elif fanout_ratio > 1.2:
+        score -= 10
+    if orphan_total > 20:
+        score -= 20
+    elif orphan_total > 5:
+        score -= 10
+    if stale_total > 10:
+        score -= 20
+    elif stale_total > 3:
+        score -= 10
+    if active_threads and renewal_rate < 0.3:
+        score -= 20
+    elif active_threads and renewal_rate < 0.6:
+        score -= 10
+    if due_threads > 3:
+        score -= 15
+    elif due_threads > 0:
+        score -= 5
+    score = max(0, min(100, score))
+
+    return {
+        "status": _dimension_status(score),
+        "score": score,
+        "detail": (
+            f"open={open_total} orphans={orphan_total} stale={stale_total} "
+            f"threads_active={active_threads} touched_7d={touched_7d} due={due_threads}"
+        ),
+        "metrics": {
+            "active_threads": active_threads,
+            "touched_threads_7d": touched_7d,
+            "touched_thread_ids_7d": touched_threads[:10],
+            "renewal_rate_7d": round(renewal_rate, 3),
+            "due_threads": due_threads,
+            "open_claims": open_total,
+            "orphan_claims": orphan_total,
+            "stale_claims": stale_total,
+            "fanout_ratio_30d": round(fanout_ratio, 2),
+            "resolved_30d": int(claims_digest.get("resolved_30d", 0) or 0),
+            "opened_30d": int(claims_digest.get("opened_30d", 0) or 0),
+        },
+    }
+
+
+def _capability_events(events: list[dict[str, Any]], *, days: int = 30) -> tuple[Counter[str], Counter[str], Counter[str], Counter[str]]:
+    cutoff = _now() - timedelta(days=days)
+    capability_invokes = Counter()
+    capability_invoke_fail = Counter()
+    capability_probe_fail = Counter()
+    primitive_probe_fail = Counter()
+    for row in events:
+        dt = _parse_ts(row.get("ts"))
+        if not dt or dt < cutoff:
+            continue
+        etype = row.get("type")
+        payload = row.get("payload") or {}
+        if etype == "CapabilityInvocationObserved":
+            name = str(payload.get("capability") or "").strip()
+            if name:
+                capability_invokes[name] += 1
+                if not payload.get("ok", False):
+                    capability_invoke_fail[name] += 1
+        elif etype == "CapabilityProbeCompleted":
+            name = str(payload.get("capability") or "").strip()
+            if name and not payload.get("ok", False):
+                capability_probe_fail[name] += 1
+        elif etype == "PrimitiveProbeCompleted":
+            source = str(payload.get("source") or "").strip()
+            if source and not payload.get("ok", False):
+                primitive_probe_fail[source] += 1
+    return capability_invokes, capability_invoke_fail, capability_probe_fail, primitive_probe_fail
+
+
+def _capabilities_dimension(events: list[dict[str, Any]], capabilities_status: dict[str, Any], primitives_status: dict[str, Any]) -> dict[str, Any]:
+    cap_summary = capabilities_status.get("summary") or {}
+    cap_rows = capabilities_status.get("capabilities") or []
+    primitive_summary = primitives_status.get("summary") or {}
+    sources = primitives_status.get("sources") or []
+    capability_invokes, capability_invoke_fail, capability_probe_fail, primitive_probe_fail = _capability_events(events)
+
+    available = int(cap_summary.get("available_total", 0) or 0)
+    missing = int(cap_summary.get("missing_total", 0) or 0)
+    broken = int(cap_summary.get("broken_total", 0) or 0)
+    drifted = int(cap_summary.get("drifted_total", 0) or 0)
+    primitive_broken = int(primitive_summary.get("broken_total", 0) or 0)
+    primitive_drifted = int(primitive_summary.get("drifted_total", 0) or 0)
+    never_used_available = sum(
+        1
+        for row in cap_rows
+        if str(row.get("effective_status")) in {"available", "active", "probed"} and int(row.get("invoke_30d", 0) or 0) == 0
+    )
+    primitive_never_used = sum(
+        1
+        for row in sources
+        if str(row.get("effective_status")) in {"active", "probed", "contract-only"} and int(row.get("usage_30d", 0) or 0) == 0
+    )
+    total_invocations = sum(capability_invokes.values())
+    total_invoke_fail = sum(capability_invoke_fail.values())
+    invoke_fail_rate = total_invoke_fail / total_invocations if total_invocations else 0.0
+    if available == 0 and missing == 0 and broken == 0 and drifted == 0 and primitive_broken == 0 and primitive_drifted == 0 and total_invocations == 0:
+        return {
+            "status": "unknown",
+            "score": 50,
+            "detail": "no capability evidence yet",
+            "metrics": {
+                "available_capabilities": 0,
+                "missing_capabilities": 0,
+                "broken_capabilities": 0,
+                "drifted_capabilities": 0,
+                "broken_primitives": 0,
+                "drifted_primitives": 0,
+                "never_used_available_capabilities": 0,
+                "never_used_primitives": 0,
+                "capability_invocations_30d": 0,
+                "capability_invoke_fail_30d": 0,
+                "capability_invoke_fail_rate_30d": 0.0,
+                "capability_probe_fail_30d": 0,
+                "primitive_probe_fail_30d": 0,
+            },
+        }
+
+    score = 100
+    score -= min(broken * 15, 40)
+    score -= min(drifted * 8, 20)
+    score -= min(primitive_broken * 15, 30)
+    score -= min(primitive_drifted * 8, 20)
+    score -= min(missing * 5, 20)
+    if available > 0:
+        score -= min(round((never_used_available / max(available, 1)) * 20), 20)
+    if total_invocations:
+        score -= min(round(invoke_fail_rate * 30), 30)
+    score = max(0, min(100, score))
+
+    return {
+        "status": _dimension_status(score),
+        "score": score,
+        "detail": (
+            f"available={available} missing={missing} broken={broken} drifted={drifted} "
+            f"primitive_broken={primitive_broken} primitive_drifted={primitive_drifted}"
+        ),
+        "metrics": {
+            "available_capabilities": available,
+            "missing_capabilities": missing,
+            "broken_capabilities": broken,
+            "drifted_capabilities": drifted,
+            "broken_primitives": primitive_broken,
+            "drifted_primitives": primitive_drifted,
+            "never_used_available_capabilities": never_used_available,
+            "never_used_primitives": primitive_never_used,
+            "capability_invocations_30d": total_invocations,
+            "capability_invoke_fail_30d": total_invoke_fail,
+            "capability_invoke_fail_rate_30d": round(invoke_fail_rate, 3),
+            "capability_probe_fail_30d": sum(capability_probe_fail.values()),
+            "primitive_probe_fail_30d": sum(primitive_probe_fail.values()),
+        },
+    }
+
+
+def _workflow_dimension(events: list[dict[str, Any]], workflow_status: dict[str, Any]) -> dict[str, Any]:
+    rows = _cycle_window(events, days=30)
+    counts = Counter(row.get("type") for row in rows)
+    recommended = counts.get("WorkflowRecommended", 0)
+    used = counts.get("WorkflowUsedObserved", 0)
+    broken = counts.get("WorkflowBrokenObserved", 0)
+    ignored = counts.get("WorkflowIgnoredObserved", 0)
+    summary = workflow_status.get("summary") or {}
+    stale_total = int(summary.get("stale_total", 0) or 0)
+    broken_total = int(summary.get("broken_total", 0) or 0)
+    workflow_total = int(summary.get("workflow_total", 0) or 0)
+    if workflow_total == 0 and recommended == 0 and used == 0 and broken == 0 and ignored == 0:
+        return {
+            "status": "unknown",
+            "score": 50,
+            "detail": "no workflow evidence yet",
+            "metrics": {
+                "workflow_total": 0,
+                "workflow_cited_total": 0,
+                "workflow_broken_total": 0,
+                "workflow_stale_total": 0,
+                "recommended_30d": 0,
+                "used_30d": 0,
+                "broken_30d": 0,
+                "ignored_30d": 0,
+                "adoption_rate_30d": 0.0,
+            },
+        }
+
+    adoption_rate = (used + broken) / recommended if recommended else 1.0
+    score = 100
+    score -= min(broken_total * 10, 30)
+    score -= min(stale_total * 3, 20)
+    if recommended:
+        score -= min(round((1.0 - adoption_rate) * 30), 30)
+        score -= min(round((ignored / recommended) * 20), 20)
+    score = max(0, min(100, score))
+
+    return {
+        "status": _dimension_status(score),
+        "score": score,
+        "detail": (
+            f"recommended_30d={recommended} used_30d={used} broken_30d={broken} "
+            f"ignored_30d={ignored} stale={stale_total} broken_total={broken_total}"
+        ),
+        "metrics": {
+            "workflow_total": workflow_total,
+            "workflow_cited_total": int(summary.get("cited_total", 0) or 0),
+            "workflow_broken_total": broken_total,
+            "workflow_stale_total": stale_total,
+            "recommended_30d": recommended,
+            "used_30d": used,
+            "broken_30d": broken,
+            "ignored_30d": ignored,
+            "adoption_rate_30d": round(adoption_rate, 3),
+        },
+    }
+
+
+def _renewal_dimension(events: list[dict[str, Any]], claims_digest: dict[str, Any]) -> dict[str, Any]:
+    rows = _cycle_window(events, days=30)
+    counts = Counter(row.get("type") for row in rows)
+    threads_touched_30d, _ = _thread_touch_counts(events, days=30)
+    active_threads, _ = _active_threads()
+    cluster_touch_rate = threads_touched_30d / active_threads if active_threads else 1.0
+    opened_30d = int(claims_digest.get("opened_30d", 0) or 0)
+    resolved_30d = int(claims_digest.get("resolved_30d", 0) or 0)
+    fanout_ratio = float(claims_digest.get("fanout_ratio", 0) or 0)
+    primitive_updates = counts.get("PrimitiveManifestUpdated", 0) + counts.get("PrimitiveMaterialized", 0)
+    primitive_probes = counts.get("PrimitiveProbeCompleted", 0)
+    thread_promotions = counts.get("ClaimPromotedToThread", 0)
+    if active_threads == 0 and threads_touched_30d == 0 and opened_30d == 0 and resolved_30d == 0 and primitive_updates == 0 and primitive_probes == 0:
+        return {
+            "status": "unknown",
+            "score": 50,
+            "detail": "no renewal evidence yet",
+            "metrics": {
+                "cluster_touch_rate_30d": 0.0,
+                "threads_touched_30d": 0,
+                "active_clusters": 0,
+                "opened_30d": 0,
+                "resolved_30d": 0,
+                "fanout_ratio_30d": round(fanout_ratio, 2),
+                "orphan_promotions_30d": 0,
+                "primitive_updates_30d": 0,
+                "primitive_probes_30d": 0,
+            },
+        }
+
+    score = 100
+    if cluster_touch_rate < 0.3 and active_threads:
+        score -= 20
+    elif cluster_touch_rate < 0.6 and active_threads:
+        score -= 10
+    if fanout_ratio > 2.0:
+        score -= 20
+    elif fanout_ratio > 1.2:
+        score -= 10
+    if primitive_updates == 0 and primitive_probes == 0:
+        score -= 10
+    if opened_30d > resolved_30d:
+        score -= min((opened_30d - resolved_30d) * 2, 20)
+    score = max(0, min(100, score))
+
+    return {
+        "status": _dimension_status(score),
+        "score": score,
+        "detail": (
+            f"clusters_touched_30d={threads_touched_30d} active_clusters={active_threads} "
+            f"opened_30d={opened_30d} resolved_30d={resolved_30d} primitive_updates_30d={primitive_updates}"
+        ),
+        "metrics": {
+            "cluster_touch_rate_30d": round(cluster_touch_rate, 3),
+            "threads_touched_30d": threads_touched_30d,
+            "active_clusters": active_threads,
+            "opened_30d": opened_30d,
+            "resolved_30d": resolved_30d,
+            "fanout_ratio_30d": round(fanout_ratio, 2),
+            "orphan_promotions_30d": thread_promotions,
+            "primitive_updates_30d": primitive_updates,
+            "primitive_probes_30d": primitive_probes,
+        },
+    }
+
+
+def _substrate_discipline_dimension(events: list[dict[str, Any]]) -> dict[str, Any]:
+    rows = _cycle_window(events, days=30)
+    counts = Counter(row.get("type") for row in rows)
+    primitive_bypass = counts.get("PrimitiveBypassObserved", 0)
+    workflow_ignored = counts.get("WorkflowIgnoredObserved", 0)
+    secret_bypass = counts.get("SecretBypassObserved", 0)
+    api_bypass = counts.get("ApiBypassObserved", 0)
+    cli_bypass = counts.get("CliBypassObserved", 0)
+    if primitive_bypass == 0 and workflow_ignored == 0 and secret_bypass == 0 and api_bypass == 0 and cli_bypass == 0:
+        return {
+            "status": "unknown",
+            "score": 50,
+            "detail": "no substrate-discipline evidence yet",
+            "metrics": {
+                "primitive_bypass_30d": 0,
+                "workflow_ignored_30d": 0,
+                "secret_bypass_30d": 0,
+                "api_bypass_30d": 0,
+                "cli_bypass_30d": 0,
+            },
+        }
+    score = 100 - min(primitive_bypass * 8, 40) - min(workflow_ignored * 4, 20) - min(secret_bypass * 20, 40) - min(api_bypass * 10, 30) - min(cli_bypass * 10, 30)
+    score = max(0, min(100, score))
+    return {
+        "status": _dimension_status(score),
+        "score": score,
+        "detail": (
+            f"primitive_bypass_30d={primitive_bypass} workflow_ignored_30d={workflow_ignored} "
+            f"secret_bypass_30d={secret_bypass} api_bypass_30d={api_bypass} cli_bypass_30d={cli_bypass}"
+        ),
+        "metrics": {
+            "primitive_bypass_30d": primitive_bypass,
+            "workflow_ignored_30d": workflow_ignored,
+            "secret_bypass_30d": secret_bypass,
+            "api_bypass_30d": api_bypass,
+            "cli_bypass_30d": cli_bypass,
+        },
+    }
+
+
+def _api_runtime_dimension(raw: dict[str, dict[str, Any]], events: list[dict[str, Any]]) -> dict[str, Any]:
+    provider_rows = _cycle_window(events, days=7)
+    provider_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    for row in provider_rows:
+        if row.get("type") != "ProviderProbeCompleted":
+            continue
+        payload = row.get("payload") or {}
+        provider = str(payload.get("provider") or "unknown")
+        provider_counts[provider]["total"] += 1
+        if payload.get("ok", False):
+            provider_counts[provider]["ok"] += 1
+        else:
+            provider_counts[provider]["fail"] += 1
+
+    exa_status = "unknown"
+    openai_status = "unknown"
+    quality_detail = str((raw.get("quality") or {}).get("detail") or "")
+    for token in quality_detail.split():
+        if token.startswith("exa="):
+            exa_status = token.split("=", 1)[1]
+        elif token.startswith("openai="):
+            openai_status = token.split("=", 1)[1]
+    if exa_status == "unknown" and openai_status == "unknown" and not provider_counts:
+        return {
+            "status": "unknown",
+            "score": 50,
+            "detail": "no provider probe evidence yet",
+            "metrics": {
+                "provider_probe_window_days": 7,
+                "providers": {},
+            },
+        }
+
+    statuses = {"exa": exa_status, "openai": openai_status}
+    weights = {"exa": 50, "openai": 50}
+    score = _weighted_score(weights, statuses)
+    return {
+        "status": _dimension_status(score),
+        "score": score,
+        "detail": f"exa={exa_status} openai={openai_status}",
+        "metrics": {
+            "provider_probe_window_days": 7,
+            "providers": {
+                provider: {
+                    "total": counts.get("total", 0),
+                    "ok": counts.get("ok", 0),
+                    "fail": counts.get("fail", 0),
+                }
+                for provider, counts in sorted(provider_counts.items())
+            },
+        },
+    }
+
+
+def _legacy_sections(raw: dict[str, dict[str, Any]]) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    infra = {}
+    for comp in ["disk", "fs_rw", "sqlite", "blog", "index", "consolidate", "git", "heartbeat", "mini_repos", "primitives"]:
+        if comp in raw:
+            infra[comp] = {
+                "status": raw[comp].get("status", "unknown"),
+                "detail": raw[comp].get("detail", ""),
+            }
+    content = {"status": "unknown", "detail": ""}
+    if "content" in raw:
+        content = {"status": raw["content"].get("status", "unknown"), "detail": raw["content"].get("detail", "")}
+    quality = {"status": "unknown", "detail": ""}
+    if "quality" in raw:
+        quality = {"status": raw["quality"].get("status", "unknown"), "detail": raw["quality"].get("detail", "")}
+    return infra, content, quality
+
+
+def _remediation_queue(dimensions: dict[str, dict[str, Any]], raw: dict[str, dict[str, Any]], *, health_dir: Path = HEALTH_DIR) -> list[dict[str, Any]]:
+    queue: list[dict[str, Any]] = []
+    if dimensions["runtime_flow"]["status"] != "ok":
+        queue.append({"domain": "runtime_flow", "priority": 1, "action": "inspect dispatch lifecycle stalls/timeouts", "detail": dimensions["runtime_flow"]["detail"]})
+    if dimensions["continuity"]["status"] != "ok":
+        queue.append({"domain": "continuity", "priority": 2, "action": "recycle overdue threads and reduce orphan claims", "detail": dimensions["continuity"]["detail"]})
+    if dimensions["capabilities"]["status"] != "ok":
+        queue.append({"domain": "capabilities", "priority": 2, "action": "repair broken capabilities/primitives and improve adoption", "detail": dimensions["capabilities"]["detail"]})
+    if dimensions["workflows"]["status"] != "ok":
+        queue.append({"domain": "workflows", "priority": 3, "action": "review stale/broken workflows and recommendation adoption", "detail": dimensions["workflows"]["detail"]})
+    if dimensions["substrate_discipline"]["status"] != "ok":
+        queue.append({"domain": "substrate_discipline", "priority": 2, "action": "reduce raw bypasses and ignored recommendations", "detail": dimensions["substrate_discipline"]["detail"]})
+    if dimensions["api_runtime"]["status"] != "ok":
+        queue.append({"domain": "api_runtime", "priority": 2, "action": "repair provider credentials or upstream API access", "detail": dimensions["api_runtime"]["detail"]})
+    if str((raw.get("disk") or {}).get("status")) == "critical":
+        queue.insert(0, {"domain": "infra", "priority": 0, "action": "free disk space immediately", "detail": str((raw.get("disk") or {}).get("detail") or "")})
+    raw_dir = health_dir / "raw"
+    for name in ("content-remediation.json", "quality-remediation.json"):
+        path = raw_dir / name
+        data = _read_json(path, [])
+        if isinstance(data, list):
+            queue.extend(item for item in data if isinstance(item, dict))
+    return sorted(queue, key=lambda item: (item.get("priority", 99), item.get("domain", "")))
+
+
+def build_health_snapshot() -> dict[str, Any]:
+    raw = _load_raw_components()
+    events = _iter_events(STATE_EVENTS_FILE)
+    infra, hard_fail = _infra_dimension(raw)
+    claims_digest = _read_json(CLAIMS_DIGEST_FILE, {})
+    orphan_claims = _read_json(ORPHAN_CLAIMS_FILE, {})
+    capabilities_status = _read_json(CAPABILITIES_STATUS_FILE, {})
+    if not isinstance(capabilities_status, dict) or "summary" not in capabilities_status:
+        capabilities_status = build_capability_status()
+    primitives_status = _read_json(PRIMITIVES_STATUS_FILE, {})
+    workflow_status = build_workflow_status()
+
+    dimensions = {
+        "infra": infra,
+        "runtime_flow": _runtime_flow_dimension(events),
+        "continuity": _continuity_dimension(events, claims_digest, orphan_claims),
+        "capabilities": _capabilities_dimension(events, capabilities_status, primitives_status),
+        "workflows": _workflow_dimension(events, workflow_status),
+        "renewal": _renewal_dimension(events, claims_digest),
+        "substrate_discipline": _substrate_discipline_dimension(events),
+        "api_runtime": _api_runtime_dimension(raw, events),
+    }
+
+    weights = {
+        "infra": 15,
+        "runtime_flow": 20,
+        "continuity": 18,
+        "capabilities": 15,
+        "workflows": 10,
+        "renewal": 12,
+        "substrate_discipline": 5,
+        "api_runtime": 5,
+    }
+    total = sum(dim["score"] * weights[name] for name, dim in dimensions.items())
+    score = round(total / sum(weights.values()))
+    status = _status_from_score(score, hard_fail=hard_fail)
+    infra_legacy, content_legacy, quality_legacy = _legacy_sections(raw)
+    remediation = _remediation_queue(dimensions, raw)
+    return {
+        "schema_version": 2,
+        "ts": _now().isoformat(),
+        "status": status,
+        "score": score,
+        "hard_fail": hard_fail,
+        "dimensions": dimensions,
+        "infra": infra_legacy,
+        "content": content_legacy,
+        "quality": quality_legacy,
+        "remediation_queue": remediation,
+    }
+
+
+def write_health_snapshot(path: Path = HEALTH_CURRENT_FILE) -> dict[str, Any]:
+    payload = build_health_snapshot()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp.replace(path)
+    emit_shadow_event(
+        "HealthSnapshotComputed",
+        actor="edge-check",
+        payload={
+            "status": payload["status"],
+            "score": payload["score"],
+            "hard_fail": payload["hard_fail"],
+            "dimensions": {
+                name: {"status": dim.get("status"), "score": dim.get("score")}
+                for name, dim in payload["dimensions"].items()
+            },
+        },
+    )
+    return payload
+
+
+def _events_for_cycle(cycle_id: str, path: Path = STATE_EVENTS_FILE) -> list[dict[str, Any]]:
+    return [row for row in _read_jsonl(path) if str(row.get("cycle_id") or "") == cycle_id]
+
+
+def observe_cycle_health_events(state: dict[str, Any], *, path: Path = STATE_EVENTS_FILE) -> dict[str, Any]:
+    cycle_id = str(state.get("cycle_id") or "").strip()
+    if not cycle_id:
+        return {"workflow_ignored": 0, "primitive_bypass": 0}
+    request = state.get("request", {}) or {}
+    rows = _events_for_cycle(cycle_id, path=path)
+    existing_ignored = {
+        str((row.get("payload") or {}).get("slug") or "")
+        for row in rows
+        if row.get("type") == "WorkflowIgnoredObserved"
+    }
+    existing_bypass = {
+        str((row.get("payload") or {}).get("source") or "")
+        for row in rows
+        if row.get("type") == "PrimitiveBypassObserved"
+    }
+    used_or_broken = {
+        str((row.get("payload") or {}).get("slug") or "")
+        for row in rows
+        if row.get("type") in {"WorkflowUsedObserved", "WorkflowBrokenObserved"}
+    }
+    recommended = {
+        str(item.get("slug") or "").strip(): item
+        for item in (request.get("workflow_recommendations") or [])
+        if str(item.get("slug") or "").strip()
+    }
+    workflow_ignored = 0
+    for slug, item in recommended.items():
+        if slug in used_or_broken or slug in existing_ignored:
+            continue
+        emit_shadow_event(
+            "WorkflowIgnoredObserved",
+            actor="edge-postflight",
+            cycle_id=cycle_id,
+            payload={
+                "slug": slug,
+                "reason": "recommended_not_cited",
+                "skill": request.get("skill"),
+                "query": request.get("corpus_query"),
+                "source": item.get("source"),
+            },
+        )
+        workflow_ignored += 1
+
+    primitive_invocations = Counter()
+    capability_invocations = Counter()
+    for row in rows:
+        payload = row.get("payload") or {}
+        if row.get("type") == "PrimitiveInvocationObserved":
+            source = str(payload.get("source") or "").strip()
+            if source:
+                primitive_invocations[source] += 1
+        elif row.get("type") == "CapabilityInvocationObserved":
+            capability = str(payload.get("capability") or "").strip()
+            if capability:
+                capability_invocations[capability] += 1
+
+    primitive_bypass = 0
+    for source, count in primitive_invocations.items():
+        capability_name = f"source.{source}"
+        if capability_invocations.get(capability_name, 0) > 0 or source in existing_bypass:
+            continue
+        emit_shadow_event(
+            "PrimitiveBypassObserved",
+            actor="edge-postflight",
+            cycle_id=cycle_id,
+            payload={
+                "source": source,
+                "capability": capability_name,
+                "reason": "primitive_used_without_capability_wrapper",
+                "primitive_invocations": count,
+                "capability_invocations": capability_invocations.get(capability_name, 0),
+            },
+        )
+        primitive_bypass += 1
+
+    return {"workflow_ignored": workflow_ignored, "primitive_bypass": primitive_bypass}
+
+
+__all__ = [
+    "build_health_snapshot",
+    "observe_cycle_health_events",
+    "write_health_snapshot",
+]

--- a/tools/_shared/telemetry.py
+++ b/tools/_shared/telemetry.py
@@ -840,6 +840,96 @@ def log_workflow_transition(
     )
 
 
+def log_workflow_recommended(
+    slug: str,
+    *,
+    title: str = "",
+    source: str = "",
+    score: float | int = 0.0,
+    query: str = "",
+    **extra: Any,
+) -> None:
+    """Record that runtime recommended a workflow before the skill ran."""
+    extra.setdefault("skill", current_skill())
+    extra.setdefault("beat", current_beat())
+    log_event(
+        "workflow_recommended",
+        slug=slug,
+        title=title,
+        source=source,
+        score=float(score or 0.0),
+        query=query,
+        **extra,
+    )
+    emit_shadow_event(
+        "WorkflowRecommended",
+        actor=_detect_caller(),
+        cycle_id=extra.get("cycle_id"),
+        payload={
+            "slug": slug,
+            "title": title,
+            "source": source,
+            "score": float(score or 0.0),
+            "query": query,
+            **{k: v for k, v in extra.items() if k not in {"cycle_id", "artifact"}},
+        },
+    )
+
+
+def log_workflow_observed(
+    slug: str,
+    *,
+    mode: str,
+    artifact: str | None = None,
+    **extra: Any,
+) -> None:
+    """Record that a workflow was cited as used or broken by an artifact."""
+    shadow_type = "WorkflowBrokenObserved" if mode == "broken" else "WorkflowUsedObserved"
+    log_event(
+        "workflow_observed",
+        slug=slug,
+        mode=mode,
+        artifact=artifact or "",
+        **extra,
+    )
+    emit_shadow_event(
+        shadow_type,
+        actor=_detect_caller(),
+        artifact=artifact,
+        cycle_id=extra.get("cycle_id"),
+        payload={
+            "slug": slug,
+            "mode": mode,
+            **{k: v for k, v in extra.items() if k not in {"cycle_id", "artifact"}},
+        },
+    )
+
+
+def log_workflow_ignored(
+    slug: str,
+    *,
+    reason: str,
+    **extra: Any,
+) -> None:
+    """Record that runtime recommended a workflow but the cycle did not cite it."""
+    log_event(
+        "workflow_ignored",
+        slug=slug,
+        reason=reason,
+        **extra,
+    )
+    emit_shadow_event(
+        "WorkflowIgnoredObserved",
+        actor=_detect_caller(),
+        cycle_id=extra.get("cycle_id"),
+        payload={
+            "slug": slug,
+            "reason": reason,
+            **{k: v for k, v in extra.items() if k not in {"cycle_id", "artifact"}},
+        },
+    )
+
+
 def log_resolution(
     *,
     obj_type: str,  # claim | friction | workflow_broken | issue | thread
@@ -898,6 +988,9 @@ __all__ = [
     "log_primitive_probe_completed",
     "log_capability_invocation",
     "log_capability_probe_completed",
+    "log_workflow_recommended",
+    "log_workflow_observed",
+    "log_workflow_ignored",
     "time_primitive",
     "log_workflow_transition",
     "log_resolution",

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -23,6 +23,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from _shared.continuity import refresh_continuity_projections  # noqa: E402
 from _shared.capability_runtime import build_capability_status  # noqa: E402
 from _shared.dispatch_runtime import read_dispatch_state, write_dispatch_state  # noqa: E402
+from _shared.health_runtime import observe_cycle_health_events  # noqa: E402
 from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
 from _shared.workflow_runtime import build_workflow_status  # noqa: E402
 
@@ -348,6 +349,17 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
         "top_used": workflow_summary.get("top_used", []),
         "top_broken": workflow_summary.get("top_broken", []),
     }
+    observations = observe_cycle_health_events(state)
+    steps.append(
+        {
+            "step": "cycle_health_observations",
+            "status": "ok",
+            "detail": (
+                f"workflow_ignored={observations.get('workflow_ignored', 0)} "
+                f"primitive_bypass={observations.get('primitive_bypass', 0)}"
+            ),
+        }
+    )
     delta = compute_delta(
         before,
         claims=claims_refresh["payload"],

--- a/tools/rollup-health-v2.py
+++ b/tools/rollup-health-v2.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""rollup-health-v2 — compute the event-backed health v2 snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.health_runtime import build_health_snapshot, write_health_snapshot  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Compute health v2 snapshot from runtime facts and projections")
+    parser.add_argument("--write", action="store_true", help="Write to health/current.json in addition to printing")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.write:
+        payload = write_health_snapshot()
+    else:
+        payload = build_health_snapshot()
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an event-backed health v2 rollup with runtime, continuity, capability, workflow, renewal, substrate-discipline, and API dimensions
- emit the missing health/workflow/provider events from preflight, postflight, publish, and quality checks
- add smoke tests for health v2 snapshots and health event emission

## Validation
- python3 -m py_compile tools/_shared/health_runtime.py tools/rollup-health-v2.py tools/_shared/dispatch_runtime.py tools/_shared/telemetry.py tools/edge-postflight
- bash tests/test_health_v2.sh
- bash tests/test_health_events.sh
- bash tests/test_health_runtime_paths.sh
- bash tests/test_edge_dispatch.sh
- bash tests/test_edge_close.sh