### PR TITLE
[codex] Fix consolidate-state partial publish resilience

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -1394,6 +1394,9 @@ title = fm.get("title", slug)
 raw_claims = fm.get("claims", [])
 threads = fm.get("threads", [])
 tags = fm.get("tags", [])
+meta_dir = Path(os.environ.get("META_DIR", os.path.expanduser("~/edge/meta-reports")))
+proposal_path = meta_dir / f"{slug}.state-proposal.yaml"
+audit_path = meta_dir / f"{slug}.state-audit.yaml"
 
 # Normalize claims: accept both str ("!claim") and dict ({claim, status})
 def _is_open(c):
@@ -1473,77 +1476,81 @@ for dirpath, prefix in TRACKED.items():
 # ── 2. Captura diffs do ~/edge/ (repo principal) ──
 try:
     edge_dir = os.environ.get("EDGE_REPO_DIR", os.environ.get("EDGE_DIR", os.path.expanduser("~/edge")))
-    tool_path = Path(edge_dir) / "tools" / "edge-publish-scope"
-    changelog_path = Path(os.environ.get("BLOG_CHANGELOG_FILE", "")).expanduser()
-    allowed_paths = [entry_path]
-    if report_html:
-        allowed_paths.append(report_html)
-    if meta_report_path:
-        allowed_paths.append(meta_report_path)
-    if proposal_path.exists():
-        allowed_paths.append(str(proposal_path))
-    if audit_path.exists():
-        allowed_paths.append(str(audit_path))
-    if changelog_path and changelog_path.exists():
-        allowed_paths.append(str(changelog_path))
+    edge_git_dir = Path(edge_dir) / ".git"
+    if not edge_git_dir.exists():
+        warn(f"EDGE_REPO_DIR is not a git repository; skipping scoped diff: {edge_dir}")
+    else:
+        tool_path = Path(edge_dir) / "tools" / "edge-publish-scope"
+        changelog_path = Path(os.environ.get("BLOG_CHANGELOG_FILE", "")).expanduser()
+        allowed_paths = [entry_path]
+        if report_html:
+            allowed_paths.append(report_html)
+        if meta_report_path:
+            allowed_paths.append(meta_report_path)
+        if proposal_path.exists():
+            allowed_paths.append(str(proposal_path))
+        if audit_path.exists():
+            allowed_paths.append(str(audit_path))
+        if changelog_path and changelog_path.exists():
+            allowed_paths.append(str(changelog_path))
 
