### PR TITLE
[codex] Block unbounded shell follow commands

### DIFF
--- a/hooks/shell-follow-guard.sh
+++ b/hooks/shell-follow-guard.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# shell-follow-guard.sh — Claude Code PreToolUse hook for Bash.
+#
+# Blocks unbounded shell follow commands that can keep autonomous beats open
+# after useful work has finished. The observed failure mode was:
+#
+#   tail -f /tmp/claude-.../tasks/<id>.output 2>&1 | head -200
+#
+# If the followed file stops before head receives enough lines, tail keeps the
+# pipe open forever. Use finite reads (`tail -n`, `sed -n`) for diagnostics
+# inside autonomous runs.
+
+set -euo pipefail
+
+if [[ "${EDGE_ALLOW_FOLLOW_COMMANDS:-0}" == "1" ]]; then
+    exit 0
+fi
+
+INPUT="$(cat)"
+
+python3 - <<'PY' "$INPUT"
+import json
+import os
+import shlex
+import sys
+
+raw_payload = sys.argv[1]
+try:
+    payload = json.loads(raw_payload)
+except Exception:
+    raise SystemExit(0)
+
+tool_name = str(payload.get("tool_name") or "").strip()
+if tool_name != "Bash":
+    raise SystemExit(0)
+
+tool_input = payload.get("tool_input") or {}
+command = str(tool_input.get("command") or tool_input.get("cmd") or "").strip()
+if not command:
+    raise SystemExit(0)
+
+
+def _is_tail_token(token: str) -> bool:
+    return os.path.basename(token) in {"tail", "gtail"}
+
+
+def _tail_has_follow_flag(tokens: list[str], start: int) -> bool:
+    idx = start + 1
+    while idx < len(tokens):
+        token = tokens[idx]
+        if token in {"|", ";", "&&", "||", "&"}:
+            return False
+        if token == "--":
+            return False
+        if token in {"--follow", "-f", "-F"}:
+            return True
+        if token.startswith("--follow="):
+            return True
+        if token.startswith("-") and not token.startswith("--") and any(ch in token[1:] for ch in ("f", "F")):
+            return True
+        if not token.startswith("-"):
+            return False
+        idx += 1
+    return False
+
+
+def _contains_blocked_follow(command_text: str, depth: int = 0) -> bool:
+    if depth > 2:
+        return False
+    try:
+        tokens = shlex.split(command_text, posix=True)
+    except ValueError:
+        # If the command cannot be parsed safely, do not block on a guess.
+        return False
+
+    for idx, token in enumerate(tokens):
+        if _is_tail_token(token) and _tail_has_follow_flag(tokens, idx):
+            return True
+        if os.path.basename(token) in {"bash", "sh", "zsh"}:
+            for offset, candidate in enumerate(tokens[idx + 1 :], start=idx + 1):
+                if candidate in {"-c", "-lc", "-ic"} and offset + 1 < len(tokens):
+                    if _contains_blocked_follow(tokens[offset + 1], depth + 1):
+                        return True
+    return False
+
+
+if not _contains_blocked_follow(command):
+    raise SystemExit(0)
+
+sys.stderr.write(
+    "[shell-follow-guard] BLOCKED: unbounded follow command in Bash tool.\n"
+    f"  command: {command[:240]}\n"
+    "  reason: tail -f/--follow can keep autonomous heartbeats open forever.\n"
+    "  use: finite reads such as `tail -n 200 <file>` or `sed -n '1,200p' <file>`.\n"
+    "  escape hatch for manual debugging only: EDGE_ALLOW_FOLLOW_COMMANDS=1.\n"
+)
+raise SystemExit(2)
+PY

