### PR TITLE
Collapse non-ready capability states into degraded

### DIFF
--- a/bin/check-infra.sh
+++ b/bin/check-infra.sh
@@ -211,22 +211,21 @@ check_primitives() {
     return
   fi
 
-  local declared contract_only active probed broken drifted
+  local declared degraded active probed broken
   declared=$(echo "$payload" | jq -r '.summary.declared_total // 0' 2>/dev/null || echo 0)
-  contract_only=$(echo "$payload" | jq -r '.summary.contract_only_total // 0' 2>/dev/null || echo 0)
+  degraded=$(echo "$payload" | jq -r '.summary.degraded_total // 0' 2>/dev/null || echo 0)
   active=$(echo "$payload" | jq -r '.summary.active_total // 0' 2>/dev/null || echo 0)
   probed=$(echo "$payload" | jq -r '.summary.probed_total // 0' 2>/dev/null || echo 0)
   broken=$(echo "$payload" | jq -r '.summary.broken_total // 0' 2>/dev/null || echo 0)
-  drifted=$(echo "$payload" | jq -r '.summary.drifted_total // 0' 2>/dev/null || echo 0)
 
   local detail
-  detail="declared=${declared} contract_only=${contract_only} active=${active} probed=${probed} broken=${broken} drifted=${drifted}"
+  detail="declared=${declared} degraded=${degraded} active=${active} probed=${probed} broken=${broken}"
 
-  if [[ "$declared" -eq 0 ]] && [[ "$contract_only" -eq 0 ]] && [[ "$active" -eq 0 ]] && [[ "$probed" -eq 0 ]] && [[ "$broken" -eq 0 ]] && [[ "$drifted" -eq 0 ]]; then
+  if [[ "$declared" -eq 0 ]] && [[ "$degraded" -eq 0 ]] && [[ "$active" -eq 0 ]] && [[ "$probed" -eq 0 ]] && [[ "$broken" -eq 0 ]]; then
     emit_component primitives unknown "no primitives declared yet"
   elif [[ "$broken" -gt 0 ]]; then
     emit_component primitives fail "$detail"
-  elif [[ "$drifted" -gt 0 ]]; then
+  elif [[ "$degraded" -gt 0 ]]; then
     emit_component primitives degraded "$detail"
   else
     emit_component primitives ok "$detail"

--- a/blog/services.py
+++ b/blog/services.py
@@ -342,6 +342,12 @@ def load_skill_evidence_summary(limit=5):
 
 def load_primitive_runtime_summary(limit=5):
     """Summarize primitives using the canonical primitives-status read model."""
+    def _normalize_effective_status(value):
+        status = str(value or "unknown")
+        if status in {"declared", "contract-only", "drifted"}:
+            return "degraded"
+        return status
+
     payload = load_json_safe(PRIMITIVES_STATUS_FILE, None)
     if not payload and (ROOT / "tools" / "edge-primitives").exists():
         try:
@@ -362,12 +368,16 @@ def load_primitive_runtime_summary(limit=5):
         sources = [
             {
                 **item,
+                "effective_status": _normalize_effective_status(item.get("effective_status")),
                 "id": item.get("name"),
                 "reference": item.get("name"),
             }
             for item in sources
             if isinstance(item, dict)
         ]
+        degraded_total = int(summary.get("degraded_total", 0) or 0)
+        if not degraded_total:
+            degraded_total = int(summary.get("declared_only_total", 0) or 0) + int(summary.get("contract_only_total", 0) or 0) + int(summary.get("drifted_total", 0) or 0)
         top_used = sorted(sources, key=lambda item: (-int(item.get("usage_30d", 0) or 0), item.get("name", "")))
         return {
             "available": True,
@@ -375,11 +385,10 @@ def load_primitive_runtime_summary(limit=5):
             "health_status": summary.get("health_status", "unknown"),
             "health_color": "red" if summary.get("health_status") == "fail" else "yellow" if summary.get("health_status") == "degraded" else "green",
             "declared_total": int(summary.get("declared_total", 0) or 0),
-            "contract_only_total": int(summary.get("contract_only_total", 0) or 0),
+            "degraded_total": degraded_total,
             "active_total": int(summary.get("active_total", 0) or 0),
             "probed_total": int(summary.get("probed_total", 0) or 0),
             "broken_total": int(summary.get("broken_total", 0) or 0),
-            "drifted_total": int(summary.get("drifted_total", 0) or 0),
             "usage_30d_total": int(summary.get("usage_30d_total", 0) or 0),
             "counts_by_effective_status": summary.get("counts_by_effective_status", {}) or {},
             "top_sources": sources[:limit],
@@ -444,11 +453,10 @@ def load_primitive_runtime_summary(limit=5):
         "health_status": "unknown",
         "health_color": "muted",
         "declared_total": len(sources),
-        "contract_only_total": status_counts.get("contract-only", 0),
+        "degraded_total": status_counts.get("declared", 0) + status_counts.get("contract-only", 0) + status_counts.get("degraded", 0),
         "active_total": status_counts.get("active", 0),
         "probed_total": 0,
         "broken_total": 0,
-        "drifted_total": 0,
         "usage_30d_total": int(usage.get("total_calls", 0) or 0),
         "counts_by_effective_status": status_counts,
         "top_sources": [],

--- a/blog/templates/partials/runtime.html
+++ b/blog/templates/partials/runtime.html
@@ -117,8 +117,8 @@
         <span class="runtime-meta">{{ runtime_primitives.declared_total }}</span>
       </div>
       <div class="runtime-row">
-        <span>contract-only</span>
-        <span class="runtime-meta">{{ runtime_primitives.contract_only_total }}</span>
+        <span>degraded</span>
+        <span class="runtime-meta">{{ runtime_primitives.degraded_total }}</span>
       </div>
       <div class="runtime-row">
         <span>active</span>
@@ -129,8 +129,8 @@
         <span class="runtime-meta">{{ runtime_primitives.probed_total }}</span>
       </div>
       <div class="runtime-row">
-        <span>drifted / broken</span>
-        <span class="runtime-meta">{{ runtime_primitives.drifted_total }} / {{ runtime_primitives.broken_total }}</span>
+        <span>broken</span>
+        <span class="runtime-meta">{{ runtime_primitives.broken_total }}</span>
       </div>
       <div class="runtime-row">
         <span>usage ({{ runtime_primitives.window_days }}d)</span>

--- a/skills/autonomy/SKILL.md
+++ b/skills/autonomy/SKILL.md
@@ -58,12 +58,13 @@ Do not manually diff raw files when the read model already explains the state.
 
 Important statuses:
 
-- `declared`
-- `contract-only`
 - `active`
 - `probed`
-- `drifted`
+- `degraded`
 - `broken`
+
+Use `manifest_status` and `problems` for the distinction between a merely
+declared source and a contract-written source that still is not activated.
 
 ### 2. Proposal pool
 
@@ -154,10 +155,9 @@ That readback is the canonical proof of the new state.
 
 Strong autonomy candidates:
 
-- `declared` sources with repeated demand but no contract
-- `contract-only` primitives with real usage pressure
+- `degraded` primitives with real usage pressure
 - `active` primitives never probed
-- `broken` or `drifted` primitives affecting current work
+- `broken` or `degraded` primitives affecting current work
 - workflows repeatedly rediscovered in artifacts
 - stale proposals that no longer have evidence
 

--- a/tests/test_dashboard_runtime.sh
+++ b/tests/test_dashboard_runtime.sh
@@ -93,16 +93,15 @@ cat >"$TMP_STATE/state/primitives-status.json" <<'JSON'
   "summary": {
     "window_days": 30,
     "declared_total": 3,
-    "contract_only_total": 1,
+    "degraded_total": 1,
     "active_total": 1,
     "probed_total": 0,
     "broken_total": 1,
-    "drifted_total": 0,
     "usage_30d_total": 17,
     "counts_by_effective_status": {
       "broken": 1,
       "active": 1,
-      "contract-only": 1
+      "degraded": 1
     },
     "health_status": "fail"
   },
@@ -125,7 +124,7 @@ cat >"$TMP_STATE/state/primitives-status.json" <<'JSON'
     },
     {
       "name": "overleaf",
-      "effective_status": "contract-only",
+      "effective_status": "degraded",
       "probe_status": "unknown",
       "usage_30d": 2,
       "manifest_status": "contract-only",
@@ -183,7 +182,7 @@ assert data["runtime_skill_evidence"]["skill_runs_total"] == 2
 assert data["runtime_primitives"]["available"] is True
 assert data["runtime_primitives"]["health_status"] == "fail"
 assert data["runtime_primitives"]["declared_total"] == 3
-assert data["runtime_primitives"]["contract_only_total"] == 1
+assert data["runtime_primitives"]["degraded_total"] == 1
 assert data["runtime_primitives"]["broken_total"] == 1
 assert data["runtime_primitives"]["usage_30d_total"] == 17
 assert data["runtime_autonomy"]["available"] is True
@@ -196,7 +195,7 @@ text = partial.get_data(as_text=True)
 assert "runtime transparency" in text
 assert "reflection" in text
 assert "primitives status" in text
-assert "contract-only" in text
+assert "degraded" in text
 assert "broken" in text
 assert "GAP-101" in text
 print("ok")

--- a/tests/test_dashboard_runtime_interventions.sh
+++ b/tests/test_dashboard_runtime_interventions.sh
@@ -79,11 +79,10 @@ cat >"$TMP_STATE/state/primitives-status.json" <<'JSON'
   "summary": {
     "window_days": 30,
     "declared_total": 2,
-    "contract_only_total": 0,
+    "degraded_total": 0,
     "active_total": 1,
     "probed_total": 0,
     "broken_total": 1,
-    "drifted_total": 0,
     "usage_30d_total": 12,
     "counts_by_effective_status": {
       "broken": 1,

--- a/tests/test_edge_cap_status.sh
+++ b/tests/test_edge_cap_status.sh
@@ -65,13 +65,13 @@ import json, sys
 payload = json.loads(sys.argv[1])
 summary = payload["summary"]
 assert summary["capability_total"] >= 5
-assert summary["health_status"] == "warn"
+assert summary["health_status"] == "degraded"
 names = {item["name"]: item for item in payload["capabilities"]}
 assert names["search.corpus"]["effective_status"] == "available"
 assert names["sources.aggregate"]["effective_status"] == "available"
 assert names["workflow.recommend"]["effective_status"] == "available"
 assert names["repo.status"]["effective_status"] == "available"
-assert names["storage.sync"]["effective_status"] == "optional-missing"
+assert names["storage.sync"]["effective_status"] == "degraded"
 assert names["source.arxiv"]["effective_status"] in {"active", "probed"}
 recommended = {item["name"] for item in payload["recommended"]}
 assert "search.corpus" in recommended

--- a/tests/test_health_v2.sh
+++ b/tests/test_health_v2.sh
@@ -78,13 +78,13 @@ cat >"$TMP_STATE/state/primitives-status.json" <<'JSON'
     "health_status": "degraded",
     "declared_total": 3,
     "broken_total": 1,
-    "drifted_total": 1,
+    "degraded_total": 1,
     "usage_30d_total": 9
   },
   "sources": [
     {"name":"arxiv","effective_status":"active","usage_30d":4},
     {"name":"exa","effective_status":"broken","usage_30d":0},
-    {"name":"grafana","effective_status":"contract-only","usage_30d":0}
+    {"name":"grafana","effective_status":"degraded","usage_30d":0}
   ]
 }
 JSON
@@ -95,15 +95,16 @@ cat >"$TMP_STATE/state/capabilities-status.json" <<'JSON'
     "health_status": "degraded",
     "capability_total": 4,
     "available_total": 2,
-    "missing_total": 1,
+    "degraded_total": 1,
     "broken_total": 1,
-    "drifted_total": 0
+    "required_degraded_total": 0,
+    "optional_degraded_total": 1
   },
   "capabilities": [
     {"name":"source.arxiv","effective_status":"available","invoke_30d":0},
     {"name":"source.github","effective_status":"available","invoke_30d":2},
     {"name":"search.corpus","effective_status":"broken","invoke_30d":1},
-    {"name":"storage.sync","effective_status":"missing","invoke_30d":0}
+    {"name":"storage.sync","effective_status":"degraded","invoke_30d":0}
   ]
 }
 JSON

