### PR TITLE
Allow async inbox postflight protocol step

### DIFF
--- a/tests/test_protocol_runtime.sh
+++ b/tests/test_protocol_runtime.sh
@@ -49,6 +49,8 @@ procedures:
     kind: source_affordance.digest
   - id: briefing-refresh
     kind: briefing.refresh
+  - id: async-inbox-response
+    kind: async_inbox.respond
 YAML
 
 cat >"$TMP_REPO/config/capabilities.yaml" <<'YAML'
@@ -108,7 +110,7 @@ else
     fail "ensure_compiled_protocol writes compiled JSON with hashes"
 fi
 
-echo "--- Test 2: postflight accepts source affordance digest step ---"
+echo "--- Test 2: postflight accepts source affordance and async inbox steps ---"
 if python3 - <<'PY' "$EDGE_DIR" "$TMP_STATE"
 import json
 import sys
@@ -122,15 +124,17 @@ compiled = ensure_compiled_protocol("postflight")
 assert compiled["protocol"] == "postflight"
 kinds = [item["kind"] for item in compiled["procedures"]]
 assert "source_affordance.digest" in kinds
+assert "async_inbox.respond" in kinds
 compiled_path = Path(state_dir) / "state" / "runtime" / "postflight.compiled.json"
 assert compiled_path.exists()
 saved = json.loads(compiled_path.read_text(encoding="utf-8"))
 assert any(item["kind"] == "source_affordance.digest" for item in saved["procedures"])
+assert any(item["kind"] == "async_inbox.respond" for item in saved["procedures"])
 PY
 then
-    pass "postflight accepts source affordance digest step"
+    pass "postflight accepts source affordance and async inbox steps"
 else
-    fail "postflight accepts source affordance digest step"
+    fail "postflight accepts source affordance and async inbox steps"
 fi
 
 echo "--- Test 3: source edits trigger automatic recompilation on next ensure ---"

--- a/tools/_shared/protocol_runtime.py
+++ b/tools/_shared/protocol_runtime.py
@@ -50,6 +50,7 @@ _ALLOWED_KINDS: dict[str, set[str]] = {
         "curation.digest",
         "briefing.refresh",
         "cycle_health.observe",
+        "async_inbox.respond",
         "capability.invoke",
         "capability.probe",
     },


### PR DESCRIPTION
Closes #365.

## Summary
- Adds `async_inbox.respond` to the postflight protocol compiler allowlist.
- Extends protocol runtime coverage so postflight protocols containing `async_inbox.respond` compile and persist.

## Verification
- `bash tests/test_protocol_runtime.sh`
- `bash tests/test_postflight_resilience.sh`
- `python3 -m py_compile tools/_shared/protocol_runtime.py tools/edge-postflight`