### PR TITLE
Add inbox fallback and resilient postflight

### DIFF
--- a/tests/test_postflight_resilience.sh
+++ b/tests/test_postflight_resilience.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-postflight-resilience-XXXXXX)"
+TMP_EDGE="$TMP_BASE/edge"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_EDGE/state" "$TMP_EDGE/logs"
+
+export EDGE_REPO_DIR="$EDGE_DIR"
+export EDGE_STATE_DIR="$TMP_EDGE"
+export EDGE_CODENAME="postflight-resilience-test"
+
+echo "=== edge-postflight resilience Test ==="
+echo ""
+
+echo "--- Test 1: postflight step exception degrades to warning instead of aborting ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+loader = importlib.machinery.SourceFileLoader("edge_postflight", str(edge_dir / "tools" / "edge-postflight"))
+spec = importlib.util.spec_from_loader("edge_postflight", loader)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+original_protocol = module.ensure_compiled_protocol
+original_execute = module._execute_postflight_step
+original_before = module.before_snapshot
+original_compute = module.compute_delta
+try:
+    module.ensure_compiled_protocol = lambda _stage: {
+        "source_hash": "sha256:test",
+        "compiled_hash": "sha256:test",
+        "context_notes": [],
+        "operator_notes": [],
+        "procedures": [{"id": "boom", "kind": "validate.recent"}],
+    }
+    module._execute_postflight_step = lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom"))
+    module.before_snapshot = lambda _state: {
+        "claims_open_total": 0,
+        "orphans_total": 0,
+        "primitive_broken_total": 0,
+        "primitive_degraded_total": 0,
+        "capability_broken_total": 0,
+        "capability_degraded_total": 0,
+        "workflow_broken_total": 0,
+        "workflow_stale_total": 0,
+    }
+    module.compute_delta = lambda before, **_kwargs: {"claims_open_delta": 0}
+    state = {"cycle_id": "cycle-postflight", "request": {"skill": "research"}, "state": {}}
+    ok, postflight_status, reason, steps, delta = module.run_standard(state, "standard")
+    assert ok is True
+    assert postflight_status == "warning"
+    assert reason == "postflight_step_warning"
+    assert steps[0]["status"] == "warning"
+    assert steps[0]["failure_mode"] == "exception"
+    assert delta["claims_open_delta"] == 0
+finally:
+    module.ensure_compiled_protocol = original_protocol
+    module._execute_postflight_step = original_execute
+    module.before_snapshot = original_before
+    module.compute_delta = original_compute
+PY
+then
+    pass "postflight exceptions degrade to warning instead of aborting"
+else
+    fail "postflight exceptions degrade to warning instead of aborting"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tests/test_skill_inbox.sh
+++ b/tests/test_skill_inbox.sh
@@ -141,6 +141,29 @@ else
     fail "edge-skill-inbox read is deterministic during an active cycle"
 fi
 
+echo "--- Test 2b: subprocess fallback returns the same captured dispatch snapshot ---"
+if python3 - <<'PY' "$(
+EDGE_SKILL_INBOX_FORCE_SUBPROCESS=1 EDGE_SEARCH_PYTHON="$(command -v python3)" \
+    "$INBOX_TOOL" read --skill research
+)" "$SEED_OUTPUT" "$LATE_OUTPUT"
+import json
+import sys
+
+snapshot = json.loads(sys.argv[1])
+seed = json.loads(sys.argv[2])
+late = json.loads(sys.argv[3])
+
+assert snapshot["message_ids"] == seed["captured_ids"]
+assert snapshot["unprocessed_total"] == 5
+assert late["late_id"] not in snapshot["message_ids"]
+assert snapshot["priority"] == "high"
+PY
+then
+    pass "edge-skill-inbox subprocess fallback stays deterministic during an active cycle"
+else
+    fail "edge-skill-inbox subprocess fallback stays deterministic during an active cycle"
+fi
+
 echo "--- Test 3: successful close consumes only the captured inbox ---"
 EDGE_CYCLE_ID=cycle-skill-inbox "$STEP_TOOL" research start >/dev/null
 EDGE_CYCLE_ID=cycle-skill-inbox "$STEP_TOOL" research end >/dev/null

--- a/tools/_shared/skill_inbox.py
+++ b/tools/_shared/skill_inbox.py
@@ -7,21 +7,85 @@ skills can inspect without scraping raw `/api/chat` output.
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+EDGE_REPO_DIR = SCRIPT_DIR.parent.parent
+SEARCH_DIR = EDGE_REPO_DIR / "search"
 sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "search"))
 
 
 def _load_dashboard_chat_api():
