### PR TITLE
Add repo sync capability and audit tool

### DIFF
--- a/config/capabilities.yaml.tpl
+++ b/config/capabilities.yaml.tpl
@@ -35,6 +35,16 @@ capabilities:
     required: true
     skills: ["reflection", "autonomy", "heartbeat"]
 
+  - name: repo.sync
+    kind: external_cli
+    description: Audit and exact-code synchronization wrapper for the genotype checkout.
+    command: ["edge-repo-sync"]
+    passthrough: true
+    probe: ["edge-repo-sync", "--help"]
+    required: true
+    roles: ["sync", "audit", "repository"]
+    skills: ["reflection", "autonomy", "heartbeat", "execute"]
+
   - name: storage.sync
     kind: external_cli
     description: File synchronization wrapper over rclone sync.

--- a/tests/test_edge_cap_invoke.sh
+++ b/tests/test_edge_cap_invoke.sh
@@ -41,7 +41,17 @@ cat >"$TMP_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 printf 'git version test\n'
 EOF
-chmod +x "$TMP_REPO/search/edge-search" "$TMP_REPO/tools/edge-sources" "$TMP_REPO/tools/edge-workflows" "$TMP_BIN/git"
+cat >"$TMP_REPO/tools/edge-repo-sync" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--help" ]]; then
+  echo 'edge-repo-sync help'
+elif [[ "${1:-}" == "status" ]]; then
+  echo '{"exact_code":true,"head_sha":"test"}'
+else
+  echo "edge-repo-sync $*"
+fi
+EOF
+chmod +x "$TMP_REPO/search/edge-search" "$TMP_REPO/tools/edge-sources" "$TMP_REPO/tools/edge-workflows" "$TMP_REPO/tools/edge-repo-sync" "$TMP_BIN/git"
 
 cat >"$TMP_STATE/state/sources-manifest.yaml" <<'YAML'
 sources:
@@ -109,6 +119,14 @@ else
   fail "probe runs static capability probe"
 fi
 
+SYNC_OUT=$(env PATH="$TMP_BIN:/bin" EDGE_REPO_DIR="$TMP_REPO" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="captest" \
+  /usr/bin/python3 "$EDGE_DIR/tools/edge-cap" invoke repo.sync -- status --json)
+if grep -q '"exact_code":true' <<<"$SYNC_OUT"; then
+  pass "invoke runs repo sync capability"
+else
+  fail "invoke runs repo sync capability"
+fi
+
 if python3 - <<'PY' "$TMP_STATE/state/events/log.jsonl"
 import json, sys
 from pathlib import Path
