### PR TITLE
[codex] Implement edge signals context pipeline

### DIFF
--- a/config/capabilities.yaml.tpl
+++ b/config/capabilities.yaml.tpl
@@ -6,7 +6,28 @@ capabilities:
     passthrough: true
     probe: ["edge-sources", "--help"]
     required: true
+    roles: ["search", "source", "external_context"]
     skills: ["sources", "research", "discovery", "report", "strategy", "planner", "heartbeat"]
+
+  - name: signals.aggregate
+    kind: external_cli
+    description: State-oriented signal aggregation wrapper over edge-signals for routing, gating, and primitive health visibility.
+    command: ["edge-signals"]
+    passthrough: true
+    probe: ["edge-signals", "--help"]
+    required: true
+    roles: ["signals", "observe", "routing", "health"]
+    skills: ["heartbeat", "reflection", "autonomy", "report", "research", "strategy", "planner", "discovery"]
+
+  - name: context.aggregate
+    kind: external_cli
+    description: Unified UX wrapper over distinct edge-signals and edge-sources lanes.
+    command: ["edge-context"]
+    passthrough: true
+    probe: ["edge-context", "--help"]
+    required: true
+    roles: ["signals", "search", "context"]
+    skills: ["heartbeat", "reflection", "autonomy", "report", "research", "strategy", "planner", "discovery"]
 
   - name: search.corpus
     kind: external_cli

--- a/docs/primitive-generation-pipeline.md
+++ b/docs/primitive-generation-pipeline.md
@@ -1,0 +1,138 @@
+# Primitive Generation Pipeline
+
+Issue: #339
+
+## Ontology
+
+Edge capabilities should be described by three separate axes:
+
+- `surface`: the system or domain being touched, such as `github`, `grafana`, `meta`, `google_drive`, or `slack`.
+- `operation`: the relationship with that surface: `signals`, `search`, or `mutate`.
+- `capability`: an atomic parameterizable action that implements one operation on one surface.
+
+Examples:
+
+- `github.signals.project_delta` observes current project movement.
+- `github.search.repo` retrieves repository knowledge.
+- `github.mutate.pr_comment` changes GitHub state by posting a comment.
+
+Shared surface does not imply shared ontology. A GitHub delta, a GitHub code search, and a GitHub PR comment must remain separate capabilities because they have different safety, cost, retry, and routing semantics.
+
+## Operation Classes
+
+`signals` retrieve information about current real state or recent deltas. They are the primary language for heartbeat routing and gating. Health is a signal.
+
+`search` retrieves broader knowledge from external or accumulated knowledge surfaces. `edge-search` and `edge-sources` remain the search lane.
+
+`mutate` changes state. Mutating capabilities require stricter operator intent, clearer contracts, and safer probes than read-only capabilities.
+
+## Human YAML Direction
+
+Human-facing `agent.yaml` should remain natural language. It should describe surfaces and how each surface is used, not force operators to hand-author every primitive.
+
+Example:
+
+```yaml
+surfaces:
+  - key: github
+    usage: Observe project movement, search repository knowledge, and change repository state only when explicitly needed.
+  - key: grafana
+    usage: Observe runtime state and inspect operational evidence.
+  - key: meta
+    usage: Observe campaign state and extract campaign signals before marketing decisions.
+```
+
+Render/apply/install turns that prose into candidate capabilities, probes, contracts, and warnings.
+
+## Intermediate Representation
+
+The install pipeline should materialize a reviewed intermediate representation before writing executable primitives:
+
+```yaml
+surface: meta
+operation: signals
+capability: meta.signals.campaign_snapshot
+description: Read current campaign state and summarize delivery, spend, conversions, and event health.
+inputs:
+  account_id: required string
+  campaign_filter: optional string
+outputs:
+  status: enum[ok,degraded,broken]
+  observations: list
+  evidence_refs: list
+install_policy:
+  materialize: eager
+  probe_required: true
+  credentials: meta.env
+runtime_policy:
+  safe_for_heartbeat: true
+  mutates_state: false
+  cache_ttl_seconds: 300
+failure_policy:
+  report_warning: true
+  retry: next_apply
+  fallback: use operator-visible degraded signal
+```
+
+## Generation Stages
+
+1. Ingest prose from `agent.yaml`, operator pressure digests, docs, and explicit install notes.
+2. Infer candidate surfaces and classify each requested use as `signals`, `search`, or `mutate`.
+3. Derive atomic capabilities with one operation per capability.
+4. Define contracts: inputs, outputs, side effects, credentials, expected evidence, and safety level.
+5. Classify install behavior: eager materialization, lazy materialization, probe-only, or manual review required.
+6. Generate probes and tests before treating the capability as healthy.
+7. Materialize wrappers into `libexec` or static CLI registry entries.
+8. Emit health and recovery metadata when materialization is absent, degraded, or broken.
+
+## Validation And Testing
+
+Every generated capability needs a probe contract. Read-only capabilities should be probeable during install/apply even if that makes install slower. Mutating capabilities should probe authentication and dry-run semantics without changing state.
+
+Validation should cover:
+
+- contract shape and parameter validation
+- credential presence without leaking values
+- provider reachability or a deterministic local substitute
+- output schema validation
+- telemetry emission
+- degraded and missing-credential paths
+- integration into `edge-search`, `edge-signals`, or a mutate-specific invoker
+
+## Recovery Strategy
+
+Broken substrate should be operator-visible, not buried in logs. Primitive/capability health should affect:
+
+- install/apply output
+- health snapshots
+- heartbeat routing and gating
+- reports after quality checks
+- postflight summaries
+
+Reports should include a `Primitive health warning` block when relevant, with:
+
+- broken or degraded primitives/capabilities
+- what they prevented
+- fallbacks used
+- likely failure class: missing credentials, degraded provider, missing materialization, broken probe, absent binding, or contract drift
+- next recovery path
+
+## Runtime Slice Implemented Now
+
+This issue introduces two runtime pieces that make the ontology executable:
+
+- `edge-signals`: collects state-oriented signals such as health, current dispatch, queue, workflow health, render/apply drift, primitive health, capability health, and recent failure events.
+- `edge-context`: provides one UX entrypoint while preserving separate internal lanes for `signals` and `sources`.
+
+The output intentionally keeps the lanes separate:
+
+```json
+{
+  "query": "meta events",
+  "signals": {"signals": []},
+  "sources": {"results_by_source": {}},
+  "summary": {}
+}
+```
+
+This gives heartbeat and skills a simple context command without collapsing signals and search into the same category.

