### PR TITLE
Fix dashboard chat history limiting

### DIFF
--- a/search/dashboard_db.py
+++ b/search/dashboard_db.py
@@ -52,7 +52,12 @@ def add_chat(author: str, text: str, conn=None) -> int:
 
 def get_chats(unprocessed_only: bool = False, pinned_only: bool = False,
               limit: int = 100, conn=None) -> list[dict]:
-    """Get chat messages, optionally filtered by processed/pinned status."""
+    """Get the latest chat messages, optionally filtered by processed/pinned status.
+
+    The UI should show the most recent conversation, but still render it in
+    chronological order. A direct ascending LIMIT hides new messages once the
+    table has more than ``limit`` rows.
+    """
     own = conn is None
     if own: conn = ensure_db()
     try:
@@ -64,8 +69,10 @@ def get_chats(unprocessed_only: bool = False, pinned_only: bool = False,
             clauses.append("pinned=1")
         if clauses:
             sql += " WHERE " + " AND ".join(clauses)
-        sql += " ORDER BY ts ASC, id ASC LIMIT ?"
-        return [dict(r) for r in conn.execute(sql, (limit,)).fetchall()]
+        sql += " ORDER BY ts DESC, id DESC LIMIT ?"
+        rows = [dict(r) for r in conn.execute(sql, (limit,)).fetchall()]
+        rows.reverse()
+        return rows
     finally:
         if own: conn.close()
 

--- a/tests/test_dashboard_chat_history.sh
+++ b/tests/test_dashboard_chat_history.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-dashboard-chat-XXXXXX)"
+TMP_EDGE="$TMP_BASE/edge"
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_EDGE/state" "$TMP_EDGE/logs" "$TMP_EDGE/search"
+
+export EDGE_REPO_DIR="$EDGE_DIR"
+export EDGE_STATE_DIR="$TMP_EDGE"
+export EDGE_CODENAME="test-agent"
+
+python3 - <<'PY' "$EDGE_DIR"
+import sys
+
+edge_dir = sys.argv[1]
+sys.path.insert(0, edge_dir + "/search")
+
+from dashboard_db import add_chat, get_chats, mark_chat_processed
+
+first_id = add_chat("user", "oldest visible only if limit is wrong")
+mark_chat_processed(first_id)
+
+for index in range(120):
+    chat_id = add_chat("user", f"filler {index:03d}")
+    mark_chat_processed(chat_id)
+
+latest_id = add_chat("user", "latest operator message")
+latest_system_id = add_chat("system", "latest system acknowledgement")
+mark_chat_processed(latest_system_id)
+
+messages = get_chats(limit=100)
+ids = [item["id"] for item in messages]
+
+assert latest_id in ids, "latest user message must remain visible in chat history"
+assert latest_system_id in ids, "latest system reply must remain visible in chat history"
+assert first_id not in ids, "chat history limit must drop oldest messages first"
+assert ids == sorted(ids), "selected latest messages must render chronologically"
+
+pending = get_chats(unprocessed_only=True, limit=10)
+assert [item["id"] for item in pending] == [latest_id], pending
+
+print("ok")
+PY


### PR DESCRIPTION
## Summary
- Return the latest chat messages before rendering them chronologically.
- Add a regression test so new operator messages and postflight replies remain visible after the chat table exceeds the UI limit.

## Tests
- `tests/test_dashboard_chat_history.sh`
- `tests/test_skill_inbox.sh`