### PR TITLE
[codex] Render source affordance postflight step

### DIFF
--- a/tests/test_runtime_router_config.sh
+++ b/tests/test_runtime_router_config.sh
@@ -61,6 +61,7 @@ edge_dir, config_path, tmp_base = sys.argv[1:]
 repo = Path(tmp_base) / "render-repo"
 (repo / "config").mkdir(parents=True, exist_ok=True)
 (repo / "config" / "runtime-routers.yaml.tpl").write_text("{{ RUNTIME_ROUTERS_FILE }}\n", encoding="utf-8")
+(repo / "config" / "postflight.yaml.tpl").write_text("{{ POSTFLIGHT_PROTOCOL_YAML }}\n", encoding="utf-8")
 
 os.environ["EDGE_STATE_DIR"] = str(Path(tmp_base) / "render-state")
 os.environ["EDGE_CYCLE_ID"] = "install:test-runtime-routers-render"
@@ -78,11 +79,13 @@ mod.render_all(repo, placeholders, dry_run=False)
 payload = yaml.safe_load((repo / "config" / "runtime-routers.yaml").read_text(encoding="utf-8"))
 assert payload["routers"]["review"]["base_url"] == "https://api.x.ai/v1"
 assert payload["routers"]["chat"]["model"] == "gpt-5.4"
+postflight = yaml.safe_load((repo / "config" / "postflight.yaml").read_text(encoding="utf-8"))
+assert any(item["kind"] == "source_affordance.digest" for item in postflight["procedures"])
 PY
 then
-    pass "edge-render materializes runtime-routers.yaml"
+    pass "edge-render materializes runtime routers and source affordance postflight"
 else
-    fail "edge-render materializes runtime-routers.yaml"
+    fail "edge-render materializes runtime routers and source affordance postflight"
 fi
 
 echo "--- Test 2: router_client reads runtime routers without agent.yaml ---"

--- a/tools/edge-render
+++ b/tools/edge-render
@@ -147,6 +147,7 @@ def _render_postflight_protocol(cfg: dict) -> str:
             {"id": "primitives-status", "kind": "primitives.status"},
             {"id": "capabilities-status", "kind": "capabilities.status"},
             {"id": "workflow-status", "kind": "workflow.status"},
+            {"id": "source-affordances", "kind": "source_affordance.digest"},
             {"id": "curation-digest", "kind": "curation.digest"},
             {"id": "briefing-refresh", "kind": "briefing.refresh"},
             {"id": "cycle-health-observe", "kind": "cycle_health.observe"},


### PR DESCRIPTION
## Summary

Keeps `edge-render` aligned with the checked-in postflight protocol by rendering the `source_affordance.digest` postflight step.

Root cause: PR #349 fixed the protocol compiler allowlist, but `edge-render` could still regenerate a postflight file without the affordance digest step. That would silently remove the digest refresh on future instance renders.

## Changes

- Adds `source_affordance.digest` to `_render_postflight_protocol`.
- Extends the runtime router render test to assert the rendered postflight contains the source affordance digest step.

## Validation

- `python3 -m py_compile tools/edge-render tools/_shared/protocol_runtime.py`
- `bash tests/test_runtime_router_config.sh`
- `bash tests/test_protocol_runtime.sh`