--- a/tests/test_edge_cap_repo_tool_resolution.sh
+++ b/tests/test_edge_cap_repo_tool_resolution.sh
@@ -27,6 +27,8 @@ payload = json.loads(sys.argv[1])
 names = {item["name"]: item for item in payload["capabilities"]}
 assert names["search.corpus"]["effective_status"] == "available"
 assert names["sources.aggregate"]["effective_status"] == "available"
+assert names["signals.aggregate"]["effective_status"] == "available"
+assert names["context.aggregate"]["effective_status"] == "available"
 assert names["workflow.recommend"]["effective_status"] == "available"
 assert names["repo.sync"]["effective_status"] == "available"
 PY

--- a/tests/test_edge_cap_status.sh
+++ b/tests/test_edge_cap_status.sh
@@ -26,6 +26,14 @@ cat >"$TMP_BIN/edge-sources" <<'EOF'
 #!/usr/bin/env bash
 echo "edge-sources $*"
 EOF
+cat >"$TMP_BIN/edge-signals" <<'EOF'
+#!/usr/bin/env bash
+echo "edge-signals $*"
+EOF
+cat >"$TMP_BIN/edge-context" <<'EOF'
+#!/usr/bin/env bash
+echo "edge-context $*"
+EOF
 cat >"$TMP_BIN/edge-workflows" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "status" ]]; then
@@ -42,7 +50,7 @@ cat >"$TMP_BIN/edge-repo-sync" <<'EOF'
 #!/usr/bin/env bash
 echo "edge-repo-sync $*"
 EOF
-chmod +x "$TMP_BIN/edge-search" "$TMP_BIN/edge-sources" "$TMP_BIN/edge-workflows" "$TMP_BIN/git" "$TMP_BIN/edge-repo-sync"
+chmod +x "$TMP_BIN/edge-search" "$TMP_BIN/edge-sources" "$TMP_BIN/edge-signals" "$TMP_BIN/edge-context" "$TMP_BIN/edge-workflows" "$TMP_BIN/git" "$TMP_BIN/edge-repo-sync"
 
 cat >"$TMP_STATE/state/sources-manifest.yaml" <<'YAML'
 sources:
@@ -73,6 +81,8 @@ assert summary["health_status"] == "degraded"
 names = {item["name"]: item for item in payload["capabilities"]}
 assert names["search.corpus"]["effective_status"] == "available"
 assert names["sources.aggregate"]["effective_status"] == "available"
+assert names["signals.aggregate"]["effective_status"] == "available"
+assert names["context.aggregate"]["effective_status"] == "available"
 assert names["workflow.recommend"]["effective_status"] == "available"
 assert names["repo.status"]["effective_status"] == "available"
 assert names["repo.sync"]["effective_status"] == "available"

--- a/tests/test_edge_context.sh
+++ b/tests/test_edge_context.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-context-XXXXXX)"
+TMP_STATE="$TMP_BASE/state"
+TMP_BIN="$TMP_BASE/bin"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE/health" "$TMP_STATE/state/events" "$TMP_BIN"
+
+cat >"$TMP_STATE/health/current.json" <<'JSON'
+{"schema_version":2,"status":"healthy","score":91,"hard_fail":false,"dimensions":{}}
+JSON
+cat >"$TMP_STATE/state/primitives-status.json" <<'JSON'
+{"summary":{"health_status":"ok","broken_total":0,"degraded_total":0},"sources":[]}
+JSON
+cat >"$TMP_STATE/state/capabilities-status.json" <<'JSON'
+{"summary":{"health_status":"ok","broken_total":0,"degraded_total":0},"capabilities":[]}
+JSON
+
+cat >"$TMP_BIN/edge-sources-fake" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "exa": {
+    "results": [
+      {"title": "Meta event planning", "url": "https://example.test/meta", "source": "Exa", "detail": "conversion window", "score": 10}
+    ],
+    "wildcard": false
+  }
+}
+JSON
+SH
+chmod +x "$TMP_BIN/edge-sources-fake"
+
+echo "=== edge-context Smoke Test ==="
+OUTPUT=$(EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="contexttest" EDGE_SOURCES_BIN="$TMP_BIN/edge-sources-fake" \
+  "$EDGE_DIR/tools/edge-context" --query "meta events" --mode all --intent research --json --no-wildcard)
+
+if python3 - <<'PY' "$OUTPUT"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+assert payload["schema_version"] == 1
+assert payload["query"] == "meta events"
+assert payload["mode"] == "all"
+assert isinstance(payload["signals"], dict)
+assert isinstance(payload["sources"], dict)
+assert payload["sources"]["ok"] is True
+assert "exa" in payload["sources"]["results_by_source"]
+summary = payload["summary"]
+assert summary["signals_returned"] >= 1
+assert summary["source_total"] == 1
+assert summary["source_result_total"] == 1
+PY
+then
+  pass "edge-context preserves signals and sources lanes"
+else
+  fail "edge-context preserves signals and sources lanes"
+fi
+
+SOURCE_ONLY=$(EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="contexttest" EDGE_SOURCES_BIN="$TMP_BIN/edge-sources-fake" \
+  "$EDGE_DIR/tools/edge-context" --query "meta events" --mode sources --json --no-wildcard)
+
+if python3 - <<'PY' "$SOURCE_ONLY"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+assert payload["signals"] is None
+assert payload["sources"]["ok"] is True
+assert payload["summary"]["source_total"] == 1
+PY
+then
+  pass "edge-context can run sources-only mode"
+else
+  fail "edge-context can run sources-only mode"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/tests/test_edge_signals.sh
+++ b/tests/test_edge_signals.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-signals-XXXXXX)"
+TMP_STATE="$TMP_BASE/state"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE/health" "$TMP_STATE/state/events"
+
+cat >"$TMP_STATE/health/current.json" <<'JSON'
+{
+  "schema_version": 2,
+  "status": "degraded",
+  "score": 74,
+  "hard_fail": false,
+  "dimensions": {
+    "capabilities": {"status": "degraded", "detail": "primitive failures"},
+    "runtime_flow": {"status": "ok", "detail": "dispatch ok"}
+  }
+}
+JSON
+
+cat >"$TMP_STATE/state/primitives-status.json" <<'JSON'
+{
+  "summary": {"health_status": "fail", "broken_total": 1, "degraded_total": 1},
+  "sources": [
+    {
+      "name": "meta",
+      "description": "Meta campaign snapshot",
+      "effective_status": "broken",
+      "problems": ["last_probe_failed"],
+      "last_probe_ok": false
+    },
+    {
+      "name": "grafana",
+      "description": "Runtime logs",
+      "effective_status": "degraded",
+      "problems": ["declared_not_activated"]
+    }
+  ]
+}
+JSON
+
+cat >"$TMP_STATE/state/capabilities-status.json" <<'JSON'
+{
+  "summary": {"health_status": "degraded", "broken_total": 0, "degraded_total": 1},
+  "capabilities": [
+    {
+      "name": "source.meta",
+      "kind": "primitive",
+      "roles": ["signals"],
+      "effective_status": "degraded",
+      "description": "Meta campaign snapshot",
+      "problems": ["missing credentials"]
+    }
+  ]
+}
+JSON
+
+cat >"$TMP_STATE/state/current-dispatch.json" <<'JSON'
+{
+  "cycle_id": "cycle-test",
+  "request": {"trigger": "heartbeat", "skill": ""},
+  "state": {"active": true, "skill_dispatched": false, "phase": "opened"}
+}
+JSON
+
+cat >"$TMP_STATE/state/dispatch-queue.json" <<'JSON'
+[
+  {"skill": "report", "status": "pending", "source": "operator"}
+]
+JSON
+
+cat >"$TMP_STATE/state/workflow-health.json" <<'JSON'
+{
+  "summary": {"broken_total": 1, "stale_total": 0, "ignored_30d": 2}
+}
+JSON
+
+cat >"$TMP_STATE/state/render-install-drift.json" <<'JSON'
+{
+  "summary": {"rendered_without_install": 0, "install_without_render": 0, "hash_mismatches": 0, "missing_on_disk": 0, "doctor_warn": 1, "doctor_fail": 0}
+}
+JSON
+
+cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
+{"ts":"2026-04-24T01:00:00+00:00","type":"PrimitiveProbeCompleted","payload":{"source":"meta","ok":false,"exit_code":1}}
+{"ts":"2026-04-24T01:01:00+00:00","type":"CapabilityInvocationObserved","payload":{"capability":"source.meta","ok":false,"exit_code":77}}
+JSONL
+
+echo "=== edge-signals Smoke Test ==="
+OUTPUT=$(EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="sigtest" \
+  "$EDGE_DIR/tools/edge-signals" --query "meta campaign heartbeat" --json --limit 20)
+
+if python3 - <<'PY' "$OUTPUT"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+summary = payload["summary"]
+signals = {item["id"]: item for item in payload["signals"]}
+
+assert payload["schema_version"] == 1
+assert summary["signal_total"] >= 6
+assert summary["critical_total"] >= 1
+assert summary["warning_total"] >= 1
+assert summary["primitive_health"] == "fail"
+assert summary["capability_health"] == "degraded"
+assert "health.current" in signals
+assert "primitives.health" in signals
+assert "capabilities.health" in signals
+assert "dispatch.current" in signals
+assert "dispatch.queue" in signals
+assert "events.attention" in signals
+assert signals["primitives.health"]["decision_effect"] == "gate"
+assert payload["report_warning"]["required"] is True
+attention = payload["report_warning"]["items"][0]["broken_or_degraded"]
+assert any(item["name"] == "meta" for item in attention)
+PY
+then
+  pass "edge-signals returns priority state signals and primitive warning"
+else
+  fail "edge-signals returns priority state signals and primitive warning"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/tests/test_protocol_runtime.sh
+++ b/tests/test_protocol_runtime.sh
@@ -29,6 +29,10 @@ operator_notes:
 procedures:
   - id: health-snapshot
     kind: health.snapshot
