### PR TITLE
Compose an ephemeral beat launch context in preflight

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -172,10 +172,22 @@ corpus_step = next(item for item in request["preflight_evidence"] if item["kind"
 assert corpus_step["satisfied"] is False
 assert corpus_step["missing_required_types"] == ["topic", "workflow", "memory"]
 assert request["operator_pressure_summary"]["item_total"] >= 3
+assert request["operator_pressure_summary"]["signal_from_operator_now"] >= 1
+assert request["operator_pressure_summary"]["operator_toil_optimizable_now"] >= 1
 assert request["operator_pressure_summary"]["workflow_candidates"] >= 1
 assert request["operator_pressure_summary"]["capability_candidates"] >= 1
-assert request["operator_pressure_digest"]["repeated_operator_guidance"]
+assert request["operator_pressure_digest"]["signal_from_operator_now"]
+assert request["operator_pressure_digest"]["operator_toil_optimizable_now"]
+assert "mistakes_to_avoid_now" in request["operator_pressure_digest"]
 assert request["operator_pressure_digest"]["active_entities"]
+assert request["beat_launch_context"]["signal_from_operator_now"]
+assert request["beat_launch_context"]["signal_from_edge_state_now"]
+assert request["beat_launch_context"]["decision_blend"] == {
+    "operator_min_weight": 0.20,
+    "edge_state_min_weight": 0.20,
+    "exploration_weight": 0.60,
+}
+assert any("Corpus coverage is missing required types" in item for item in request["beat_launch_context"]["signal_from_edge_state_now"])
 assert request["search_protocol"]["required"] is True
 assert request["epistemic_protocol"]["required"] is True
 assert request["heartbeat_routing"]["suggested_skill"] == "autonomy"
@@ -194,6 +206,7 @@ assert "pre_skill_context" in invocations[0]
 assert "preflight_evidence" in invocations[0]
 assert "corpus_coverage" in invocations[0]
 assert "operator_pressure_digest" in invocations[0]
+assert "beat_launch_context" in invocations[0]
 assert "search_protocol" in invocations[0]
 assert "epistemic_protocol" in invocations[0]
 assert "configured_integrations" in invocations[0]

--- a/tests/test_operator_pressure_layers.sh
+++ b/tests/test_operator_pressure_layers.sh
@@ -70,10 +70,15 @@ assert ledger_path.exists()
 assert hot_path.exists()
 assert (redigest_dir / "latest.json").exists()
 assert summary["item_total"] >= 3
+assert summary["signal_from_operator_now"] >= 1
+assert summary["operator_toil_optimizable_now"] >= 1
 assert summary["workflow_candidates"] >= 1
 assert summary["capability_candidates"] >= 1
 assert hot["render_mode"] == "deterministic"
-assert hot["repeated_operator_guidance"]
+assert hot["signal_from_operator_now"]
+assert hot["operator_pains_resolvable_now"]
+assert hot["operator_toil_optimizable_now"]
+assert hot["mistakes_to_avoid_now"]
 assert any(item["target"] == "workflow" for item in hot["workflow_candidates"])
 assert any(item["target"] == "capability" for item in hot["capability_candidates"])
 assert "topic" in hot["active_entities"]

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -77,6 +77,13 @@ SUBSTANTIVE_SKILLS = {
     "prd",
 }
 
+BEAT_LAUNCH_SECTION_LIMIT = 4
+BEAT_LAUNCH_DECISION_BLEND = {
+    "operator_min_weight": 0.20,
+    "edge_state_min_weight": 0.20,
+    "exploration_weight": 0.60,
+}
+
 EXTERNAL_SEARCH_INTENTS = {
     "autonomy": "strategy",
     "discovery": "discovery",
@@ -423,6 +430,142 @@ def _operator_pressure_digest() -> dict[str, Any]:
             "source_hash": str((payload.get("redigest") or {}).get("source_hash") or ""),
         },
     }
+
+
+def _unique_compact_strings(values: list[str], *, limit: int = BEAT_LAUNCH_SECTION_LIMIT) -> list[str]:
+    seen: set[str] = set()
+    compact: list[str] = []
+    for value in values:
+        text = re.sub(r"\s+", " ", str(value or "").strip())
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        compact.append(text[:220])
+        if len(compact) >= limit:
+            break
+    return compact
+
+
+def _item_texts(items: Any, *, limit: int = BEAT_LAUNCH_SECTION_LIMIT) -> list[str]:
+    texts: list[str] = []
+    if not isinstance(items, list):
+        return texts
+    for item in items:
+        if isinstance(item, dict):
+            text = str(item.get("text") or "").strip()
+            if text:
+                texts.append(text)
+        else:
+            text = str(item or "").strip()
+            if text:
+                texts.append(text)
+    return _unique_compact_strings(texts, limit=limit)
+
+
+def _edge_state_signals(request: dict[str, Any]) -> list[str]:
+    signals: list[str] = []
+    inbox = request.get("async_inbox") or {}
+    health = request.get("health_snapshot") or {}
+    coverage = request.get("corpus_coverage") or {}
+    workflow_recommendations = request.get("workflow_recommendations") or []
+    queue = request.get("dispatch_queue_summary") or {}
+    onboarding = request.get("onboarding_summary") or {}
+    capabilities = request.get("capabilities_status") or {}
+    integrations = request.get("unbound_integrations") or []
+
+    unprocessed_total = int(inbox.get("unprocessed_total", 0) or 0)
+    if unprocessed_total > 0:
+        priority = str(inbox.get("priority") or "").strip().lower() or "active"
+        signals.append(f"There are {unprocessed_total} unprocessed async operator messages with {priority} priority.")
+
+    health_status = str(health.get("status") or "").strip().lower()
+    if health_status in {"degraded", "unhealthy", "critical"}:
+        score = health.get("score")
+        if score is None:
+            signals.append(f"Health is {health_status}.")
+        else:
+            signals.append(f"Health is {health_status} with score {score}.")
+
+    missing_required = list(coverage.get("missing_required_types") or [])
+    if missing_required:
+        signals.append(f"Corpus coverage is missing required types: {', '.join(missing_required)}.")
+
+    if workflow_recommendations:
+        signals.append(f"There are {len(workflow_recommendations)} workflow recommendations available for the current query.")
+
+    pending_queue = int(queue.get("pending_total", 0) or 0)
+    if pending_queue > 0:
+        signals.append(f"The dispatch queue has {pending_queue} pending entries.")
+
+    onboarding_pending = int(onboarding.get("pending_total", 0) or 0)
+    if onboarding_pending > 0:
+        signals.append(f"Onboarding has {onboarding_pending} pending steps.")
+
+    capability_health = str(capabilities.get("health_status") or "").strip().lower()
+    if capability_health in {"degraded", "broken"}:
+        signals.append(f"Capability health is {capability_health}.")
+
+    if integrations:
+        names = [str(item.get("name") or "").strip() for item in integrations if isinstance(item, dict) and str(item.get("name") or "").strip()]
+        if names:
+            signals.append(f"Configured integrations without capability bindings still exist: {', '.join(names[:3])}.")
+
+    if not signals:
+        signals.append("Edge state is nominal enough that no urgent runtime signal dominates this beat.")
+    return _unique_compact_strings(signals)
+
+
+def _expected_state_change(request: dict[str, Any], operator_signal: list[str], edge_signal: list[str]) -> list[str]:
+    changes: list[str] = []
+    if operator_signal:
+        changes.append("Reduce at least one active operator pressure item with a concrete state change in this beat.")
+    if int((request.get("async_inbox") or {}).get("unprocessed_total", 0) or 0) > 0:
+        changes.append("Consume or explicitly address pending async operator input.")
+    missing_required = list((request.get("corpus_coverage") or {}).get("missing_required_types") or [])
+    if missing_required:
+        changes.append(f"Close the missing corpus coverage for {', '.join(missing_required)} before irreversible synthesis or publication.")
+    if request.get("workflow_recommendations"):
+        changes.append("Either use the top workflow recommendation or explicitly reject it.")
+    if not changes and edge_signal:
+        changes.append("Leave the system in a more explicit and less ambiguous state than it started.")
+    return _unique_compact_strings(changes)
+
+
+def _unknowns_that_still_matter(request: dict[str, Any], digest: dict[str, Any]) -> list[str]:
+    unknowns = _item_texts(digest.get("implicit_needs_hypotheses"))
+    missing_required = list((request.get("corpus_coverage") or {}).get("missing_required_types") or [])
+    if missing_required:
+        unknowns.append(f"Internal memory search is still missing {', '.join(missing_required)}.")
+    integrations = request.get("unbound_integrations") or []
+    names = [str(item.get("name") or "").strip() for item in integrations if isinstance(item, dict) and str(item.get("name") or "").strip()]
+    if names:
+        unknowns.append(f"Some configured integrations are still unbound: {', '.join(names[:3])}.")
+    if not unknowns:
+        unknowns.append("No dominant unresolved unknown has been extracted from recent operator sessions.")
+    return _unique_compact_strings(unknowns)
+
+
+def build_beat_launch_context(request: dict[str, Any]) -> dict[str, Any]:
+    digest = request.get("operator_pressure_digest") or {}
+    operator_signal = _item_texts(digest.get("signal_from_operator_now"))
+    edge_signal = _edge_state_signals(request)
+    context = {
+        "schema_version": REQUEST_SCHEMA_VERSION,
+        "ephemeral": True,
+        "signal_from_operator_now": operator_signal,
+        "signal_from_edge_state_now": edge_signal,
+        "operator_pains_resolvable_now": _item_texts(digest.get("operator_pains_resolvable_now")),
+        "operator_toil_optimizable_now": _item_texts(digest.get("operator_toil_optimizable_now")),
+        "mistakes_to_avoid_now": _item_texts(digest.get("mistakes_to_avoid_now")),
+        "implicit_needs_hypotheses": _item_texts(digest.get("implicit_needs_hypotheses")),
+        "expected_state_change": _expected_state_change(request, operator_signal, edge_signal),
+        "unknowns_that_still_matter": _unknowns_that_still_matter(request, digest),
+        "decision_blend": dict(BEAT_LAUNCH_DECISION_BLEND),
+    }
+    return context
 
 
 def _primitives_status() -> dict[str, Any]:
@@ -940,12 +1083,15 @@ def _execute_preflight_step(
             satisfied=True,
             detail=(
                 f"items={summary.get('item_total', 0)} "
-                f"required={summary.get('required_state_changes', 0)} "
+                f"operator_signal={summary.get('signal_from_operator_now', 0)} "
+                f"toil={summary.get('operator_toil_optimizable_now', 0)} "
                 f"workflow_candidates={summary.get('workflow_candidates', 0)} "
                 f"capability_candidates={summary.get('capability_candidates', 0)}"
             ),
             extra={
                 "item_total": int(summary.get("item_total", 0) or 0),
+                "signal_from_operator_now": int(summary.get("signal_from_operator_now", 0) or 0),
+                "operator_toil_optimizable_now": int(summary.get("operator_toil_optimizable_now", 0) or 0),
                 "workflow_candidates": int(summary.get("workflow_candidates", 0) or 0),
                 "capability_candidates": int(summary.get("capability_candidates", 0) or 0),
                 "render_mode": str(summary.get("render_mode") or ""),
@@ -1152,6 +1298,7 @@ def enrich_dispatch_state(
         "has_pending_inbox": (request.get("async_inbox") or {}).get("unprocessed_total", 0) > 0,
         "has_onboarding": (request.get("onboarding_summary") or {}).get("pending_total", 0) > 0,
     }
+    request["beat_launch_context"] = build_beat_launch_context(request)
     if _heartbeat_skill_active(state, skill):
         prepare_heartbeat_routing(state, skill=skill)
     state_block["preflight_status"] = "warning" if failed_steps else "completed"
@@ -1183,7 +1330,11 @@ def enrich_dispatch_state(
         "builtin_web_search": (request.get("search_runtime") or {}).get("builtin_web_search"),
         "web_provider": (request.get("search_runtime") or {}).get("web_provider"),
         "operator_pressure_items": (request.get("operator_pressure_summary") or {}).get("item_total", 0),
+        "operator_pressure_signal_from_operator_now": (request.get("operator_pressure_summary") or {}).get("signal_from_operator_now", 0),
+        "operator_pressure_operator_toil_optimizable_now": (request.get("operator_pressure_summary") or {}).get("operator_toil_optimizable_now", 0),
         "operator_pressure_workflow_candidates": (request.get("operator_pressure_summary") or {}).get("workflow_candidates", 0),
+        "beat_launch_operator_signals": len((request.get("beat_launch_context") or {}).get("signal_from_operator_now") or []),
+        "beat_launch_edge_state_signals": len((request.get("beat_launch_context") or {}).get("signal_from_edge_state_now") or []),
         "open_claims": claims_summary.get("open_total", 0),
         "orphans": orphan_summary.get("orphan_total", 0),
         "primitive_health": (request.get("primitives_status") or {}).get("health_status"),
@@ -1250,6 +1401,7 @@ def render_skill_runtime_prompt(skill: str, state: dict[str, Any]) -> str:
         "duplicate_risk": request.get("duplicate_risk", {}),
         "operator_pressure_digest": request.get("operator_pressure_digest", {}),
         "operator_pressure_summary": request.get("operator_pressure_summary", {}),
+        "beat_launch_context": request.get("beat_launch_context", {}),
         "configured_integrations": request.get("configured_integrations", [])[:12],
         "unbound_integrations": request.get("unbound_integrations", [])[:12],
         "search_runtime": request.get("search_runtime", {}),
@@ -1283,7 +1435,7 @@ def render_skill_runtime_prompt(skill: str, state: dict[str, Any]) -> str:
         "(health, inbox, corpus, claims, primitives, workflows, queue, onboarding, protocol execution).\n"
         "Do not re-derive those manually unless a field is missing or obviously stale.\n\n"
         f"{heartbeat_contract}"
-        "The `operator_pressure_digest` is the hot, recent operator-feedback layer. Treat it as the highest-signal short-horizon constraint on what the operator keeps trying to change right now.\n\n"
+        "The `operator_pressure_digest` captures recent operator signal only. The `beat_launch_context` is the ephemeral composition of that operator signal with current edge-state signals and the exploration budget for this beat. Treat those two together as the launch frame for what matters now.\n\n"
         "Prefer `edge-cap invoke <capability> -- ...` over direct CLI/tool calls when a capability exists in `capabilities_status`.\n\n"
         "Before any substantive decision, synthesis, or artifact drafting in non-heartbeat skills, follow the runtime decision protocol:\n"
         "1. Run the required search protocol to consult live memory (`topic`, `workflow`, `memory`) and external sources when available.\n"

--- a/tools/_shared/operator_pressure.py
+++ b/tools/_shared/operator_pressure.py
@@ -33,7 +33,7 @@ from paths import (  # noqa: E402
 from .router_client import make_client  # noqa: E402
 from .telemetry import emit_shadow_event, log_event  # noqa: E402
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 LEDGER_WINDOW_DAYS = int(os.environ.get("EDGE_OPERATOR_PRESSURE_WINDOW_DAYS", "7") or "7")
 MAX_SESSIONS = int(os.environ.get("EDGE_OPERATOR_PRESSURE_MAX_SESSIONS", "8") or "8")
 MAX_MESSAGES = int(os.environ.get("EDGE_OPERATOR_PRESSURE_MAX_MESSAGES", "48") or "48")
@@ -89,6 +89,19 @@ _ENTITY_RULES: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\bclaude\b", re.I), "claude"),
     (re.compile(r"\bopenai\b", re.I), "openai"),
 ]
+
+_HOT_DIGEST_KEYS = {
+    "summary",
+    "signal_from_operator_now",
+    "operator_pains_resolvable_now",
+    "operator_toil_optimizable_now",
+    "mistakes_to_avoid_now",
+    "implicit_needs_hypotheses",
+    "workflow_candidates",
+    "capability_candidates",
+    "active_entities",
+    "item_ids",
+}
 
 
 def _now() -> datetime:
@@ -369,15 +382,37 @@ def _compact_item(item: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _hot_digest_matches_schema(payload: dict[str, Any] | None) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    if int(payload.get("schema_version") or 0) != SCHEMA_VERSION:
+        return False
+    return all(key in payload for key in _HOT_DIGEST_KEYS)
+
+
 def _deterministic_hot_digest(ledger: dict[str, Any], previous_digest: dict[str, Any] | None = None) -> dict[str, Any]:
     items = list(ledger.get("items") or [])
     ranked = _rank_items(items)
     directives = [item for item in ranked if item.get("explicit_operator_direction")]
-    repeated = [item for item in ranked if int(item.get("repeat_count") or 0) >= 2]
-    unresolved = [
+    pains = [
         item
         for item in ranked
-        if str(item.get("kind") or "") in {"failure", "contradiction", "question", "tentative", "correction"}
+        if item.get("explicit_operator_direction") or str(item.get("kind") or "") in {"failure", "question", "tentative"}
+    ]
+    toil = [
+        item
+        for item in ranked
+        if int(item.get("repeat_count") or 0) >= 2 and (item.get("explicit_operator_direction") or str(item.get("kind") or "") in {"correction", "contradiction"})
+    ]
+    mistakes = [
+        item
+        for item in ranked
+        if str(item.get("kind") or "") in {"correction", "contradiction", "failure"}
+    ]
+    hypotheses = [
+        item
+        for item in ranked
+        if str(item.get("kind") or "") in {"tentative", "question"}
     ]
     workflow_candidates = [
         item for item in directives if str(item.get("target") or "") in {"workflow", "procedure", "policy"}
@@ -389,11 +424,11 @@ def _deterministic_hot_digest(ledger: dict[str, Any], previous_digest: dict[str,
     top_entities = [name for name, _count in entity_counts.most_common(8)]
     summary_parts = []
     if directives:
-        summary_parts.append(f"{len(directives)} active operator directives")
-    if repeated:
-        summary_parts.append(f"{len(repeated)} repeated guidance items")
-    if unresolved:
-        summary_parts.append(f"{len(unresolved)} unresolved feedback items")
+        summary_parts.append(f"{len(directives)} active operator signals")
+    if toil:
+        summary_parts.append(f"{len(toil)} recurring operator toil patterns")
+    if mistakes:
+        summary_parts.append(f"{len(mistakes)} recent mistakes to avoid")
     if not summary_parts:
         summary_parts.append("no strong recent operator pressure detected")
     digest = {
@@ -404,11 +439,13 @@ def _deterministic_hot_digest(ledger: dict[str, Any], previous_digest: dict[str,
         "model": "",
         "previous_digest_hash": str(previous_digest.get("digest_hash") or "") if isinstance(previous_digest, dict) else "",
         "summary": "; ".join(summary_parts),
-        "required_state_changes": [_compact_item(item) for item in directives[:SECTION_LIMIT]],
-        "repeated_operator_guidance": [_compact_item(item) for item in repeated[:SECTION_LIMIT]],
+        "signal_from_operator_now": [_compact_item(item) for item in directives[:SECTION_LIMIT]],
+        "operator_pains_resolvable_now": [_compact_item(item) for item in pains[:SECTION_LIMIT]],
+        "operator_toil_optimizable_now": [_compact_item(item) for item in toil[:SECTION_LIMIT]],
+        "mistakes_to_avoid_now": [_compact_item(item) for item in mistakes[:SECTION_LIMIT]],
+        "implicit_needs_hypotheses": [_compact_item(item) for item in hypotheses[:SECTION_LIMIT]],
         "workflow_candidates": [_compact_item(item) for item in workflow_candidates[:SECTION_LIMIT]],
         "capability_candidates": [_compact_item(item) for item in capability_candidates[:SECTION_LIMIT]],
-        "unresolved_feedback": [_compact_item(item) for item in unresolved[:SECTION_LIMIT]],
         "active_entities": top_entities,
         "item_ids": [str(item.get("id") or "") for item in ranked[: max(SECTION_LIMIT * 4, 1)]],
     }
@@ -439,11 +476,13 @@ def _llm_prompt(
         "Required JSON schema:\n"
         "{\n"
         '  "summary": "short paragraph",\n'
-        '  "required_state_changes": [{"item_id":"...","text":"...","target":"...","kind":"...","repeat_count":1,"status":"active","entities":["..."],"last_seen_at":"..."}],\n'
-        '  "repeated_operator_guidance": [same shape],\n'
+        '  "signal_from_operator_now": [{"item_id":"...","text":"...","target":"...","kind":"...","repeat_count":1,"status":"active","entities":["..."],"last_seen_at":"..."}],\n'
+        '  "operator_pains_resolvable_now": [same shape],\n'
+        '  "operator_toil_optimizable_now": [same shape],\n'
+        '  "mistakes_to_avoid_now": [same shape],\n'
+        '  "implicit_needs_hypotheses": [same shape],\n'
         '  "workflow_candidates": [same shape],\n'
         '  "capability_candidates": [same shape],\n'
-        '  "unresolved_feedback": [same shape],\n'
         '  "active_entities": ["..."]\n'
         "}\n\n"
         "Rules:\n"
@@ -482,11 +521,13 @@ def _coerce_digest_shape(candidate: dict[str, Any], fallback: dict[str, Any]) ->
     digest = dict(fallback)
     digest["summary"] = str(candidate.get("summary") or fallback.get("summary") or "").strip()
     for key in (
-        "required_state_changes",
-        "repeated_operator_guidance",
+        "signal_from_operator_now",
+        "operator_pains_resolvable_now",
+        "operator_toil_optimizable_now",
+        "mistakes_to_avoid_now",
+        "implicit_needs_hypotheses",
         "workflow_candidates",
         "capability_candidates",
-        "unresolved_feedback",
     ):
         items = candidate.get(key)
         if isinstance(items, list):
@@ -526,11 +567,13 @@ def _render_hot_digest_with_llm(
         "source_hash": ledger.get("source_hash"),
         "item_total": ledger.get("item_total", 0),
         "session_total": ledger.get("session_total", 0),
-        "required_state_changes": fallback.get("required_state_changes", []),
-        "repeated_operator_guidance": fallback.get("repeated_operator_guidance", []),
+        "signal_from_operator_now": fallback.get("signal_from_operator_now", []),
+        "operator_pains_resolvable_now": fallback.get("operator_pains_resolvable_now", []),
+        "operator_toil_optimizable_now": fallback.get("operator_toil_optimizable_now", []),
+        "mistakes_to_avoid_now": fallback.get("mistakes_to_avoid_now", []),
+        "implicit_needs_hypotheses": fallback.get("implicit_needs_hypotheses", []),
         "workflow_candidates": fallback.get("workflow_candidates", []),
         "capability_candidates": fallback.get("capability_candidates", []),
-        "unresolved_feedback": fallback.get("unresolved_feedback", []),
         "active_entities": fallback.get("active_entities", []),
     }
     prompt = _llm_prompt(render_input, previous_digest=previous_digest, delta_items=delta_items[:SECTION_LIMIT])
@@ -575,11 +618,13 @@ def _build_redigest(ledger: dict[str, Any], hot_digest: dict[str, Any], previous
     by_kind = Counter(str(item.get("kind") or "directive") for item in items)
     segments: list[dict[str, Any]] = []
     for section in (
-        "required_state_changes",
-        "repeated_operator_guidance",
+        "signal_from_operator_now",
+        "operator_pains_resolvable_now",
+        "operator_toil_optimizable_now",
+        "mistakes_to_avoid_now",
+        "implicit_needs_hypotheses",
         "workflow_candidates",
         "capability_candidates",
-        "unresolved_feedback",
     ):
         for item in hot_digest.get(section) or []:
             if not isinstance(item, dict):
@@ -672,7 +717,7 @@ def build_operator_pressure_layers(
     messages = _iter_recent_user_messages(project_dir=project_dir)
     ledger = _ledger_from_messages(messages, project_dir=project_dir)
     previous_digest = _read_json(hot_digest_path)
-    if previous_digest and previous_digest.get("source_hash") == ledger.get("source_hash"):
+    if _hot_digest_matches_schema(previous_digest) and previous_digest.get("source_hash") == ledger.get("source_hash"):
         hot_digest = previous_digest
     else:
         previous_item_ids = set(previous_digest.get("item_ids") or []) if isinstance(previous_digest, dict) else set()
@@ -696,11 +741,13 @@ def build_operator_pressure_layers(
         "session_total": ledger.get("session_total", 0),
         "item_total": ledger.get("item_total", 0),
         "active_entities": hot_digest.get("active_entities", []),
-        "required_state_changes": len(hot_digest.get("required_state_changes") or []),
-        "repeated_guidance": len(hot_digest.get("repeated_operator_guidance") or []),
+        "signal_from_operator_now": len(hot_digest.get("signal_from_operator_now") or []),
+        "operator_pains_resolvable_now": len(hot_digest.get("operator_pains_resolvable_now") or []),
+        "operator_toil_optimizable_now": len(hot_digest.get("operator_toil_optimizable_now") or []),
+        "mistakes_to_avoid_now": len(hot_digest.get("mistakes_to_avoid_now") or []),
+        "implicit_needs_hypotheses": len(hot_digest.get("implicit_needs_hypotheses") or []),
         "workflow_candidates": len(hot_digest.get("workflow_candidates") or []),
         "capability_candidates": len(hot_digest.get("capability_candidates") or []),
-        "unresolved_feedback": len(hot_digest.get("unresolved_feedback") or []),
         "render_mode": hot_digest.get("render_mode", "deterministic"),
         "source_hash": ledger.get("source_hash"),
         "ledger_path": str(ledger_path),
@@ -722,9 +769,11 @@ def build_operator_pressure_layers(
         item_total=summary["item_total"],
         session_total=summary["session_total"],
         render_mode=summary["render_mode"],
+        signal_from_operator_now=summary["signal_from_operator_now"],
+        operator_toil_optimizable_now=summary["operator_toil_optimizable_now"],
         workflow_candidates=summary["workflow_candidates"],
         capability_candidates=summary["capability_candidates"],
-        unresolved_feedback=summary["unresolved_feedback"],
+        mistakes_to_avoid_now=summary["mistakes_to_avoid_now"],
     )
     return {
         "ledger": ledger,


### PR DESCRIPTION
## Summary
- reshape the hot operator-pressure digest around operator-only signal sections
- derive an ephemeral `beat_launch_context` from operator pressure plus preflight state
- inject the launch context into the skill request/prompt with the agreed decision blend

## Testing
- python3 -m py_compile tools/_shared/operator_pressure.py tools/_shared/dispatch_runtime.py
- bash tests/test_operator_pressure_layers.sh
- bash tests/test_edge_runner.sh
- bash tests/test_runtime_decision_protocol.sh
- bash tests/test_protocol_runtime.sh
- bash tests/test_edge_dispatch.sh