### PR TITLE
Enforce publish guard and commit scope

### DIFF
--- a/blog/blog-publish.sh
+++ b/blog/blog-publish.sh
@@ -97,6 +97,11 @@ SLUG="${FILENAME%.md}"
 export EDGE_PUBLISH_SLUG="$SLUG"
 export EDGE_BLOG_PUBLISH_RUN_ID="${EDGE_BLOG_PUBLISH_RUN_ID:-blog-publish:${SLUG}:$(date -u +%Y%m%dT%H%M%SZ)}"
 
+if ! "$TOOLS_DIR/edge-publish-guard" --operation blog-publish --target "$ENTRY_PATH" >/dev/null; then
+    echo "ERROR: inline publication blocked until heartbeat dispatch completes."
+    exit 65
+fi
+
 # Guardrail: BLOCK direct calls — everything must go through consolidate-state
 if [[ -z "${CALLED_FROM_CONSOLIDAR_ESTADO:-}" && -z "${CALLED_FROM_FULL_PUBLISH:-}" ]]; then
     echo "ERROR: blog-publish.sh cannot be called directly."

--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -49,6 +49,11 @@ export EDGE_CONSOLIDATE_ACTIVE=1
 # Unset on exit so subsequent processes lose authorization.
 trap 'unset EDGE_CONSOLIDATE_ACTIVE' EXIT
 
