### PR TITLE
Move async chat acknowledgement to postflight

### DIFF
--- a/config/postflight.yaml
+++ b/config/postflight.yaml
@@ -19,3 +19,5 @@ procedures:
     kind: briefing.refresh
   - id: cycle-health
     kind: cycle_health.observe
+  - id: async-inbox-response
+    kind: async_inbox.respond

--- a/skills/_shared/state-protocol.md
+++ b/skills/_shared/state-protocol.md
@@ -89,9 +89,10 @@ Rules:
   rotation, or opportunistic work.
 - `task_intents`, `steering_intents`, and `runtime_intents` are operator
   instructions queued for the **next dispatch**, not immediate mutations.
-- Do **not** mark chat messages as processed manually inside the skill. The
-  captured `message_ids` are consumed by `edge-close` only after successful
-  completion of the cycle.
+- Do **not** mark chat messages as processed or post manual acknowledgements
+  inside the skill. The captured `message_ids` are acknowledged and consumed
+  by the `async_inbox.respond` postflight procedure only after the skill
+  reaches completion evidence.
 - The shared protocol is the genotype of this rule. `pre-skill` is its
   phenotype. They must agree: user interaction outranks generic exploration.
 

--- a/skills/reflection/SKILL.md
+++ b/skills/reflection/SKILL.md
@@ -433,7 +433,8 @@ If found:
 - Execute changes
 - Mark as `[PROCESSED]`
 
-Read async chat (HN-4) — classify but DO NOT respond.
+Read async chat (HN-4) — classify it, but do not manually acknowledge or mark
+it processed; postflight owns the final dashboard acknowledgement.
 
 ### M-7: Evaluate pending discoveries
 

--- a/tests/test_postflight_resilience.sh
+++ b/tests/test_postflight_resilience.sh
@@ -15,7 +15,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$TMP_EDGE/state" "$TMP_EDGE/logs"
+mkdir -p "$TMP_EDGE/state" "$TMP_EDGE/logs" "$TMP_EDGE/search"
 
 export EDGE_REPO_DIR="$EDGE_DIR"
 export EDGE_STATE_DIR="$TMP_EDGE"
@@ -80,6 +80,115 @@ then
     pass "postflight exceptions degrade to warning instead of aborting"
 else
     fail "postflight exceptions degrade to warning instead of aborting"
+fi
+
+echo "--- Test 2: async inbox postflight responds before consuming captured chat ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import importlib.machinery
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+sys.path.insert(0, str(edge_dir / "search"))
+from dashboard_db import add_chat, get_chats
+
+loader = importlib.machinery.SourceFileLoader("edge_postflight", str(edge_dir / "tools" / "edge-postflight"))
+spec = importlib.util.spec_from_loader("edge_postflight", loader)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+captured_id = add_chat("user", "Please use the async dashboard input in this cycle.")
+late_id = add_chat("user", "This arrived after dispatch and should stay pending.")
+state = {
+    "cycle_id": "cycle-postflight-inbox",
+    "request": {
+        "skill": "research",
+        "async_inbox": {
+            "skill": "research",
+            "message_ids": [captured_id],
+            "direct_messages": [{
+                "chat_id": captured_id,
+                "author": "user",
+                "text": "Please use the async dashboard input in this cycle.",
+                "preview": "Please use the async dashboard input in this cycle.",
+            }],
+            "task_intents": [],
+            "steering_intents": [],
+            "runtime_intents": [],
+            "pinned_messages": [],
+        },
+    },
+    "state": {},
+}
+
+result = module._execute_postflight_step(
+    {"id": "async-inbox-response", "kind": "async_inbox.respond"},
+    state,
+)
+messages = get_chats(limit=20)
+by_id = {int(item["id"]): item for item in messages}
+replies = [
+    item for item in messages
+    if item["author"] == "system" and "Processed async dashboard input" in item["text"]
+]
+
+assert result["status"] == "ok"
+assert result["satisfied"] is True
+assert by_id[captured_id]["processed"] == 1
+assert by_id[late_id]["processed"] == 0
+assert replies
+assert "cycle-postflight-inbox" in replies[-1]["text"]
+assert replies[-1]["processed"] == 1
+assert state["request"]["async_inbox"]["response_chat_id"] == replies[-1]["id"]
+assert state["request"]["async_inbox"]["response_processed"] is True
+assert state["request"]["async_inbox"]["processed_message_ids"] == [captured_id]
+PY
+then
+    pass "async inbox response is written before captured messages are consumed"
+else
+    fail "async inbox response is written before captured messages are consumed"
+fi
+
+echo "--- Test 3: async inbox response failure is a warning step ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+loader = importlib.machinery.SourceFileLoader("edge_postflight", str(edge_dir / "tools" / "edge-postflight"))
+spec = importlib.util.spec_from_loader("edge_postflight", loader)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+original_ack = module.acknowledge_captured_inbox
+try:
+    module.acknowledge_captured_inbox = lambda _state: {
+        "ok": False,
+        "detail": "dashboard unavailable",
+        "reply_posted": False,
+        "processed_count": 0,
+        "captured_total": 1,
+    }
+    result = module._execute_postflight_step(
+        {"id": "async-inbox-response", "kind": "async_inbox.respond"},
+        {"request": {"skill": "research", "async_inbox": {"message_ids": [1]}}, "state": {}},
+    )
+    assert result["status"] == "warning"
+    assert result["satisfied"] is False
+    assert result["payload"]["processed_count"] == 0
+finally:
+    module.acknowledge_captured_inbox = original_ack
+PY
+then
+    pass "async inbox response failures degrade to warning"
+else
+    fail "async inbox response failures degrade to warning"
 fi
 
 echo ""

