### PR TITLE
Fix install bookkeeping drift for in-place config and temp avatar files

### DIFF
--- a/memory/events.md
+++ b/memory/events.md
@@ -220,6 +220,23 @@ Represents the shadow validation result for continuity claim extraction.
 
 Required later for render/install drift, but defined now so the envelope does not drift again during rollout.
 
+### `InstallRemoved`
+
+```json
+{
+  "type": "InstallRemoved",
+  "artifact": "~/edge/.avatar-gen.py",
+  "payload": {
+    "source_template": "generated:avatar-openai-script",
+    "kind": "file",
+    "reason": "temporary-avatar-cleanup"
+  }
+}
+```
+
+Represents an install-time artifact cleanup so drift projections can distinguish
+durable state from intentional temporary files.
+
 ### `RenderProduced`
 
 ```json
@@ -482,7 +499,7 @@ The first projections depend on this subset:
 
 - `dispatch-completeness` reads `CycleStarted`, `SkillDispatched`, and `CycleClosed`
 - `pipeline-state` reads `PhaseCompleted` and `ArtifactPublished`
-- `render-install-drift` reads `RenderProduced`, `InstallApplied`, and `InstallCheckObserved`
+- `render-install-drift` reads `RenderProduced`, `InstallApplied`, `InstallRemoved`, and `InstallCheckObserved`
 
 ## Compatibility Rule
 

--- a/tests/test_edge_apply_bookkeeping_drift.sh
+++ b/tests/test_edge_apply_bookkeeping_drift.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-apply-drift-XXXXXX)"
+TMP_HOME="$TMP_BASE/home"
+TMP_REPO="$TMP_BASE/repo"
+TMP_STATE="$TMP_BASE/state"
+TMP_CONFIG="$TMP_BASE/agent.yaml"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME" "$TMP_REPO/config" "$TMP_REPO/templates" "$TMP_REPO/memory" "$TMP_REPO/secrets" "$TMP_STATE"
+
+cat >"$TMP_CONFIG" <<YAML
+name: Drift Test
+codename: drift-test
+skill_prefix: drift-test
+mission: Validate install bookkeeping drift
+voice: Direct and factual
+domain: testing
+edge_home: $TMP_REPO
+blog_port: 8766
+onboarding_mode: true
+YAML
+
+for file in branding.yaml capabilities.yaml features.yaml interests.md post-skill.md pre-skill.md runtime-routers.yaml strategy.md; do
+    printf 'rendered %s\n' "$file" >"$TMP_REPO/config/$file"
+done
+for file in paths.py paths.sh branding.py health-config.yaml; do
+    printf 'static %s\n' "$file" >"$TMP_REPO/config/$file"
+done
+for file in CLAUDE.md onboarding.md onboarding_checklist.md quick_win_archetypes.md self_intro_template.md; do
+    printf '# %s\n' "$file" >"$TMP_REPO/templates/$file"
+done
+for file in personality.md rules-core.md metodo.md debugging.md knowledge-design.md; do
+    printf '# %s\n' "$file" >"$TMP_REPO/memory/$file"
+done
+cat >"$TMP_REPO/secrets/openai.env" <<'ENV'
+OPENAI_API_KEY=fake-test-key
+ENV
+
+echo "=== edge-apply bookkeeping drift Smoke Test ==="
+echo "Temp repo: $TMP_REPO"
+echo ""
+
+echo "--- Test 1: phase_identity logs InstallApplied for rendered config in-place ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_CONFIG" "$TMP_HOME" "$TMP_REPO" "$TMP_STATE"
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+edge_dir, config_path, home_dir, repo_dir, state_dir = sys.argv[1:]
+os.environ["HOME"] = home_dir
+os.environ["EDGE_STATE_DIR"] = state_dir
+os.environ["EDGE_CODENAME"] = "drift-test"
+os.environ["EDGE_CYCLE_ID"] = "install:test-identity-in-place"
+
+loader = importlib.machinery.SourceFileLoader("edge_apply_mod", f"{edge_dir}/tools/edge-apply")
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+mod.REPO_ROOT = Path(repo_dir)
+
+cfg = mod.load_config(Path(config_path))
+assert mod.phase_identity(cfg, dry_run=False) is True
+
+events = [
+    json.loads(line)
+    for line in (Path(state_dir) / "state" / "events" / "log.jsonl").read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+matches = [
+    event for event in events
+    if event.get("type") == "InstallApplied"
+    and event.get("cycle_id") == "install:test-identity-in-place"
+    and (event.get("payload") or {}).get("action") == "in-place"
+]
+expected = {
+    "branding.yaml",
+    "capabilities.yaml",
+    "features.yaml",
+    "interests.md",
+    "post-skill.md",
+    "pre-skill.md",
+    "runtime-routers.yaml",
+    "strategy.md",
+}
+seen = {Path(event["artifact"]).name for event in matches}
+assert seen == expected, seen
+assert all((event.get("payload") or {}).get("in_place") is True for event in matches)
+PY
+then
+    pass "phase_identity logs in-place config installs"
+else
+    fail "phase_identity logs in-place config installs"
+fi
+
+echo "--- Test 2: phase_avatar emits InstallRemoved for temp files ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_CONFIG" "$TMP_HOME" "$TMP_REPO" "$TMP_STATE"
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+edge_dir, config_path, home_dir, repo_dir, state_dir = sys.argv[1:]
+os.environ["HOME"] = home_dir
+os.environ["EDGE_STATE_DIR"] = state_dir
+os.environ["EDGE_CODENAME"] = "drift-test"
+os.environ["EDGE_CYCLE_ID"] = "install:test-avatar-cleanup"
+
+loader = importlib.machinery.SourceFileLoader("edge_apply_mod", f"{edge_dir}/tools/edge-apply")
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+mod.REPO_ROOT = Path(repo_dir)
+mod.run = lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr="forced test failure")
+
+cfg = mod.load_config(Path(config_path))
+assert mod.phase_avatar(cfg, dry_run=False) is True
+
+events = [
+    json.loads(line)
+    for line in (Path(state_dir) / "state" / "events" / "log.jsonl").read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+matches = [
+    event for event in events
+    if event.get("type") == "InstallRemoved"
+    and event.get("cycle_id") == "install:test-avatar-cleanup"
+]
+artifacts = {Path(event["artifact"]).name for event in matches}
+assert {".avatar-prompt.txt", ".avatar-gen.py"} <= artifacts, artifacts
+assert not (Path(repo_dir) / ".avatar-prompt.txt").exists()
+assert not (Path(repo_dir) / ".avatar-gen.py").exists()
+PY
+then
+    pass "phase_avatar emits InstallRemoved for temp files"
+else
+    fail "phase_avatar emits InstallRemoved for temp files"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tests/test_render_install_drift.sh
+++ b/tests/test_render_install_drift.sh
@@ -107,6 +107,27 @@ events = [
     },
     {
         "ts": "2026-04-20T20:06:00+00:00",
+        "type": "InstallApplied",
+        "artifact": str(edge / ".avatar-gen.py"),
+        "payload": {
+            "source_template": "generated:avatar-openai-script",
+            "hash": "sha256:temp",
+            "kind": "file",
+            "action": "write",
+        },
+    },
+    {
+        "ts": "2026-04-20T20:06:30+00:00",
+        "type": "InstallRemoved",
+        "artifact": str(edge / ".avatar-gen.py"),
+        "payload": {
+            "source_template": "generated:avatar-openai-script",
+            "kind": "file",
+            "reason": "temporary-avatar-cleanup",
+        },
+    },
+    {
+        "ts": "2026-04-20T20:07:00+00:00",
         "type": "InstallCheckObserved",
         "artifact": str(edge / "install" / "missing.md"),
         "payload": {
@@ -156,6 +177,7 @@ payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 assert payload["rendered_without_install"][0]["output_path"] == "config/branding.yaml"
 assert payload["hash_mismatches"][0]["output_path"] == "config/paths.py"
 assert payload["missing_on_disk"][0]["artifact"].endswith("missing.md")
+assert all(not item["artifact"].endswith(".avatar-gen.py") for item in payload["missing_on_disk"])
 assert payload["doctor_failures"][0]["check_id"] == "file:missing-md"
 PY
 then

--- a/tools/_shared/telemetry.py
+++ b/tools/_shared/telemetry.py
@@ -296,6 +296,43 @@ def log_install_applied(
     )
 
 
+def log_install_removed(
+    artifact: str | os.PathLike[str],
+    *,
+    source_template: str,
+    kind: str,
+    reason: str,
+    dry_run: bool = False,
+    **extra: Any,
+) -> None:
+    """Record one install-time cleanup/removal and dual-write the canonical fact."""
+    artifact_str = os.fspath(artifact)
+    payload = {
+        "source_template": source_template,
+        "kind": kind,
+        "reason": reason,
+        "dry_run": dry_run,
+    }
+    payload.update({k: v for k, v in extra.items() if k not in {"cycle_id", "artifact"}})
+
+    log_event(
+        "install_removed",
+        artifact=artifact_str,
+        source_template=source_template,
+        kind=kind,
+        reason=reason,
+        dry_run=dry_run,
+        **extra,
+    )
+    emit_shadow_event(
+        "InstallRemoved",
+        actor=_detect_caller(),
+        artifact=artifact_str,
+        cycle_id=extra.get("cycle_id"),
+        payload=payload,
+    )
+
+
 def log_install_check(
     check_id: str,
     status: str,

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -104,6 +104,27 @@ def _log_install_applied(
     )
 
 
+def _log_install_removed(
+    artifact: Path | str,
+    *,
+    source_template: str,
+    kind: str,
+    reason: str,
+    dry_run: bool,
+    **extra,
+) -> None:
+    from telemetry import log_install_removed
+
+    log_install_removed(
+        str(artifact),
+        source_template=source_template,
+        kind=kind,
+        reason=reason,
+        dry_run=dry_run,
+        **extra,
+    )
+
+
 def _ensure_dir(path: Path, *, phase: str, dry_run: bool, source_template: str = "generated:mkdir") -> None:
     if dry_run:
         return
@@ -513,8 +534,19 @@ def phase_identity(cfg, dry_run):
     # Config files → edge_home/config/ (skip if same dir)
     config_files = ["pre-skill.md", "post-skill.md", "strategy.md",
                     "interests.md", "features.yaml", "branding.yaml",
+                    "capabilities.yaml",
                     "runtime-routers.yaml",
                     "paths.py", "paths.sh", "branding.py"]
+    rendered_config_files = {
+        "branding.yaml",
+        "capabilities.yaml",
+        "features.yaml",
+        "interests.md",
+        "post-skill.md",
+        "pre-skill.md",
+        "runtime-routers.yaml",
+        "strategy.md",
+    }
     config_src = REPO_ROOT / "config"
     config_dst = edge / "config"
     if config_src.resolve() != config_dst.resolve():
@@ -525,6 +557,20 @@ def phase_identity(cfg, dry_run):
                 _copy_file(src, config_dst / f, phase="identity", dry_run=False)
         ok(f"Config → {config_dst}")
     else:
+        if not dry_run:
+            for f in rendered_config_files:
+                artifact = config_dst / f
+                if artifact.exists():
+                    _log_install_applied(
+                        artifact,
+                        source_template=_repo_relative(artifact),
+                        action="in-place",
+                        kind="file",
+                        hash_value=_hash_path(artifact),
+                        phase="identity",
+                        dry_run=False,
+                        in_place=True,
+                    )
         ok("Config: repo = edge_home (in-place)")
 
     # Memory → ~/.claude/projects/{project}/memory/ (only if not exists)
@@ -1207,9 +1253,11 @@ def phase_avatar(cfg, dry_run):
 
     # Write avatar generation script to temp file (avoids shell quoting issues)
     avatar_script = edge / ".avatar-gen.py"
+    avatar_script_template = None
 
     if openai_key:
         try:
+            avatar_script_template = "generated:avatar-openai-script"
             _write_text(
                 avatar_script,
                 f'import urllib.request, json, base64, pathlib\n'
@@ -1225,7 +1273,7 @@ def phase_avatar(cfg, dry_run):
                 f'print(f"OK: {{len(img_bytes)}} bytes")\n'
                 ,
                 phase="avatar",
-                source_template="generated:avatar-openai-script",
+                source_template=avatar_script_template,
                 dry_run=False,
             )
             result = run(f'python3 "{avatar_script}"')
@@ -1248,6 +1296,7 @@ def phase_avatar(cfg, dry_run):
 
     if not generated and xai_key:
         try:
+            avatar_script_template = "generated:avatar-xai-script"
             _write_text(
                 avatar_script,
                 f'import urllib.request, json, base64, pathlib\n'
@@ -1263,7 +1312,7 @@ def phase_avatar(cfg, dry_run):
                 f'print(f"OK: {{len(img_bytes)}} bytes")\n'
                 ,
                 phase="avatar",
-                source_template="generated:avatar-xai-script",
+                source_template=avatar_script_template,
                 dry_run=False,
             )
             result = run(f'python3 "{avatar_script}"')
@@ -1306,8 +1355,26 @@ def phase_avatar(cfg, dry_run):
     if not generated:
         warn("No avatar generated (no API keys and DiceBear unavailable)")
 
-    prompt_file.unlink(missing_ok=True)
-    avatar_script.unlink(missing_ok=True)
+    if prompt_file.exists():
+        prompt_file.unlink()
+        _log_install_removed(
+            prompt_file,
+            source_template="generated:avatar-prompt",
+            kind="file",
+            reason="temporary-avatar-cleanup",
+            phase="avatar",
+            dry_run=False,
+        )
+    if avatar_script.exists():
+        avatar_script.unlink()
+        _log_install_removed(
+            avatar_script,
+            source_template=avatar_script_template or "generated:avatar-script",
+            kind="file",
+            reason="temporary-avatar-cleanup",
+            phase="avatar",
+            dry_run=False,
+        )
     return True
 
 

--- a/tools/rollup-render-install-drift.py
+++ b/tools/rollup-render-install-drift.py
@@ -46,6 +46,7 @@ def _latest_by_key(existing: dict, key: str, event: dict) -> None:
 def build_projection(limit: int = 20) -> dict:
     render_by_output: dict[str, dict] = {}
     install_by_artifact: dict[str, dict] = {}
+    removed_by_artifact: dict[str, dict] = {}
     checks_by_id: dict[str, dict] = {}
 
     for event in _iter_jsonl(STATE_EVENTS_FILE) or []:
@@ -57,12 +58,22 @@ def build_projection(limit: int = 20) -> dict:
         elif etype == "InstallApplied":
             artifact = str(event.get("artifact") or "")
             _latest_by_key(install_by_artifact, artifact, event)
+        elif etype == "InstallRemoved":
+            artifact = str(event.get("artifact") or "")
+            _latest_by_key(removed_by_artifact, artifact, event)
         elif etype == "InstallCheckObserved":
             check_id = str(payload.get("check_id") or "")
             _latest_by_key(checks_by_id, check_id, event)
 
+    active_installs: dict[str, dict] = {}
+    for artifact, install_event in install_by_artifact.items():
+        removed_event = removed_by_artifact.get(artifact)
+        if removed_event and _parse_ts(removed_event.get("ts")) >= _parse_ts(install_event.get("ts")):
+            continue
+        active_installs[artifact] = install_event
+
     installs_by_source: dict[str, list[dict]] = {}
-    for event in install_by_artifact.values():
+    for event in active_installs.values():
         source_template = str((event.get("payload") or {}).get("source_template") or "")
         installs_by_source.setdefault(source_template, []).append(event)
 
@@ -96,7 +107,7 @@ def build_projection(limit: int = 20) -> dict:
 
     install_without_render = []
     missing_on_disk = []
-    for artifact, install_event in install_by_artifact.items():
+    for artifact, install_event in active_installs.items():
         payload = install_event.get("payload") or {}
         source_template = str(payload.get("source_template") or "")
         if source_template and source_template not in render_by_output and not source_template.startswith(("generated:", "command:")):
@@ -138,7 +149,7 @@ def build_projection(limit: int = 20) -> dict:
         "state_events_path": str(STATE_EVENTS_FILE),
         "summary": {
             "rendered_outputs": len(render_by_output),
-            "installed_artifacts": len(install_by_artifact),
+            "installed_artifacts": len(active_installs),
             "render_linked_installs": linked_installs,
             "rendered_without_install": len(rendered_without_install),
             "install_without_render": len(install_without_render),


### PR DESCRIPTION
Fixes #308.

## What changed
- emit `InstallApplied` for rendered config files when `edge_home == repo`
- emit `InstallRemoved` for temporary avatar artifacts so drift projections stop treating them as durable installs
- teach `render-install-drift` to ignore artifacts removed after install
- add focused tests for the projection and the edge-apply bookkeeping paths

## Validation
- `python3 -m py_compile tools/edge-apply tools/rollup-render-install-drift.py tools/_shared/telemetry.py`
- `bash tests/test_render_install_drift.sh`
- `bash tests/test_edge_apply_bookkeeping_drift.sh`
- full in-place validation: `edge-render` + `edge-apply --skip-venv` + `edge-doctor --config ...` with `render-install-drift: rendered_without_install=0, hash_mismatches=0, missing_on_disk=0, doctor_fail=0`