+if ! "$TOOLS_DIR/edge-publish-guard" --operation consolidate-state --target "${1:-}" >/dev/null; then
+    echo "ERROR: inline publication blocked until heartbeat dispatch completes."
+    exit 65
+fi
+
 # Peça 3: telemetry helper — record phase start/end in edge-ledger.
 # Fails silently if edge-ledger is unavailable (telemetry is never blocking).
 ledger_record() {
@@ -1236,7 +1241,7 @@ emit_run_step_event "phase-6" "started" "diffs_and_git_commit" ""
 
 # Note: BLOG_PORT, BLOG_AUTH_USER, BLOG_AUTH_PASS already exported by paths.sh
 
-python3 - "$ENTRY_PATH" "$SLUG" "$REPORT_FOR_COMMIT" "$COMMIT_REASON" "$STATE_AUDIT_EXIT" "$REPORT_RESULT" <<'PYPHASE5'
+if python3 - "$ENTRY_PATH" "$SLUG" "$REPORT_FOR_COMMIT" "$COMMIT_REASON" "$STATE_AUDIT_EXIT" "$REPORT_RESULT" "$REPORT_HTML" "$META_REPORT_PATH" <<'PYPHASE5'
 import sys, yaml, json, os, subprocess, urllib.request, traceback
 from pathlib import Path
 from datetime import datetime, timezone
@@ -1244,6 +1249,8 @@ from datetime import datetime, timezone
 entry_path, slug, report, reason = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 state_audit_exit = int(sys.argv[5]) if len(sys.argv) > 5 and sys.argv[5].isdigit() else -1
 report_result = sys.argv[6] if len(sys.argv) > 6 else "skip"
+report_html = sys.argv[7] if len(sys.argv) > 7 else ""
+meta_report_path = sys.argv[8] if len(sys.argv) > 8 else ""
 
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -1270,6 +1277,25 @@ def log_failure(phase, operation, error, tb=None):
     try:
         with open(FAILURES_FILE, "a") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+
+def emit_scope_violation(payload):
+    try:
+        tools_dir = Path(
+            os.environ.get("TOOLS_DIR")
+            or (Path(os.environ.get("EDGE_REPO_DIR", os.environ.get("EDGE_DIR", str(Path.home() / "edge")))).expanduser() / "tools")
+        )
+        if str(tools_dir) not in sys.path:
+            sys.path.insert(0, str(tools_dir))
+        from _shared.telemetry import emit_shadow_event  # type: ignore
+
+        emit_shadow_event(
+            "PublishCommitScopeViolation",
+            actor="consolidate-state",
+            cycle_id=os.environ.get("EDGE_CYCLE_ID") or None,
+            payload=payload,
+        )
     except Exception:
         pass
 
@@ -1367,33 +1393,51 @@ for dirpath, prefix in TRACKED.items():
 # ── 2. Captura diffs do ~/edge/ (repo principal) ──
 try:
     edge_dir = os.environ.get("EDGE_REPO_DIR", os.environ.get("EDGE_DIR", os.path.expanduser("~/edge")))
-    subprocess.run(["git", "add", "-A"], cwd=edge_dir, capture_output=True, timeout=30)
+    tool_path = Path(edge_dir) / "tools" / "edge-publish-scope"
+    changelog_path = Path(os.environ.get("BLOG_CHANGELOG_FILE", "")).expanduser()
+    allowed_paths = [entry_path]
+    if report_html:
+        allowed_paths.append(report_html)
+    if meta_report_path:
+        allowed_paths.append(meta_report_path)
+    if proposal_path.exists():
+        allowed_paths.append(str(proposal_path))
+    if audit_path.exists():
+        allowed_paths.append(str(audit_path))
+    if changelog_path and changelog_path.exists():
+        allowed_paths.append(str(changelog_path))
 
-    # ORPHAN GUARD: unstage blog entries/reports/meta-reports that don't belong to this slug.
-    # Prevents files written to disk but never published via consolidate-state from being
-    # swept into another slug's commit by git add -A. (Root cause of orphan entries bug.)
-    staged_result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only"],
-        cwd=edge_dir, capture_output=True, text=True, timeout=10
+    scope_cmd = [str(tool_path), "stage", "--slug", slug, "--json"]
+    for allowed_path in allowed_paths:
+        if allowed_path:
+            scope_cmd.extend(["--allow", allowed_path])
+    scope_result = subprocess.run(
+        scope_cmd,
+        cwd=edge_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
-    if staged_result.returncode == 0 and staged_result.stdout.strip():
-        staged_files = staged_result.stdout.strip().split("\n")
-        orphans = []
-        for f in staged_files:
-            is_entry = f.startswith("blog/entries/") and f.endswith(".md")
-            is_report = f.startswith("reports/") and (f.endswith(".html") or f.endswith(".yaml"))
-            is_meta = f.startswith("meta-reports/")
-            if (is_entry or is_report or is_meta) and slug not in f:
-                orphans.append(f)
-        if orphans:
-            warn(f"ORPHAN GUARD: {len(orphans)} file(s) from ANOTHER slug in staging — removing:")
-            for o in orphans:
-                warn(f"  ↳ {o}")
-            subprocess.run(
-                ["git", "reset", "HEAD", "--"] + orphans,
-                cwd=edge_dir, capture_output=True, timeout=10
-            )
-            warn("Publish orphan files via consolidate-state separately.")
+    scope_payload = {}
+    if scope_result.stdout.strip():
+        try:
+            scope_payload = json.loads(scope_result.stdout)
+        except Exception:
+            scope_payload = {"raw": scope_result.stdout.strip()}
+    if scope_result.returncode == 2:
+        emit_scope_violation({
+            "slug": slug,
+            "allowed_paths": scope_payload.get("allowed_paths", []),
+            "illegal_files": scope_payload.get("illegal_files", []),
+        })
+        illegal = scope_payload.get("illegal_files", []) or []
+        if illegal:
+            warn(f"SCOPE GUARD: {len(illegal)} file(s) outside publish allowlist in staging:")
+            for item in illegal:
+                warn(f"  ↳ {item}")
+        raise SystemExit(2)
+    if scope_result.returncode != 0:
+        raise RuntimeError(scope_result.stderr.strip() or scope_result.stdout.strip() or "edge-publish-scope failed")
 
     result = subprocess.run(
         ["git", "diff", "--cached", "--unified=3", "--", ".", ":(exclude)*.venv*", ":(exclude)*.b64", ":(exclude)*.png", ":(exclude)*.jpg", ":(exclude)*.pdf", ":(exclude)*.db"],
@@ -1621,7 +1665,12 @@ except Exception as e:
     log_failure("6", "commit_edge", e, traceback.format_exc())
     fail(f"Git commit failed: {e}")
 PYPHASE5
-emit_run_step_event "phase-6" "completed" "diffs_and_git_commit" ""
+then
+    emit_run_step_event "phase-6" "completed" "diffs_and_git_commit" ""
+else
+    emit_run_step_event "phase-6" "failed" "diffs_and_git_commit" "phase 6 failed"
+    ALL_OK=false
+fi
 
 echo ""
 echo "========================================="

--- a/tests/test_edge_publish_guard.sh
+++ b/tests/test_edge_publish_guard.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-publish-guard-XXXXXX)"
+TMP_EDGE="$TMP_BASE/edge"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_EDGE/state/events"
+
+export EDGE_REPO_DIR="$EDGE_DIR"
+export EDGE_STATE_DIR="$TMP_EDGE"
+export EDGE_CODENAME="publish-guard-test"
+
+GUARD_TOOL="$EDGE_DIR/tools/edge-publish-guard"
+DISPATCH_FILE="$TMP_EDGE/state/current-dispatch.json"
+EVENTS_FILE="$TMP_EDGE/state/events/log.jsonl"
+
+echo "=== edge-publish-guard Smoke Test ==="
+echo "Temp state: $TMP_EDGE"
+echo ""
+
+echo "--- Test 1: no active cycle allows publish ---"
+if "$GUARD_TOOL" --operation blog-publish --target "$TMP_EDGE/blog/entries/test.md" >/dev/null; then
+    pass "guard allows publish with no active cycle"
+else
+    fail "guard allows publish with no active cycle"
+fi
+
+echo "--- Test 2: active heartbeat before dispatch is blocked and emits event ---"
+cat >"$DISPATCH_FILE" <<'JSON'
+{
+  "cycle_id": "cycle-heartbeat-inline",
+  "request": {
+    "trigger": "heartbeat",
+    "skill": "bob-heartbeat"
+  },
+  "state": {
+    "active": true,
+    "skill_dispatched": false
+  }
+}
+JSON
+
+set +e
+"$GUARD_TOOL" --operation consolidate-state --target "$TMP_EDGE/blog/entries/test.md" >/dev/null 2>/dev/null
+STATUS=$?
+set -e
+
+if python3 - <<'PY' "$STATUS" "$EVENTS_FILE"
+import json
+import sys
+status = int(sys.argv[1])
+events_path = sys.argv[2]
+events = [json.loads(line) for line in open(events_path, encoding="utf-8") if line.strip()]
+assert status == 2
+event = [item for item in events if item["type"] == "HeartbeatInlineWorkDetected"][-1]
+assert event["payload"]["operation"] == "consolidate-state"
+assert event["payload"]["skill"] == "bob-heartbeat"
+assert event["payload"]["skill_dispatched"] is False
+PY
+then
+    pass "guard blocks inline publish before dispatch and emits event"
+else
+    fail "guard blocks inline publish before dispatch and emits event"
+fi
+
+echo "--- Test 3: dispatched substantive skill allows publish ---"
+cat >"$DISPATCH_FILE" <<'JSON'
+{
+  "cycle_id": "cycle-heartbeat-dispatched",
+  "request": {
+    "trigger": "heartbeat",
+    "skill": "research"
+  },
+  "state": {
+    "active": true,
+    "skill_dispatched": true
+  }
+}
+JSON
+
+if "$GUARD_TOOL" --operation blog-publish --target "$TMP_EDGE/blog/entries/test.md" >/dev/null; then
+    pass "guard allows publish after substantive dispatch"
+else
+    fail "guard allows publish after substantive dispatch"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tests/test_edge_publish_scope.sh
+++ b/tests/test_edge_publish_scope.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-publish-scope-XXXXXX)"
+TMP_REPO="$TMP_BASE/repo"
+TMP_STATE="$TMP_BASE/state"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_REPO" "$TMP_STATE/state/events"
+
+export EDGE_REPO_DIR="$TMP_REPO"
+export EDGE_STATE_DIR="$TMP_STATE"
+export EDGE_CODENAME="publish-scope-test"
+
+SCOPE_TOOL="$EDGE_DIR/tools/edge-publish-scope"
+EVENTS_FILE="$TMP_STATE/state/events/log.jsonl"
+
+git -C "$TMP_REPO" init -q
+git -C "$TMP_REPO" config user.name "Codex"
+git -C "$TMP_REPO" config user.email "codex@example.com"
+
+cat >"$TMP_REPO/allowed.txt" <<'EOF'
+allowed old
+EOF
+cat >"$TMP_REPO/other.txt" <<'EOF'
+other old
+EOF
+git -C "$TMP_REPO" add allowed.txt other.txt
+git -C "$TMP_REPO" commit -q -m "init"
+
+echo "allowed new" >"$TMP_REPO/allowed.txt"
+echo "other new" >"$TMP_REPO/other.txt"
+
+echo "=== edge-publish-scope Smoke Test ==="
+echo "Temp repo: $TMP_REPO"
+echo ""
+
+echo "--- Test 1: stages only allowlisted file when index is clean ---"
+OUTPUT=$("$SCOPE_TOOL" stage --slug demo --allow "$TMP_REPO/allowed.txt" --json)
+if python3 - <<'PY' "$OUTPUT" "$TMP_REPO"
+import json
+import subprocess
+import sys
+payload = json.loads(sys.argv[1])
+repo = sys.argv[2]
+staged = subprocess.check_output(["git", "diff", "--cached", "--name-only"], cwd=repo, text=True).splitlines()
+assert payload["illegal_files"] == []
+assert staged == ["allowed.txt"]
+PY
+then
+    pass "scope stages only allowlisted file"
+else
+    fail "scope stages only allowlisted file"
+fi
+
+git -C "$TMP_REPO" reset -q HEAD -- .
+git -C "$TMP_REPO" add other.txt
+
+echo "--- Test 2: detects staged versioned file outside allowlist ---"
+set +e
+OUTPUT=$("$SCOPE_TOOL" stage --slug demo --allow "$TMP_REPO/allowed.txt" --json 2>/dev/null)
+STATUS=$?
+set -e
+if python3 - <<'PY' "$STATUS" "$OUTPUT" "$EVENTS_FILE"
+import json
+import sys
+status = int(sys.argv[1])
+payload = json.loads(sys.argv[2])
+events_path = sys.argv[3]
+events = [json.loads(line) for line in open(events_path, encoding="utf-8") if line.strip()]
+assert status == 2
+assert payload["illegal_files"] == ["other.txt"]
+event = [item for item in events if item["type"] == "PublishCommitScopeViolation"][-1]
+assert event["payload"]["illegal_files"] == ["other.txt"]
+PY
+then
+    pass "scope detects staged file outside allowlist and emits event"
+else
+    fail "scope detects staged file outside allowlist and emits event"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tools/edge-publish-guard
+++ b/tools/edge-publish-guard
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""edge-publish-guard — block inline artifact publication before heartbeat dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import CURRENT_DISPATCH_FILE  # noqa: E402
+sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.telemetry import emit_shadow_event  # noqa: E402
+
+
+def read_dispatch_state() -> dict:
+    if not CURRENT_DISPATCH_FILE.exists():
+        return {}
+    try:
+        return json.loads(CURRENT_DISPATCH_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def should_block(dispatch: dict) -> tuple[bool, dict]:
+    request = dispatch.get("request", {}) or {}
+    state = dispatch.get("state", {}) or {}
+    trigger = str(request.get("trigger") or "")
+    skill = str(request.get("skill") or "")
+    payload = {
+        "trigger": trigger or None,
+        "skill": skill or None,
+        "active": bool(state.get("active")),
+        "skill_dispatched": bool(state.get("skill_dispatched")),
+    }
+    if not state.get("active"):
+        return False, payload
+    if trigger != "heartbeat":
+        return False, payload
+    if state.get("skill_dispatched"):
+        return False, payload
+    if skill and not skill.endswith("heartbeat"):
+        return False, payload
+    return True, payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--operation", default="", help="Logical operation name")
+    parser.add_argument("--target", default="", help="Artifact path or label")
+    parser.add_argument("--json", action="store_true", help="Print JSON response")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    dispatch = read_dispatch_state()
+    blocked, payload = should_block(dispatch)
+    payload.update(
+        {
+            "operation": args.operation or None,
+            "target": args.target or None,
+            "guard": "edge-publish-guard",
+        }
+    )
+    if blocked:
+        emit_shadow_event(
+            "HeartbeatInlineWorkDetected",
+            actor="edge-publish-guard",
+            cycle_id=str(dispatch.get("cycle_id") or "") or None,
+            artifact=args.target or None,
+            payload=payload,
+        )
+        if args.json:
+            print(json.dumps({"ok": False, "blocked": True, **payload}, ensure_ascii=False))
+        else:
+            target = args.target or "<unknown>"
+            op = args.operation or "publish"
+            sys.stderr.write(
+                "BLOCK(edge-publish-guard): heartbeat cannot publish inline before dispatch.\n"
+                f"  operation: {op}\n"
+                f"  target: {target}\n"
+                "  fix: dispatch a substantive skill first.\n"
+            )
+        return 2
+
+    if args.json:
+        print(json.dumps({"ok": True, "blocked": False, **payload}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/edge-publish-scope
+++ b/tools/edge-publish-scope
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""edge-publish-scope — stage only an explicit allowlist during publish."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.telemetry import emit_shadow_event  # noqa: E402
+
+
+def repo_root() -> Path:
+    return Path(os.environ.get("EDGE_REPO_DIR") or os.getcwd()).expanduser().resolve()
+
+
+def normalize_paths(values: list[str]) -> list[str]:
+    root = repo_root()
+    normalized: list[str] = []
+    for raw in values:
+        if not raw:
+            continue
+        path = Path(raw).expanduser()
+        if not path.is_absolute():
+            path = (root / path).resolve()
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            continue
+        rel_str = rel.as_posix()
+        if rel_str == "." or rel_str in normalized:
+            continue
+        normalized.append(rel_str)
+    return normalized
+
+
+def is_ignored(path: str) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "--", path],
+        cwd=str(repo_root()),
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def stage_paths(paths: list[str]) -> None:
+    if not paths:
+        return
+    subprocess.run(["git", "add", "--", *paths], cwd=str(repo_root()), check=True, capture_output=True, text=True)
+
+
+def staged_files() -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=str(repo_root()),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def cmd_stage(args: argparse.Namespace) -> int:
+    allowed_paths = normalize_paths(args.allow or [])
+    stageable = [path for path in allowed_paths if not is_ignored(path)]
+    if stageable:
+        stage_paths(stageable)
+
+    staged = staged_files()
+    allowed_set = set(stageable)
+    illegal = sorted(path for path in staged if path not in allowed_set)
+    payload = {
+        "slug": args.slug,
+        "allowed_paths": allowed_paths,
+        "stageable_paths": stageable,
+        "staged_files": staged,
+        "illegal_files": illegal,
+    }
+    if illegal:
+        emit_shadow_event(
+            "PublishCommitScopeViolation",
+            actor="edge-publish-scope",
+            payload=payload,
+        )
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False))
+    return 2 if illegal else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    stage = sub.add_parser("stage", help="Stage only the allowlisted files and detect scope violations")
+    stage.add_argument("--slug", required=True)
+    stage.add_argument("--allow", action="append", default=[], help="Allowlisted repo-relative or absolute path")
+    stage.add_argument("--json", action="store_true", help="Emit JSON result")
+    stage.set_defaults(func=cmd_stage)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `edge-publish-guard` to block inline heartbeat publication before a skill dispatch exists
- add `edge-publish-scope` so `consolidate-state` stages only an explicit allowlist instead of sweeping the whole repo
- make phase 6 of `consolidate-state` fail loudly when scope validation fails and cover the new behavior with smokes

## Testing
- `python3 -m py_compile tools/edge-publish-guard tools/edge-publish-scope`
- `bash tests/test_edge_publish_guard.sh`
- `bash tests/test_edge_publish_scope.sh`
- `bash tests/test_edge_dispatch.sh`

Closes #324.