--- a/tests/test_primitives_status.sh
+++ b/tests/test_primitives_status.sh
@@ -99,10 +99,10 @@ tool, status_file = sys.argv[1:]
 result = subprocess.run([tool, "status", "--json"], capture_output=True, text=True, check=True)
 payload = json.loads(result.stdout)
 assert payload["summary"]["declared_total"] == 2
-assert payload["summary"]["declared_only_total"] == 2
+assert payload["summary"]["degraded_total"] == 2
 rows = {row["name"]: row for row in payload["sources"]}
-assert rows["arxiv"]["effective_status"] == "declared"
-assert rows["exa"]["effective_status"] == "declared"
+assert rows["arxiv"]["effective_status"] == "degraded"
+assert rows["exa"]["effective_status"] == "degraded"
 assert Path(status_file).exists()
 PY
 then
@@ -132,9 +132,9 @@ tool = sys.argv[1]
 payload = json.loads(subprocess.run([tool, "status", "--json"], capture_output=True, text=True, check=True).stdout)
 rows = {row["name"]: row for row in payload["sources"]}
 assert payload["summary"]["probed_total"] == 1
-assert payload["summary"]["declared_only_total"] == 1
+assert payload["summary"]["degraded_total"] == 1
 assert rows["arxiv"]["effective_status"] == "probed"
