### PR TITLE
[codex] Ignore install-only render drift signals

### DIFF
--- a/tests/test_edge_signals.sh
+++ b/tests/test_edge_signals.sh
@@ -134,6 +134,29 @@ else
   fail "edge-signals returns priority state signals and primitive warning"
 fi
 
+cat >"$TMP_STATE/state/render-install-drift.json" <<'JSON'
+{
+  "summary": {"rendered_without_install": 0, "install_without_render": 67, "hash_mismatches": 0, "missing_on_disk": 0, "doctor_warn": 0, "doctor_fail": 0}
+}
+JSON
+
+OUTPUT_INSTALL_ONLY=$(EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="sigtest" \
+  "$EDGE_DIR/tools/edge-signals" --json --limit 20)
+
+if python3 - <<'PY' "$OUTPUT_INSTALL_ONLY"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+signals = {item["id"]: item for item in payload["signals"]}
+assert "render_install.drift" not in signals
+PY
+then
+  pass "edge-signals ignores install-only render drift bookkeeping"
+else
+  fail "edge-signals emitted false render drift warning for install-only bookkeeping"
+fi
+
 if grep -q '"type": "OdiObserved"' "$TMP_STATE/state/events/log.jsonl" && grep -q '"source_id": "signal.primitives"' "$TMP_STATE/state/events/log.jsonl"; then
   pass "edge-signals emits ODI observations for atomic signal channels"
 else

--- a/tools/_shared/signal_runtime.py
+++ b/tools/_shared/signal_runtime.py
@@ -430,7 +430,7 @@ def collect_render_install_signal(signals: list[dict[str, Any]]) -> None:
         return
     drift_total = sum(
         int(summary.get(key, 0) or 0)
-        for key in ("rendered_without_install", "install_without_render", "hash_mismatches", "missing_on_disk", "doctor_fail")
+        for key in ("rendered_without_install", "hash_mismatches", "missing_on_disk", "doctor_fail")
     )
     warning_total = int(summary.get("doctor_warn", 0) or 0)
     if not drift_total and not warning_total:


### PR DESCRIPTION
## Summary

Aligns `edge-signals` with `edge-doctor` by not treating `install_without_render` bookkeeping as hard render/apply drift.

## Root Cause

The render/install projection legitimately tracks installed artifacts such as skills copied from `skills/*`, but those install-only records are not a doctor failure. `edge-signals` still included them in the hard drift count, producing noisy route warnings after a healthy `edge-apply`.

## Changes

- Exclude `install_without_render` from the hard drift signal count.
- Keep actual drift conditions: `rendered_without_install`, `hash_mismatches`, `missing_on_disk`, and `doctor_fail`.
- Add a smoke test proving install-only bookkeeping does not emit `render_install.drift`.

## Validation

- `./tests/test_edge_signals.sh`
- `./tests/test_render_install_drift.sh`
- `python3 -m py_compile tools/_shared/signal_runtime.py`