### PR TITLE
Prevent dispatch cycle overwrite races

### DIFF
--- a/tests/test_edge_close.sh
+++ b/tests/test_edge_close.sh
@@ -113,6 +113,36 @@ else
     fail "edge-close downgrades incomplete cycles to failed"
 fi
 
+echo "--- Test 1b: edge-close refuses to close a different EDGE_CYCLE_ID ---"
+"$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-mismatch --force >/dev/null
+"$DISPATCH_TOOL" dispatch --skill discovery >/dev/null
+EDGE_CYCLE_ID=cycle-close-mismatch "$STEP_TOOL" discovery start >/dev/null
+EDGE_CYCLE_ID=cycle-close-mismatch "$STEP_TOOL" discovery end >/dev/null
+set +e
+EDGE_CYCLE_ID=cycle-other "$CLOSE_TOOL" --status completed >/dev/null 2>/dev/null
+STATUS=$?
+set -e
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$STATUS"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+status = int(sys.argv[2])
+
+assert status == 1
+assert dispatch["cycle_id"] == "cycle-close-mismatch"
+assert dispatch["state"]["active"] is True
+assert dispatch["state"]["close_status"] is None
+PY
+then
+    pass "edge-close validates EDGE_CYCLE_ID before postflight"
+else
+    fail "edge-close validates EDGE_CYCLE_ID before postflight"
+fi
+
+EDGE_CYCLE_ID=cycle-close-mismatch "$DISPATCH_TOOL" close --status aborted >/dev/null
+
 echo "--- Test 2: completed close succeeds with skill end evidence and postflight ---"
 "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-complete --force >/dev/null
 "$DISPATCH_TOOL" dispatch --skill discovery >/dev/null

--- a/tests/test_edge_dispatch.sh
+++ b/tests/test_edge_dispatch.sh
@@ -258,6 +258,84 @@ else
     fail "close finalizes state and emits CycleClosed"
 fi
 