-assert rows["exa"]["effective_status"] == "declared"
+assert rows["exa"]["effective_status"] == "degraded"
 assert rows["arxiv"]["probe_status"] == "ok"
 PY
 then
@@ -143,7 +143,7 @@ else
     fail "lifecycle transitions update status to probed"
 fi
 
-echo "--- Test 4: missing active binary is reported as drifted ---"
+echo "--- Test 4: missing active binary is reported as degraded ---"
 rm -f "$LIBEXEC_DIR/arxiv"
 if python3 - <<'PY' "$STATUS_TOOL"
 import json
@@ -153,13 +153,13 @@ import sys
 tool = sys.argv[1]
 payload = json.loads(subprocess.run([tool, "status", "--json"], capture_output=True, text=True, check=True).stdout)
 rows = {row["name"]: row for row in payload["sources"]}
-assert payload["summary"]["drifted_total"] == 1
-assert rows["arxiv"]["effective_status"] == "drifted"
+assert payload["summary"]["degraded_total"] == 2
+assert rows["arxiv"]["effective_status"] == "degraded"
 PY
 then
-    pass "status reports drift when active binary disappears"
+    pass "status reports degraded when active binary disappears"
 else
-    fail "status reports drift when active binary disappears"
+    fail "status reports degraded when active binary disappears"
 fi
 
 echo ""

