### PR TITLE
[codex] run corpus lookup through edge-search wrapper

### DIFF
--- a/search/search.py
+++ b/search/search.py
@@ -598,6 +598,12 @@ def main():
     parser.add_argument(
         "--doc-stats", action="store_true", help="Show per-doc retrieval stats"
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON instead of formatted text",
+    )
     args = parser.parse_args()
 
     if args.doc_stats:
@@ -673,7 +679,17 @@ def main():
             )
             mode = "hybrid"
 
-        print(format_results(results, mode, workflows=workflows, coverage=coverage))
+        if args.json_output:
+            payload = {
+                "mode": mode,
+                "query": query,
+                "results": results,
+                "workflows": workflows,
+                "coverage": coverage or {},
+            }
+            print(json.dumps(payload, ensure_ascii=False))
+        else:
+            print(format_results(results, mode, workflows=workflows, coverage=coverage))
 
         all_results = results + workflows
         if not args.no_telemetry and all_results:

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -723,15 +723,29 @@ def corpus_lookup(query: str | None, *, skill: str | None = None, corpus_policy:
         return [], {"level": "none", "recent_hits": [], "reason": "no_query", "coverage": {"required": [], "optional": [], "required_covered": False, "missing_required_types": ["topic", "workflow", "memory"]}}, []
 
     try:
-        sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "search"))
-        from search import search_with_coverage  # type: ignore
-
-        results, coverage, workflows = search_with_coverage(
-            query,
-            limit=6,
-            required_types=["topic", "workflow", "memory"],
-            optional_types=[],
+        code, stdout, stderr = _run_subprocess(
+            [
+                str(EDGE_REPO_DIR / "search" / "edge-search"),
+                "--json",
+                "--require-type",
+                "topic",
+                "--require-type",
+                "workflow",
+                "--require-type",
+                "memory",
+                "-k",
+                "6",
+                query,
+            ]
         )
+        if code != 0:
+            raise RuntimeError(stderr or stdout or f"edge-search exit={code}")
+        payload = json.loads(stdout or "{}")
+        if not isinstance(payload, dict):
+            raise RuntimeError("edge-search did not return a JSON object")
+        results = payload.get("results") or []
+        coverage = payload.get("coverage") or {}
+        workflows = payload.get("workflows") or []
     except Exception as exc:
         return [], {"level": "none", "recent_hits": [], "reason": f"search_failed:{exc}", "coverage": {"required": [], "optional": [], "required_covered": False, "missing_required_types": ["topic", "workflow", "memory"]}}, []
 


### PR DESCRIPTION
## Summary
- make `corpus_lookup()` call the `edge-search` wrapper in subprocess mode instead of importing `search.py` directly
- add JSON output mode to `edge-search` so runtime callers can consume structured search results without depending on the host Python environment
- avoid runtime failures on hosts where the main Python does not have `sqlite_vec`, while still using the search venv that `edge-search` already owns

## Validation
- `python3 -m py_compile /tmp/edge-protocol/search/search.py /tmp/edge-protocol/tools/_shared/dispatch_runtime.py`
- `bash /tmp/edge-protocol/tests/test_edge_search_coverage.sh`
- `bash /tmp/edge-protocol/tests/test_edge_dispatch.sh`
- `bash /tmp/edge-protocol/tests/test_edge_runner.sh`
- `bash /tmp/edge-protocol/tests/test_runtime_decision_protocol.sh`