### PR TITLE
Disable legacy telemetry shadow by default

### DIFF
--- a/tests/test_consolidate_adversarial_phase.sh
+++ b/tests/test_consolidate_adversarial_phase.sh
@@ -94,6 +94,7 @@ export PATH="$TMP_BIN:$PATH"
 
 CONSOLIDATE="$EDGE_DIR/blog/consolidate-state.sh"
 EVENTS_FILE="$TMP_STATE/state/events/log.jsonl"
+LEGACY_EVENTS_FILE="$TMP_STATE/logs/events.jsonl"
 
 echo "=== consolidate-state adversarial phase test ==="
 echo "Temp state: $TMP_STATE"
@@ -101,7 +102,7 @@ echo ""
 
 echo "--- Test 1: missing review.json triggers phase-0.3 generation ---"
 if "$CONSOLIDATE" "$TMP_ENTRY" "$TMP_REPORT" --review-only >/tmp/test-consolidate-adversarial.log 2>&1; then
-    if python3 - <<'PY' "$TMP_REPORT" "$EVENTS_FILE"
+    if python3 - <<'PY' "$TMP_REPORT" "$LEGACY_EVENTS_FILE"
 import json, pathlib, sys
 report = pathlib.Path(sys.argv[1])
 events_path = pathlib.Path(sys.argv[2])
@@ -110,9 +111,9 @@ resolved = report.with_suffix(".resolved")
 assert review.exists(), "review.json missing"
 assert resolved.exists(), "resolved marker missing"
 events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
-steps = [e for e in events if e.get("type") == "LegacyTelemetryObserved" and (e.get("payload") or {}).get("legacy_type") == "run_step"]
-phase03 = [(e["payload"]["phase"], e["payload"]["status"], e["payload"].get("operation")) for e in steps if e["payload"]["phase"] == "phase-0.3"]
-phase05 = [(e["payload"]["phase"], e["payload"]["status"]) for e in steps if e["payload"]["phase"] == "phase-0.5"]
+steps = [e for e in events if e.get("type") == "run_step"]
+phase03 = [(e["phase"], e["status"], e.get("operation")) for e in steps if e["phase"] == "phase-0.3"]
+phase05 = [(e["phase"], e["status"]) for e in steps if e["phase"] == "phase-0.5"]
 assert ("phase-0.3", "started", "adversarial_review") in phase03
 assert ("phase-0.3", "completed", "adversarial_review_generated") in phase03
 assert ("phase-0.5", "started") in phase05
@@ -134,14 +135,14 @@ set +e
 "$CONSOLIDATE" "$TMP_ENTRY" "$TMP_REPORT" --review-only >/tmp/test-consolidate-adversarial.log 2>&1
 STATUS=$?
 set -e
-if python3 - <<'PY' "$STATUS" "$EVENTS_FILE"
+if python3 - <<'PY' "$STATUS" "$LEGACY_EVENTS_FILE"
 import json, sys, pathlib
 status = int(sys.argv[1])
 events_path = pathlib.Path(sys.argv[2])
 assert status == 3
 events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
-steps = [e for e in events if e.get("type") == "LegacyTelemetryObserved" and (e.get("payload") or {}).get("legacy_type") == "run_step"]
-phase03 = [(e["payload"]["phase"], e["payload"]["status"], e["payload"].get("operation")) for e in steps if e["payload"]["phase"] == "phase-0.3"]
+steps = [e for e in events if e.get("type") == "run_step"]
+phase03 = [(e["phase"], e["status"], e.get("operation")) for e in steps if e["phase"] == "phase-0.3"]
 assert ("phase-0.3", "failed", "adversarial_review") in phase03
 PY
 then

--- a/tests/test_telemetry_shadow.sh
+++ b/tests/test_telemetry_shadow.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-telemetry-shadow-XXXXXX)"
+TMP_STATE="$TMP_BASE/state"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE"
+
+echo "=== telemetry shadow Smoke Test ==="
+
+if EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="shadow-test" \
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+import sys
+
+sys.path.insert(0, os.environ["EDGE_REPO_DIR"])
+from tools._shared.telemetry import log_event
+from config.paths import EVENTS_FILE, STATE_EVENTS_FILE
+
+log_event("demo_event", answer=42)
+events = [json.loads(line) for line in EVENTS_FILE.read_text(encoding="utf-8").splitlines() if line.strip()]
+assert events[-1]["type"] == "demo_event"
+assert not STATE_EVENTS_FILE.exists() or "LegacyTelemetryObserved" not in STATE_EVENTS_FILE.read_text(encoding="utf-8")
+PY
+then
+  pass "legacy shadow is disabled by default"
+else
+  fail "legacy shadow is disabled by default"
+fi
+
+rm -rf "$TMP_STATE"
+mkdir -p "$TMP_STATE"
+
+if EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="shadow-test" EDGE_EMIT_LEGACY_SHADOW=1 \
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+import sys
+
+sys.path.insert(0, os.environ["EDGE_REPO_DIR"])
+from tools._shared.telemetry import log_event
+from config.paths import STATE_EVENTS_FILE
+
+log_event("demo_event", answer=42)
+events = [json.loads(line) for line in STATE_EVENTS_FILE.read_text(encoding="utf-8").splitlines() if line.strip()]
+assert any(event.get("type") == "LegacyTelemetryObserved" for event in events)
+PY
+then
+  pass "legacy shadow can be re-enabled explicitly"
+else
+  fail "legacy shadow can be re-enabled explicitly"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/tools/_shared/telemetry.py
+++ b/tools/_shared/telemetry.py
@@ -118,6 +118,11 @@ def _append_event(event: dict[str, Any]) -> None:
         pass
 
 
+def _should_emit_legacy_shadow() -> bool:
+    value = (os.environ.get("EDGE_EMIT_LEGACY_SHADOW", "0") or "0").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
 def emit_shadow_event(
     event_type: str,
     *,
@@ -159,13 +164,14 @@ def log_event(event_type: str, **fields: Any) -> None:
     }
     event.update(fields)
     _append_event(event)
-    emit_shadow_event(
-        "LegacyTelemetryObserved",
-        actor=_detect_caller(),
-        cycle_id=fields.get("cycle_id"),
-        artifact=fields.get("artifact"),
-        payload={"legacy_type": event_type, **fields},
-    )
+    if _should_emit_legacy_shadow():
+        emit_shadow_event(
+            "LegacyTelemetryObserved",
+            actor=_detect_caller(),
+            cycle_id=fields.get("cycle_id"),
+            artifact=fields.get("artifact"),
+            payload={"legacy_type": event_type, **fields},
+        )
 
 
 def log_llm_call(


### PR DESCRIPTION
## Summary
- stop mirroring every legacy `log_event()` into `state/events/log.jsonl` by default
- keep the shadow path available behind `EDGE_EMIT_LEGACY_SHADOW=1`
- update consolidate-state coverage tests to assert against the canonical legacy log and add an explicit shadow smoke test

## Testing
- `python3 -m py_compile tools/_shared/telemetry.py`
- `bash tests/test_consolidate_adversarial_phase.sh`
- `bash tests/test_telemetry_shadow.sh`