### PR TITLE
[codex] Re-enter direct heartbeat slash through runner

### DIFF
--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -10,6 +10,23 @@ The heartbeat is a router, not a worker.
 
 Its job is to choose the next internal skill and dispatch it quickly.
 
+## Direct Slash Re-entry
+
+If `EDGE_CYCLE_ID` is empty, this slash command was invoked directly inside
+Claude instead of through `edge-runner`. Do not open a cycle manually in that
+case. Re-enter through the canonical wrapper so the parent runner owns
+preflight, dispatch, follow-on skill execution, postflight, and foreground
+output:
+
+```bash
+if [ -z "${EDGE_CYCLE_ID:-}" ]; then
+  EDGE_HEARTBEAT_FOREGROUND=1 ~/.local/bin/heartbeat.sh
+fi
+```
+
+After that command returns, stop. Do not call `edge-dispatch open`,
+`edge-dispatch dispatch`, or `edge-close` from the direct slash process.
+
 ## What The Runtime Already Did
 
 By the time this skill starts, the runtime already handled the mechanical layer:
@@ -145,29 +162,9 @@ Direct `/ed-heartbeat` invocation is still a full beat.
 
 It is not a preview and not a planning-only mode.
 
-The heartbeat still must dispatch one internal skill and let the normal lifecycle continue.
-
-If `EDGE_CYCLE_ID` is empty, open the fallback lifecycle before routing:
-
-```bash
-if [ -z "${EDGE_CYCLE_ID:-}" ]; then
-  edge-dispatch open \
-    --trigger heartbeat \
-    --policy autonomous \
-    --routing-mode auto \
-    --preflight-profile heartbeat_default \
-    --postflight-profile standard \
-    --force
-fi
-```
-
-If this direct invocation path opened the fallback lifecycle itself, close it through the normal closer after the beat completes:
-
-```bash
-if [ -z "${EDGE_CYCLE_ID:-}" ]; then
-  edge-close --status completed
-fi
-```
+The heartbeat still must run through the normal lifecycle. Direct slash
+invocation re-enters via `~/.local/bin/heartbeat.sh`; it does not manually
+manage the lifecycle.
 
 ## Router-only rule:
 

--- a/tests/test_heartbeat_entrypoints.sh
+++ b/tests/test_heartbeat_entrypoints.sh
@@ -34,7 +34,7 @@ else
     fail "manual docs avoid the direct slash-command bootstrap path"
 fi
 
-echo "--- Test 2: heartbeat skill carries fallback lifecycle + no-HITL contract ---"
+echo "--- Test 2: direct heartbeat slash re-enters through wrapper instead of manual lifecycle ---"
 if python3 - <<'PY' "$EDGE_DIR/skills/heartbeat/SKILL.md"
 from pathlib import Path
 import sys
@@ -42,23 +42,30 @@ import sys
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
 required = [
     "Direct `/ed-heartbeat` invocation is still a full beat.",
+    "Direct Slash Re-entry",
     "The heartbeat is a router, not a worker.",
     "It must dispatch exactly one internal skill.",
     "Router-only rule:",
     "does not draft the final artifact",
     "After `edge-dispatch dispatch --skill <skill>` succeeds, stop doing inline work",
-    "edge-dispatch open \\",
-    '--trigger heartbeat',
     'if [ -z "${EDGE_CYCLE_ID:-}" ]; then',
-    'edge-close --status completed',
+    'EDGE_HEARTBEAT_FOREGROUND=1 ~/.local/bin/heartbeat.sh',
+    "Do not call `edge-dispatch open`",
+    "invocation re-enters via `~/.local/bin/heartbeat.sh`",
 ]
 for needle in required:
     assert needle in text, needle
+for forbidden in [
+    "edge-dispatch open \\",
+    "--trigger heartbeat",
+    "edge-close --status completed",
+]:
+    assert forbidden not in text, forbidden
 PY
 then
-    pass "heartbeat skill documents fallback lifecycle and the minimal router contract"
+    pass "heartbeat skill delegates direct slash invocation to the wrapper"
 else
-    fail "heartbeat skill documents fallback lifecycle and the minimal router contract"
+    fail "heartbeat skill delegates direct slash invocation to the wrapper"
 fi
 
 echo "--- Test 3: heartbeat wrapper streams manual runs while preserving systemd logging ---"


### PR DESCRIPTION
## Summary
- Change direct `/ed-heartbeat` fallback behavior to re-enter through `EDGE_HEARTBEAT_FOREGROUND=1 ~/.local/bin/heartbeat.sh` when `EDGE_CYCLE_ID` is empty.
- Remove stale direct slash lifecycle instructions that manually used `edge-dispatch open` / `edge-close`.
- Update heartbeat entrypoint tests to ensure direct slash delegates to the wrapper instead of bypassing `edge-runner`.

## Validation
- `bash tests/test_heartbeat_entrypoints.sh`
- `python3 tools/edge-render --config /home/vboxuser/edge/agent.yaml --dry-run`
- `git diff --check`

Fixes #359.