### PR TITLE
Fallback to local Claude CLI when remote LLM calls fail

### DIFF
--- a/tests/test_runtime_router_config.sh
+++ b/tests/test_runtime_router_config.sh
@@ -180,6 +180,57 @@ else
     fail "edge-doctor uses runtime branding by default"
 fi
 
+echo "--- Test 4: router_client falls back to local Claude CLI on remote failure ---"
+if EDGE_REPO_DIR="$TMP_RUNTIME" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="router-runtime-test" python3 - <<'PY' "$EDGE_DIR"
+import sys
+from types import SimpleNamespace
+
+edge_dir = sys.argv[1]
+sys.path.insert(0, f"{edge_dir}/tools")
+import _shared.router_client as rc
+
+class FailingResource:
+    def create(self, *args, **kwargs):
+        raise RuntimeError("429 insufficient_quota")
+
+class DummyClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=FailingResource())
+        self.responses = FailingResource()
+        self.embeddings = FailingResource()
+
+rc.claude_cli_available = lambda: True
+rc.call_claude_cli_text = lambda prompt, timeout=60: "claude fallback ok"
+
+client = rc._wrap_with_telemetry(DummyClient(), "review", "gpt-5.4", 30)
+chat = client.chat.completions.create(
+    model="gpt-5.4",
+    messages=[
+        {"role": "system", "content": "System prompt"},
+        {"role": "user", "content": "User prompt"},
+    ],
+)
+assert chat.choices[0].message.content == "claude fallback ok"
+assert chat.usage.prompt_tokens == 0
+
+resp = client.responses.create(
+    model="gpt-5.4",
+    input=[
+        {"role": "system", "content": "System prompt"},
+        {"role": "user", "content": "User prompt"},
+    ],
+    tools=[{"type": "web_search_preview"}],
+)
+assert resp.output_text == "claude fallback ok"
+assert resp.usage.input_tokens == 0
+assert resp.output[0].type == "message"
+PY
+then
+    pass "router_client falls back to local Claude CLI on remote failure"
+else
+    fail "router_client falls back to local Claude CLI on remote failure"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/tests/test_seed_claude_fallback.sh
+++ b/tests/test_seed_claude_fallback.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-seed-fallback-XXXXXX)"
+TMP_HOME="$TMP_BASE/home"
+TMP_EDGE="$TMP_BASE/agent"
+TMP_STATE="$TMP_BASE/state"
+TMP_CONFIG="$TMP_BASE/agent.yaml"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME" "$TMP_EDGE/secrets" "$TMP_STATE"
+
+cat >"$TMP_CONFIG" <<YAML
+name: Seed Fallback Test
+codename: seed-fallback-test
+skill_prefix: sft
+mission: Validate Claude CLI seed fallback
+voice: Direct and factual
+domain: testing
+short_term_goal: Validate install fallback path
+edge_home: $TMP_EDGE
+blog_port: 8766
+onboarding_mode: true
+interests:
+  - area: Observability
+    connection: Track what the system is really doing
+YAML
+
+cat >"$TMP_EDGE/secrets/openai.env" <<'ENV'
+OPENAI_API_KEY=fake-openai-key
+ENV
+
+echo "=== seed Claude fallback Smoke Test ==="
+echo "Temp base: $TMP_BASE"
+echo ""
+
+echo "--- Test 1: phase_seed falls back to local Claude CLI before deterministic seed ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_CONFIG" "$TMP_HOME" "$TMP_EDGE" "$TMP_STATE"
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+edge_dir, config_path, home_dir, edge_home, state_dir = sys.argv[1:]
+os.environ["HOME"] = home_dir
+os.environ["EDGE_STATE_DIR"] = state_dir
+os.environ["EDGE_CODENAME"] = "seed-fallback-test"
+os.environ["EDGE_CYCLE_ID"] = "install:test-seed-claude-fallback"
+
+loader = importlib.machinery.SourceFileLoader("edge_apply_mod", f"{edge_dir}/tools/edge-apply")
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+
+import urllib.request
+sys.path.insert(0, f"{edge_dir}/tools")
+import _shared.router_client as router_client
+
+def fail_remote(*args, **kwargs):
+    raise RuntimeError("429 insufficient_quota")
+
+urllib.request.urlopen = fail_remote
+router_client.call_claude_cli_text = lambda prompt, timeout=60: json.dumps(
+    {
+        "strategy": ["Use runtime facts before prose"],
+        "autonomy": ["!Need GitHub access"],
+        "friction": ["!Remote quota can fail during seed"],
+        "serendipity": ["Claude fallback is available locally"],
+        "reflection": ["Bootstrap can still progress with local CLI"],
+        "threads": [
+            {
+                "id": "runtime-fallbacks",
+                "title": "Runtime fallbacks",
+                "description": "Keep local fallbacks alive when providers fail",
+                "status": "active",
+            }
+        ],
+        "briefing": "# Briefing\n\nFallback worked.\n\n<!-- SYNTHETIC — replace on first /ed-strategy run -->",
+    }
+)
+
+cfg = mod.load_config(Path(config_path))
+assert mod.phase_seed(cfg, dry_run=False) is True
+
+strategy = (Path(edge_home) / "state" / "signals" / "strategy.md").read_text(encoding="utf-8")
+briefing = (Path(edge_home) / "briefing.md").read_text(encoding="utf-8")
+thread = (Path(edge_home) / "threads" / "runtime-fallbacks.md").read_text(encoding="utf-8")
+
+assert "Use runtime facts before prose" in strategy
+assert "Fallback worked." in briefing
+assert "Runtime fallbacks" in thread
+PY
+then
+    pass "phase_seed falls back to local Claude CLI before deterministic seed"
+else
+    fail "phase_seed falls back to local Claude CLI before deterministic seed"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tools/_shared/router_client.py
+++ b/tools/_shared/router_client.py
@@ -18,10 +18,14 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
+import subprocess
 import sys
 import time