--- a/tests/test_skill_inbox.sh
+++ b/tests/test_skill_inbox.sh
@@ -164,12 +164,29 @@ else
     fail "edge-skill-inbox subprocess fallback stays deterministic during an active cycle"
 fi
 
-echo "--- Test 3: successful close consumes only the captured inbox ---"
+echo "--- Test 3: postflight acknowledgement consumes only the captured inbox ---"
 EDGE_CYCLE_ID=cycle-skill-inbox "$STEP_TOOL" research start >/dev/null
 EDGE_CYCLE_ID=cycle-skill-inbox "$STEP_TOOL" research end >/dev/null
+ACK_OUTPUT=$(python3 - <<'PY' "$EDGE_DIR" "$TMP_EDGE/state/current-dispatch.json"
+import json
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+state_path = Path(sys.argv[2])
+sys.path.insert(0, str(edge_dir / "tools"))
+
+from _shared.skill_inbox import acknowledge_captured_inbox
+
+state = json.loads(state_path.read_text(encoding="utf-8"))
+result = acknowledge_captured_inbox(state)
+state_path.write_text(json.dumps(state, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+print(json.dumps(result, ensure_ascii=False))
+PY
+)
 "$CLOSE_TOOL" --status completed >/dev/null
 
-if python3 - <<'PY' "$EDGE_DIR" "$SEED_OUTPUT" "$LATE_OUTPUT" "$TMP_EDGE/state/current-dispatch.json"
+if python3 - <<'PY' "$EDGE_DIR" "$SEED_OUTPUT" "$LATE_OUTPUT" "$TMP_EDGE/state/current-dispatch.json" "$ACK_OUTPUT"
 import json
 import sys
 
@@ -177,26 +194,37 @@ edge_dir = sys.argv[1]
 seed = json.loads(sys.argv[2])
 late = json.loads(sys.argv[3])
 dispatch = json.load(open(sys.argv[4], encoding="utf-8"))
+ack = json.loads(sys.argv[5])
 
 sys.path.insert(0, edge_dir + "/search")
 from dashboard_db import get_chats
 
-messages = {int(item["id"]): item for item in get_chats(limit=20)}
+all_messages = get_chats(limit=20)
+messages = {int(item["id"]): item for item in all_messages}
 for chat_id in seed["captured_ids"]:
     assert messages[chat_id]["processed"] == 1
 assert messages[seed["pinned_id"]]["pinned"] == 1
 assert messages[late["late_id"]]["processed"] == 0
+replies = [
+    item for item in all_messages
+    if item["author"] == "system" and "Processed async dashboard input" in item["text"]
+]
+assert replies
 
 inbox = dispatch["request"]["async_inbox"]
 assert dispatch["state"]["close_status"] == "completed"
 assert inbox["processed_count"] == 5
 assert inbox["processed_message_ids"] == seed["captured_ids"]
+assert inbox["response_chat_id"] == replies[-1]["id"]
+assert inbox["response_processed"] is True
+assert ack["reply_id"] == replies[-1]["id"]
+assert replies[-1]["processed"] == 1
 assert "processed_at" in inbox
 PY
 then
-    pass "edge-close consumes captured ids and leaves late input for the next cycle"
+    pass "postflight acknowledgement consumes captured ids and leaves late input for the next cycle"
 else
-    fail "edge-close consumes captured ids and leaves late input for the next cycle"
+    fail "postflight acknowledgement consumes captured ids and leaves late input for the next cycle"
 fi
 
 echo "--- Test 4: after close, read falls back to the live inbox ---"

--- a/tools/_shared/skill_inbox.py
+++ b/tools/_shared/skill_inbox.py
@@ -22,12 +22,12 @@ sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "search"))
 
 def _load_dashboard_chat_api():
     if os.environ.get("EDGE_SKILL_INBOX_FORCE_SUBPROCESS") == "1":
