### PR TITLE
[codex] Show heartbeat output in foreground

### DIFF
--- a/config/heartbeat.sh.tpl
+++ b/config/heartbeat.sh.tpl
@@ -26,18 +26,28 @@ mkdir -p "$LOGS_DIR"
 
 cd "$EDGE_REPO_DIR"
 
-# Run heartbeat through our CLI boundary. The runner owns the shadow
-# dispatch lifecycle so the skill body no longer needs to open/close it.
-"$EDGE_REPO_DIR/tools/edge-runner" skill \
-    --skill "$SKILL" \
-    --dispatch-trigger heartbeat \
-    --dispatch-policy autonomous \
-    --dispatch-routing-mode auto \
-    --dispatch-preflight-profile heartbeat_default \
-    --dispatch-postflight-profile standard \
-    --dispatch-force \
-    --dangerously-skip-permissions \
-    >> "$LOGFILE" 2>&1
+run_heartbeat() {
+    "$EDGE_REPO_DIR/tools/edge-runner" skill \
+        --skill "$SKILL" \
+        --dispatch-trigger heartbeat \
+        --dispatch-policy autonomous \
+        --dispatch-routing-mode auto \
+        --dispatch-preflight-profile heartbeat_default \
+        --dispatch-postflight-profile standard \
+        --dispatch-force \
+        --dangerously-skip-permissions
+}
+
+# Systemd should stay quiet and log to file. Manual terminal runs should show
+# the dispatch and follow-on skill live while still keeping the same log trail.
+HEARTBEAT_STATUS=0
+if [[ -t 1 || "${EDGE_HEARTBEAT_FOREGROUND:-0}" == "1" ]]; then
+    run_heartbeat 2>&1 | tee -a "$LOGFILE"
+    HEARTBEAT_STATUS=${PIPESTATUS[0]}
+else
+    run_heartbeat >> "$LOGFILE" 2>&1
+    HEARTBEAT_STATUS=$?
+fi
 
 # Index new content after heartbeat
 if command -v edge-index &>/dev/null; then
@@ -45,3 +55,5 @@ if command -v edge-index &>/dev/null; then
         [ -f "$f" ] && edge-index "$f" 2>/dev/null
     done
 fi
+
+exit "$HEARTBEAT_STATUS"

--- a/tests/test_heartbeat_entrypoints.sh
+++ b/tests/test_heartbeat_entrypoints.sh
@@ -61,6 +61,29 @@ else
     fail "heartbeat skill documents fallback lifecycle and the minimal router contract"
 fi
 
+echo "--- Test 3: heartbeat wrapper streams manual runs while preserving systemd logging ---"
+if python3 - <<'PY' "$EDGE_DIR/config/heartbeat.sh.tpl"
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+required = [
+    "run_heartbeat()",
+    'if [[ -t 1 || "${EDGE_HEARTBEAT_FOREGROUND:-0}" == "1" ]]; then',
+    'run_heartbeat 2>&1 | tee -a "$LOGFILE"',
+    "HEARTBEAT_STATUS=${PIPESTATUS[0]}",
+    'run_heartbeat >> "$LOGFILE" 2>&1',
+    'exit "$HEARTBEAT_STATUS"',
+]
+for needle in required:
+    assert needle in text, needle
+PY
+then
+    pass "heartbeat wrapper shows manual runs and keeps systemd log behavior"
+else
+    fail "heartbeat wrapper shows manual runs and keeps systemd log behavior"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"


### PR DESCRIPTION
## Summary
- Stream manual/TTY heartbeat runs through `tee` so the operator sees dispatch and follow-on skill output live.
- Keep non-interactive/systemd runs quiet with file-only logging.
- Preserve the `edge-runner` exit status after post-run indexing.
- Add a heartbeat entrypoint contract test for foreground behavior.

## Validation
- `bash -n config/heartbeat.sh.tpl`
- `bash tests/test_heartbeat_entrypoints.sh`
- `python3 tools/edge-render --config /home/vboxuser/edge/agent.yaml --dry-run`
- `git diff --check`

Fixes #355.