+import uuid
 from functools import lru_cache
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from .telemetry import log_llm_call
@@ -70,6 +74,8 @@ _LEGACY_DEFAULTS: dict[str, dict[str, Any]] = {
         "model_default": "gpt-5.4",
     },
 }
+
+CLAUDE_FALLBACK_MODEL = "claude-cli"
 
 
 @lru_cache(maxsize=1)
@@ -221,6 +227,208 @@ def _substitute(template: str, mapping: dict[str, str]) -> str:
     return _SUBST_RE.sub(_sub, template)
 
 
+def resolve_claude_bin() -> str:
+    env_override = os.environ.get("EDGE_CLAUDE_BIN") or os.environ.get("CLAUDE_BIN")
+    candidates: list[str] = []
+    if env_override:
+        candidates.append(env_override)
+
+    path_hit = shutil.which("claude")
+    if path_hit:
+        candidates.append(path_hit)
+
+    home = Path.home()
+    candidates.extend(
+        [
+            str(home / ".local" / "bin" / "claude"),
+            str(home / "bin" / "claude"),
+        ]
+    )
+    for glob_hit in sorted((home / ".nvm" / "versions" / "node").glob("*/bin/claude"), reverse=True):
+        candidates.append(str(glob_hit))
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    raise FileNotFoundError("claude CLI not found on PATH or common install locations")
+
+
+def claude_cli_available() -> bool:
+    try:
+        resolve_claude_bin()
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def call_claude_cli_text(prompt: str, *, timeout: int = 60) -> str:
+    """Invoke the local Claude CLI and return plain text output."""
+    result = subprocess.run(
+        [resolve_claude_bin(), "-p", prompt, "--dangerously-skip-permissions"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        stderr_tail = (result.stderr or "").strip()[-500:]
+        raise RuntimeError(
+            f"claude CLI exited {result.returncode}: {stderr_tail or '(no stderr)'}"
+        )
+    text = (result.stdout or "").strip()
+    if not text:
+        raise RuntimeError("claude CLI produced empty output")
+    return text
+
+
+def _content_to_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                if isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+                elif isinstance(item.get("content"), str):
+                    parts.append(item["content"])
+            else:
+                text = getattr(item, "text", None)
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(part.strip() for part in parts if part and part.strip())
+    if isinstance(content, dict):
+        if isinstance(content.get("text"), str):
+            return content["text"]
+        if isinstance(content.get("content"), str):
+            return content["content"]
+    text = getattr(content, "text", None)
+    if isinstance(text, str):
+        return text
+    return str(content)
+
+
+def _message_field(message: Any, field: str, default: Any = "") -> Any:
+    if isinstance(message, dict):
+        return message.get(field, default)
+    return getattr(message, field, default)
+
+
+def _messages_to_prompt(messages: list[Any]) -> str:
+    sections: list[str] = []
+    for message in messages or []:
+        role = str(_message_field(message, "role", "user") or "user")
+        content = _content_to_text(_message_field(message, "content", ""))
+        if not content.strip():
+            continue
+        sections.append(f"## {role.title()}\n\n{content.strip()}")
+    return "\n\n".join(sections).strip()
+
+
+def _responses_input_to_prompt(input_value: Any, tools: list[Any] | None) -> str:
+    sections: list[str] = []
+    if isinstance(input_value, str):
+        sections.append(input_value.strip())
+    elif isinstance(input_value, list):
+        for item in input_value:
+            role = str(_message_field(item, "role", "user") or "user")
+            content = _content_to_text(_message_field(item, "content", ""))
+            if not content.strip():
+                continue
+            sections.append(f"## {role.title()}\n\n{content.strip()}")
+    elif input_value is not None:
+        sections.append(str(input_value).strip())
+
+    tool_types: list[str] = []
+    for tool in tools or []:
+        if isinstance(tool, dict):
+            tool_type = str(tool.get("type") or "").strip()
+        else:
+            tool_type = str(getattr(tool, "type", "") or "").strip()
+        if tool_type:
+            tool_types.append(tool_type)
+    if tool_types:
+        sections.append(
+            "## Requested tools\n\n"
+            + "\n".join(f"- {tool_type} (not available in local Claude CLI fallback)" for tool_type in tool_types)
+        )
+    return "\n\n".join(section for section in sections if section).strip()
+
+
+def _fallback_prompt(resource_name: str, kwargs: dict[str, Any]) -> str:
+    if resource_name == "chat.completions":
+        return _messages_to_prompt(list(kwargs.get("messages") or []))
+    if resource_name == "responses":
+        return _responses_input_to_prompt(kwargs.get("input"), list(kwargs.get("tools") or []))
+    return ""
+
+
+def _should_fallback_to_claude(exc: Exception, resource_name: str) -> bool:
+    if resource_name == "embeddings":
+        return False
+    if not claude_cli_available():
+        return False
+    status_code = getattr(exc, "status_code", None)
+    if status_code in {401, 403, 429}:
+        return True
+    lowered = f"{type(exc).__name__}: {exc}".lower()
+    needles = (
+        "insufficient_quota",
+        "quota",
+        "rate limit",
+        "429",
+        "401",
+        "403",
+        "unauthoriz",
+        "forbidden",
+        "timeout",
+        "timed out",
+        "timedout",
+        "connection error",
+        "api connection",
+        "service unavailable",
+    )
+    return any(needle in lowered for needle in needles)
+
+
+def _build_chat_fallback_response(text: str) -> Any:
+    return SimpleNamespace(
+        id=f"{CLAUDE_FALLBACK_MODEL}-{uuid.uuid4().hex[:8]}",
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=text, tool_calls=None)
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0),
+    )
+
+
+def _build_responses_fallback_response(text: str) -> Any:
+    return SimpleNamespace(
+        id=f"{CLAUDE_FALLBACK_MODEL}-{uuid.uuid4().hex[:8]}",
+        output=[SimpleNamespace(type="message", content=[SimpleNamespace(text=text, annotations=[])])],
+        output_text=text,
+        usage=SimpleNamespace(input_tokens=0, output_tokens=0),
+    )
+
+
+def _call_claude_fallback(resource_name: str, kwargs: dict[str, Any], *, timeout_s: int) -> Any:
+    prompt = _fallback_prompt(resource_name, kwargs)
+    if not prompt.strip():
+        raise RuntimeError(f"cannot build Claude fallback prompt for resource={resource_name}")
+    text = call_claude_cli_text(prompt, timeout=timeout_s)
+    if resource_name == "responses":
+        return _build_responses_fallback_response(text)
+    return _build_chat_fallback_response(text)
+
+
 def make_client(
     purpose: str | None = None,
     *,
@@ -278,7 +486,8 @@ def make_client(
 
     client = OpenAI(**client_kwargs)
     purpose_name = purpose if purpose is not None else _resolve_purpose_name(cfg["model"])
-    return _wrap_with_telemetry(client, purpose_name, cfg["model"]), cfg["model"]
+    fallback_timeout_s = int(timeout) if timeout else 60
+    return _wrap_with_telemetry(client, purpose_name, cfg["model"], fallback_timeout_s), cfg["model"]
 
 
 def _resolve_purpose_name(model: str) -> str:
@@ -292,22 +501,44 @@ def _resolve_purpose_name(model: str) -> str:
 class _InstrumentedCreate:
     """Wrap `resource.create(...)` so every call emits an llm_call event."""
 
-    def __init__(self, inner_create: Any, router: str, default_model: str) -> None:
+    def __init__(self, inner_create: Any, router: str, default_model: str, resource_name: str, fallback_timeout_s: int) -> None:
         self._inner = inner_create
         self._router = router
         self._default_model = default_model
+        self._resource_name = resource_name
+        self._fallback_timeout_s = fallback_timeout_s
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         model = kwargs.get("model") or self._default_model
         t0 = time.monotonic()
         try:
             resp = self._inner(*args, **kwargs)
-        except Exception:
+        except Exception as exc:
             dt_ms = int((time.monotonic() - t0) * 1000)
+            fallback_candidate = _should_fallback_to_claude(exc, self._resource_name)
             log_llm_call(
                 router=self._router, model=model, tokens_in=0, tokens_out=0,
                 latency_ms=dt_ms, error=True,
+                fallback_candidate=fallback_candidate,
             )
+            if fallback_candidate:
+                fallback_started = time.monotonic()
+                fallback_resp = _call_claude_fallback(
+                    self._resource_name,
+                    kwargs,
+                    timeout_s=self._fallback_timeout_s,
+                )
+                fallback_dt_ms = int((time.monotonic() - fallback_started) * 1000)
+                log_llm_call(
+                    router=f"{self._router}:claude-fallback",
+                    model=CLAUDE_FALLBACK_MODEL,
+                    tokens_in=0,
+                    tokens_out=0,
+                    latency_ms=fallback_dt_ms,
+                    fallback_for=model,
+                    resource=self._resource_name,
+                )
+                return fallback_resp
             raise
         dt_ms = int((time.monotonic() - t0) * 1000)
         tokens_in, tokens_out = _extract_tokens(resp)
@@ -321,30 +552,33 @@ class _InstrumentedCreate:
 class _InstrumentedResource:
     """Proxy a resource object (e.g., chat.completions). Wraps `.create` only."""
 
-    def __init__(self, inner: Any, router: str, default_model: str) -> None:
+    def __init__(self, inner: Any, router: str, default_model: str, resource_name: str, fallback_timeout_s: int) -> None:
         self._inner = inner
         self._router = router
         self._default_model = default_model
+        self._resource_name = resource_name
+        self._fallback_timeout_s = fallback_timeout_s
 
     def __getattr__(self, name: str) -> Any:
         attr = getattr(self._inner, name)
         if name == "create":
-            return _InstrumentedCreate(attr, self._router, self._default_model)
+            return _InstrumentedCreate(attr, self._router, self._default_model, self._resource_name, self._fallback_timeout_s)
         return attr
 
 
 class _InstrumentedChat:
     """Proxy client.chat, wrap client.chat.completions."""
 
-    def __init__(self, inner: Any, router: str, default_model: str) -> None:
+    def __init__(self, inner: Any, router: str, default_model: str, fallback_timeout_s: int) -> None:
         self._inner = inner
         self._router = router
         self._default_model = default_model
+        self._fallback_timeout_s = fallback_timeout_s
 
     def __getattr__(self, name: str) -> Any:
         attr = getattr(self._inner, name)
         if name == "completions":
-            return _InstrumentedResource(attr, self._router, self._default_model)
+            return _InstrumentedResource(attr, self._router, self._default_model, "chat.completions", self._fallback_timeout_s)
         return attr
 
 
@@ -353,25 +587,26 @@ class _InstrumentedClient:
     `embeddings.create`, and `responses.create` to emit llm_call telemetry.
     Every other attribute passes through unchanged."""
 
-    def __init__(self, inner: Any, router: str, default_model: str) -> None:
+    def __init__(self, inner: Any, router: str, default_model: str, fallback_timeout_s: int) -> None:
         self._inner = inner
         self._router = router
         self._default_model = default_model
+        self._fallback_timeout_s = fallback_timeout_s
 
     def __getattr__(self, name: str) -> Any:
         attr = getattr(self._inner, name)
         if name == "chat":
-            return _InstrumentedChat(attr, self._router, self._default_model)
+            return _InstrumentedChat(attr, self._router, self._default_model, self._fallback_timeout_s)
         if name in ("embeddings", "responses"):
-            return _InstrumentedResource(attr, self._router, self._default_model)
+            return _InstrumentedResource(attr, self._router, self._default_model, name, self._fallback_timeout_s)
         return attr
 
 
-def _wrap_with_telemetry(client: Any, router: str, default_model: str) -> Any:
+def _wrap_with_telemetry(client: Any, router: str, default_model: str, fallback_timeout_s: int) -> Any:
     """Opt-out via env: ED_TELEMETRY_DISABLE=1."""
     if os.environ.get("ED_TELEMETRY_DISABLE") == "1":
         return client
-    return _InstrumentedClient(client, router, default_model)
+    return _InstrumentedClient(client, router, default_model, fallback_timeout_s)
 
 
 def _extract_tokens(resp: Any) -> tuple[int, int]:
@@ -389,8 +624,12 @@ def _extract_tokens(resp: Any) -> tuple[int, int]:
 
 
 __all__ = [
+    "CLAUDE_FALLBACK_MODEL",
+    "call_claude_cli_text",
+    "claude_cli_available",
     "load_router_config",
     "find_router_for_model",
     "load_secret",
     "make_client",
+    "resolve_claude_bin",
 ]

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -26,7 +26,9 @@ from pathlib import Path
 
 import yaml
 
-sys.path.insert(0, str(Path(__file__).resolve().parent / "_shared"))
+TOOLS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(TOOLS_DIR))
+sys.path.insert(0, str(TOOLS_DIR / "_shared"))
 from intervals import parse_interval  # noqa: E402
 from routines import (  # noqa: E402
     build_entry_markdown,
@@ -1465,6 +1467,18 @@ Generate EXACTLY this JSON structure (no markdown, no explanation, just valid JS
 Each signal should be a short sentence (under 120 chars). Use ! prefix for open gaps, ? for speculative ideas.
 Threads should be concrete workstreams (e.g. 'competitive-landscape', 'positioning-wedge'), not interest areas."""
 
+        def _parse_seed_json(raw: str) -> dict | None:
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                match = re.search(r"\{[\s\S]*\}", raw)
+                if not match:
+                    return None
+                try:
+                    return json.loads(match.group(0))
+                except json.JSONDecodeError:
+                    return None
+
         if openai_key:
             try:
                 import urllib.request
@@ -1480,10 +1494,23 @@ Threads should be concrete workstreams (e.g. 'competitive-landscape', 'positioni
                 resp = urllib.request.urlopen(req, timeout=30)
                 result = json.loads(resp.read())
                 content = result["choices"][0]["message"]["content"]
-                llm_seed = json.loads(content)
+                llm_seed = _parse_seed_json(content)
+                if llm_seed is None:
+                    raise ValueError("provider returned non-JSON seed payload")
                 ok("Seed generated via LLM")
             except Exception as e:
                 warn(f"LLM seed generation failed: {e}")
+        if not llm_seed:
+            try:
+                from _shared.router_client import call_claude_cli_text
+
+                content = call_claude_cli_text(llm_prompt, timeout=60)
+                llm_seed = _parse_seed_json(content)
+                if llm_seed is None:
+                    raise ValueError("claude CLI returned non-JSON seed payload")
+                ok("Seed generated via local Claude CLI fallback")
+            except Exception as e:
+                warn(f"Claude CLI seed fallback failed: {e}")
 
         # Write signal files (LLM content or deterministic fallback)
         for stype in ["strategy", "autonomy", "friction", "serendipity", "reflection"]:


### PR DESCRIPTION
Fixes #307.

## What changed
- add a reusable local Claude CLI fallback path in `_shared/router_client.py` for `chat.completions.create` and `responses.create` when remote providers fail with quota/auth/timeout-style errors
- keep embeddings untouched
- use the same Claude CLI fallback in `edge-apply` seed generation before degrading to deterministic synthetic seed content
- add smoke coverage for both router fallback and install seed fallback

## Validation
- `python3 -m py_compile tools/_shared/router_client.py tools/edge-apply`
- `bash tests/test_runtime_router_config.sh`
- `bash tests/test_seed_claude_fallback.sh`