@@ -116,6 +134,7 @@ events = [json.loads(line) for line in Path(sys.argv[1]).read_text(encoding="utf
 types = {(event.get("type"), (event.get("payload") or {}).get("capability")) for event in events}
 assert ("CapabilityInvocationObserved", "search.corpus") in types
 assert ("CapabilityInvocationObserved", "source.arxiv") in types
+assert ("CapabilityInvocationObserved", "repo.sync") in types
 assert ("CapabilityProbeCompleted", "repo.status") in types
 PY
 then

--- a/tests/test_edge_cap_repo_tool_resolution.sh
+++ b/tests/test_edge_cap_repo_tool_resolution.sh
@@ -28,6 +28,7 @@ names = {item["name"]: item for item in payload["capabilities"]}
 assert names["search.corpus"]["effective_status"] == "available"
 assert names["sources.aggregate"]["effective_status"] == "available"
 assert names["workflow.recommend"]["effective_status"] == "available"
+assert names["repo.sync"]["effective_status"] == "available"
 PY
 then
   pass "repo-local edge-* tools resolve without PATH"

--- a/tests/test_edge_cap_status.sh
+++ b/tests/test_edge_cap_status.sh
@@ -38,7 +38,11 @@ cat >"$TMP_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 echo "git $*"
 EOF
-chmod +x "$TMP_BIN/edge-search" "$TMP_BIN/edge-sources" "$TMP_BIN/edge-workflows" "$TMP_BIN/git"
+cat >"$TMP_BIN/edge-repo-sync" <<'EOF'
+#!/usr/bin/env bash
+echo "edge-repo-sync $*"
+EOF
+chmod +x "$TMP_BIN/edge-search" "$TMP_BIN/edge-sources" "$TMP_BIN/edge-workflows" "$TMP_BIN/git" "$TMP_BIN/edge-repo-sync"
 
 cat >"$TMP_STATE/state/sources-manifest.yaml" <<'YAML'
 sources:
@@ -64,13 +68,14 @@ if python3 - <<'PY' "$OUTPUT"
 import json, sys
 payload = json.loads(sys.argv[1])
 summary = payload["summary"]
-assert summary["capability_total"] >= 5
+assert summary["capability_total"] >= 6
 assert summary["health_status"] == "degraded"
 names = {item["name"]: item for item in payload["capabilities"]}
 assert names["search.corpus"]["effective_status"] == "available"
 assert names["sources.aggregate"]["effective_status"] == "available"
 assert names["workflow.recommend"]["effective_status"] == "available"
 assert names["repo.status"]["effective_status"] == "available"
+assert names["repo.sync"]["effective_status"] == "available"
 assert names["storage.sync"]["effective_status"] == "degraded"
 assert names["source.arxiv"]["effective_status"] in {"active", "probed"}
 recommended = {item["name"] for item in payload["recommended"]}

--- a/tests/test_edge_repo_sync.sh
+++ b/tests/test_edge_repo_sync.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-repo-sync-XXXXXX)"
+TMP_REPO="$TMP_BASE/repo"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_REPO"
+
+git -C "$TMP_REPO" init -b main >/dev/null
+git -C "$TMP_REPO" config user.name "Codex Test"
+git -C "$TMP_REPO" config user.email "codex@example.com"
+
+mkdir -p "$TMP_REPO/tools"
+cat >"$TMP_REPO/tools/demo.sh" <<'EOF'
+#!/usr/bin/env bash
+echo demo
+EOF
+chmod +x "$TMP_REPO/tools/demo.sh"
+git -C "$TMP_REPO" add tools/demo.sh
+git -C "$TMP_REPO" commit -m "initial" >/dev/null
+BASE_SHA=$(git -C "$TMP_REPO" rev-parse HEAD)
+
+mkdir -p "$TMP_REPO/bin"
+cat >"$TMP_REPO/bin/new-tool.sh" <<'EOF'
+#!/usr/bin/env bash
+echo new
+EOF
+chmod +x "$TMP_REPO/bin/new-tool.sh"
+git -C "$TMP_REPO" add bin/new-tool.sh
+git -C "$TMP_REPO" commit -m "add new tool" >/dev/null
+
+echo "changed" >>"$TMP_REPO/tools/demo.sh"
+mkdir -p "$TMP_REPO/state" "$TMP_REPO/config"
+cat >"$TMP_REPO/state/local.json" <<'EOF'
+{"state":"local"}
+EOF
+cat >"$TMP_REPO/config/preflight.yaml" <<'EOF'
+version: 1
+protocol: preflight
+EOF
+
+echo "=== edge-repo-sync Smoke Test ==="
+
+STATUS_JSON=$(/usr/bin/python3 "$EDGE_DIR/tools/edge-repo-sync" --repo "$TMP_REPO" status --ref "$BASE_SHA" --json)
+if python3 - <<'PY' "$STATUS_JSON"
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["head_sha"]
+assert payload["ref_sha"]
+assert payload["ahead_count"] == 1
+assert payload["tracked_dirty_count"] == 1
+assert payload["untracked_count"] == 2
+assert payload["exact_code"] is False
+PY
+then
+  pass "status reports ahead/dirty state"
+else
+  fail "status reports ahead/dirty state"
+fi
+
+AUDIT_JSON=$(/usr/bin/python3 "$EDGE_DIR/tools/edge-repo-sync" --repo "$TMP_REPO" audit --ref "$BASE_SHA" --json)
+if python3 - <<'PY' "$AUDIT_JSON"
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["local_only_commit_count"] == 1
+commits = payload["local_only_commits"]
+assert commits[0]["subject"] == "add new tool"
+local_files = {item["path"]: item["classification"] for item in payload["local_only_versioned_files"]}
+assert local_files["bin/new-tool.sh"] == "genotype_candidate"
+tracked = {item["path"]: item["classification"] for item in payload["status"]["tracked_dirty_files"]}
+assert tracked["tools/demo.sh"] == "genotype_candidate"
+untracked = {item["path"]: item["classification"] for item in payload["status"]["untracked_files"]}
+assert untracked["state/local.json"] == "state_only"
+assert untracked["config/preflight.yaml"] == "host_migration"
+PY
+then
+  pass "audit classifies genotype, host migration, and state drift"
+else
+  fail "audit classifies genotype, host migration, and state drift"
+fi
+
+set +e
+/usr/bin/python3 "$EDGE_DIR/tools/edge-repo-sync" --repo "$TMP_REPO" sync-exact-code --ref "$BASE_SHA" >/dev/null 2>&1
+SYNC_STATUS=$?
+set -e
+if [[ "$SYNC_STATUS" -eq 2 ]]; then
+  pass "sync-exact-code blocks without --force when tracked code is dirty"
+else
+  fail "sync-exact-code blocks without --force when tracked code is dirty"
+fi
+
+SYNC_JSON=$(/usr/bin/python3 "$EDGE_DIR/tools/edge-repo-sync" --repo "$TMP_REPO" sync-exact-code --ref "$BASE_SHA" --force --json)
+if python3 - <<'PY' "$SYNC_JSON" "$TMP_REPO" "$BASE_SHA"
+import json, sys
+from pathlib import Path
+payload = json.loads(sys.argv[1])
+repo = Path(sys.argv[2])
+base_sha = sys.argv[3]
+assert payload["status"]["head_sha"] == base_sha
+assert payload["status"]["tracked_dirty_count"] == 0
+assert payload["status"]["exact_code"] is True
+assert (repo / "state" / "local.json").exists()
+assert (repo / "config" / "preflight.yaml").exists()
+assert not (repo / "bin" / "new-tool.sh").exists()
+PY
+then
+  pass "sync-exact-code resets tracked code while preserving untracked state"
+else
+  fail "sync-exact-code resets tracked code while preserving untracked state"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/tools/edge-repo-sync
+++ b/tools/edge-repo-sync
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""edge-repo-sync — audit and synchronize the genotype checkout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+STATE_ONLY_PREFIXES = (
+    "blog/entries/",
+    "blog/diffs/",
+    "health/",
+    "logs/",
+    "meta-reports/",
+    "notes/",
+    "reports/",
+    "scratchpads/",
+    "search/",
+    "state-snapshots/",
+    "state/",
+    "threads/",
+    "topics/",
+)
+
+HOST_MIGRATION_PATHS = {
+    "briefing.md",
+    "config/CLAUDE.md",
+    "config/branding.yaml",
+    "config/capabilities.yaml",
+    "config/features.yaml",
+    "config/health-config.yaml",
+    "config/heartbeat.sh",
+    "config/postflight.yaml",
+    "config/preflight.yaml",
+    "config/runtime-routers.yaml",
+    "config/strategy.md",
+    "onboarding.md",
+    "onboarding_checklist.md",
+}
+
+HOST_MIGRATION_PREFIXES = (
+    "systemd/",
+)
+
+
+class RepoSyncError(RuntimeError):
+    """The repository cannot be synchronized safely."""
+
+
+def _repo_root(value: str | None) -> Path:
+    if value:
+        return Path(os.path.expanduser(value)).resolve()
+    env = os.environ.get("EDGE_REPO_DIR")
+    if env:
+        return Path(os.path.expanduser(env)).resolve()
+    return Path.cwd().resolve()
+
+
+def _run_git(repo: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        message = (result.stderr or result.stdout or "").strip() or f"git {' '.join(args)} failed"
+        raise RepoSyncError(message)
+    return result
+
+
+def _maybe_fetch(repo: Path, ref: str, enabled: bool) -> None:
+    if not enabled:
+        return
+    remote = "origin"
+    if "/" in ref and not ref.startswith("refs/"):
+        remote = ref.split("/", 1)[0] or "origin"
+    _run_git(repo, ["fetch", remote])
+
+
+def _head_sha(repo: Path) -> str:
+    return _run_git(repo, ["rev-parse", "HEAD"]).stdout.strip()
+
+
+def _branch(repo: Path) -> str:
+    result = _run_git(repo, ["symbolic-ref", "--quiet", "--short", "HEAD"], check=False)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _ref_sha(repo: Path, ref: str) -> str:
+    result = _run_git(repo, ["rev-parse", ref], check=False)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _ahead_behind(repo: Path, ref: str) -> tuple[int | None, int | None]:
+    result = _run_git(repo, ["rev-list", "--left-right", "--count", f"{ref}...HEAD"], check=False)
+    if result.returncode != 0:
+        return None, None
+    parts = result.stdout.strip().split()
+    if len(parts) != 2:
+        return None, None
+    behind, ahead = (int(parts[0]), int(parts[1]))
+    return behind, ahead
+
+
+def _parse_status_lines(repo: Path, *, include_untracked: bool) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    args = ["status", "--porcelain=1"]
+    if include_untracked:
+        args.append("--untracked-files=all")
+    else:
+        args.append("--untracked-files=no")
+    result = _run_git(repo, args)
+    tracked: list[dict[str, str]] = []
+    untracked: list[dict[str, str]] = []
+    for raw_line in result.stdout.splitlines():
+        if not raw_line:
+            continue
+        code = raw_line[:2]
+        path = raw_line[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1].strip()
+        entry = {"code": code, "path": path}
+        if code == "??":
+            untracked.append(entry)
+        else:
+            tracked.append(entry)
+    return tracked, untracked
+
+
+def _classify_path(path: str) -> str:
+    if path in HOST_MIGRATION_PATHS:
+        return "host_migration"
+    if path.startswith(STATE_ONLY_PREFIXES):
+        return "state_only"
+    if path.startswith(HOST_MIGRATION_PREFIXES):
+        return "host_migration"
+    return "genotype_candidate"
+
+
+def _classify_entries(entries: list[dict[str, str]]) -> list[dict[str, str]]:
+    classified: list[dict[str, str]] = []
+    for item in entries:
+        row = dict(item)
+        row["classification"] = _classify_path(str(item.get("path") or ""))
+        classified.append(row)
+    return classified
+
+
+def _local_only_commits(repo: Path, ref: str, *, limit: int = 20) -> list[dict[str, str]]:
+    result = _run_git(
+        repo,
+        ["log", "--format=%H%x09%s", f"{ref}..HEAD", f"-n{limit}"],
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    commits: list[dict[str, str]] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        sha, _, subject = line.partition("\t")
+        commits.append({"sha": sha.strip(), "subject": subject.strip()})
+    return commits
+
+
+def _local_only_files(repo: Path, ref: str) -> list[dict[str, str]]:
+    result = _run_git(repo, ["diff", "--name-only", "--diff-filter=ACMRTUXB", f"{ref}..HEAD"], check=False)
+    if result.returncode != 0:
+        return []
+    rows = [{"path": line.strip()} for line in result.stdout.splitlines() if line.strip()]
+    return _classify_entries(rows)
+
+
+def _status_payload(repo: Path, *, ref: str) -> dict[str, Any]:
+    tracked_dirty, untracked = _parse_status_lines(repo, include_untracked=True)
+    ref_sha = _ref_sha(repo, ref)
+    behind_count, ahead_count = _ahead_behind(repo, ref)
+    branch = _branch(repo)
+    clean_tracked = len(tracked_dirty) == 0
+    exact_code = bool(ref_sha) and clean_tracked and _head_sha(repo) == ref_sha
+    return {
+        "repo_root": str(repo),
+        "branch": branch,
+        "detached": branch == "",
+        "head_sha": _head_sha(repo),
+        "ref": ref,
+        "ref_exists": bool(ref_sha),
+        "ref_sha": ref_sha,
+        "behind_count": behind_count,
+        "ahead_count": ahead_count,
+        "tracked_dirty_count": len(tracked_dirty),
+        "untracked_count": len(untracked),
+        "tracked_dirty_files": _classify_entries(tracked_dirty),
+        "untracked_files": _classify_entries(untracked),
+        "clean_tracked": clean_tracked,
+        "exact_code": exact_code,
+    }
+
+
+def _audit_payload(repo: Path, *, ref: str) -> dict[str, Any]:
+    status = _status_payload(repo, ref=ref)
+    local_only_commits = _local_only_commits(repo, ref)
+    local_only_files = _local_only_files(repo, ref)
+    counts = {
+        "genotype_candidate": 0,
+        "host_migration": 0,
+        "state_only": 0,
+    }
+    for bucket in (
+        status.get("tracked_dirty_files") or [],
+        status.get("untracked_files") or [],
+        local_only_files,
+    ):
+        for item in bucket:
+            key = str(item.get("classification") or "genotype_candidate")
+            counts[key] = counts.get(key, 0) + 1
+    return {
+        "status": status,
+        "local_only_commits": local_only_commits,
+        "local_only_commit_count": len(local_only_commits),
+        "local_only_versioned_files": local_only_files,
+        "counts_by_classification": counts,
+    }
+
+
+def _print_status(payload: dict[str, Any]) -> None:
+    branch = payload.get("branch") or "(detached)"
+    print(f"repo_root={payload.get('repo_root')}")
+    print(f"branch={branch}")
+    print(f"head={payload.get('head_sha')}")
+    print(f"ref={payload.get('ref')} sha={payload.get('ref_sha') or 'missing'}")
+    print(
+        "sync:"
+        f" exact_code={payload.get('exact_code')}"
+        f" clean_tracked={payload.get('clean_tracked')}"
+        f" ahead={payload.get('ahead_count')}"
+        f" behind={payload.get('behind_count')}"
+        f" tracked_dirty={payload.get('tracked_dirty_count')}"
+        f" untracked={payload.get('untracked_count')}"
+    )
+    for item in payload.get("tracked_dirty_files") or []:
+        print(f"  tracked {item.get('code')} {item.get('path')} [{item.get('classification')}]")
+    for item in payload.get("untracked_files") or []:
+        print(f"  untracked {item.get('path')} [{item.get('classification')}]")
+
+
+def _print_audit(payload: dict[str, Any]) -> None:
+    _print_status(payload.get("status") or {})
+    print("local_only_commits:")
+    for item in payload.get("local_only_commits") or []:
+        print(f"  - {item.get('sha')} {item.get('subject')}")
+    print("local_only_versioned_files:")
+    for item in payload.get("local_only_versioned_files") or []:
+        print(f"  - {item.get('path')} [{item.get('classification')}]")
+    counts = payload.get("counts_by_classification") or {}
+    print(
+        "classified:"
+        f" genotype_candidate={counts.get('genotype_candidate', 0)}"
+        f" host_migration={counts.get('host_migration', 0)}"
+        f" state_only={counts.get('state_only', 0)}"
+    )
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    repo = _repo_root(args.repo)
+    _maybe_fetch(repo, args.ref, args.fetch)
+    payload = _status_payload(repo, ref=args.ref)
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False))
+    else:
+        _print_status(payload)
+    return 0
+
+
+def cmd_audit(args: argparse.Namespace) -> int:
+    repo = _repo_root(args.repo)
+    _maybe_fetch(repo, args.ref, args.fetch)
+    payload = _audit_payload(repo, ref=args.ref)
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False))
+    else:
+        _print_audit(payload)
+    return 0
+
+
+def cmd_sync_exact_code(args: argparse.Namespace) -> int:
+    repo = _repo_root(args.repo)
+    _maybe_fetch(repo, args.ref, args.fetch)
+    audit = _audit_payload(repo, ref=args.ref)
+    tracked_dirty = audit["status"]["tracked_dirty_count"]
+    if tracked_dirty and not args.force:
+        message = {
+            "error": "tracked_dirty",
+            "hint": "rerun with --force after auditing the repo",
+            "audit": audit,
+        }
+        if args.json:
+            print(json.dumps(message, ensure_ascii=False))
+        else:
+            _print_audit(audit)
+            print("sync blocked: tracked versioned changes detected; rerun with --force")
+        return 2
+    if not audit["status"]["ref_exists"]:
+        raise RepoSyncError(f"ref not found: {args.ref}")
+    _run_git(repo, ["reset", "--hard", args.ref])
+    payload = _status_payload(repo, ref=args.ref)
+    result = {
+        "sync": "completed",
+        "repo_root": str(repo),
+        "ref": args.ref,
+        "status": payload,
+    }
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False))
+    else:
+        print(f"sync_exact_code reset repo to {args.ref}")
+        _print_status(payload)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audit and synchronize a git checkout without touching runtime state")
+    parser.add_argument("--repo", default="", help="Repository root (defaults to EDGE_REPO_DIR or cwd)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_status = sub.add_parser("status", help="Show sync status against a ref")
+    p_status.add_argument("--ref", default="origin/main")
+    p_status.add_argument("--fetch", action="store_true")
+    p_status.add_argument("--json", action="store_true")
+
+    p_audit = sub.add_parser("audit", help="Classify local drift against a ref")
+    p_audit.add_argument("--ref", default="origin/main")
+    p_audit.add_argument("--fetch", action="store_true")
+    p_audit.add_argument("--json", action="store_true")
+
+    p_sync = sub.add_parser("sync-exact-code", help="Reset tracked code to an exact ref without cleaning untracked state")
+    p_sync.add_argument("--ref", default="origin/main")
+    p_sync.add_argument("--fetch", action="store_true")
+    p_sync.add_argument("--force", action="store_true", help="Allow reset even with tracked dirty files")
+    p_sync.add_argument("--json", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        if args.cmd == "status":
+            return cmd_status(args)
+        if args.cmd == "audit":
+            return cmd_audit(args)
+        if args.cmd == "sync-exact-code":
+            return cmd_sync_exact_code(args)
+    except RepoSyncError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `repo.sync` as a first-class capability alongside `repo.status`
- add `edge-repo-sync` with `status`, `audit`, and `sync-exact-code`
- add coverage tests for capability resolution, invocation, and drift classification

## Testing
- `bash tests/test_edge_cap_status.sh`
- `bash tests/test_edge_cap_repo_tool_resolution.sh`
- `bash tests/test_edge_cap_invoke.sh`
- `bash tests/test_edge_repo_sync.sh`