### PR TITLE
[codex] Fix render install drift rollup false positives

### DIFF
--- a/tests/test_render_install_drift.sh
+++ b/tests/test_render_install_drift.sh
@@ -38,6 +38,10 @@ good = edge / "install" / "claude.md"
 good.write_text("same", encoding="utf-8")
 mismatch = edge / "install" / "paths.py"
 mismatch.write_text("installed", encoding="utf-8")
+in_place = edge / "install" / "in-place.md"
+in_place.write_text("same", encoding="utf-8")
+superseded = edge / "install" / "seeded.md"
+superseded.write_text("seeded", encoding="utf-8")
 events = [
     {
         "ts": "2026-04-20T20:00:00+00:00",
@@ -137,6 +141,61 @@ events = [
             "detail": "missing.md: not found",
         },
     },
+    {
+        "ts": "2026-04-20T20:08:00+00:00",
+        "type": "RenderProduced",
+        "artifact": str(edge / "install" / "obsolete.md"),
+        "payload": {
+            "source_template": "config/obsolete.md.tpl",
+            "output_path": "config/obsolete.md",
+            "hash": "sha256:obsolete-render",
+            "residual_count": 1,
+        },
+    },
+    {
+        "ts": "2026-04-20T20:10:00+00:00",
+        "type": "RenderProduced",
+        "artifact": str(in_place),
+        "payload": {
+            "source_template": "config/in-place.md.tpl",
+            "output_path": "config/in-place.md",
+            "hash": "sha256:0967115f2813a3541eaef77de9d9d5773f1c0c04314b0bbfe4ff3b3b1c55b5d5",
+            "residual_count": 0,
+        },
+    },
+    {
+        "ts": "2026-04-20T20:11:00+00:00",
+        "type": "RenderProduced",
+        "artifact": str(superseded),
+        "payload": {
+            "source_template": "config/seeded.md.tpl",
+            "output_path": "config/seeded.md",
+            "hash": "sha256:rendered-seed",
+            "residual_count": 0,
+        },
+    },
+    {
+        "ts": "2026-04-20T20:12:00+00:00",
+        "type": "InstallApplied",
+        "artifact": str(superseded),
+        "payload": {
+            "source_template": "generated:seed:seeded",
+            "hash": "sha256:seeded",
+            "kind": "file",
+            "action": "write",
+        },
+    },
+    {
+        "ts": "2026-04-20T20:13:00+00:00",
+        "type": "InstallCheckObserved",
+        "artifact": str(edge / "state" / "render-install-drift.json"),
+        "payload": {
+            "check_id": "projection:render-install-drift",
+            "status": "fail",
+            "severity": "fail",
+            "detail": "self-referential prior failure",
+        },
+    },
 ]
 log_path = edge / "state" / "events" / "log.jsonl"
 with open(log_path, "w", encoding="utf-8") as f:
@@ -152,9 +211,9 @@ from pathlib import Path
 
 payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 summary = payload["summary"]
-assert summary["rendered_outputs"] == 3
-assert summary["installed_artifacts"] == 3
-assert summary["render_linked_installs"] == 2
+assert summary["rendered_outputs"] == 5
+assert summary["installed_artifacts"] == 4
+assert summary["render_linked_installs"] == 3
 assert summary["rendered_without_install"] == 1
 assert summary["install_without_render"] == 1
 assert summary["hash_mismatches"] == 1
@@ -178,7 +237,11 @@ assert payload["rendered_without_install"][0]["output_path"] == "config/branding
 assert payload["hash_mismatches"][0]["output_path"] == "config/paths.py"
 assert payload["missing_on_disk"][0]["artifact"].endswith("missing.md")
 assert all(not item["artifact"].endswith(".avatar-gen.py") for item in payload["missing_on_disk"])
+assert all(item["output_path"] != "config/obsolete.md" for item in payload["hash_mismatches"])
+assert all(item["output_path"] != "config/in-place.md" for item in payload["rendered_without_install"])
+assert all(item["output_path"] != "config/seeded.md" for item in payload["rendered_without_install"])
 assert payload["doctor_failures"][0]["check_id"] == "file:missing-md"
+assert all(item["check_id"] != "projection:render-install-drift" for item in payload["doctor_failures"])
 PY
 then
     pass "rollup captures representative examples"

--- a/tools/rollup-render-install-drift.py
+++ b/tools/rollup-render-install-drift.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import json
 import sys
+import hashlib
 from datetime import datetime, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import RENDER_INSTALL_DRIFT_FILE, STATE_EVENTS_FILE  # noqa: E402