--- a/tests/test_shell_follow_guard.sh
+++ b/tests/test_shell_follow_guard.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$EDGE_DIR/hooks/shell-follow-guard.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+run_hook() {
+  local payload="$1"
+  set +e
+  OUTPUT=$(bash "$HOOK" <<<"$payload" 2>&1)
+  STATUS=$?
+  set -e
+}
+
+payload() {
+  python3 - <<'PY' "$1" "$2"
+import json
+import sys
+print(json.dumps({"tool_name": sys.argv[1], "tool_input": {"command": sys.argv[2]}}))
+PY
+}
+
+echo "=== shell follow guard Smoke Test ==="
+echo ""
+
+echo "--- Test 1: blocks tail -f ---"
+run_hook "$(payload Bash 'tail -f /tmp/output.log')"
+if [[ "$STATUS" -eq 2 ]] && grep -q "BLOCKED" <<<"$OUTPUT"; then
+  pass "hook blocks tail -f"
+else
+  echo "$OUTPUT"
+  fail "hook blocks tail -f"
+fi
+
+echo "--- Test 2: blocks tail -F in a pipeline ---"
+run_hook "$(payload Bash 'tail -F /tmp/output.log 2>&1 | head -200')"
+if [[ "$STATUS" -eq 2 ]] && grep -q "tail -f/--follow" <<<"$OUTPUT"; then
+  pass "hook blocks tail -F pipeline"
+else
+  echo "$OUTPUT"
+  fail "hook blocks tail -F pipeline"
+fi
+
+echo "--- Test 3: blocks tail --follow ---"
+run_hook "$(payload Bash 'tail --follow=name /tmp/output.log')"
+if [[ "$STATUS" -eq 2 ]]; then
+  pass "hook blocks tail --follow"
+else
+  echo "$OUTPUT"
+  fail "hook blocks tail --follow"
+fi
+
+echo "--- Test 4: blocks nested bash -lc tail -f ---"
+run_hook "$(payload Bash "bash -lc 'tail -f /tmp/output.log | head -200'")"
+if [[ "$STATUS" -eq 2 ]]; then
+  pass "hook blocks nested bash -lc tail -f"
+else
+  echo "$OUTPUT"
+  fail "hook blocks nested bash -lc tail -f"
+fi
+
+echo "--- Test 5: allows finite tail reads ---"
+run_hook "$(payload Bash 'tail -n 200 /tmp/output.log')"
+if [[ "$STATUS" -eq 0 ]]; then
+  pass "hook allows tail -n"
+else
+  echo "$OUTPUT"
+  fail "hook allows tail -n"
+fi
+
+echo "--- Test 6: allows quoted text mentioning tail -f ---"
+run_hook "$(payload Bash 'echo \"tail -f /tmp/output.log\"')"
+if [[ "$STATUS" -eq 0 ]]; then
+  pass "hook allows quoted tail -f text"
+else
+  echo "$OUTPUT"
+  fail "hook allows quoted tail -f text"
+fi
+
+echo "--- Test 7: ignores non-Bash tools ---"
+run_hook '{"tool_name":"WebSearch","tool_input":{"query":"tail -f bug"}}'
+if [[ "$STATUS" -eq 0 ]]; then
+  pass "hook ignores non-Bash tools"
+else
+  echo "$OUTPUT"
+  fail "hook ignores non-Bash tools"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -676,10 +676,11 @@ def phase_identity(cfg, dry_run):
 
 def phase_hooks(cfg, dry_run):
     """Install Claude PreToolUse hooks and register them in settings.json."""
-    header("4b/8  Hooks (write guard + web search policy)")
+    header("4b/8  Hooks (write guard + web/search/shell policy)")
     hook_specs = [
         ("write-guard.sh", "Write|Edit|NotebookEdit"),
         ("web-search-policy-guard.sh", "WebSearch|WebFetch"),
+        ("shell-follow-guard.sh", "Bash"),
     ]
 
     hooks_dst = Path.home() / ".claude" / "hooks"


### PR DESCRIPTION
## Summary
- Add a Claude Bash PreToolUse hook that blocks unbounded `tail -f` / `tail --follow` commands.
- Register the hook during `edge-apply` with the existing write/web policy hooks.
- Add smoke coverage for direct, piped, long-form, nested-shell, finite-read, quoted-text, and non-Bash cases.

## Validation
- `bash -n hooks/shell-follow-guard.sh`
- `bash -n tests/test_shell_follow_guard.sh`
- `bash tests/test_shell_follow_guard.sh`
- `bash tests/test_web_search_policy_guard.sh`
- `bash tests/test_edge_publish_guard.sh`

Fixes #351.