+echo "--- Test 4b: force does not replace an active cycle owned by a live runner ---"
+EDGE_RUNNER_PID=$$ "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-active-owner >/dev/null
+set +e
+ACTIVE_REPLACE_OUTPUT=$(EDGE_RUNNER_PID=$$ "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-active-replacement --force 2>&1)
+ACTIVE_REPLACE_STATUS=$?
+set -e
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$ACTIVE_REPLACE_STATUS" "$ACTIVE_REPLACE_OUTPUT"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+status = int(sys.argv[2])
+output = sys.argv[3]
+
+assert status == 1
+assert dispatch["cycle_id"] == "cycle-active-owner"
+assert dispatch["state"]["active"] is True
+assert "running process" in output
+PY
+then
+    pass "force refuses to overwrite a live active cycle"
+else
+    fail "force refuses to overwrite a live active cycle"
+fi
+
+EDGE_CYCLE_ID=cycle-active-owner "$DISPATCH_TOOL" close --status aborted >/dev/null
+
+echo "--- Test 4c: force can replace a stale active cycle whose owner pid is gone ---"
+STALE_PID=99999999
+while kill -0 "$STALE_PID" 2>/dev/null; do STALE_PID=$((STALE_PID + 1)); done
+EDGE_RUNNER_PID=$STALE_PID "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-stale-owner >/dev/null
+EDGE_RUNNER_PID=$$ "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-stale-replacement --force >/dev/null
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+assert dispatch["cycle_id"] == "cycle-stale-replacement"
+assert dispatch["state"]["active"] is True
+PY
+then
+    pass "force replaces only stale active cycles"
+else
+    fail "force replaces only stale active cycles"
+fi
+
+EDGE_CYCLE_ID=cycle-stale-replacement "$DISPATCH_TOOL" close --status aborted >/dev/null
+
+echo "--- Test 4d: dispatch refuses to mutate a different EDGE_CYCLE_ID ---"
+"$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-mismatch >/dev/null
+set +e
+MISMATCH_OUTPUT=$(EDGE_CYCLE_ID=cycle-other "$DISPATCH_TOOL" dispatch --skill research 2>&1)
+MISMATCH_STATUS=$?
+set -e
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$MISMATCH_STATUS" "$MISMATCH_OUTPUT"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+status = int(sys.argv[2])
+output = sys.argv[3]
+
+assert status == 1
+assert dispatch["cycle_id"] == "cycle-mismatch"
+assert dispatch["state"]["skill_dispatched"] is False
+assert "cycle mismatch" in output
+PY
+then
+    pass "dispatch validates EDGE_CYCLE_ID before mutation"
+else
+    fail "dispatch validates EDGE_CYCLE_ID before mutation"
+fi
+
+EDGE_CYCLE_ID=cycle-mismatch "$DISPATCH_TOOL" close --status aborted >/dev/null
+
 echo "--- Test 5: operator cycle suppresses legacy heartbeat guard fallback ---"
 python3 - <<'PY' "$TMP_EDGE/state/current-beat.json"
 import json

--- a/tools/edge-close
+++ b/tools/edge-close
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -31,6 +32,26 @@ def read_state() -> dict:
     if not CURRENT_DISPATCH_FILE.exists():
         raise FileNotFoundError(f"{CURRENT_DISPATCH_FILE} not found")
     return json.loads(CURRENT_DISPATCH_FILE.read_text(encoding="utf-8"))
+
+
+def expected_cycle_id() -> str | None:
+    value = os.environ.get("EDGE_CYCLE_ID")
+    if value and value.strip():
+        return value.strip()
+    return None
+
+
+def validate_cycle_id(state: dict) -> tuple[bool, dict]:
+    expected = expected_cycle_id()
+    current = state.get("cycle_id")
+    if not expected or current == expected:
+        return True, {}
+    return False, {
+        "ok": False,
+        "error": "close cycle mismatch",
+        "expected_cycle_id": expected,
+        "current_cycle_id": current,
+    }
 
 
 def write_state(state: dict) -> None:
@@ -168,6 +189,10 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = build_parser().parse_args()
     state = read_state()
+    cycle_ok, cycle_error = validate_cycle_id(state)
+    if not cycle_ok:
+        print(json.dumps(cycle_error, indent=2, ensure_ascii=False), file=sys.stderr)
+        return 1
     request = state.get("request", {}) or {}
     profile = request.get("postflight_profile") or "standard"
     requested_status = args.status

--- a/tools/edge-dispatch
+++ b/tools/edge-dispatch
@@ -12,10 +12,14 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
+import os
 import re
+import socket
 import sys
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -35,6 +39,15 @@ def now_iso() -> str:
 def make_cycle_id() -> str:
     stamp = datetime.now(timezone.utc).strftime("cycle-%Y%m%dT%H%M%SZ")
     return f"{stamp}-{uuid.uuid4().hex[:6]}"
+
+
+@contextmanager
+def dispatch_lock():
+    lock_path = CURRENT_DISPATCH_FILE.parent / ".current-dispatch.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        yield
 
 
 def canonical_trigger(value: str) -> str:
@@ -79,6 +92,71 @@ def read_state(require_exists: bool = True) -> dict:
 def state_active(state: dict) -> bool:
     state_block = state.get("state", {}) or {}
     return bool(state_block.get("active"))
+
+
+def expected_cycle_id() -> str | None:
+    value = os.environ.get("EDGE_CYCLE_ID")
+    if value and value.strip():
+        return value.strip()
+    return None
+
+
+def current_cycle_matches(state: dict) -> bool:
+    expected = expected_cycle_id()
+    return not expected or state.get("cycle_id") == expected
+
+
+def pid_is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def owner_pid(state: dict) -> int | None:
+    value = ((state.get("state", {}) or {}).get("owner_pid") or (state.get("runtime", {}) or {}).get("owner_pid"))
+    try:
+        pid = int(value)
+    except (TypeError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+def owner_alive(state: dict) -> bool | None:
+    host = ((state.get("state", {}) or {}).get("owner_host") or (state.get("runtime", {}) or {}).get("owner_host"))
+    if host and str(host) != socket.gethostname():
+        return None
+    pid = owner_pid(state)
+    if pid is None:
+        return None
+    return pid_is_alive(pid)
+
+
+def owner_metadata() -> dict[str, object]:
+    pid_value = os.environ.get("EDGE_RUNNER_PID") or str(os.getppid())
+    try:
+        pid = int(pid_value)
+    except ValueError:
+        pid = os.getppid()
+    return {
+        "owner_pid": pid,
+        "owner_host": socket.gethostname(),
+        "owner_actor": current_actor(),
+        "owner_started_at": os.environ.get("EDGE_RUNNER_STARTED_AT") or "",
+    }
+
+
+def active_cycle_error(existing: dict, *, reason: str) -> dict:
+    return {
+        "ok": False,
+        "error": reason,
+        "cycle_id": existing.get("cycle_id"),
+        "owner_pid": owner_pid(existing),
+        "hint": "close the active cycle explicitly before opening another one",
+    }
 
 
 def mirror_heartbeat_guard(state: dict) -> None:
@@ -176,21 +254,18 @@ def touch_thread(thread_id: str, *, reason: str, cycle_id: str | None) -> None:
 
 def cmd_open(args: argparse.Namespace) -> int:
     existing = read_state(require_exists=False)
-    if existing and state_active(existing) and not args.force:
-        print(
-            json.dumps(
-                {
-                    "ok": False,
-                    "error": "active dispatch cycle already exists",
-                    "cycle_id": existing.get("cycle_id"),
-                    "hint": "use --force only if you are replacing a stale shadow cycle",
-                },
-                indent=2,
-                ensure_ascii=False,
-            ),
-            file=sys.stderr,
-        )
-        return 1
+    if existing and state_active(existing):
+        alive = owner_alive(existing)
+        if args.force and alive is False:
+            pass
+        else:
+            reason = "active dispatch cycle already exists"
+            if args.force and alive is True:
+                reason = "active dispatch cycle is still owned by a running process"
+            elif args.force and alive is None:
+                reason = "active dispatch cycle owner is unknown"
+            print(json.dumps(active_cycle_error(existing, reason=reason), indent=2, ensure_ascii=False), file=sys.stderr)
+            return 1
 
     cycle_id = args.cycle_id or make_cycle_id()
     requested_trigger = args.trigger
@@ -230,6 +305,7 @@ def cmd_open(args: argparse.Namespace) -> int:
             "dispatched_at": None,
             "closed_at": None,
             "close_reason": None,
+            **owner_metadata(),
         },
     }
     write_json(CURRENT_DISPATCH_FILE, state)