+from paths import EDGE_REPO_DIR, RENDER_INSTALL_DRIFT_FILE, STATE_EVENTS_FILE  # noqa: E402
 
 
 def _iter_jsonl(path: Path):
@@ -43,6 +44,28 @@ def _latest_by_key(existing: dict, key: str, event: dict) -> None:
         existing[key] = event
 
 
+def _repo_relative(path: str | None) -> str:
+    if not path:
+        return ""
+    try:
+        return str(Path(path).resolve().relative_to(EDGE_REPO_DIR.resolve()))
+    except (OSError, ValueError):
+        return str(path)
+
+
+def _hash_file(path: Path) -> str:
+    return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+
+
+def _is_in_place_self_install(event: dict) -> bool:
+    payload = event.get("payload") or {}
+    if payload.get("in_place") is not True:
+        return False
+    artifact = str(event.get("artifact") or "")
+    source_template = str(payload.get("source_template") or "")
+    return bool(source_template and source_template == _repo_relative(artifact))
+
+
 def build_projection(limit: int = 20) -> dict:
     render_by_output: dict[str, dict] = {}
     install_by_artifact: dict[str, dict] = {}
@@ -53,6 +76,8 @@ def build_projection(limit: int = 20) -> dict:
         etype = event.get("type")
         payload = event.get("payload") or {}
         if etype == "RenderProduced":
+            if int(payload.get("residual_count", 0) or 0) > 0:
+                continue
             output_path = str(payload.get("output_path") or event.get("artifact") or "")
             _latest_by_key(render_by_output, output_path, event)
         elif etype == "InstallApplied":
@@ -83,6 +108,21 @@ def build_projection(limit: int = 20) -> dict:
     for output_path, render_event in render_by_output.items():
         installs = installs_by_source.get(output_path, [])
         if not installs:
+            artifact = str(render_event.get("artifact") or "")
+            render_ts = _parse_ts(render_event.get("ts"))
+            active_install = active_installs.get(artifact)
+            if active_install and _parse_ts(active_install.get("ts")) >= render_ts:
+                continue
+
+            render_hash = (render_event.get("payload") or {}).get("hash")
+            artifact_path = Path(artifact) if artifact else None
+            if artifact_path and artifact_path.exists() and render_hash:
+                try:
+                    if _hash_file(artifact_path) == render_hash:
+                        linked_installs += 1
+                        continue
+                except OSError:
+                    pass
             rendered_without_install.append(
                 {
                     "output_path": output_path,
@@ -111,14 +151,15 @@ def build_projection(limit: int = 20) -> dict:
         payload = install_event.get("payload") or {}
         source_template = str(payload.get("source_template") or "")
         if source_template and source_template not in render_by_output and not source_template.startswith(("generated:", "command:")):
-            install_without_render.append(
-                {
-                    "artifact": artifact,
-                    "source_template": source_template,
-                    "kind": payload.get("kind"),
-                    "action": payload.get("action"),
-                }
-            )
+            if not _is_in_place_self_install(install_event):
+                install_without_render.append(
+                    {
+                        "artifact": artifact,
+                        "source_template": source_template,
+                        "kind": payload.get("kind"),
+                        "action": payload.get("action"),
+                    }
+                )
         if artifact and not Path(artifact).exists():
             missing_on_disk.append(
                 {
@@ -132,6 +173,8 @@ def build_projection(limit: int = 20) -> dict:
     doctor_warnings = []
     for event in checks_by_id.values():
         payload = event.get("payload") or {}
+        if payload.get("check_id") == "projection:render-install-drift":
+            continue
         entry = {
             "check_id": payload.get("check_id"),
             "status": payload.get("status"),


### PR DESCRIPTION
## Summary

Fixes false positives in `rollup-render-install-drift.py` that made healthy installs look critically drifted after the pre/post-skill migration.

## Root Cause

The projection treated residual render events, in-place rendered files, generated seed overwrites, and the projection's own previous doctor failure as current drift.

## Changes

- Ignore render events with residual placeholders.
- Treat later generated writes as superseding earlier render output.
- Accept in-place render output when the artifact exists and matches the render hash.
- Exclude `projection:render-install-drift` from its own doctor-failure count.
- Extend the drift smoke test to cover these cases.

## Validation

- `./tests/test_render_install_drift.sh`
- `./tests/test_edge_signals.sh`
- `./tests/test_edge_apply_bookkeeping_drift.sh`
- `python3 -m py_compile tools/rollup-render-install-drift.py`