### PR TITLE
Fix routine seed router import fallback

### DIFF
--- a/tests/test_routines_import.sh
+++ b/tests/test_routines_import.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 - "$EDGE_DIR" <<'PY'
+import sys
+import types
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+sys.path.insert(0, str(edge_dir / "tools"))
+sys.path.insert(0, str(edge_dir / "tools" / "_shared"))
+
+# edge-apply imports routines as a top-level module. In that mode,
+# `from .router_client` fails and routines must fall back to the package import
+# path, not to top-level `router_client` (which breaks its own relative imports).
+pkg = types.ModuleType("_shared")
+pkg.__path__ = [str(edge_dir / "tools" / "_shared")]
+router = types.ModuleType("_shared.router_client")
+
+def make_client(*args, **kwargs):
+    raise RuntimeError("sentinel: import succeeded")
+
+router.make_client = make_client
+sys.modules["_shared"] = pkg
+sys.modules["_shared.router_client"] = router
+
+import routines
+
+assert routines._call_openai("test", timeout=1) is None
+PY
+
+echo "PASS: routines OpenAI fallback imports package router_client under edge-apply path layout"

--- a/tools/_shared/routines.py
+++ b/tools/_shared/routines.py
@@ -19,6 +19,8 @@ import os
 import re
 import shutil
 import subprocess
+import sys
+from pathlib import Path
 
 
 # ─── Prompt ────────────────────────────────────────────────────────────────
@@ -93,7 +95,10 @@ def _call_openai(prompt: str, timeout: int = 60) -> str | None:
     try:
         from .router_client import make_client
     except ImportError:
-        from router_client import make_client  # type: ignore
+        tools_dir = Path(__file__).resolve().parent.parent
+        if str(tools_dir) not in sys.path:
+            sys.path.insert(0, str(tools_dir))
+        from _shared.router_client import make_client  # type: ignore
     try:
         client, model = make_client("chat_mini", timeout=timeout)
         response = client.chat.completions.create(


### PR DESCRIPTION
## Summary
- fix  fallback import when [31m✗[0m /home/vboxuser/edge-of-chaos/agent.yaml not found
  Copy agent.yaml.example → agent.yaml and fill in imports it as a top-level module
- add regression coverage for the edge-apply sys.path layout

## Tests
- tests/test_routines_import.sh
- tests/test_seed_claude_fallback.sh
- python3 -m py_compile tools/_shared/routines.py tools/edge-apply