+  - id: edge-signals
+    kind: signals.context
+    scope: routing
+    limit: 5
   - id: capability-probe
     kind: capability.probe
     capability: storage.sync
@@ -91,7 +95,10 @@ compiled_path = Path(state_dir) / "state" / "runtime" / "preflight.compiled.json
 assert compiled_path.exists()
 saved = json.loads(compiled_path.read_text(encoding="utf-8"))
 assert saved["source_hash"] == compiled["source_hash"]
-assert len(saved["procedures"]) == 2
+assert len(saved["procedures"]) == 3
+signal_step = next(item for item in saved["procedures"] if item["kind"] == "signals.context")
+assert signal_step["scope"] == "routing"
+assert signal_step["limit"] == 5
 PY
 then
     pass "ensure_compiled_protocol writes compiled JSON with hashes"

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -35,6 +35,7 @@ from .capability_runtime import build_capability_status, build_configured_integr
 from .operator_pressure import build_operator_pressure_layers  # noqa: E402
 from .protocol_runtime import emit_protocol_step_observed, ensure_compiled_protocol, protocol_context  # noqa: E402
 from .search_runtime import search_runtime_summary  # noqa: E402
+from .signal_runtime import build_signal_context  # noqa: E402
 from .skill_inbox import attach_snapshot_to_dispatch  # noqa: E402
 from .telemetry import emit_shadow_event, log_event, log_run_step, log_workflow_recommended  # noqa: E402
 from .workflow_runtime import build_workflow_status, recommend_workflows  # noqa: E402