@@ -267,6 +343,21 @@ def cmd_open(args: argparse.Namespace) -> int:
 
 def cmd_dispatch(args: argparse.Namespace) -> int:
     state = read_state()
+    if not current_cycle_matches(state):
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": "dispatch cycle mismatch",
+                    "expected_cycle_id": expected_cycle_id(),
+                    "current_cycle_id": state.get("cycle_id"),
+                },
+                indent=2,
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+        )
+        return 1
     if not state_active(state):
         print(json.dumps({"ok": False, "error": "no active dispatch cycle"}, indent=2), file=sys.stderr)
         return 1
@@ -401,6 +492,21 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 
 def cmd_close(args: argparse.Namespace) -> int:
     state = read_state()
+    if not current_cycle_matches(state):
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": "close cycle mismatch",
+                    "expected_cycle_id": expected_cycle_id(),
+                    "current_cycle_id": state.get("cycle_id"),
+                },
+                indent=2,
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+        )
+        return 1
     request = state.setdefault("request", {})
     state_block = state.setdefault("state", {})
     timestamp = now_iso()
@@ -466,7 +572,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_open.add_argument("--cycle-id", help="Override generated cycle id")
     p_open.add_argument("--arg", action="append", help="Request arg (key=value). Repeatable.")
     p_open.add_argument("--args-json", help="JSON object with request args")
-    p_open.add_argument("--force", action="store_true", help="Replace an active shadow cycle")
+    p_open.add_argument("--force", action="store_true", help="Replace only stale active cycles whose owner process is gone")
 
     p_dispatch = sub.add_parser("dispatch", help="Mark the current cycle as skill-dispatched")
     p_dispatch.add_argument("--skill", help="Dispatched skill name")
@@ -485,12 +591,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    if args.cmd == "open":
-        return cmd_open(args)
-    if args.cmd == "dispatch":
-        return cmd_dispatch(args)
-    if args.cmd == "close":
-        return cmd_close(args)
+    if args.cmd in {"open", "dispatch", "close"}:
+        with dispatch_lock():
+            if args.cmd == "open":
+                return cmd_open(args)
+            if args.cmd == "dispatch":
+                return cmd_dispatch(args)
+            if args.cmd == "close":
+                return cmd_close(args)
     if args.cmd == "status":
         return cmd_status(args)
     parser.print_help()

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -38,6 +38,10 @@ def now_stamp() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
 def make_cycle_id() -> str:
     return f"cycle-runner-{now_stamp()}-{uuid.uuid4().hex[:6]}"
 
@@ -561,6 +565,8 @@ def main() -> int:
     env.setdefault("EDGE_REPO_DIR", str(EDGE_REPO_DIR))
     env["EDGE_RUNNER_BACKEND"] = args.backend
     env["EDGE_RUNNER_MODE"] = args.cmd
+    env["EDGE_RUNNER_PID"] = str(os.getpid())
+    env["EDGE_RUNNER_STARTED_AT"] = now_iso()
 
     cycle_id = None
     exit_code = 0


### PR DESCRIPTION
## Summary
- serialize current dispatch mutations with a lock
- record the edge-runner owner PID on opened cycles
- block `--force` from replacing an active cycle while its owner process is alive
- validate `EDGE_CYCLE_ID` before dispatch/close mutations

Fixes #368

## Tests
- `tests/test_edge_dispatch.sh`
- `tests/test_edge_close.sh`
- `tests/test_dashboard_chat_history.sh`
- `tests/test_skill_inbox.sh`