### PR TITLE
Run dispatched heartbeat skills in edge-runner

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -83,15 +83,20 @@ RUNNER_TOOL="$EDGE_DIR/tools/edge-runner"
 cat >"$TMP_HOME/.local/bin/claude" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$EDGE_CYCLE_ID" > "${MOCK_CLAUDE_ENV_OUT:?}"
-printf '%s\n' "$*" > "${MOCK_CLAUDE_ARGS_OUT:?}"
+printf '%s\n' "$EDGE_CYCLE_ID" >> "${MOCK_CLAUDE_ENV_OUT:?}"
+printf '__INVOCATION__\n' >> "${MOCK_CLAUDE_ARGS_OUT:?}"
+printf '%s\n' "$*" >> "${MOCK_CLAUDE_ARGS_OUT:?}"
+printf '__END__\n' >> "${MOCK_CLAUDE_ARGS_OUT:?}"
 if [ -n "${MOCK_CLAUDE_SLEEP_SECONDS:-}" ]; then
   sleep "${MOCK_CLAUDE_SLEEP_SECONDS}"
 fi
 if [ "${MOCK_CLAUDE_HEARTBEAT_FLOW:-0}" = "1" ]; then
-  "${EDGE_REPO_DIR:?}/tools/edge-dispatch" dispatch --skill discovery >/dev/null
-  "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery start >/dev/null
-  "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery end >/dev/null
+  if [[ "$*" == *"/ed-heartbeat"* ]]; then
+    "${EDGE_REPO_DIR:?}/tools/edge-dispatch" dispatch --skill discovery >/dev/null
+  elif [[ "$*" == *"/discovery"* ]]; then
+    "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery start >/dev/null
+    "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery end >/dev/null
+  fi
 fi
 exit "${MOCK_CLAUDE_EXIT_CODE:-0}"
 SH
@@ -105,6 +110,7 @@ echo ""
 echo "--- Test 1: heartbeat skill run opens and closes cycle mechanically ---"
 export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id.txt"
 export MOCK_CLAUDE_ARGS_OUT="$TMP_BASE/args.txt"
+rm -f "$MOCK_CLAUDE_ENV_OUT" "$MOCK_CLAUDE_ARGS_OUT"
 unset MOCK_CLAUDE_EXIT_CODE || true
 export MOCK_CLAUDE_HEARTBEAT_FLOW=1
 "$RUNNER_TOOL" skill \
@@ -123,11 +129,24 @@ import sys
 dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
 legacy = json.load(open(sys.argv[2], encoding="utf-8"))
 events = [json.loads(line) for line in open(sys.argv[3], encoding="utf-8") if line.strip()]
-cycle_id = open(sys.argv[4], encoding="utf-8").read().strip()
-args = open(sys.argv[5], encoding="utf-8").read().strip()
+cycle_ids = [line.strip() for line in open(sys.argv[4], encoding="utf-8") if line.strip()]
+invocations = []
+current = []
+for raw_line in open(sys.argv[5], encoding="utf-8"):
+    line = raw_line.rstrip("\n")
+    if line == "__INVOCATION__":
+        current = []
+        continue
+    if line == "__END__":
+        invocations.append("\n".join(current))
+        current = []
+        continue
+    current.append(line)
 request = dispatch["request"]
 
-assert cycle_id == dispatch["cycle_id"]
+assert len(cycle_ids) == 2
+assert cycle_ids[0] == dispatch["cycle_id"]
+assert cycle_ids[1] == dispatch["cycle_id"]
 assert request["trigger"] == "heartbeat"
 assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
@@ -152,28 +171,34 @@ assert request["heartbeat_routing"]["round_robin_skills"] == [
     "discovery",
     "strategy",
 ]
-assert "Dispatch runtime context below" in args
-assert "health_snapshot" in args
-assert "pre_skill_context" in args
-assert "preflight_evidence" in args
-assert "corpus_coverage" in args
-assert "search_protocol" in args
-assert "epistemic_protocol" in args
-assert "configured_integrations" in args
-assert "heartbeat_routing" in args
+assert "Dispatch runtime context below" in invocations[0]
+assert "health_snapshot" in invocations[0]
+assert "pre_skill_context" in invocations[0]
+assert "preflight_evidence" in invocations[0]
+assert "corpus_coverage" in invocations[0]
+assert "search_protocol" in invocations[0]
+assert "epistemic_protocol" in invocations[0]
+assert "configured_integrations" in invocations[0]
+assert "heartbeat_routing" in invocations[0]
 assert request["primitives_status"]["summary"]["health_status"] == "ok"
 assert "workflow_status" in request
 assert "claims_summary" in request
 assert legacy["active"] is False
 assert any(event["type"] == "CycleStarted" for event in events)
 assert any(event["type"] == "PreflightCompleted" for event in events)
