### PR TITLE
Enforce artifact quality gates for HTML reports

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -13,8 +13,9 @@
 # Pipeline (8 fases):
 #   0.  Frontmatter injection (report: field)
 #   0b. Note link injection (note: field, if matching note exists)
-#   0.3 Adversarial review enforcement (edge-consult --gate)
-#   0.5 Review gate (LLM-as-judge, content report only)
+#   0.3 Adversarial review enforcement (edge-consult --gate; YAML or HTML)
+#   0.45 Feynman judge (YAML or HTML)
+#   0.5 Review gate (LLM-as-judge, content report only; YAML or HTML)
 #   1.  Blog entry (blog-publish.sh)
 #   2.  Content report (generate_report.py, mandatory — #245)
 #   3.  Verificação (API, frontmatter, files)
@@ -123,6 +124,41 @@ run_adversarial_gate_review() {
     fi
     echo "$review_output"
     return 0
+}
+
+artifact_stem_for() {
+    local artifact="$1"
+    case "$artifact" in
+        *.yaml) echo "${artifact%.yaml}" ;;
+        *.yml) echo "${artifact%.yml}" ;;
+        *.html) echo "${artifact%.html}" ;;
+        *) echo "${artifact%.*}" ;;
+    esac
+}
+
+artifact_kind_for() {
+    local artifact="$1"
+    case "$artifact" in
+        *.yaml|*.yml) echo "YAML" ;;
+        *.html) echo "HTML" ;;
+        *) echo "unknown" ;;
+    esac
+}
+
+run_review_gate() {
+    local artifact="$1"
+    local skill_name="${2:-}"
+    local review_cmd=()
+    if command -v review-gate &>/dev/null; then
+        review_cmd=(review-gate "$artifact" --json)
+    elif [[ -x "$TOOLS_DIR/review-gate.py" ]]; then
+        review_cmd=(python3 "$TOOLS_DIR/review-gate.py" "$artifact" --json)
+    else
+        return 127
+    fi
+    [[ -n "$skill_name" ]] && review_cmd+=(--skill "$skill_name")
+    [[ -n "${ENTRY_PATH:-}" ]] && review_cmd+=(--entry "$ENTRY_PATH")
+    "${review_cmd[@]}"
 }
 
 # Parse flags
@@ -438,16 +474,29 @@ else
 fi
 
 # ─── PHASE 0.3: Adversarial Review Enforcement ───