--- a/tools/_shared/capability_runtime.py
+++ b/tools/_shared/capability_runtime.py
@@ -30,16 +30,19 @@ from .telemetry import log_capability_invocation, log_capability_probe_completed
 WINDOW_DAYS = 30
 STATUS_ORDER = {
     "broken": 0,
-    "drifted": 1,
-    "missing": 2,
-    "optional-missing": 3,
-    "probed": 4,
-    "active": 5,
-    "available": 6,
-    "contract-only": 7,
-    "declared": 8,
-    "unknown": 9,
+    "degraded": 1,
+    "probed": 2,
+    "active": 3,
+    "available": 4,
+    "unknown": 5,
 }
+
+
+def _normalize_effective_status(value: Any) -> str:
+    status = str(value or "unknown").strip() or "unknown"
+    if status in {"missing", "optional-missing", "drifted", "contract-only", "declared"}:
+        return "degraded"
+    return status
 
 
 def _normalize_skill(skill: str | None) -> str:
@@ -201,12 +204,9 @@ def _static_capability_row(item: dict[str, Any], *, invocations: dict[str, Any],
     elif available:
         effective_status = "available"
         problems = []
-    elif required:
-        effective_status = "missing"
-        problems = ["required_command_missing"]
     else:
-        effective_status = "optional-missing"
-        problems = ["optional_command_missing"]
+        effective_status = "degraded"
+        problems = ["required_command_missing" if required else "optional_command_missing"]
     skills = item.get("skills") or []
     normalized_skill = _normalize_skill(skill)
     return {
@@ -239,7 +239,7 @@ def _primitive_capability_row(item: dict[str, Any], *, invocations: dict[str, An
     name = f"source.{item.get('name')}"
     probe_event = probes.get(name, {})
     invocation_event = invocations.get(name, {})
-    effective_status = str(item.get("effective_status") or "unknown")
+    effective_status = _normalize_effective_status(item.get("effective_status"))
     normalized_skill = _normalize_skill(skill)
     return {
         "name": name,
@@ -285,14 +285,13 @@ def build_capability_status(*, skill: str | None = None) -> dict[str, Any]:
     rows.sort(key=lambda row: (STATUS_ORDER.get(str(row.get("effective_status") or "unknown"), 99), str(row.get("name") or "")))
     counts = Counter(str(row.get("effective_status") or "unknown") for row in rows)
     kind_counts = Counter(str(row.get("kind") or "unknown") for row in rows)
-    required_missing_total = sum(1 for row in rows if row.get("effective_status") == "missing" and row.get("required"))
+    required_degraded_total = sum(1 for row in rows if row.get("effective_status") == "degraded" and row.get("required"))
     broken_total = counts.get("broken", 0)
-    drifted_total = counts.get("drifted", 0)
-    optional_missing_total = counts.get("optional-missing", 0)
-    if required_missing_total or broken_total:
+    degraded_total = counts.get("degraded", 0)
+    if required_degraded_total or broken_total:
         health_status = "fail"
-    elif drifted_total or optional_missing_total:
-        health_status = "warn"
+    elif degraded_total:
+        health_status = "degraded"
     else:
         health_status = "ok"
 
@@ -314,10 +313,10 @@ def build_capability_status(*, skill: str | None = None) -> dict[str, Any]:
         "static_total": sum(1 for row in rows if row.get("source") == "static_registry"),
         "primitive_total": sum(1 for row in rows if row.get("source") == "primitives_status"),
         "available_total": sum(1 for row in rows if row.get("effective_status") in {"available", "active", "probed"}),
-        "missing_total": counts.get("missing", 0),
-        "optional_missing_total": optional_missing_total,
+        "degraded_total": degraded_total,
+        "required_degraded_total": required_degraded_total,
+        "optional_degraded_total": max(0, degraded_total - required_degraded_total),
         "broken_total": broken_total,
-        "drifted_total": drifted_total,
         "counts_by_effective_status": dict(sorted(counts.items(), key=lambda item: (STATUS_ORDER.get(item[0], 99), item[0]))),
         "counts_by_kind": dict(sorted(kind_counts.items())),
         "health_status": health_status,
@@ -354,7 +353,7 @@ def invoke_capability(name: str, argv: list[str], *, skill: str | None = None) -
     if not command:
         raise RuntimeError(f"capability has no command: {name}")
     effective_status = str(capability.get("effective_status") or "unknown")
-    if effective_status in {"missing", "optional-missing", "contract-only", "declared"}:
+    if effective_status == "degraded":
         raise RuntimeError(f"capability unavailable: {name} ({effective_status})")
     final_cmd = command + (argv if capability.get("passthrough", True) else [])
     started = time.monotonic()

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -199,7 +199,7 @@ def _primitives_status() -> dict[str, Any]:
             "usage_30d": item.get("usage_30d", 0),
         }
         for item in sources[:5]
-        if item.get("effective_status") in {"broken", "drifted"}
+        if item.get("effective_status") in {"broken", "degraded"}
     ]
     return {
         "health_status": summary.get("health_status", "unknown"),
@@ -237,7 +237,7 @@ def _capabilities_status(skill: str | None = None) -> dict[str, Any]:
             "description": item.get("description", ""),
         }
         for item in (payload.get("capabilities") or [])
-        if item.get("effective_status") in {"missing", "optional-missing", "broken", "drifted"}
+        if item.get("effective_status") in {"broken", "degraded"}
     ][:5]
     return {
         "health_status": summary.get("health_status", "unknown"),

--- a/tools/_shared/health_runtime.py
+++ b/tools/_shared/health_runtime.py
@@ -419,11 +419,10 @@ def _capabilities_dimension(events: list[dict[str, Any]], capabilities_status: d
     capability_invokes, capability_invoke_fail, capability_probe_fail, primitive_probe_fail = _capability_events(events)
 
     available = int(cap_summary.get("available_total", 0) or 0)
-    missing = int(cap_summary.get("missing_total", 0) or 0)
+    degraded = int(cap_summary.get("degraded_total", 0) or 0)
     broken = int(cap_summary.get("broken_total", 0) or 0)
-    drifted = int(cap_summary.get("drifted_total", 0) or 0)
     primitive_broken = int(primitive_summary.get("broken_total", 0) or 0)
-    primitive_drifted = int(primitive_summary.get("drifted_total", 0) or 0)
+    primitive_degraded = int(primitive_summary.get("degraded_total", 0) or 0)
     never_used_available = sum(
         1
         for row in cap_rows
@@ -432,23 +431,22 @@ def _capabilities_dimension(events: list[dict[str, Any]], capabilities_status: d
     primitive_never_used = sum(
         1
         for row in sources
-        if str(row.get("effective_status")) in {"active", "probed", "contract-only"} and int(row.get("usage_30d", 0) or 0) == 0
+        if str(row.get("effective_status")) in {"active", "probed"} and int(row.get("usage_30d", 0) or 0) == 0
     )
     total_invocations = sum(capability_invokes.values())
     total_invoke_fail = sum(capability_invoke_fail.values())
     invoke_fail_rate = total_invoke_fail / total_invocations if total_invocations else 0.0
-    if available == 0 and missing == 0 and broken == 0 and drifted == 0 and primitive_broken == 0 and primitive_drifted == 0 and total_invocations == 0:
+    if available == 0 and degraded == 0 and broken == 0 and primitive_broken == 0 and primitive_degraded == 0 and total_invocations == 0:
         return {
             "status": "unknown",
             "score": 50,
             "detail": "no capability evidence yet",
             "metrics": {
                 "available_capabilities": 0,
-                "missing_capabilities": 0,
+                "degraded_capabilities": 0,
                 "broken_capabilities": 0,
-                "drifted_capabilities": 0,
+                "degraded_primitives": 0,
                 "broken_primitives": 0,
-                "drifted_primitives": 0,
                 "never_used_available_capabilities": 0,
                 "never_used_primitives": 0,
                 "capability_invocations_30d": 0,
@@ -461,30 +459,33 @@ def _capabilities_dimension(events: list[dict[str, Any]], capabilities_status: d
 
     score = 100
     score -= min(broken * 15, 40)
-    score -= min(drifted * 8, 20)
+    score -= min(degraded * 8, 20)
     score -= min(primitive_broken * 15, 30)
-    score -= min(primitive_drifted * 8, 20)
-    score -= min(missing * 5, 20)
+    score -= min(primitive_degraded * 8, 20)
     if available > 0:
         score -= min(round((never_used_available / max(available, 1)) * 20), 20)
     if total_invocations:
         score -= min(round(invoke_fail_rate * 30), 30)
     score = max(0, min(100, score))
+    status = _dimension_status(score)
+    if broken or primitive_broken:
+        status = "fail"
+    elif status == "ok" and (degraded or primitive_degraded):
+        status = "degraded"
 
     return {
-        "status": _dimension_status(score),
+        "status": status,
         "score": score,
         "detail": (
-            f"available={available} missing={missing} broken={broken} drifted={drifted} "
-            f"primitive_broken={primitive_broken} primitive_drifted={primitive_drifted}"
+            f"available={available} degraded={degraded} broken={broken} "
+            f"primitive_broken={primitive_broken} primitive_degraded={primitive_degraded}"
         ),
         "metrics": {
             "available_capabilities": available,
-            "missing_capabilities": missing,
+            "degraded_capabilities": degraded,
             "broken_capabilities": broken,
-            "drifted_capabilities": drifted,
+            "degraded_primitives": primitive_degraded,
             "broken_primitives": primitive_broken,
-            "drifted_primitives": primitive_drifted,
             "never_used_available_capabilities": never_used_available,
             "never_used_primitives": primitive_never_used,
             "capability_invocations_30d": total_invocations,

--- a/tools/edge-cap
+++ b/tools/edge-cap
@@ -25,9 +25,8 @@ def _print_status(payload: dict[str, object]) -> None:
           f" static={summary.get('static_total', 0)}"
           f" primitive={summary.get('primitive_total', 0)}"
           f" available={summary.get('available_total', 0)}"
-          f" missing={summary.get('missing_total', 0)}"
+          f" degraded={summary.get('degraded_total', 0)}"
           f" broken={summary.get('broken_total', 0)}"
-          f" drifted={summary.get('drifted_total', 0)}"
           f" health={summary.get('health_status', 'unknown')}")
     recommended = payload.get("recommended") or []
     if recommended:

--- a/tools/edge-doctor
+++ b/tools/edge-doctor
@@ -446,17 +446,16 @@ def check_primitives_status():
     detail = (
         "primitives-status: "
         f"declared={summary.get('declared_total', 0)}, "
-        f"contract_only={summary.get('contract_only_total', 0)}, "
+        f"degraded={summary.get('degraded_total', 0)}, "
         f"active={summary.get('active_total', 0)}, "
         f"probed={summary.get('probed_total', 0)}, "
-        f"broken={summary.get('broken_total', 0)}, "
-        f"drifted={summary.get('drifted_total', 0)}"
+        f"broken={summary.get('broken_total', 0)}"
     )
     artifact = payload.get("output_path") or tool
     if summary.get("broken_total", 0):
         fail(detail)
         _record_check("projection:primitives-status", "fail", detail, artifact=artifact)
-    elif summary.get("drifted_total", 0):
+    elif summary.get("degraded_total", 0):
         warn(detail)
         _record_check("projection:primitives-status", "warn", detail, artifact=artifact)
     else:

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -59,9 +59,9 @@ def before_snapshot(state: dict[str, Any]) -> dict[str, Any]:
         "claims_open_total": int(claims_summary.get("open_total", 0) or 0),
         "orphans_total": int(orphan_summary.get("orphan_total", 0) or 0),
         "primitive_broken_total": int((primitives_status.get("summary") or {}).get("broken_total", 0) or 0),
-        "primitive_drifted_total": int((primitives_status.get("summary") or {}).get("drifted_total", 0) or 0),
+        "primitive_degraded_total": int((primitives_status.get("summary") or {}).get("degraded_total", 0) or 0),
         "capability_broken_total": int((capabilities_status.get("summary") or {}).get("broken_total", 0) or 0),
-        "capability_missing_total": int((capabilities_status.get("summary") or {}).get("missing_total", 0) or 0),
+        "capability_degraded_total": int((capabilities_status.get("summary") or {}).get("degraded_total", 0) or 0),
         "workflow_broken_total": int(workflow_status.get("broken_total", 0) or 0),
         "workflow_stale_total": int(workflow_status.get("stale_total", 0) or 0),
     }
@@ -180,7 +180,7 @@ def refresh_capabilities_status(skill: str | None = None) -> dict[str, Any]:
     detail = (
         f"health={summary.get('health_status', 'unknown')} "
         f"available={summary.get('available_total', 0)} "
-        f"missing={summary.get('missing_total', 0)} "
+        f"degraded={summary.get('degraded_total', 0)} "
         f"broken={summary.get('broken_total', 0)}"
     )
     append_postskill_log("capabilities_status", "OK", detail)
@@ -223,9 +223,9 @@ def compute_delta(
         "claims_open_delta": int(digest.get("open_total", 0) or 0) - before["claims_open_total"],
         "orphans_delta": int(orphans.get("orphan_total", 0) or 0) - before["orphans_total"],
         "primitive_broken_delta": int(primitives_summary.get("broken_total", 0) or 0) - before["primitive_broken_total"],
-        "primitive_drifted_delta": int(primitives_summary.get("drifted_total", 0) or 0) - before["primitive_drifted_total"],
+        "primitive_degraded_delta": int(primitives_summary.get("degraded_total", 0) or 0) - before["primitive_degraded_total"],
         "capability_broken_delta": int(capabilities_summary.get("broken_total", 0) or 0) - before["capability_broken_total"],
-        "capability_missing_delta": int(capabilities_summary.get("missing_total", 0) or 0) - before["capability_missing_total"],
+        "capability_degraded_delta": int(capabilities_summary.get("degraded_total", 0) or 0) - before["capability_degraded_total"],
         "workflow_broken_delta": int(workflow_summary.get("broken_total", 0) or 0) - before["workflow_broken_total"],
         "workflow_stale_delta": int(workflow_summary.get("stale_total", 0) or 0) - before["workflow_stale_total"],
     }
@@ -321,7 +321,7 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
                 "usage_30d": item.get("usage_30d", 0),
             }
             for item in (primitives_payload.get("sources") or [])[:5]
-            if item.get("effective_status") in {"broken", "drifted"}
+            if item.get("effective_status") in {"broken", "degraded"}
         ],
     }
     capabilities_payload = capabilities_refresh["payload"] or {}
@@ -337,7 +337,7 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
                 "description": item.get("description", ""),
             }
             for item in (capabilities_payload.get("capabilities") or [])
-            if item.get("effective_status") in {"missing", "optional-missing", "broken", "drifted"}
+            if item.get("effective_status") in {"broken", "degraded"}
         ][:5],
     }
     workflow_summary = workflows_payload.get("summary") or {}

--- a/tools/edge-primitives
+++ b/tools/edge-primitives
@@ -31,12 +31,10 @@ from paths import (  # noqa: E402
 WINDOW_DAYS = 30
 STATUS_ORDER = {
     "broken": 0,
-    "drifted": 1,
+    "degraded": 1,
     "probed": 2,
     "active": 3,
-    "contract-only": 4,
-    "declared": 5,
-    "unknown": 6,
+    "unknown": 4,
 }
 
 
@@ -208,15 +206,17 @@ def _effective_status(
     if binary_exists and probe_ok is False:
         return "broken", problems + ["last_probe_failed"]
     if problems:
-        return "drifted", problems
+        return "degraded", problems
     if binary_exists and probe_ok is True:
         return "probed", problems
     if binary_exists:
         return "active", problems
-    if meta_exists or manifest_status == "contract-only":
-        return "contract-only", problems
     if declared or manifest_status == "declared" or manifest_exists:
-        return "declared", problems
+        if meta_exists:
+            problems.append("not_activated")
+        else:
+            problems.append("declared_not_activated")
+        return "degraded", problems
     return "unknown", problems
 
 
@@ -280,7 +280,8 @@ def build_status(config_path: Path | None = None) -> dict:
     sources.sort(key=lambda row: (STATUS_ORDER.get(row["effective_status"], 99), row["name"]))
     counts = Counter(row["effective_status"] for row in sources)
     broken_total = counts.get("broken", 0)
-    drifted_total = counts.get("drifted", 0)
+    degraded_total = counts.get("degraded", 0)
+    manifest_status_counts = Counter((row.get("manifest_status") or "unknown") for row in sources)
     summary = {
         "generated_at": now.isoformat(),
         "window_days": WINDOW_DAYS,
@@ -289,17 +290,16 @@ def build_status(config_path: Path | None = None) -> dict:
         "manifest_total": sum(1 for row in sources if row["manifest_exists"]),
         "meta_total": sum(1 for row in sources if row["meta_exists"]),
         "binary_total": sum(1 for row in sources if row["binary_exists"]),
-        "declared_only_total": counts.get("declared", 0),
-        "contract_only_total": counts.get("contract-only", 0),
+        "degraded_total": degraded_total,
         "active_total": counts.get("active", 0),
         "probed_total": counts.get("probed", 0),
         "broken_total": broken_total,
-        "drifted_total": drifted_total,
         "missing_127_30d_total": sum(row["missing_127_30d"] for row in sources),
         "missing_77_30d_total": sum(row["missing_77_30d"] for row in sources),
         "usage_30d_total": sum(row["usage_30d"] for row in sources),
         "counts_by_effective_status": dict(sorted(counts.items(), key=lambda item: (STATUS_ORDER.get(item[0], 99), item[0]))),
-        "health_status": "fail" if broken_total else "degraded" if drifted_total else "ok",
+        "counts_by_manifest_status": dict(sorted(manifest_status_counts.items())),
+        "health_status": "fail" if broken_total else "degraded" if degraded_total else "ok",
     }
     payload = {
         "generated_at": now.isoformat(),
@@ -320,11 +320,10 @@ def print_human(payload: dict) -> None:
     print(
         "primitives:"
         f" declared={summary['declared_total']}"
-        f" contract_only={summary['contract_only_total']}"
+        f" degraded={summary['degraded_total']}"
         f" active={summary['active_total']}"
         f" probed={summary['probed_total']}"
         f" broken={summary['broken_total']}"
-        f" drifted={summary['drifted_total']}"
         f" health={summary['health_status']}"
     )
     for row in payload["sources"]:


### PR DESCRIPTION
## Summary\n- collapse operator-facing non-ready primitive/capability states into \n- update health, doctor, postflight, dashboard, and autonomy guidance to use degraded instead of missing/drifted/contract-only buckets\n- refresh targeted tests for the new status model\n\n## Validation\n- python3 -m py_compile tools/_shared/capability_runtime.py tools/edge-primitives tools/_shared/health_runtime.py tools/_shared/dispatch_runtime.py tools/edge-postflight tools/edge-cap tools/edge-doctor blog/services.py\n- bash tests/test_edge_cap_status.sh\n- bash tests/test_primitives_status.sh\n- bash tests/test_health_v2.sh\n- EDGE_BLOG_VENV=/home/vboxuser/edge/blog/.venv/bin/python3 bash tests/test_dashboard_runtime.sh\n- bash tests/test_edge_cap_invoke.sh\n- bash tests/test_edge_dispatch.sh\n- bash tests/test_edge_close.sh\n