+assert any(event["type"] == "SkillDispatched" for event in events)
+assert any(event["type"] == "SkillRunCompleted" for event in events)
 assert any(event["type"] == "CycleClosed" for event in events)
-assert "/ed-heartbeat" in args
+assert len(invocations) == 2
+assert "/ed-heartbeat" in invocations[0]
+assert "/discovery" in invocations[1]
+assert "Dispatch runtime context below" in invocations[0]
+assert "Dispatch runtime context below" in invocations[1]
 PY
 then
-    pass "heartbeat run exports cycle id, request context, and closes the shadow cycle"
+    pass "heartbeat run dispatches and executes the follow-on skill before closing the cycle"
 else
-    fail "heartbeat run exports cycle id, request context, and closes the shadow cycle"
+    fail "heartbeat run dispatches and executes the follow-on skill before closing the cycle"
 fi
 
 echo "--- Test 2: success without skill completion evidence closes as failed ---"

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -23,7 +23,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import EDGE_REPO_DIR  # noqa: E402
+from paths import EDGE_REPO_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
 from _shared.dispatch_runtime import read_dispatch_state, render_skill_runtime_prompt  # noqa: E402
 from _shared.telemetry import emit_shadow_event  # noqa: E402
@@ -248,6 +248,75 @@ def dispatch_state_matches(cycle_id: str) -> dict | None:
     return state
 
 
+def iter_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+
+def iso_ge(left: str | None, right: str | None) -> bool:
+    if not left or not right:
+        return False
+    try:
+        left_dt = datetime.fromisoformat(left)
+        right_dt = datetime.fromisoformat(right)
+    except ValueError:
+        return False
+    if left_dt.tzinfo is None:
+        left_dt = left_dt.replace(tzinfo=timezone.utc)
+    if right_dt.tzinfo is None:
+        right_dt = right_dt.replace(tzinfo=timezone.utc)
+    return left_dt >= right_dt
+
+
+def normalize_skill_name(skill: str | None) -> str:
+    return str(skill or "").strip().lstrip("/")
+
+
+def skill_run_completed_for_cycle(cycle_id: str, skill: str | None) -> bool:
+    state = dispatch_state_matches(cycle_id)
+    if not state:
+        return False
+    requested_skill = normalize_skill_name(skill)
+    if not requested_skill:
+        return False
+    state_block = state.get("state", {}) or {}
+    threshold = state_block.get("dispatched_at") or state_block.get("opened_at")
+
+    accepted = {requested_skill, f"/{requested_skill}"}
+    for event in reversed(iter_jsonl(STATE_EVENTS_FILE)):
+        if event.get("type") != "SkillRunCompleted":
+            continue
+        if event.get("cycle_id") != cycle_id:
+            continue
+        payload = event.get("payload", {}) or {}
+        event_skill = normalize_skill_name(payload.get("skill"))
+        registry_skill = normalize_skill_name(payload.get("registry_skill"))
+        if event_skill not in accepted and registry_skill not in accepted:
+            continue
+        if threshold and not iso_ge(event.get("ts"), threshold):
+            continue
+        return True
+
+    for row in reversed(iter_jsonl(SKILL_STEPS_FILE)):
+        if row.get("event") != "end":
+            continue
+        if normalize_skill_name(row.get("skill")) not in accepted and normalize_skill_name(row.get("registry_skill")) not in accepted:
+            continue
+        if threshold and not iso_ge(row.get("ts"), threshold):
+            continue
+        return True
+    return False
+
+
 def heartbeat_dispatch_completed(cycle_id: str) -> bool:
     state = dispatch_state_matches(cycle_id)
     if not state:
@@ -256,6 +325,31 @@ def heartbeat_dispatch_completed(cycle_id: str) -> bool:
     state_block = state.get("state", {}) or {}
     skill = str(request.get("skill") or "").strip()
     return bool(state_block.get("skill_dispatched") and skill and not skill.endswith("heartbeat"))
+
+
+def dispatched_follow_on_skill(args: argparse.Namespace, cycle_id: str | None) -> str | None:
+    if not cycle_id or args.cmd != "skill":
+        return None
+    initial_skill = normalize_skill_name(args.skill)
+    if not initial_skill.endswith("heartbeat"):
+        return None
+    state = dispatch_state_matches(cycle_id)
+    if not state:
+        return None
+    request = state.get("request", {}) or {}
+    state_block = state.get("state", {}) or {}
+    dispatched_skill = normalize_skill_name(request.get("skill"))
+    if not state_block.get("skill_dispatched"):
+        return None
+    if not dispatched_skill or dispatched_skill == initial_skill or dispatched_skill.endswith("heartbeat"):
+        return None
+    return dispatched_skill
+
+
+def make_follow_on_skill_args(args: argparse.Namespace, skill_name: str) -> argparse.Namespace:
+    follow_on = argparse.Namespace(**vars(args))
+    follow_on.skill = f"/{normalize_skill_name(skill_name)}"
+    return follow_on
 
 
 def terminate_backend_process(proc: subprocess.Popen[bytes | str]) -> None:
@@ -340,22 +434,36 @@ def invoke_backend(args: argparse.Namespace, env: dict[str, str], *, cycle_id: s
         time.sleep(HEARTBEAT_DISPATCH_POLL_SECONDS)
 
 
-def maybe_mark_prompt_completion(args: argparse.Namespace, cycle_id: str | None, exit_code: int) -> None:
-    if args.cmd != "prompt" or not cycle_id or exit_code != 0:
+def maybe_mark_skill_completion(skill: str, cycle_id: str | None, exit_code: int) -> None:
+    if not cycle_id or exit_code != 0:
+        return
+    normalized = normalize_skill_name(skill)
+    if not normalized:
+        return
+    state = dispatch_state_matches(cycle_id)
+    if not state:
+        return
+    current_skill = normalize_skill_name((state.get("request", {}) or {}).get("skill"))
+    if normalized != current_skill:
+        return
+    if not (state.get("state", {}) or {}).get("skill_dispatched") and normalized != "prompt":
+        return
+    if skill_run_completed_for_cycle(cycle_id, normalized):
         return
     emit_shadow_event(
         "SkillRunCompleted",
         actor="edge-runner",
         cycle_id=cycle_id,
         payload={
-            "skill": "prompt",
-            "registry_skill": "prompt",
+            "skill": normalized,
+            "registry_skill": normalized,
             "event": "end",
             "expected": 1,
             "done": 1,
             "explicit_skips": 0,
             "silent_skips": [],
             "completion_pct": 100,
+            "completion_source": "edge_runner_fallback",
         },
     )
 
@@ -423,10 +531,43 @@ def main() -> int:
             )
 
         exit_code = invoke_backend(args, env, cycle_id=cycle_id)
-        maybe_mark_prompt_completion(args, cycle_id, exit_code)
+        if args.cmd == "prompt":
+            maybe_mark_skill_completion("prompt", cycle_id, exit_code)
+        elif args.cmd == "skill":
+            maybe_mark_skill_completion(args.skill, cycle_id, exit_code)
+
+        follow_on_skill = dispatched_follow_on_skill(args, cycle_id)
+        if follow_on_skill and exit_code == 0:
+            log_run_step(
+                "edge-runner",
+                "handoff",
+                "started",
+                run_id=cycle_id,
+                backend=args.backend,
+                mode=args.cmd,
+                target=follow_on_skill,
+            )
+            follow_on_args = make_follow_on_skill_args(args, follow_on_skill)
+            follow_on_exit = invoke_backend(follow_on_args, env, cycle_id=cycle_id)
+            maybe_mark_skill_completion(follow_on_skill, cycle_id, follow_on_exit)
+            final_status = "completed" if follow_on_exit == 0 else "failed"
+            log_run_step(
+                "edge-runner",
+                "handoff",
+                final_status,
+                run_id=cycle_id,
+                backend=args.backend,
+                mode="skill",
+                target=follow_on_skill,
+                exit_code=follow_on_exit,
+            )
+            if follow_on_exit != 0:
+                exit_code = follow_on_exit
+                close_status = "failed"
+                close_reason = f"dispatched_backend_exit_{follow_on_exit}"
         if exit_code != 0:
             close_status = "failed"
-            close_reason = f"backend_exit_{exit_code}"
+            close_reason = close_reason or f"backend_exit_{exit_code}"
     except KeyboardInterrupt:
         exit_code = 130
         close_status = "aborted"


### PR DESCRIPTION
## Summary
- make `edge-runner` execute the skill that heartbeat dispatches in the active cycle
- emit fallback `SkillRunCompleted` only when the dispatched skill finishes cleanly without explicit completion evidence
- update the runner smoke test to assert the two-step heartbeat handoff contract

## Why
Recent `bobmarley` beats showed `SkillDispatched` without any real handoff to the chosen skill, so cycles failed with `missing_skill_run_completed` even though heartbeat routing had already selected work.

## Testing
- `python3 -m py_compile tools/edge-runner tools/edge-dispatch tools/edge-close tools/edge-skill-step`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_edge_dispatch.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_heartbeat_entrypoints.sh`

Closes #322.