+    if os.environ.get("EDGE_SKILL_INBOX_FORCE_SUBPROCESS") == "1":
+        return None, None
     try:
         from dashboard_db import get_chats, mark_chat_processed  # type: ignore
     except Exception:
         return None, None
     return get_chats, mark_chat_processed
+
+
+def _search_python() -> str | None:
+    override = str(os.environ.get("EDGE_SEARCH_PYTHON") or "").strip()
+    if override:
+        return override
+    candidate = SEARCH_DIR / ".venv" / "bin" / "python3"
+    if candidate.exists():
+        return str(candidate)
+    return sys.executable
+
+
+def _dashboard_chat_via_subprocess(payload: dict[str, Any]) -> dict[str, Any] | None:
+    search_python = _search_python()
+    if not search_python:
+        return None
+    helper = """
+import json
+import sys
+from pathlib import Path
+
+search_dir = Path(sys.argv[1])
+payload = json.loads(sys.argv[2])
+sys.path.insert(0, str(search_dir))
+
+from dashboard_db import get_chats, mark_chat_processed
+
+action = str(payload.get("action") or "").strip()
+if action == "snapshot":
+    limit = int(payload.get("limit") or 200)
+    print(json.dumps({
+        "unprocessed": get_chats(unprocessed_only=True, limit=limit),
+        "pinned": get_chats(pinned_only=True, limit=min(limit, 50)),
+    }))
+elif action == "consume":
+    processed = []
+    for chat_id in payload.get("chat_ids") or []:
+        mark_chat_processed(int(chat_id))
+        processed.append(int(chat_id))
+    print(json.dumps({"processed_ids": processed}))
+else:
+    raise SystemExit(f"unsupported action: {action}")
+""".strip()
+    env = os.environ.copy()
+    env["EDGE_REPO_DIR"] = str(EDGE_REPO_DIR)
+    result = subprocess.run(
+        [search_python, "-c", helper, str(SEARCH_DIR), json.dumps(payload, ensure_ascii=False)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        parsed = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
 
 
 def now_iso() -> str:
@@ -149,8 +213,9 @@ def build_async_inbox_snapshot(*, skill: str | None = None, limit: int = 200) ->
     """Return the structured async inbox contract for the next skill."""
     get_chats, _ = _load_dashboard_chat_api()
     if get_chats is None:
-        unprocessed = []
-        pinned = []
+        payload = _dashboard_chat_via_subprocess({"action": "snapshot", "limit": limit}) or {}
+        unprocessed = payload.get("unprocessed") or []
+        pinned = payload.get("pinned") or []
     else:
         try:
             unprocessed = get_chats(unprocessed_only=True, limit=limit)
@@ -248,17 +313,15 @@ def consume_captured_inbox(state: dict[str, Any]) -> dict[str, Any]:
     processed_ids: list[int] = []
     _, mark_chat_processed = _load_dashboard_chat_api()
     if mark_chat_processed is None:
-        return {
-            "processed_ids": processed_ids,
-            "processed_count": 0,
-            "captured_total": len(ids),
-        }
-    for chat_id in ids:
-        try:
-            mark_chat_processed(chat_id)
-            processed_ids.append(chat_id)
-        except Exception:
-            continue
+        payload = _dashboard_chat_via_subprocess({"action": "consume", "chat_ids": ids}) or {}
+        processed_ids = [int(item) for item in payload.get("processed_ids") or [] if str(item).strip()]
+    else:
+        for chat_id in ids:
+            try:
+                mark_chat_processed(chat_id)
+                processed_ids.append(chat_id)
+            except Exception:
+                continue
 
     if snapshot:
         snapshot["processed_at"] = now_iso()

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -421,7 +421,16 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
     warning_seen = False
 
     for step in protocol.get("procedures") or []:
-        result = _execute_postflight_step(step, state)
+        try:
+            result = _execute_postflight_step(step, state)
+        except Exception as exc:
+            result = _protocol_step(
+                step,
+                status="warning",
+                satisfied=False,
+                detail=str(exc),
+                extra={"error": str(exc), "failure_mode": "exception"},
+            )
         steps.append(result)
         if not result.get("satisfied"):
             failed_steps += 1


### PR DESCRIPTION
## Summary
- add a subprocess fallback for `skill_inbox` so async chat capture and consumption still work when the direct dashboard import path breaks on the host
- degrade postflight step exceptions to warnings instead of aborting the whole postflight loop
- cover both behaviors with dedicated smokes plus the existing inbox/close tests

## Testing
- `python3 -m py_compile tools/_shared/skill_inbox.py tools/edge-postflight`
- `bash tests/test_skill_inbox.sh`
- `bash tests/test_postflight_resilience.sh`
- `bash tests/test_edge_close.sh`
