### PR TITLE
Remove stale async inbox close rule

### DIFF
--- a/skills/reflection/SKILL.md
+++ b/skills/reflection/SKILL.md
@@ -219,8 +219,9 @@ This creates a `workflow` entry immediately (operator authority = approval). The
   from reflection unless reflection itself is the dispatched skill responsible
   for that action.
 
-**DO NOT mark as processed manually** — `edge-close` consumes the captured
-message ids only after the cycle completes successfully.
+**DO NOT mark as processed manually** — `async_inbox.respond` in postflight
+posts the final dashboard acknowledgement and consumes captured message ids
+only after the cycle reaches completion evidence.
 
 ### HN-5: State drift check + skill step completion
 


### PR DESCRIPTION
Closes #363.

## Summary
- Updates the reflection skill rule that still claimed `edge-close` consumes captured async chat messages.
- Points reflection to the new owner: `async_inbox.respond` in postflight.

## Verification
- `rg -n "edge-close consumes|consumed by edge-close|edge-close.*consumes.*inbox|edge-close.*captured message|mark as processed manually" skills tools config tests -S`
- `git diff --check`