-        return None, None
+        return None, None, None
     try:
-        from dashboard_db import get_chats, mark_chat_processed  # type: ignore
+        from dashboard_db import add_chat, get_chats, mark_chat_processed  # type: ignore
     except Exception:
-        return None, None
-    return get_chats, mark_chat_processed
+        return None, None, None
+    return get_chats, add_chat, mark_chat_processed
 
 
 def _search_python() -> str | None:
@@ -53,7 +53,7 @@ search_dir = Path(sys.argv[1])
 payload = json.loads(sys.argv[2])
 sys.path.insert(0, str(search_dir))
 
-from dashboard_db import get_chats, mark_chat_processed
+from dashboard_db import add_chat, get_chats, mark_chat_processed
 
 action = str(payload.get("action") or "").strip()
 if action == "snapshot":
@@ -68,6 +68,32 @@ elif action == "consume":
         mark_chat_processed(int(chat_id))
         processed.append(int(chat_id))
     print(json.dumps({"processed_ids": processed}))
+elif action == "respond_and_consume":
+    author = str(payload.get("author") or "system").strip() or "system"
+    text = str(payload.get("text") or "").strip()
+    if not text:
+        raise SystemExit("response text is required")
+    reply_id = add_chat(author, text)
+    reply_processed = False
+    try:
+        mark_chat_processed(int(reply_id))
+        reply_processed = True
+    except Exception:
+        pass
+    processed = []
+    failed = []
+    for chat_id in payload.get("chat_ids") or []:
+        try:
+            mark_chat_processed(int(chat_id))
+            processed.append(int(chat_id))
+        except Exception:
+            failed.append(int(chat_id))
+    print(json.dumps({
+        "reply_id": reply_id,
+        "reply_processed": reply_processed,
+        "processed_ids": processed,
+        "failed_ids": failed,
+    }))
 else:
     raise SystemExit(f"unsupported action: {action}")
 """.strip()
@@ -97,6 +123,16 @@ def _preview(text: str, *, limit: int = 180) -> str:
     if len(blob) <= limit:
         return blob
     return blob[: limit - 1] + "…"
+
+
+def _captured_message_ids(snapshot: dict[str, Any]) -> list[int]:
+    ids: list[int] = []
+    for item in snapshot.get("message_ids") or []:
+        try:
+            ids.append(int(item))
+        except (TypeError, ValueError):
+            continue
+    return ids
 
 
 def _parse_kv_block(prefix: str, text: str) -> dict[str, str] | None:
@@ -211,7 +247,7 @@ def classify_message(message: dict[str, Any]) -> tuple[str, dict[str, Any]]:
 
 def build_async_inbox_snapshot(*, skill: str | None = None, limit: int = 200) -> dict[str, Any]:
     """Return the structured async inbox contract for the next skill."""
-    get_chats, _ = _load_dashboard_chat_api()
+    get_chats, _, _ = _load_dashboard_chat_api()
     if get_chats is None:
         payload = _dashboard_chat_via_subprocess({"action": "snapshot", "limit": limit}) or {}
         unprocessed = payload.get("unprocessed") or []
@@ -309,9 +345,9 @@ def consume_captured_inbox(state: dict[str, Any]) -> dict[str, Any]:
     """Mark captured async inbox messages as processed after a successful skill run."""
     request = state.setdefault("request", {})
     snapshot = request.get("async_inbox") or {}
-    ids = [int(item) for item in snapshot.get("message_ids", []) if str(item).strip()]
+    ids = _captured_message_ids(snapshot)
     processed_ids: list[int] = []
-    _, mark_chat_processed = _load_dashboard_chat_api()
+    _, _, mark_chat_processed = _load_dashboard_chat_api()
     if mark_chat_processed is None:
         payload = _dashboard_chat_via_subprocess({"action": "consume", "chat_ids": ids}) or {}
         processed_ids = [int(item) for item in payload.get("processed_ids") or [] if str(item).strip()]
@@ -331,6 +367,154 @@ def consume_captured_inbox(state: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "processed_ids": processed_ids,
+        "processed_count": len(processed_ids),
+        "captured_total": len(ids),
+    }
+
+
+def build_postflight_response_text(state: dict[str, Any], snapshot: dict[str, Any]) -> str:
+    """Build a concise dashboard response for captured async operator input."""
+    request = state.get("request", {}) or {}
+    cycle_id = state.get("cycle_id") or "unknown-cycle"
+    skill = request.get("skill") or snapshot.get("skill") or "unknown-skill"
+    direct = len(snapshot.get("direct_messages") or [])
+    task = len(snapshot.get("task_intents") or [])
+    steering = len(snapshot.get("steering_intents") or [])
+    runtime = len(snapshot.get("runtime_intents") or [])
+    captured_total = len(_captured_message_ids(snapshot))
+
+    lines = [
+        f"[postflight] Processed async dashboard input for cycle {cycle_id}.",
+        f"Skill: {skill}. Captured: {captured_total} message(s) "
+        f"(direct={direct}, task={task}, steering={steering}, runtime={runtime}).",
+        "The substantive result belongs to the generated artifact/report; late messages remain queued for the next cycle.",
+    ]
+
+    previews: list[str] = []
+    for bucket in ("direct_messages", "task_intents", "steering_intents", "runtime_intents"):
+        for item in snapshot.get(bucket) or []:
+            preview = str(item.get("preview") or item.get("text") or "").strip()
+            if preview:
+                previews.append(_preview(preview, limit=120))
+            if len(previews) >= 3:
+                break
+        if len(previews) >= 3:
+            break
+    if previews:
+        lines.append("Seen: " + " | ".join(previews))
+    return "\n".join(lines)
+
+
+def acknowledge_captured_inbox(state: dict[str, Any], *, author: str = "system") -> dict[str, Any]:
+    """Post a final dashboard acknowledgement, then consume captured user chat ids.
+
+    The captured dispatch snapshot is authoritative. Live chat is intentionally
+    not scanned here, so messages that arrive after dispatch remain pending for
+    the next cycle.
+    """
+    request = state.setdefault("request", {})
+    snapshot = request.get("async_inbox") or {}
+    ids = _captured_message_ids(snapshot)
+
+    if not ids:
+        return {
+            "ok": True,
+            "detail": "no captured async inbox messages",
+            "reply_posted": False,
+            "processed_ids": [],
+            "processed_count": 0,
+            "captured_total": 0,
+        }
+
+    if int(snapshot.get("processed_count") or 0) >= len(ids) and snapshot.get("response_chat_id"):
+        return {
+            "ok": True,
+            "detail": "captured async inbox already acknowledged",
+            "reply_posted": True,
+            "reply_id": snapshot.get("response_chat_id"),
+            "reply_processed": bool(snapshot.get("response_processed", False)),
+            "processed_ids": snapshot.get("processed_message_ids") or [],
+            "processed_count": int(snapshot.get("processed_count") or 0),
+            "captured_total": len(ids),
+        }
+
+    text = build_postflight_response_text(state, snapshot)
+    processed_ids: list[int] = []
+    failed_ids: list[int] = []
+    reply_id: int | None = None
+    reply_processed = False
+    _, add_chat, mark_chat_processed = _load_dashboard_chat_api()
+
+    try:
+        if add_chat is None or mark_chat_processed is None:
+            payload = _dashboard_chat_via_subprocess({
+                "action": "respond_and_consume",
+                "author": author,
+                "text": text,
+                "chat_ids": ids,
+            })
+            if not payload:
+                raise RuntimeError("dashboard chat API unavailable")
+            reply_id = int(payload.get("reply_id"))
+            reply_processed = bool(payload.get("reply_processed", False))
+            processed_ids = [
+                int(item)
+                for item in payload.get("processed_ids") or []
+                if str(item).strip()
+            ]
+            failed_ids = [
+                int(item)
+                for item in payload.get("failed_ids") or []
+                if str(item).strip()
+            ]
+        else:
+            reply_id = int(add_chat(author, text))
+            try:
+                mark_chat_processed(reply_id)
+                reply_processed = True
+            except Exception:
+                pass
+            for chat_id in ids:
+                try:
+                    mark_chat_processed(chat_id)
+                    processed_ids.append(chat_id)
+                except Exception:
+                    failed_ids.append(chat_id)
+    except Exception as exc:
+        snapshot["response_error"] = str(exc)
+        request["async_inbox"] = snapshot
+        return {
+            "ok": False,
+            "detail": f"async inbox response failed: {exc}",
+            "reply_posted": reply_id is not None,
+            "reply_id": reply_id,
+            "reply_processed": reply_processed,
+            "processed_ids": processed_ids,
+            "failed_ids": failed_ids,
+            "processed_count": len(processed_ids),
+            "captured_total": len(ids),
+        }
+
+    now = now_iso()
+    snapshot["response_posted_at"] = now
+    snapshot["response_chat_id"] = reply_id
+    snapshot["response_author"] = author
+    snapshot["response_processed"] = reply_processed
+    snapshot["response_text_preview"] = _preview(text)
+    snapshot["processed_at"] = now
+    snapshot["processed_message_ids"] = processed_ids
+    snapshot["processed_count"] = len(processed_ids)
+    request["async_inbox"] = snapshot
+
+    ok = reply_processed and len(processed_ids) == len(ids)
+    return {
+        "ok": ok,
+        "detail": f"reply_id={reply_id} reply_processed={reply_processed} processed={len(processed_ids)}/{len(ids)}",
+        "reply_posted": True,
+        "reply_id": reply_id,
+        "reply_processed": reply_processed,
+        "processed_ids": processed_ids,
+        "failed_ids": failed_ids,
         "processed_count": len(processed_ids),
         "captured_total": len(ids),
     }

--- a/tools/edge-close
+++ b/tools/edge-close
@@ -18,8 +18,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import CURRENT_DISPATCH_FILE, EDGE_REPO_DIR, LOGS_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
-from _shared.telemetry import current_actor, emit_shadow_event, log_event  # noqa: E402
-from _shared.skill_inbox import consume_captured_inbox  # noqa: E402
+from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
 
 POST_SKILL_LOG = LOGS_DIR / "post-skill.log"
 
@@ -241,44 +240,6 @@ def main() -> int:
         )
 
     _, payload = close_dispatch(effective_status, effective_reason)
-    if effective_status == "completed":
-        try:
-            consumed = consume_captured_inbox(payload)
-            write_state(payload)
-            emit_shadow_event(
-                "AsyncInboxConsumed",
-                actor="edge-close",
-                cycle_id=payload.get("cycle_id"),
-                payload={
-                    "processed_count": consumed.get("processed_count", 0),
-                    "captured_total": consumed.get("captured_total", 0),
-                    "processed_ids": consumed.get("processed_ids", []),
-                },
-            )
-            log_event(
-                "async_inbox",
-                actor="edge-close",
-                action="consumed",
-                cycle_id=payload.get("cycle_id"),
-                skill=(payload.get("request", {}) or {}).get("skill", ""),
-                processed_count=consumed.get("processed_count", 0),
-                captured_total=consumed.get("captured_total", 0),
-            )
-        except Exception as exc:
-            emit_shadow_event(
-                "AsyncInboxConsumeFailed",
-                actor="edge-close",
-                cycle_id=payload.get("cycle_id"),
-                payload={"error": str(exc)},
-            )
-            log_event(
-                "async_inbox",
-                actor="edge-close",
-                action="consume_failed",
-                cycle_id=payload.get("cycle_id"),
-                skill=(payload.get("request", {}) or {}).get("skill", ""),
-                error=str(exc),
-            )
     print(json.dumps(payload, indent=2, ensure_ascii=False))
     return exit_code
 

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -25,6 +25,7 @@ from _shared.capability_runtime import build_capability_status, invoke_capabilit
 from _shared.dispatch_runtime import read_dispatch_state, write_dispatch_state  # noqa: E402
 from _shared.health_runtime import observe_cycle_health_events  # noqa: E402
 from _shared.protocol_runtime import emit_protocol_step_observed, ensure_compiled_protocol, protocol_context  # noqa: E402
+from _shared.skill_inbox import acknowledge_captured_inbox  # noqa: E402
 from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
 from _shared.workflow_runtime import build_workflow_status  # noqa: E402
 
@@ -351,6 +352,19 @@ def _execute_postflight_step(step: dict[str, Any], state: dict[str, Any]) -> dic
             extra={"payload": observations},
         )
 
+    if kind == "async_inbox.respond":
+        result = acknowledge_captured_inbox(state)
+        ok = bool(result.get("ok", False))
+        status = "ok" if ok else "warning"
+        append_postskill_log("async_inbox_response", "OK" if ok else "WARN", str(result.get("detail") or ""))
+        return _protocol_step(
+            step,
+            status=status,
+            satisfied=ok,
+            detail=str(result.get("detail") or ""),
+            extra={"payload": result},
+        )
+
     if kind == "capability.probe":
         capability_name = str(step.get("capability") or "")
         try:
@@ -439,6 +453,7 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
     workflows_payload: dict[str, Any] = {}
     capabilities_payload: dict[str, Any] = {}
     curation_payload: dict[str, Any] = {}
+    async_inbox_payload: dict[str, Any] = {}
     warning_seen = False
 
     for step in protocol.get("procedures") or []:
@@ -479,6 +494,8 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
             capabilities_payload = payload
         elif kind == "curation.digest" and isinstance(payload, dict):
             curation_payload = payload
+        elif kind == "async_inbox.respond" and isinstance(payload, dict):
+            async_inbox_payload = payload
 
     digest = claims_payload.get("digest") or {}
     orphans = claims_payload.get("orphans") or {}
@@ -546,6 +563,15 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
         }
     if curation_payload:
         request["curation_digest"] = curation_payload
+    if async_inbox_payload:
+        request["async_inbox_response"] = {
+            "ok": bool(async_inbox_payload.get("ok", False)),
+            "reply_posted": bool(async_inbox_payload.get("reply_posted", False)),
+            "reply_id": async_inbox_payload.get("reply_id"),
+            "processed_count": int(async_inbox_payload.get("processed_count", 0) or 0),
+            "captured_total": int(async_inbox_payload.get("captured_total", 0) or 0),
+            "detail": async_inbox_payload.get("detail") or "",
+        }
 
     delta = compute_delta(
         before,
@@ -565,6 +591,11 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
             "stale_candidates": int((curation_payload.get("corpus") or {}).get("stale_candidates", 0) or 0),
             "procedure_candidates": int((curation_payload.get("procedures") or {}).get("candidate_total", 0) or 0),
         } if curation_payload else {},
+        "async_inbox": {
+            "reply_posted": bool(async_inbox_payload.get("reply_posted", False)),
+            "processed_count": int(async_inbox_payload.get("processed_count", 0) or 0),
+            "captured_total": int(async_inbox_payload.get("captured_total", 0) or 0),
+        } if async_inbox_payload else {},
     }
 
     if failed_steps or warning_seen:

--- a/tools/edge-render
+++ b/tools/edge-render
@@ -151,6 +151,7 @@ def _render_postflight_protocol(cfg: dict) -> str:
             {"id": "curation-digest", "kind": "curation.digest"},
             {"id": "briefing-refresh", "kind": "briefing.refresh"},
             {"id": "cycle-health-observe", "kind": "cycle_health.observe"},
+            {"id": "async-inbox-response", "kind": "async_inbox.respond"},
         ],
     }
     return _render_protocol_yaml(payload)


### PR DESCRIPTION
Closes #361.

## Summary
- Adds `async_inbox.respond` as a postflight procedure generated by `edge-render` and present in the default postflight config.
- Posts a concise dashboard chat acknowledgement from the captured `request.async_inbox`, marks the system reply processed, then consumes captured user message ids.
- Removes async inbox consumption from `edge-close` so final chat handling is owned by postflight.
- Updates async inbox rules to make skill-level manual acknowledgement/processing forbidden.

## Verification
- `python3 -m py_compile tools/_shared/skill_inbox.py tools/edge-postflight tools/edge-close`
- `bash tests/test_postflight_resilience.sh`
- `bash tests/test_skill_inbox.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_edge_dispatch.sh`

Note: `tools/edge-render --dry-run` cannot run in this issue clone because it has no `agent.yaml`; the generated postflight procedure was updated in `tools/edge-render` and the tracked default `config/postflight.yaml`.