-# Phase 0.3 is mandatory for YAML-backed publishes. If a gate review does not
-# already exist, generate it now so telemetry and artifact provenance always
-# include the adversarial pass. Pre-existing unresolved reviews still block.
-if [[ -n "$REPORT_INPUT" && ("$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.yml) ]]; then
-    REVIEW_JSON_FILE="${REPORT_INPUT%.yaml}.review.json"
-    [[ "$REPORT_INPUT" == *.yml ]] && REVIEW_JSON_FILE="${REPORT_INPUT%.yml}.review.json"
-    RESOLVED_FILE="${REVIEW_JSON_FILE%.review.json}.resolved"
-    REVIEW_QUESTION="Adversarially review this publication spec before publish. Identify the weakest reasoning, unsupported assumptions, protocol violations, and what is most likely to break."
+# Every content artifact path must pass the same pre-publication gates. YAML
+# specs and pre-rendered HTML both become reader-visible reports, so neither
+# may bypass adversarial review, Feynman review, or the review gate.
+if [[ -n "$REPORT_INPUT" ]]; then
+    if [[ ! -f "$REPORT_INPUT" ]]; then
+        fail "Report not found before quality gates: $REPORT_INPUT"
+        emit_run_step_event "phase-0.3" "failed" "adversarial_review" "report artifact missing before gates"
+        exit 1
+    fi
 
-    echo "── Phase 0.3: Adversarial Review ──"
+    REPORT_KIND="$(artifact_kind_for "$REPORT_INPUT")"
+    if [[ "$REPORT_KIND" == "unknown" ]]; then
+        fail "Unsupported report format before publish: $REPORT_INPUT"
+        emit_run_step_event "phase-0.3" "failed" "adversarial_review" "unsupported report artifact format"
+        exit 1
+    fi
+
+    REPORT_ARTIFACT_STEM="$(artifact_stem_for "$REPORT_INPUT")"
+    REVIEW_JSON_FILE="${REPORT_ARTIFACT_STEM}.review.json"
+    RESOLVED_FILE="${REPORT_ARTIFACT_STEM}.resolved"
+    REVIEW_QUESTION="Adversarially review this publication artifact before publish. It may be a YAML report spec or pre-rendered HTML. Identify the weakest reasoning, unsupported assumptions, missing evidence, protocol violations, missing visual/explanatory structure, and what is most likely to break. If it is HTML, review the final reader-visible artifact."
+
+    echo "── Phase 0.3: Adversarial Review ($REPORT_KIND) ──"
     emit_run_step_event "phase-0.3" "started" "adversarial_review" ""
 
     if [[ ! -f "$REVIEW_JSON_FILE" ]]; then
@@ -475,12 +524,11 @@ if [[ -n "$REPORT_INPUT" && ("$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.y
         fail "Adversarial review pending: $(basename "$REVIEW_JSON_FILE")"
         echo ""
         echo "  edge-consult generated feedback that has not been addressed."
-        echo "  Address the feedback in YAML and create the marker to proceed:"
+        echo "  Address the feedback in the artifact and create the marker to proceed:"
         echo "    touch $RESOLVED_FILE"
         echo ""
         echo "  (Enforcement #218: bypass flags removed — adversarial review is mandatory.)"
         echo ""
-        # Show the review summary
         python3 -c "
 import json, sys
 try:
@@ -491,7 +539,8 @@ try:
         print(f'    {line}')
     if len(resp.split('\n')) > 8:
         print('    ...')
-except: pass
+except Exception:
+    pass
 " 2>/dev/null
         echo ""
         emit_run_step_event "phase-0.3" "failed" "adversarial_review" "pending unresolved review"
@@ -501,14 +550,10 @@ except: pass
         emit_run_step_event "phase-0.3" "completed" "adversarial_review" ""
         echo ""
     fi
-fi
 
-# ─── PHASE 0.5: Review Gate (LLM-as-judge) ───
-if [[ -n "$REPORT_INPUT" && ("$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.yml) ]]; then
-    echo "── Phase 0.45: Feynman Judge ──"
+    echo "── Phase 0.45: Feynman Judge ($REPORT_KIND) ──"
     emit_run_step_event "phase-0.45" "started" "feynman_judge" ""
-    FEYNMAN_REVIEW_FILE="${REPORT_INPUT%.yaml}.feynman-review.json"
-    [[ "$REPORT_INPUT" == *.yml ]] && FEYNMAN_REVIEW_FILE="${REPORT_INPUT%.yml}.feynman-review.json"
+    FEYNMAN_REVIEW_FILE="${REPORT_ARTIFACT_STEM}.feynman-review.json"
     if [[ -x "$TOOLS_DIR/feynman-judge" ]]; then
         FEYNMAN_JSON=$("$TOOLS_DIR/feynman-judge" "$REPORT_INPUT" --json --output "$FEYNMAN_REVIEW_FILE" 2>/dev/null)
         FEYNMAN_EXIT=$?
@@ -531,38 +576,38 @@ except Exception:
         echo "  Review: $FEYNMAN_REVIEW_FILE"
         emit_run_step_event "phase-0.45" "completed" "feynman_judge" ""
     else
-        warn "Feynman judge unavailable or failed (non-fatal)"
+        fail "Feynman judge unavailable or failed"
         emit_run_step_event "phase-0.45" "failed" "feynman_judge" "judge unavailable or failed"
+        exit 3
     fi
     echo ""
 
-    if command -v review-gate &>/dev/null; then
-        echo "── Phase 0.5: Review Gate ──"
-        emit_run_step_event "phase-0.5" "started" "review_gate" ""
-        # Detect skill from YAML filename (spec-SKILL-slug.yaml)
-        YAML_BASENAME=$(basename "$REPORT_INPUT")
-        SKILL_NAME=""
-        if [[ "$YAML_BASENAME" =~ ^spec-([a-z]+)- ]]; then
-            SKILL_NAME="${BASH_REMATCH[1]}"
-        fi
+    echo "── Phase 0.5: Review Gate ($REPORT_KIND) ──"
+    emit_run_step_event "phase-0.5" "started" "review_gate" ""
+    REPORT_BASENAME=$(basename "$REPORT_INPUT")
+    SKILL_NAME=""
+    if [[ "$REPORT_BASENAME" =~ ^spec-([a-z]+)- ]]; then
+        SKILL_NAME="${BASH_REMATCH[1]}"
+    fi
 
-        REVIEW_CMD="review-gate $REPORT_INPUT --json"
-        [[ -n "$SKILL_NAME" ]] && REVIEW_CMD="$REVIEW_CMD --skill $SKILL_NAME"
+    REVIEW_JSON=$(run_review_gate "$REPORT_INPUT" "$SKILL_NAME" 2>/dev/null)
+    REVIEW_EXIT=$?
+    if [[ $REVIEW_EXIT -ne 0 ]]; then
+        fail "review-gate unavailable or failed (exit $REVIEW_EXIT)"
+        emit_run_step_event "phase-0.5" "failed" "review_gate" "review-gate unavailable or failed"
+        exit 3
+    fi
 
-        REVIEW_JSON=$($REVIEW_CMD 2>/dev/null)
-        REVIEW_EXIT=$?
-
-        # Extract overall score and total cost from full --json output
-        REVIEW_SCORE=$(echo "$REVIEW_JSON" | python3 -c "
+    REVIEW_SCORE=$(echo "$REVIEW_JSON" | python3 -c "
 import json, sys
 try:
     d = json.load(sys.stdin)
     fr = d.get('final_review', d)
     print(fr.get('overall', 0))
-except:
+except Exception:
     print(0)
 " 2>/dev/null)
-        REVIEW_COST=$(echo "$REVIEW_JSON" | python3 -c "
+    REVIEW_COST=$(echo "$REVIEW_JSON" | python3 -c "
 import json, sys, re
 try:
     d = json.load(sys.stdin)
@@ -581,19 +626,15 @@ try:
         c = meta.get('cost_estimate', '')
         total = float(re.sub(r'[^\d.]', '', c) or 0)
     print(f'{total:.4f}')
-except:
+except Exception:
     print('0')
 " 2>/dev/null)
-        TOTAL_LLM_COST="$REVIEW_COST"
+    TOTAL_LLM_COST="$REVIEW_COST"
 
-        # Review gate now returns advisory feedback (exit 0 always)
-        # Feedback saved in .feedback.json alongside YAML
-        ok "Review gate: score ${REVIEW_SCORE}/5.0, cost \$${REVIEW_COST}"
-        FEEDBACK_FILE="${REPORT_INPUT%.yaml}.feedback.json"
-        [[ ! -f "$FEEDBACK_FILE" ]] && FEEDBACK_FILE="${REPORT_INPUT%.yml}.feedback.json"
-        if [[ -f "$FEEDBACK_FILE" ]]; then
-            # Show top suggestions for agent to incorporate
-            echo "$REVIEW_JSON" | python3 -c "
+    ok "Review gate: score ${REVIEW_SCORE}/5.0, cost \$${REVIEW_COST}"
+    FEEDBACK_FILE="${REPORT_ARTIFACT_STEM}.feedback.json"
+    if [[ -f "$FEEDBACK_FILE" ]]; then
+        echo "$REVIEW_JSON" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
 r = d.get('final_review', d)
@@ -603,7 +644,8 @@ ca = d.get('coauthor', {})
 ca_suggestions = ca.get('suggestions', [])
 if issues:
     print('  Critical issues:')
-    for i in issues[:3]: print(f'    - {i}')
+    for i in issues[:3]:
+        print(f'    - {i}')
 if ca_suggestions:
     print(f'  Co-author suggestions: {len(ca_suggestions)}')
     for s in ca_suggestions[:3]:
@@ -611,20 +653,20 @@ if ca_suggestions:
         print(f'    - {str(desc)[:120]}')
 if suggestions:
     print(f'  Reviewer suggestions: {len(suggestions)}')
-    for s in suggestions[:3]: print(f'    - {str(s)[:120]}')
+    for s in suggestions[:3]:
+        print(f'    - {str(s)[:120]}')
 " 2>/dev/null
-            echo "  Feedback: $FEEDBACK_FILE"
-        fi
+        echo "  Feedback: $FEEDBACK_FILE"
+    fi
 
-        if [[ "$REVIEW_ONLY" == "true" ]]; then
-            emit_run_step_event "phase-0.5" "completed" "review_gate" ""
-            echo ""
-            echo "Review-only mode. Nothing published."
-            exit 0
-        fi
+    if [[ "$REVIEW_ONLY" == "true" ]]; then
         emit_run_step_event "phase-0.5" "completed" "review_gate" ""
         echo ""
+        echo "Review-only mode. Nothing published."
+        exit 0
     fi
+    emit_run_step_event "phase-0.5" "completed" "review_gate" ""
+    echo ""
 fi
 
 # ─── PHASE 1: Blog entry ───
@@ -863,6 +905,10 @@ if $ALL_OK && [[ "$REPORT_RESULT" != "fail" ]]; then
     emit_run_step_event "phase-3" "completed" "verification" ""
 else
     emit_run_step_event "phase-3" "failed" "verification" "verification ended with warnings or failures"
+    fail "Verification failed before state commit; publication will not be recorded as Published"
+    ledger_record "pipeline-end" "fail"
+    emit_run_step_event "pipeline" "failed" "pipeline_end" "verification failed before state commit"
+    exit 2
 fi
 
 # ─── PHASE 4: Meta-report (cognitive mirror) ───

--- a/tests/test_consolidate_adversarial_phase.sh
+++ b/tests/test_consolidate_adversarial_phase.sh
@@ -7,6 +7,7 @@ TMP_STATE="$TMP_BASE/state"
 TMP_BIN="$TMP_BASE/bin"
 TMP_ENTRY="$TMP_STATE/blog/entries/test-entry.md"
 TMP_REPORT="$TMP_STATE/reports/test-spec.yaml"
+TMP_REPORT_HTML="$TMP_STATE/reports/test-report.html"
 PASS=0
 FAIL=0
 
@@ -40,6 +41,19 @@ date: "23/04/2026"
 sections:
   - title: "1. Test"
     content: "Test content"
+EOF
+
+cat >"$TMP_REPORT_HTML" <<'EOF'
+<!doctype html>
+<html lang="pt-BR">
+<head><title>Test HTML report</title></head>
+<body>
+<h1>Test HTML report</h1>
+<p>Em termos simples, este relatorio testa o gate de HTML pre-renderizado.</p>
+<h2>O que Nao Sei</h2>
+<p>Nao sabemos se o ambiente externo esta disponivel.</p>
+</body>
+</html>
 EOF
 
 cat >"$TMP_BIN/review-gate" <<'EOF'
@@ -155,6 +169,39 @@ then
 else
     cat /tmp/test-consolidate-adversarial.log
     fail "unresolved existing review still blocks phase-0.3"
+fi
+
+echo "--- Test 3: HTML report path also runs mandatory gates ---"
+if "$CONSOLIDATE" "$TMP_ENTRY" "$TMP_REPORT_HTML" --review-only >/tmp/test-consolidate-adversarial.log 2>&1; then
+    if python3 - <<'PY' "$TMP_REPORT_HTML" "$EVENTS_MIRROR_FILE"
+import json, pathlib, sys
+report = pathlib.Path(sys.argv[1])
+events_path = pathlib.Path(sys.argv[2])
+stem = report.with_suffix("")
+review = stem.with_suffix(".review.json")
+feynman = stem.with_suffix(".feynman-review.json")
+resolved = stem.with_suffix(".resolved")
+assert review.exists(), "html review.json missing"
+assert feynman.exists(), "html feynman-review.json missing"
+assert resolved.exists(), "html resolved marker missing"
+events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+steps = [e for e in events if e.get("type") == "run_step"]
+phase03 = [(e["phase"], e["status"], e.get("operation")) for e in steps if e["phase"] == "phase-0.3"]
+phase045 = [(e["phase"], e["status"], e.get("operation")) for e in steps if e["phase"] == "phase-0.45"]
+phase05 = [(e["phase"], e["status"]) for e in steps if e["phase"] == "phase-0.5"]
+assert ("phase-0.3", "completed", "adversarial_review_generated") in phase03
+assert ("phase-0.45", "completed", "feynman_judge") in phase045
+assert ("phase-0.5", "completed") in phase05
+PY
+    then
+        pass "HTML report path runs adversarial, Feynman, and review gates"
+    else
+        cat /tmp/test-consolidate-adversarial.log
+        fail "HTML report path runs adversarial, Feynman, and review gates"
+    fi
+else
+    cat /tmp/test-consolidate-adversarial.log
+    fail "review-only HTML publish with generated review succeeds"
 fi
 
 echo ""

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """
-review-gate — Quality gate for YAML report specs.
+review-gate — Quality gate for report artifacts.
 
 Three-phase pipeline with 2 hardcoded improvement rounds:
-  Phase 1 (co-author): GPT with tools enriches/generates YAML draft
-  Phase 2 (review+refine loop): Reviewer evaluates → Refiner rewrites YAML → repeat 2x
-  Result: improved YAML written back to file
+  Phase 1 (co-author): GPT with tools suggests artifact improvements
+  Phase 2 (review): Reviewer evaluates the report artifact
+  Result: structured feedback saved alongside the artifact
 
 Usage:
     review-gate spec.yaml                          # Full pipeline (co-author + 2x review/refine)
+    review-gate report.html                        # Review a pre-rendered HTML report artifact
     review-gate spec.yaml --review-only            # Review only (no co-authoring, no refinement)
     review-gate spec.yaml --coauthor-only          # Co-author only (no review)
     review-gate spec.yaml --entry blog-entry.md    # Include blog entry for consistency
@@ -348,12 +349,12 @@ DIMENSION_WEIGHTS = [0.15, 0.15, 0.12, 0.12, 0.06, 0.12, 0.10, 0.06, 0.12]
 
 COAUTHOR_SYSTEM = """You are a co-author helping an autonomous AI agent (""" + _AGENT_NAME + """) improve a YAML report specification before publication. The YAML will be converted to an HTML report, published to an internal blog, and indexed into long-term memory.
 
-Your role: SUGGEST improvements to the YAML. You do NOT rewrite it — the agent keeps control. You pull context using your tools and return structured suggestions that the agent will decide whether to incorporate.
+Your role: SUGGEST improvements to the report artifact. You do NOT rewrite it — the agent keeps control. You pull context using your tools and return structured suggestions that the agent will decide whether to incorporate.
 
 Language: Portuguese (PT-BR).
 
 ## What to do:
-1. Read the YAML spec carefully
+1. Read the artifact carefully. It may be a YAML report spec or a pre-rendered HTML report.
 2. Use your tools to pull relevant context (memory files, previous reports, corpus search, blog entries)
 3. Return a JSON object with specific, actionable SUGGESTIONS (not rewrites)
 
@@ -397,15 +398,16 @@ Return JSON with these keys:
     }}
   ],
   "missing_connections": ["things the YAML should reference but doesn't"],
-  "factual_issues": ["any claims in the YAML that contradict what you found in context"]
+  "factual_issues": ["any claims in the artifact that contradict what you found in context"]
 }}
 """
 
-REVIEWER_SYSTEM = """You are a quality reviewer for YAML report specifications used by an autonomous AI agent (""" + _AGENT_NAME + """). These specs get converted to HTML reports via yaml_to_html.py, published to an internal blog, and indexed into long-term memory.
+REVIEWER_SYSTEM = """You are a quality reviewer for report artifacts used by an autonomous AI agent (""" + _AGENT_NAME + """). Artifacts may be YAML report specs that get converted to HTML, or pre-rendered HTML reports. They are published to an internal blog and indexed into long-term memory.
 
-Your job: evaluate the YAML spec against the rubric and provide structured, SPECIFIC feedback. Cite section titles, block types, and exact content when pointing out issues. Your feedback will be used by the agent to improve the spec in a self-refinement loop.
+Your job: evaluate the artifact against the rubric and provide structured, SPECIFIC feedback. Cite section titles, block types, visible HTML sections, and exact content when pointing out issues. Your feedback will be used by the agent to improve the artifact before publication.
 
 IMPORTANT: You are evaluating the artifact AS-IS. You have no tools and no external context. Judge only what's in front of you. If a claim seems unverified, flag it. If context seems missing, note it.
+If the artifact is HTML, judge the reader-visible structure and content equivalents instead of requiring YAML syntax or YAML top-level keys.
 
 Language: respond in Portuguese (PT-BR).
 
@@ -437,7 +439,7 @@ Rate each dimension 0-5:
 
 Flag as critical_issues if ANY of these:
 - Required section completely missing (linhagem, "O que Nao Sei", glossario)
-- executive_summary or metrics missing at top level
+- executive_summary or metrics missing at top level, or no reader-visible equivalent in HTML
 - Empty sections (title present but no blocks/content)
 - Zero SVG visualizations in entire spec
 - A report compares 3+ items/steps/metrics/risks/alternatives but has no chart, flow, matrix, timeline, or diagram representing that comparison visually
@@ -548,6 +550,15 @@ def load_entry(entry_path: str) -> str:
 # Phase 1: Co-author
 # ---------------------------------------------------------------------------
 
+def artifact_label(path: str) -> str:
+    suffix = Path(path).suffix.lower()
+    if suffix == ".html":
+        return "pre-rendered HTML report artifact"
+    if suffix in {".yaml", ".yml"}:
+        return "YAML report spec"
+    return "report artifact"
+
+
 def coauthor(yaml_path: str, skill: str = None, model: str = None,
              purpose: str = DEFAULT_PURPOSE,
              entry_path: str = None, brief: str = None) -> dict:
@@ -562,7 +573,8 @@ def coauthor(yaml_path: str, skill: str = None, model: str = None,
         skill_rules=load_skill_rules(skill) if skill else "",
     )
 
-    user_msg = f"Enrich this YAML report spec:\n\n{yaml_content}"
+    label = artifact_label(yaml_path)
+    user_msg = f"Enrich this {label}:\n\n{yaml_content}"
     if entry_path:
         entry_content = load_entry(entry_path)
         if entry_content:
@@ -721,7 +733,8 @@ def review(yaml_path: str, skill: str = None, model: str = None,
         threshold=threshold,
     )
 
-    user_msg = f"Review this YAML report spec:\n\n{yaml_content}"
+    label = artifact_label(yaml_path)
+    user_msg = f"Review this {label}:\n\n{yaml_content}"
     if entry_path:
         entry_content = load_entry(entry_path)
         if entry_content:


### PR DESCRIPTION
## Summary
- run adversarial, Feynman, and review-gate phases for both YAML specs and pre-rendered HTML reports
- make review-gate prompt artifact-aware so HTML is judged as reader-visible output, not as YAML syntax
- abort before meta/state commit when final verification fails, preventing false Published events

## Tests
- bash -n blog/consolidate-state.sh
- python3 -m py_compile tools/review-gate.py
- tests/test_consolidate_adversarial_phase.sh
- tests/test_consolidate_phase6_paths.sh
- tests/test_blog_publish_branding.sh
- tests/test_edge_publish_guard.sh