@@ -1125,6 +1126,38 @@ def _execute_preflight_step(
         request["configured_integrations"] = capabilities.get("configured_integrations") or []
         request["unbound_integrations"] = capabilities.get("unbound_integrations") or []
         return _step_result(step, status="ok", satisfied=True, detail=f"health={capabilities.get('health_status', 'unknown')}")
+
+    if kind == "signals.context":
+        signal_query = str(step.get("query") or "").strip()
+        if not signal_query:
+            signal_query = derive_corpus_query(skill, request.get("args", {}) or {}, primary_thread_id=request.get("primary_thread_id"))
+        payload = build_signal_context(
+            query=signal_query,
+            scope=str(step.get("scope") or "routing"),
+            limit=max(1, int(step.get("limit") or 12)),
+            skill=skill,
+            refresh=bool(step.get("refresh", False)),
+        )
+        request["edge_signals"] = payload
+        request["primitive_health_warning"] = payload.get("report_warning") or {}
+        summary = payload.get("summary") or {}
+        status = "warning" if summary.get("critical_total", 0) or summary.get("warning_total", 0) else "ok"
+        return _step_result(
+            step,
+            status=status,
+            satisfied=True,
+            detail=(
+                f"signals={summary.get('signal_total', 0)} "
+                f"critical={summary.get('critical_total', 0)} "
+                f"warning={summary.get('warning_total', 0)}"
+            ),
+            extra={
+                "signal_total": int(summary.get("signal_total", 0) or 0),
+                "critical_total": int(summary.get("critical_total", 0) or 0),
+                "warning_total": int(summary.get("warning_total", 0) or 0),
+                "query": signal_query,
+            },
+        )
 
     if kind == "corpus.lookup":
         corpus_query = derive_corpus_query(skill, request.get("args", {}) or {}, primary_thread_id=request.get("primary_thread_id"))

--- a/tools/_shared/protocol_runtime.py
+++ b/tools/_shared/protocol_runtime.py
@@ -32,6 +32,7 @@ _ALLOWED_KINDS: dict[str, set[str]] = {
         "claims.refresh",
         "primitives.status",
         "capabilities.status",
+        "signals.context",
         "corpus.lookup",
         "workflow.status",
         "queue.status",
@@ -156,6 +157,19 @@ def _normalize_step(
         effective_status = str(capability_row.get("effective_status") or "").strip()
         if effective_status in {"degraded", "broken"}:
             warnings.append(f"{capability} currently {effective_status}")
+
+    if kind == "signals.context":
+        scope = str(raw_step.get("scope") or "routing").strip() or "routing"
+        if scope not in {"routing", "skill", "all"}:
+            raise ProtocolCompileError(f"{protocol} procedures[{index}] signals.context scope must be routing, skill, or all")
+        step["scope"] = scope
+        if raw_step.get("query") is not None:
+            step["query"] = str(raw_step.get("query") or "").strip()
+        try:
+            step["limit"] = max(1, int(raw_step.get("limit") or 12))
+        except (TypeError, ValueError) as exc:
+            raise ProtocolCompileError(f"{protocol} procedures[{index}] signals.context limit must be an integer") from exc
+        step["refresh"] = bool(raw_step.get("refresh", False))
 
     return step, warnings
 

--- a/tools/_shared/signal_runtime.py
+++ b/tools/_shared/signal_runtime.py
@@ -1,0 +1,600 @@
+"""Runtime signal aggregation for heartbeat routing and preflight context."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from collections import Counter, deque
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "config"))
+from paths import (  # noqa: E402
+    CAPABILITIES_STATUS_FILE,
+    CURRENT_DISPATCH_FILE,
+    DISPATCH_QUEUE_FILE,
+    EDGE_REPO_DIR,
+    HEALTH_CURRENT_FILE,
+    PRIMITIVES_STATUS_FILE,
+    RENDER_INSTALL_DRIFT_FILE,
+    STATE_EVENTS_FILE,
+    WORKFLOW_HEALTH_FILE,
+)
+from .capability_runtime import build_capability_status, build_configured_integrations  # noqa: E402
+
+SIGNAL_SCHEMA_VERSION = 1
+DEFAULT_LIMIT = 12
+HIGH_PRIORITY_SEVERITIES = {"critical", "warning"}
+HIGH_PRIORITY_EFFECTS = {"gate", "route"}
+ALWAYS_INCLUDE_IDS = {"health.current", "primitives.health", "capabilities.health"}
+
+SEVERITY_SCORE = {
+    "critical": 100,
+    "warning": 70,
+    "info": 35,
+}
+DECISION_SCORE = {
+    "gate": 30,
+    "route": 20,
+    "inform": 0,
+}
+STATUS_SEVERITY = {
+    "critical": "critical",
+    "unhealthy": "critical",
+    "fail": "critical",
+    "failed": "critical",
+    "broken": "critical",
+    "degraded": "warning",
+    "warning": "warning",
+    "warn": "warning",
+    "healthy": "info",
+    "ok": "info",
+    "available": "info",
+    "active": "info",
+    "probed": "info",
+}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {"_read_error": str(exc), "_path": str(path)}
+
+
+def iter_jsonl_tail(path: Path, limit: int = 80) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: deque[dict[str, Any]] = deque(maxlen=max(1, limit))
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict):
+                    rows.append(row)
+    except OSError:
+        return []
+    return list(rows)
+
+
+def status_to_severity(status: Any, *, default: str = "info") -> str:
+    return STATUS_SEVERITY.get(str(status or "").strip().lower(), default)
+
+
+def normalize_terms(query: str | None) -> list[str]:
+    if not query:
+        return []
+    terms = []
+    for term in re.findall(r"[\w.-]+", query.lower()):
+        if len(term) >= 3 and term not in {"the", "and", "for", "com", "uma", "que", "para"}:
+            terms.append(term)
+    return sorted(set(terms))
+
+
+def text_blob(value: Any) -> str:
+    if isinstance(value, str):
+        return value.lower()
+    if isinstance(value, dict):
+        return " ".join(text_blob(v) for v in value.values())
+    if isinstance(value, list):
+        return " ".join(text_blob(v) for v in value)
+    return str(value).lower()
+
+
+def classify_failure(problems: list[Any], row: dict[str, Any]) -> list[str]:
+    text = " ".join(str(item or "") for item in problems).lower()
+    classes: list[str] = []
+    if any(token in text for token in ("credential", "secret", "token", "api_key", "env")):
+        classes.append("missing_credentials")
+    if any(token in text for token in ("declared_not_activated", "not_activated", "manifest_requires", "required_command_missing", "optional_command_missing")):
+        classes.append("missing_install_time_materialization")
+    if "last_probe_failed" in text or row.get("last_probe_ok") is False:
+        classes.append("broken_probe")
+    if "untracked_local_artifact" in text or "binary_without_meta" in text:
+        classes.append("contract_drift")
+    if not classes and problems:
+        classes.append("degraded_provider_or_unknown")
+    return sorted(set(classes))
+
+
+def make_signal(
+    *,
+    signal_id: str,
+    source: str,
+    kind: str,
+    summary: str,
+    severity: str = "info",
+    decision_effect: str = "inform",
+    evidence: dict[str, Any] | None = None,
+    surface: str = "edge",
+    operation: str = "signals",
+) -> dict[str, Any]:
+    return {
+        "id": signal_id,
+        "source": source,
+        "surface": surface,
+        "operation": operation,
+        "kind": kind,
+        "decision_effect": decision_effect,
+        "severity": severity,
+        "summary": summary,
+        "evidence": evidence or {},
+    }
+
+
+def load_primitives_status(*, refresh: bool = False) -> dict[str, Any]:
+    cached = read_json(PRIMITIVES_STATUS_FILE, {})
+    if isinstance(cached, dict) and cached and not refresh and "_read_error" not in cached:
+        return cached
+
+    tool = EDGE_REPO_DIR / "tools" / "edge-primitives"
+    if not tool.exists():
+        return cached if isinstance(cached, dict) and cached else {"summary": {"health_status": "unknown"}, "sources": []}
+    result = subprocess.run(
+        [sys.executable, str(tool), "status", "--json"],
+        cwd=str(EDGE_REPO_DIR),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return {"summary": {"health_status": "fail"}, "sources": [], "error": result.stderr.strip()}
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"summary": {"health_status": "fail"}, "sources": [], "error": "invalid edge-primitives json"}
+
+
+def load_capabilities_status(*, skill: str | None = None, refresh: bool = False) -> dict[str, Any]:
+    cached = read_json(CAPABILITIES_STATUS_FILE, {})
+    if isinstance(cached, dict) and cached and not refresh and "_read_error" not in cached:
+        return cached
+    return build_capability_status(skill=skill)
+
+
+def collect_health_signal(signals: list[dict[str, Any]]) -> None:
+    payload = read_json(HEALTH_CURRENT_FILE, {})
+    if not payload:
+        signals.append(
+            make_signal(
+                signal_id="health.missing",
+                source="health",
+                kind="snapshot",
+                summary="No health/current.json snapshot is available.",
+                severity="warning",
+                decision_effect="route",
+                evidence={"path": str(HEALTH_CURRENT_FILE)},
+            )
+        )
+        return
+    if isinstance(payload, dict) and payload.get("_read_error"):
+        signals.append(
+            make_signal(
+                signal_id="health.read_error",
+                source="health",
+                kind="snapshot",
+                summary="Health snapshot could not be read.",
+                severity="warning",
+                decision_effect="route",
+                evidence=payload,
+            )
+        )
+        return
+
+    status = str(payload.get("status") or payload.get("health_status") or "unknown")
+    score = payload.get("score")
+    severity = status_to_severity(status, default="warning")
+    decision_effect = "gate" if severity == "critical" else "route" if severity == "warning" else "inform"
+    dimensions = payload.get("dimensions") if isinstance(payload.get("dimensions"), dict) else {}
+    attention_dimensions = [
+        {"name": name, "status": value.get("status"), "detail": value.get("detail", "")}
+        for name, value in dimensions.items()
+        if isinstance(value, dict) and str(value.get("status") or "ok") != "ok"
+    ][:6]
+    summary = f"Health status is {status}"
+    if score is not None:
+        summary += f" with score {score}"
+    signals.append(
+        make_signal(
+            signal_id="health.current",
+            source="health",
+            kind="snapshot",
+            summary=summary + ".",
+            severity=severity,
+            decision_effect=decision_effect,
+            evidence={
+                "status": status,
+                "score": score,
+                "hard_fail": payload.get("hard_fail"),
+                "attention_dimensions": attention_dimensions,
+                "path": str(HEALTH_CURRENT_FILE),
+            },
+        )
+    )
+
+
+def collect_primitives_signal(signals: list[dict[str, Any]], *, refresh: bool = False) -> None:
+    payload = load_primitives_status(refresh=refresh)
+    summary = payload.get("summary") if isinstance(payload, dict) else {}
+    sources = payload.get("sources") if isinstance(payload, dict) else []
+    if not isinstance(summary, dict):
+        summary = {}
+    if not isinstance(sources, list):
+        sources = []
+    health_status = str(summary.get("health_status") or "unknown")
+    attention = [
+        {
+            "name": item.get("name"),
+            "effective_status": item.get("effective_status"),
+            "problems": list(item.get("problems") or []),
+            "failure_classes": classify_failure(list(item.get("problems") or []), item),
+            "description": item.get("description", ""),
+        }
+        for item in sources
+        if isinstance(item, dict) and item.get("effective_status") in {"broken", "degraded"}
+    ][:8]
+    severity = status_to_severity(health_status, default="warning" if attention else "info")
+    if attention and severity == "info":
+        severity = "warning"
+    decision_effect = "gate" if severity == "critical" else "route" if severity == "warning" else "inform"
+    signals.append(
+        make_signal(
+            signal_id="primitives.health",
+            source="primitives",
+            kind="status",
+            summary=(
+                f"Primitive health is {health_status}; "
+                f"broken={summary.get('broken_total', 0)} degraded={summary.get('degraded_total', 0)}."
+            ),
+            severity=severity,
+            decision_effect=decision_effect,
+            evidence={
+                "summary": summary,
+                "attention": attention,
+                "path": str(PRIMITIVES_STATUS_FILE),
+                "prevents": [
+                    "reliable edge-sources / edge-signals expansion for affected surfaces",
+                    "operator-visible confidence that requested integrations were materialized",
+                ] if attention else [],
+            },
+        )
+    )
+
+
+def collect_capabilities_signal(signals: list[dict[str, Any]], *, skill: str | None = None, refresh: bool = False) -> None:
+    payload = load_capabilities_status(skill=skill, refresh=refresh)
+    summary = payload.get("summary") if isinstance(payload, dict) else {}
+    capabilities = payload.get("capabilities") if isinstance(payload, dict) else []
+    if not isinstance(summary, dict):
+        summary = {}
+    if not isinstance(capabilities, list):
+        capabilities = []
+    integrations = build_configured_integrations(skill=skill)
+    unbound = integrations.get("unbound_integrations") or []
+    health_status = str(summary.get("health_status") or "unknown")
+    attention = [
+        {
+            "name": item.get("name"),
+            "kind": item.get("kind"),
+            "roles": list(item.get("roles") or []),
+            "effective_status": item.get("effective_status"),
+            "problems": list(item.get("problems") or []),
+            "failure_classes": classify_failure(list(item.get("problems") or []), item),
+            "description": item.get("description", ""),
+        }
+        for item in capabilities
+        if isinstance(item, dict) and item.get("effective_status") in {"broken", "degraded"}
+    ][:8]
+    severity = status_to_severity(health_status, default="warning" if attention or unbound else "info")
+    if (attention or unbound) and severity == "info":
+        severity = "warning"
+    decision_effect = "gate" if severity == "critical" else "route" if severity == "warning" else "inform"
+    signals.append(
+        make_signal(
+            signal_id="capabilities.health",
+            source="capabilities",
+            kind="status",
+            summary=(
+                f"Capability health is {health_status}; "
+                f"broken={summary.get('broken_total', 0)} degraded={summary.get('degraded_total', 0)} "
+                f"unbound_integrations={len(unbound)}."
+            ),
+            severity=severity,
+            decision_effect=decision_effect,
+            evidence={
+                "summary": summary,
+                "attention": attention,
+                "unbound_integrations": unbound[:8],
+                "integrations_summary": integrations.get("summary") or {},
+                "path": str(CAPABILITIES_STATUS_FILE),
+                "prevents": [
+                    "using affected capabilities through edge-context, edge-search, edge-signals, or edge-cap",
+                    "separating reasoning failure from substrate failure in reports",
+                ] if attention or unbound else [],
+            },
+        )
+    )
+
+
+def collect_dispatch_signals(signals: list[dict[str, Any]]) -> None:
+    dispatch = read_json(CURRENT_DISPATCH_FILE, {})
+    if isinstance(dispatch, dict) and dispatch and "_read_error" not in dispatch:
+        state = dispatch.get("state") or {}
+        request = dispatch.get("request") or {}
+        active = bool(state.get("active"))
+        dispatched = bool(state.get("skill_dispatched"))
+        severity = "warning" if active and not dispatched else "info"
+        decision_effect = "route" if active and not dispatched else "inform"
+        signals.append(
+            make_signal(
+                signal_id="dispatch.current",
+                source="dispatch",
+                kind="snapshot",
+                summary=(
+                    f"Current dispatch active={active} skill_dispatched={dispatched} "
+                    f"skill={request.get('skill') or ''}."
+                ),
+                severity=severity,
+                decision_effect=decision_effect,
+                evidence={
+                    "cycle_id": dispatch.get("cycle_id"),
+                    "active": active,
+                    "skill_dispatched": dispatched,
+                    "phase": state.get("phase"),
+                    "skill": request.get("skill"),
+                    "trigger": request.get("trigger"),
+                    "path": str(CURRENT_DISPATCH_FILE),
+                },
+            )
+        )
+
+    queue = read_json(DISPATCH_QUEUE_FILE, [])
+    queue_items = queue if isinstance(queue, list) else queue.get("items", []) if isinstance(queue, dict) else []
+    pending = [item for item in queue_items if isinstance(item, dict) and str(item.get("status") or "pending") in {"pending", "queued"}]
+    if pending:
+        signals.append(
+            make_signal(
+                signal_id="dispatch.queue",
+                source="dispatch_queue",
+                kind="snapshot",
+                summary=f"Dispatch queue has {len(pending)} pending item(s).",
+                severity="warning",
+                decision_effect="route",
+                evidence={"pending": pending[:5], "path": str(DISPATCH_QUEUE_FILE)},
+            )
+        )
+
+
+def collect_workflow_signal(signals: list[dict[str, Any]]) -> None:
+    payload = read_json(WORKFLOW_HEALTH_FILE, {})
+    if not isinstance(payload, dict) or not payload:
+        return
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else payload
+    broken = int(summary.get("broken_total", 0) or 0)
+    stale = int(summary.get("stale_total", 0) or 0)
+    ignored = int(summary.get("ignored_30d", 0) or 0)
+    severity = "warning" if broken or stale else "info"
+    signals.append(
+        make_signal(
+            signal_id="workflow.health",
+            source="workflow",
+            kind="status",
+            summary=f"Workflow health: broken={broken} stale={stale} ignored_30d={ignored}.",
+            severity=severity,
+            decision_effect="route" if severity == "warning" else "inform",
+            evidence={"summary": summary, "path": str(WORKFLOW_HEALTH_FILE)},
+        )
+    )
+
+
+def collect_render_install_signal(signals: list[dict[str, Any]]) -> None:
+    payload = read_json(RENDER_INSTALL_DRIFT_FILE, {})
+    if not isinstance(payload, dict) or not payload:
+        return
+    summary = payload.get("summary") or {}
+    if not isinstance(summary, dict):
+        return
+    drift_total = sum(
+        int(summary.get(key, 0) or 0)
+        for key in ("rendered_without_install", "install_without_render", "hash_mismatches", "missing_on_disk", "doctor_fail")
+    )
+    warning_total = int(summary.get("doctor_warn", 0) or 0)
+    if not drift_total and not warning_total:
+        return
+    signals.append(
+        make_signal(
+            signal_id="render_install.drift",
+            source="render_install",
+            kind="status",
+            summary=f"Render/apply drift detected: hard={drift_total} warnings={warning_total}.",
+            severity="critical" if int(summary.get("doctor_fail", 0) or 0) else "warning",
+            decision_effect="gate" if int(summary.get("doctor_fail", 0) or 0) else "route",
+            evidence={"summary": summary, "path": str(RENDER_INSTALL_DRIFT_FILE)},
+        )
+    )
+
+
+def collect_recent_event_signals(signals: list[dict[str, Any]]) -> None:
+    rows = iter_jsonl_tail(STATE_EVENTS_FILE, limit=120)
+    attention_types = Counter()
+    examples: list[dict[str, Any]] = []
+    for row in rows:
+        event_type = str(row.get("type") or "")
+        payload = row.get("payload") if isinstance(row.get("payload"), dict) else {}
+        payload_error = any(
+            str(payload.get(key) or "").strip()
+            for key in ("error", "error_class", "error_fingerprint", "stderr_tail")
+        )
+        is_attention = (
+            any(token in event_type.lower() for token in ("failed", "missing", "timeout", "bypass"))
+            or "ok" in payload and payload.get("ok") is False
+            or "exit_code" in payload and payload.get("exit_code") not in (0, None)
+            or payload_error
+        )
+        if not is_attention:
+            continue
+        attention_types[event_type or "unknown"] += 1
+        if len(examples) < 8:
+            examples.append({"ts": row.get("ts"), "type": event_type, "payload": payload})
+    if attention_types:
+        signals.append(
+            make_signal(
+                signal_id="events.attention",
+                source="state_events",
+                kind="delta",
+                summary=f"Recent state events contain {sum(attention_types.values())} attention event(s).",
+                severity="warning",
+                decision_effect="route",
+                evidence={
+                    "counts_by_type": dict(attention_types.most_common(8)),
+                    "examples": examples,
+                    "path": str(STATE_EVENTS_FILE),
+                },
+            )
+        )
+
+
+def rank_and_filter(signals: list[dict[str, Any]], *, query: str | None, limit: int) -> list[dict[str, Any]]:
+    terms = normalize_terms(query)
+    ranked = []
+    for index, signal in enumerate(signals):
+        blob = text_blob(signal)
+        matched = not terms or any(term in blob for term in terms)
+        keep = (
+            matched
+            or signal.get("id") in ALWAYS_INCLUDE_IDS
+            or signal.get("severity") in HIGH_PRIORITY_SEVERITIES
+            or signal.get("decision_effect") in HIGH_PRIORITY_EFFECTS
+        )
+        if not keep:
+            continue
+        score = SEVERITY_SCORE.get(str(signal.get("severity") or "info"), 0)
+        score += DECISION_SCORE.get(str(signal.get("decision_effect") or "inform"), 0)
+        if matched and terms:
+            score += 40
+        if signal.get("id") in {"health.current", "primitives.health", "capabilities.health"}:
+            score += 10
+        enriched = dict(signal)
+        enriched["query_match"] = bool(matched)
+        enriched["score"] = score
+        enriched["_index"] = index
+        ranked.append(enriched)
+    ranked.sort(key=lambda item: (-int(item.get("score") or 0), item.get("_index", 0), item.get("id", "")))
+    output = []
+    for item in ranked[: max(1, limit)]:
+        item.pop("_index", None)
+        output.append(item)
+    return output
+
+
+def build_report_warning(signals: list[dict[str, Any]]) -> dict[str, Any]:
+    relevant = [
+        signal
+        for signal in signals
+        if signal.get("id") in {"primitives.health", "capabilities.health"}
+        and signal.get("severity") in {"critical", "warning"}
+    ]
+    if not relevant:
+        return {"required": False, "items": []}
+    items = []
+    for signal in relevant:
+        evidence = signal.get("evidence") or {}
+        items.append(
+            {
+                "signal_id": signal.get("id"),
+                "summary": signal.get("summary"),
+                "broken_or_degraded": evidence.get("attention") or [],
+                "what_it_prevented": evidence.get("prevents") or [],
+                "fallbacks_used": [],
+                "recovery_status": "repair install/materialization/probe path, then re-run edge-signals",
+            }
+        )
+    return {
+        "required": True,
+        "title": "Primitive health warning",
+        "items": items,
+    }
+
+
+def build_signal_context(
+    *,
+    query: str | None = None,
+    scope: str = "routing",
+    limit: int = DEFAULT_LIMIT,
+    skill: str | None = None,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    signals: list[dict[str, Any]] = []
+    collect_health_signal(signals)
+    collect_primitives_signal(signals, refresh=refresh)
+    collect_capabilities_signal(signals, skill=skill, refresh=refresh)
+    collect_dispatch_signals(signals)
+    collect_workflow_signal(signals)
+    collect_render_install_signal(signals)
+    collect_recent_event_signals(signals)
+
+    filtered = rank_and_filter(signals, query=query, limit=limit)
+    severity_counts = Counter(str(signal.get("severity") or "info") for signal in filtered)
+    effect_counts = Counter(str(signal.get("decision_effect") or "inform") for signal in filtered)
+    primitive_signal = next((item for item in signals if item.get("id") == "primitives.health"), {})
+    capability_signal = next((item for item in signals if item.get("id") == "capabilities.health"), {})
+    summary = {
+        "signal_total": len(filtered),
+        "available_signal_total": len(signals),
+        "critical_total": severity_counts.get("critical", 0),
+        "warning_total": severity_counts.get("warning", 0),
+        "info_total": severity_counts.get("info", 0),
+        "gating_total": effect_counts.get("gate", 0),
+        "routing_total": effect_counts.get("route", 0),
+        "primitive_health": ((primitive_signal.get("evidence") or {}).get("summary") or {}).get("health_status", "unknown"),
+        "capability_health": ((capability_signal.get("evidence") or {}).get("summary") or {}).get("health_status", "unknown"),
+        "report_warning_required": build_report_warning(filtered).get("required", False),
+    }
+    return {
+        "schema_version": SIGNAL_SCHEMA_VERSION,
+        "generated_at": now_iso(),
+        "query": query or "",
+        "scope": scope,
+        "skill": skill or "",
+        "summary": summary,
+        "signals": filtered,
+        "report_warning": build_report_warning(filtered),
+    }
+
+
+__all__ = ["build_signal_context", "build_report_warning"]

--- a/tools/edge-context
+++ b/tools/edge-context
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""edge-context - unified UX for distinct signals and source-search lanes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import EDGE_REPO_DIR, TOOLS_DIR  # noqa: E402
+from _shared.signal_runtime import build_signal_context  # noqa: E402
+
+
+def sources_command() -> list[str]:
+    override = os.environ.get("EDGE_SOURCES_BIN", "").strip()
+    if override:
+        return [override]
+    return [str(TOOLS_DIR / "edge-sources")]
+
+
+def run_sources(query: str, *, intent: str, sources: str, no_wildcard: bool) -> dict[str, Any]:
+    cmd = sources_command() + [query, "--intent", intent, "--json"]
+    if sources:
+        cmd.extend(["--sources", sources])
+    if no_wildcard:
+        cmd.append("--no-wildcard")
+    result = subprocess.run(cmd, cwd=str(EDGE_REPO_DIR), capture_output=True, text=True)
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "error": result.stderr.strip() or result.stdout.strip() or f"edge-sources exit={result.returncode}",
+            "results_by_source": {},
+        }
+    try:
+        parsed = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return {"ok": False, "error": f"invalid edge-sources json: {exc}", "results_by_source": {}}
+    return {"ok": True, "results_by_source": parsed}
+
+
+def summarize_sources(payload: dict[str, Any]) -> dict[str, Any]:
+    results_by_source = payload.get("results_by_source") or {}
+    source_total = len(results_by_source) if isinstance(results_by_source, dict) else 0
+    result_total = 0
+    failed_total = 0
+    if isinstance(results_by_source, dict):
+        for row in results_by_source.values():
+            items = row.get("results") if isinstance(row, dict) else []
+            if not isinstance(items, list):
+                continue
+            result_total += len(items)
+            if any("error" in str(item.get("title") or "").lower() for item in items if isinstance(item, dict)):
+                failed_total += 1
+    return {
+        "source_total": source_total,
+        "source_result_total": result_total,
+        "source_failed_total": failed_total,
+        "sources_ok": bool(payload.get("ok")),
+    }
+
+
+def compose_context(
+    *,
+    query: str,
+    mode: str,
+    intent: str,
+    sources: str,
+    limit: int,
+    skill: str,
+    refresh: bool,
+    no_wildcard: bool,
+) -> dict[str, Any]:
+    signals_payload: dict[str, Any] | None = None
+    sources_payload: dict[str, Any] | None = None
+    if mode in {"all", "signals"}:
+        signals_payload = build_signal_context(query=query, scope="routing", limit=limit, skill=skill, refresh=refresh)
+    if mode in {"all", "sources"}:
+        if not query:
+            sources_payload = {"ok": False, "error": "query required for sources mode", "results_by_source": {}}
+        else:
+            sources_payload = run_sources(query, intent=intent, sources=sources, no_wildcard=no_wildcard)
+
+    signals_summary = (signals_payload or {}).get("summary") or {}
+    sources_summary = summarize_sources(sources_payload or {}) if sources_payload is not None else {}
+    summary = {
+        "mode": mode,
+        "signals_returned": signals_summary.get("signal_total", 0),
+        "signal_critical_total": signals_summary.get("critical_total", 0),
+        "signal_warning_total": signals_summary.get("warning_total", 0),
+        "signal_gating_total": signals_summary.get("gating_total", 0),
+        **sources_summary,
+    }
+    return {
+        "schema_version": 1,
+        "query": query,
+        "mode": mode,
+        "intent": intent,
+        "signals": signals_payload,
+        "sources": sources_payload,
+        "summary": summary,
+    }
+
+
+def print_markdown(payload: dict[str, Any]) -> None:
+    print(f"## Edge Context - {payload.get('query') or 'current state'}")
+    summary = payload.get("summary") or {}
+    print(
+        "summary:"
+        f" mode={summary.get('mode')}"
+        f" signals={summary.get('signals_returned', 0)}"
+        f" warnings={summary.get('signal_warning_total', 0)}"
+        f" sources={summary.get('source_total', 0)}"
+        f" source_results={summary.get('source_result_total', 0)}"
+    )
+    signals = payload.get("signals") or {}
+    if signals:
+        print("")
+        print("### Signals")
+        for signal in signals.get("signals") or []:
+            print(f"- [{signal.get('severity')}/{signal.get('decision_effect')}] {signal.get('id')}: {signal.get('summary')}")
+    sources = payload.get("sources") or {}
+    if sources:
+        print("")
+        print("### Sources")
+        if not sources.get("ok"):
+            print(f"- error: {sources.get('error')}")
+        for name, row in (sources.get("results_by_source") or {}).items():
+            results = row.get("results") if isinstance(row, dict) else []
+            print(f"- {name}: {len(results or [])} result(s)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Unified UX over distinct edge-signals and edge-sources lanes")
+    parser.add_argument("query_pos", nargs="?", default="", help="Query/focus")
+    parser.add_argument("--query", "-q", default="", help="Query/focus")
+    parser.add_argument("--mode", choices=["all", "signals", "sources"], default="all")
+    parser.add_argument("--intent", default="research", help="edge-sources intent")
+    parser.add_argument("--sources", default="", help="Comma-separated edge-sources override")
+    parser.add_argument("--skill", default="", help="Optional skill hint")
+    parser.add_argument("--limit", type=int, default=12, help="Maximum signals to include")
+    parser.add_argument("--refresh", action="store_true", help="Refresh primitive/capability status")
+    parser.add_argument("--no-wildcard", action="store_true", help="Disable edge-sources wildcard")
+    parser.add_argument("--json", action="store_true", help="Print JSON")
+    args = parser.parse_args()
+
+    query = args.query or args.query_pos
+    payload = compose_context(
+        query=query,
+        mode=args.mode,
+        intent=args.intent,
+        sources=args.sources,
+        limit=max(1, args.limit),
+        skill=args.skill,
+        refresh=args.refresh,
+        no_wildcard=args.no_wildcard,
+    )
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False))
+    else:
+        print_markdown(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/edge-signals
+++ b/tools/edge-signals
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""edge-signals - aggregate state-oriented signals for routing and gating."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.signal_runtime import build_signal_context  # noqa: E402
+
+
+def print_markdown(payload: dict[str, object]) -> None:
+    summary = payload.get("summary") or {}
+    query = payload.get("query") or ""
+    print(f"## Edge Signals - {query or 'current state'}")
+    print(
+        "summary:"
+        f" total={summary.get('signal_total', 0)}"
+        f" critical={summary.get('critical_total', 0)}"
+        f" warning={summary.get('warning_total', 0)}"
+        f" gate={summary.get('gating_total', 0)}"
+        f" route={summary.get('routing_total', 0)}"
+        f" primitive_health={summary.get('primitive_health', 'unknown')}"
+        f" capability_health={summary.get('capability_health', 'unknown')}"
+    )
+    print("")
+    for signal in payload.get("signals") or []:
+        print(
+            f"- [{signal.get('severity')}/{signal.get('decision_effect')}] "
+            f"{signal.get('id')}: {signal.get('summary')}"
+        )
+        evidence = signal.get("evidence") or {}
+        prevents = evidence.get("prevents") if isinstance(evidence, dict) else []
+        if prevents:
+            print(f"  prevents: {'; '.join(str(item) for item in prevents[:2])}")
+    warning = payload.get("report_warning") or {}
+    if isinstance(warning, dict) and warning.get("required"):
+        print("")
+        print("### Primitive Health Warning")
+        for item in warning.get("items") or []:
+            print(f"- {item.get('summary')}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Aggregate state-oriented edge signals")
+    parser.add_argument("query_pos", nargs="?", default="", help="Optional query/focus")
+    parser.add_argument("--query", "-q", default="", help="Optional query/focus")
+    parser.add_argument("--scope", default="routing", choices=["routing", "skill", "all"], help="Signal scope label")
+    parser.add_argument("--skill", default="", help="Optional skill hint for capability recommendations")
+    parser.add_argument("--limit", type=int, default=12, help="Maximum signals to return")
+    parser.add_argument("--refresh", action="store_true", help="Refresh primitive/capability status instead of using cached snapshots")
+    parser.add_argument("--json", action="store_true", help="Print JSON")
+    args = parser.parse_args()
+
+    query = args.query or args.query_pos
+    payload = build_signal_context(
+        query=query,
+        scope=args.scope,
+        limit=max(1, args.limit),
+        skill=args.skill,
+        refresh=args.refresh,
+    )
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False))
+    else:
+        print_markdown(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #339.

This implements the first runtime slice of the signals/search/mutate ontology:

- adds `edge-signals` for state-oriented routing/gating signals, including health, dispatch, queue, workflow health, render/apply drift, primitive health, capability health, and recent attention events
- adds `edge-context` as a unified UX entrypoint that preserves distinct `signals` and `sources` lanes in structured output
- registers `signals.aggregate` and `context.aggregate` in the capability registry
- adds `signals.context` as a preflight protocol kind so signals can be injected into runtime context
- documents the primitive-generation pipeline design, including ontology, IR, generation stages, validation/testing, and recovery/report warnings

## Validation

- `python3 -m py_compile tools/_shared/signal_runtime.py tools/_shared/dispatch_runtime.py tools/_shared/protocol_runtime.py tools/edge-signals tools/edge-context`
- `bash tests/test_edge_signals.sh`
- `bash tests/test_edge_context.sh`
- `bash tests/test_edge_cap_status.sh`
- `bash tests/test_edge_cap_repo_tool_resolution.sh`
- `bash tests/test_edge_cap_invoke.sh`
- `bash tests/test_protocol_runtime.sh`
- `bash tests/test_runtime_decision_protocol.sh`
- `bash tests/test_edge_dispatch.sh`
- `bash tests/test_edge_runner.sh`

Note: `test_edge_dispatch.sh` and `test_edge_runner.sh` must not run in parallel because both mutate temporary rendered protocol files in `config/` during the test.