-    scope_cmd = [str(tool_path), "stage", "--slug", slug, "--json"]
-    for allowed_path in allowed_paths:
-        if allowed_path:
-            scope_cmd.extend(["--allow", allowed_path])
-    scope_result = subprocess.run(
-        scope_cmd,
-        cwd=edge_dir,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    scope_payload = {}
-    if scope_result.stdout.strip():
-        try:
-            scope_payload = json.loads(scope_result.stdout)
-        except Exception:
-            scope_payload = {"raw": scope_result.stdout.strip()}
-    if scope_result.returncode == 2:
-        emit_scope_violation({
-            "slug": slug,
-            "allowed_paths": scope_payload.get("allowed_paths", []),
-            "illegal_files": scope_payload.get("illegal_files", []),
-        })
-        illegal = scope_payload.get("illegal_files", []) or []
-        if illegal:
-            warn(f"SCOPE GUARD: {len(illegal)} file(s) outside publish allowlist in staging:")
-            for item in illegal:
-                warn(f"  ↳ {item}")
-        raise SystemExit(2)
-    if scope_result.returncode != 0:
-        raise RuntimeError(scope_result.stderr.strip() or scope_result.stdout.strip() or "edge-publish-scope failed")
-
-    result = subprocess.run(
-        ["git", "diff", "--cached", "--unified=3", "--", ".", ":(exclude)*.venv*", ":(exclude)*.b64", ":(exclude)*.png", ":(exclude)*.jpg", ":(exclude)*.pdf", ":(exclude)*.db"],
-        cwd=edge_dir, capture_output=True, text=True, errors="replace", timeout=30
-    )
-    edge_diff = result.stdout.strip()
-    if edge_diff:
-        current_file = None
-        current_lines = []
-        for line in edge_diff.split("\n"):
-            if line.startswith("diff --git a/"):
-                if current_file and current_lines:
-                    all_diffs.append({
-                        "path": f"edge/{current_file}",
-                        "diff": "\n".join(current_lines)
-                    })
-                file_parts = line.split(" b/", 1)
-                current_file = file_parts[1] if len(file_parts) > 1 else line.split("a/", 1)[-1].split(" ")[0]
-                current_lines = [line]
-            else:
-                current_lines.append(line)
-        if current_file and current_lines:
-            all_diffs.append({
-                "path": f"edge/{current_file}",
-                "diff": "\n".join(current_lines)
+        scope_cmd = [str(tool_path), "stage", "--slug", slug, "--json"]
+        for allowed_path in allowed_paths:
+            if allowed_path:
+                scope_cmd.extend(["--allow", allowed_path])
+        scope_result = subprocess.run(
+            scope_cmd,
+            cwd=edge_dir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        scope_payload = {}
+        if scope_result.stdout.strip():
+            try:
+                scope_payload = json.loads(scope_result.stdout)
+            except Exception:
+                scope_payload = {"raw": scope_result.stdout.strip()}
+        if scope_result.returncode == 2:
+            emit_scope_violation({
+                "slug": slug,
+                "allowed_paths": scope_payload.get("allowed_paths", []),
+                "illegal_files": scope_payload.get("illegal_files", []),
             })
+            illegal = scope_payload.get("illegal_files", []) or []
+            if illegal:
+                warn(f"SCOPE GUARD: {len(illegal)} file(s) outside publish allowlist in staging:")
+                for item in illegal:
+                    warn(f"  ↳ {item}")
+            raise SystemExit(2)
+        if scope_result.returncode != 0:
+            raise RuntimeError(scope_result.stderr.strip() or scope_result.stdout.strip() or "edge-publish-scope failed")
+
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--unified=3", "--", ".", ":(exclude)*.venv*", ":(exclude)*.b64", ":(exclude)*.png", ":(exclude)*.jpg", ":(exclude)*.pdf", ":(exclude)*.db"],
+            cwd=edge_dir, capture_output=True, text=True, errors="replace", timeout=30
+        )
+        edge_diff = result.stdout.strip()
+        if edge_diff:
+            current_file = None
+            current_lines = []
+            for line in edge_diff.split("\n"):
+                if line.startswith("diff --git a/"):
+                    if current_file and current_lines:
+                        all_diffs.append({
+                            "path": f"edge/{current_file}",
+                            "diff": "\n".join(current_lines)
+                        })
+                    file_parts = line.split(" b/", 1)
+                    current_file = file_parts[1] if len(file_parts) > 1 else line.split("a/", 1)[-1].split(" ")[0]
+                    current_lines = [line]
+                else:
+                    current_lines.append(line)
+            if current_file and current_lines:
+                all_diffs.append({
+                    "path": f"edge/{current_file}",
+                    "diff": "\n".join(current_lines)
+                })
 except Exception as e:
     log_failure("6", "diff_edge_repo", e, traceback.format_exc())
     warn(f"Diff edge repo failed: {e}")
@@ -1613,9 +1620,6 @@ if failures:
 lines.append("")
 
 # State audit summary (if audit ran)
-meta_dir = Path(os.environ.get("META_DIR", os.path.expanduser("~/edge/meta-reports")))
-proposal_path = meta_dir / f"{slug}.state-proposal.yaml"
-audit_path = meta_dir / f"{slug}.state-audit.yaml"
 if audit_path.exists():
     try:
         audit_data = yaml.safe_load(audit_path.read_text())
@@ -1729,18 +1733,21 @@ for dirpath, prefix in mini_repos_with_changes:
 
 # ── 6. Commit ~/edge/ ──
 try:
-    result = subprocess.run(
-        ["git", "commit", "-m", commit_msg],
-        cwd=edge_dir, capture_output=True, text=True, timeout=30
-    )
-    if result.returncode == 0:
-        hash_result = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
-            cwd=edge_dir, capture_output=True, text=True, timeout=10
-        )
-        ok(f"Commit: {hash_result.stdout.strip()}")
+    if not (Path(edge_dir) / ".git").exists():
+        warn(f"EDGE_REPO_DIR is not a git repository; skipping git commit: {edge_dir}")
     else:
-        warn("Nothing to commit or git failed")
+        result = subprocess.run(
+            ["git", "commit", "-m", commit_msg],
+            cwd=edge_dir, capture_output=True, text=True, timeout=30
+        )
+        if result.returncode == 0:
+            hash_result = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=edge_dir, capture_output=True, text=True, timeout=10
+            )
+            ok(f"Commit: {hash_result.stdout.strip()}")
+        else:
+            warn("Nothing to commit or git failed")
 except Exception as e:
     log_failure("6", "commit_edge", e, traceback.format_exc())
     fail(f"Git commit failed: {e}")
@@ -1773,8 +1780,8 @@ elif $ALL_OK; then
     [[ -n "$META_REPORT_PATH" ]] && echo " Meta-report: $META_REPORT_PATH"
     echo "========================================="
     ledger_record "pipeline-end" "partial"
-    emit_run_step_event "pipeline" "failed" "pipeline_end" "partial publication"
-    exit 2
+    emit_run_step_event "pipeline" "degraded" "pipeline_end" "partial publication"
+    exit 0
 else
     echo -e " ${RED}ISSUES${NC}: verify manually"
     echo "========================================="

--- a/tests/test_consolidate_phase6_paths.sh
+++ b/tests/test_consolidate_phase6_paths.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$EDGE_DIR/blog/consolidate-state.sh"
+
+python3 - "$SCRIPT" <<'PY'
+import pathlib
+import sys
+
+script = pathlib.Path(sys.argv[1])
+lines = script.read_text(encoding="utf-8").splitlines()
+
+def first_index(needle: str) -> int:
+    for idx, line in enumerate(lines, start=1):
+        if needle in line:
+            return idx
+    raise AssertionError(f"missing {needle!r}")
+
+phase6_start = first_index('emit_run_step_event "phase-6" "started"')
+definition = first_index('proposal_path = meta_dir / f"{slug}.state-proposal.yaml"')
+first_use = first_index('if proposal_path.exists():')
+audit_definition = first_index('audit_path = meta_dir / f"{slug}.state-audit.yaml"')
+audit_use = first_index('if audit_path.exists():')
+non_git_diff_guard = first_index('skipping scoped diff')
+non_git_commit_guard = first_index('skipping git commit')
+partial_degraded = first_index('emit_run_step_event "pipeline" "degraded" "pipeline_end" "partial publication"')
+
+assert phase6_start < definition < first_use, (
+    f"proposal_path must be defined before phase-6 allowlist use "
+    f"(phase6={phase6_start}, definition={definition}, use={first_use})"
+)
+assert phase6_start < audit_definition < audit_use, (
+    f"audit_path must be defined before phase-6 allowlist use "
+    f"(phase6={phase6_start}, definition={audit_definition}, use={audit_use})"
+)
+assert phase6_start < non_git_diff_guard, "non-git EDGE_REPO_DIR must skip scoped diff in phase 6"
+assert phase6_start < non_git_commit_guard, "non-git EDGE_REPO_DIR must skip git commit in phase 6"
+assert phase6_start < partial_degraded, "partial publication must be degraded, not a hard pipeline failure"
+PY
+
+echo "PASS: consolidate-state phase-6 paths are initialized before use"


### PR DESCRIPTION
## Summary

Fixes the consolidate-state resilience issues found while monitoring Ed's heartbeat:

- initializes phase-6 proposal/audit paths before the publish allowlist uses them
- skips scoped diff and git commit when `EDGE_REPO_DIR` is a rendered runtime directory without `.git`
- records partial publication as `degraded` and exits 0 so a post-publication warning does not induce retry loops
- adds a regression test for phase-6 path initialization and degraded partial publication behavior

## Validation

- `tests/test_consolidate_phase6_paths.sh`
- `bash tests/test_consolidate_adversarial_phase.sh`
- `bash tests/test_postflight_resilience.sh`
- `git diff --check`