### PR TITLE
Stale-lock watchdog for edge-runner + heartbeat.sh (#374)

### DIFF
--- a/config/heartbeat.sh.tpl
+++ b/config/heartbeat.sh.tpl
@@ -15,11 +15,66 @@ SKILL="/{{ SKILL_PREFIX }}-heartbeat"
 # Load secrets
 [ -f "$SECRETS_DIR/keys.env" ] && set -a && source "$SECRETS_DIR/keys.env" && set +a
 
+# Stale-lock recovery — issue #374. When the prior heartbeat's `claude -p` hangs
+# (e.g. self-matching `pgrep -f` wait loops), the lockfile is held forever and
+# every cron tick SKIPs silently. If the dispatch state has not advanced for
+# longer than the threshold, kill the holders, force-close the cycle, and let
+# this beat proceed. Set EDGE_HEARTBEAT_STALE_LOCK_SEC=0 to disable.
+EDGE_HEARTBEAT_STALE_LOCK_SEC="${EDGE_HEARTBEAT_STALE_LOCK_SEC:-5400}"
+
+try_recover_stale_lock() {
+    [ "$EDGE_HEARTBEAT_STALE_LOCK_SEC" -gt 0 ] 2>/dev/null || return 1
+    [ -f "$CURRENT_DISPATCH_FILE" ] || return 1
+    local age stale_cycle holders
+    age=$(python3 -c '
+import json, sys, os
+from datetime import datetime, timezone
+try:
+    state = json.load(open(sys.argv[1])).get("state", {}) or {}
+except Exception:
+    sys.exit(0)
+ts = state.get("updated_at") or state.get("opened_at")
+if not ts:
+    sys.exit(0)
+try:
+    dt = datetime.fromisoformat(ts)
+except ValueError:
+    sys.exit(0)
+if dt.tzinfo is None:
+    dt = dt.replace(tzinfo=timezone.utc)
+print(int((datetime.now(timezone.utc) - dt).total_seconds()))
+' "$CURRENT_DISPATCH_FILE" 2>/dev/null)
+    [ -n "$age" ] || return 1
+    [ "$age" -gt "$EDGE_HEARTBEAT_STALE_LOCK_SEC" ] || return 1
+    stale_cycle=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("cycle_id",""))' "$CURRENT_DISPATCH_FILE" 2>/dev/null)
+    echo "[$(date +%H:%M)] STALE LOCK — cycle=$stale_cycle age=${age}s threshold=${EDGE_HEARTBEAT_STALE_LOCK_SEC}s; killing holders and force-closing" >> "$LOGFILE"
+    holders=$(fuser "$LOCKFILE" 2>/dev/null | tr -s ' ')
+    if [ -n "$holders" ]; then
+        for pid in $holders; do kill -TERM "$pid" 2>/dev/null || true; done
+        sleep 5
+        for pid in $holders; do kill -KILL "$pid" 2>/dev/null || true; done
+    fi
+    if [ -n "$stale_cycle" ]; then
+        EDGE_CYCLE_ID="$stale_cycle" "$EDGE_REPO_DIR/tools/edge-dispatch" close \
+            --status failed --reason stale_lock >> "$LOGFILE" 2>&1 || true
+    fi
+    rm -f "$LOCKFILE"
+    return 0
+}
+
 # Prevent overlapping heartbeats
 exec 200>"$LOCKFILE"
 if ! flock -n 200; then
-    echo "[$(date +%H:%M)] SKIP — previous heartbeat still running" >> "$LOGFILE"
-    exit 0
+    if try_recover_stale_lock; then
+        exec 200>"$LOCKFILE"
+        if ! flock -n 200; then
+            echo "[$(date +%H:%M)] SKIP — could not acquire lock after stale recovery" >> "$LOGFILE"
+            exit 1
+        fi
+    else
+        echo "[$(date +%H:%M)] SKIP — previous heartbeat still running" >> "$LOGFILE"
+        exit 0
+    fi
 fi
 
 mkdir -p "$LOGS_DIR"

--- a/skills/_shared/workflow-conventions.md
+++ b/skills/_shared/workflow-conventions.md
@@ -247,6 +247,22 @@ If a secret expires, there's no need to update each workflow — just consult th
 
 ---
 
+## Waiting on background subprocesses (anti-pattern)
+
+When a skill backgrounds a sibling job (e.g. `review-gate`, `consolidate-state`) and needs to wait for it, **do not poll with `pgrep -f "<pattern>"`**.
+
+`pgrep -f` matches against the full command line, and the shell that runs the loop carries the literal pattern in its own argv. The loop matches itself, the condition is never false, the wait never terminates. This is the failure mode that triggered issue #374 — a skill subprocess held the heartbeat lock for 12+ hours after its substantive work had already completed.
+
+Use one of these instead:
+
+- `wait <pid>` when you have the PID of the backgrounded job.
+- Marker file: the bg job writes `done` on exit, the waiter polls (`until [ -f /tmp/<job>.done ]; do sleep 3; done`).
+- Regex-bracket trick: `pgrep -f "[r]eview-gate /tmp/spec-..."` — the bracket prevents the pattern from matching itself.
+
+`edge-runner` enforces a hard wall-clock cap on the dispatched subprocess (default 5400s, env override `EDGE_RUNNER_SKILL_TIMEOUT_SEC`); `heartbeat.sh` recovers a stale lock after `EDGE_HEARTBEAT_STALE_LOCK_SEC` (default 5400s). Both are defense in depth — write the wait correctly so neither has to fire.
+
+---
+
 ## Migration from legacy workflows.md
 
 The file `~/edge/autonomy/workflows.md` contains 15 workflows in the old format. These serve as historical reference but **new workflows must be blog entries** with tag `workflow`.

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -436,6 +436,45 @@ else
     fail "heartbeat timeout env no longer kills long beats"
 fi
 
+echo "--- Test 8: backend exceeding EDGE_RUNNER_SKILL_TIMEOUT_SEC is killed and cycle closes failed ---"
+unset MOCK_CLAUDE_HEARTBEAT_FLOW || true
+unset MOCK_CLAUDE_EXIT_CODE || true
+export MOCK_CLAUDE_SLEEP_SECONDS=10
+export EDGE_RUNNER_SKILL_TIMEOUT_SEC=2
+set +e
+"$RUNNER_TOOL" skill \
+    --skill /ed-heartbeat \
+    --dispatch-trigger heartbeat \
+    --dispatch-policy autonomous \
+    --dispatch-routing-mode auto \
+    --dispatch-preflight-profile heartbeat_default \
+    --dispatch-postflight-profile standard \
+    --dispatch-force >/dev/null 2>&1
+STATUS=$?
+set -e
+unset MOCK_CLAUDE_SLEEP_SECONDS || true
+unset EDGE_RUNNER_SKILL_TIMEOUT_SEC || true
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$STATUS"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+status = int(sys.argv[3])
+
+assert status != 0
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "failed"
+assert dispatch["state"]["close_reason"] == "skill_subprocess_timeout"
+assert any(event["type"] == "SkillSubprocessTimeout" for event in events[-30:])
+PY
+then
+    pass "watchdog kills hung backend and closes cycle as skill_subprocess_timeout"
+else
+    fail "watchdog kills hung backend and closes cycle as skill_subprocess_timeout"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/tests/test_heartbeat_entrypoints.sh
+++ b/tests/test_heartbeat_entrypoints.sh
@@ -11,6 +11,26 @@ fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 echo "=== heartbeat entrypoint contract ==="
 echo ""
 
+echo "--- Test 0: heartbeat.sh.tpl parses as bash with stale-lock recovery wired (issue #374) ---"
+TMP_HB=$(mktemp /tmp/heartbeat-rendered-XXXXXX.sh)
+trap 'rm -f "$TMP_HB"' EXIT
+sed \
+    -e 's|{{ WORK_DIR }}|/tmp/edge-test|g' \
+    -e 's|{{ CODENAME }}|test|g' \
+    -e 's|{{ SKILL_PREFIX }}|test|g' \
+    -e 's|{{ HEARTBEAT_INTERVAL }}|2h|g' \
+    "$EDGE_DIR/config/heartbeat.sh.tpl" > "$TMP_HB"
+if bash -n "$TMP_HB" 2>&1; then
+    pass "rendered heartbeat.sh parses without syntax errors"
+else
+    fail "rendered heartbeat.sh has syntax errors"
+fi
+if grep -q "try_recover_stale_lock" "$TMP_HB" && grep -q "EDGE_HEARTBEAT_STALE_LOCK_SEC" "$TMP_HB"; then
+    pass "rendered heartbeat.sh wires stale-lock recovery"
+else
+    fail "rendered heartbeat.sh missing stale-lock recovery"
+fi
+
 echo "--- Test 1: manual docs no longer point to direct claude -p heartbeat ---"
 if python3 - <<'PY' "$EDGE_DIR"
 from pathlib import Path

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import uuid
@@ -473,6 +474,22 @@ def make_follow_on_skill_args(args: argparse.Namespace, skill_name: str) -> argp
     return follow_on
 
 
+DEFAULT_SKILL_TIMEOUT_SECONDS = 5400  # 90 minutes — see issue #374
+
+
+def resolve_skill_timeout_seconds() -> int | None:
+    raw = os.environ.get("EDGE_RUNNER_SKILL_TIMEOUT_SEC")
+    if raw is None or raw == "":
+        return DEFAULT_SKILL_TIMEOUT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_SKILL_TIMEOUT_SECONDS
+    if value <= 0:
+        return None
+    return value
+
+
 def invoke_backend(args: argparse.Namespace, env: dict[str, str], *, cycle_id: str | None = None) -> int:
     content = build_backend_content(args, cycle_id)
     original = args.skill if args.cmd == "skill" else args.prompt
@@ -486,8 +503,66 @@ def invoke_backend(args: argparse.Namespace, env: dict[str, str], *, cycle_id: s
     else:
         cmd = build_backend_command(args)
 
-    result = subprocess.run(cmd, env=env, cwd=resolve_cwd(args.cwd))
-    return result.returncode
+    timeout_seconds = resolve_skill_timeout_seconds()
+    if timeout_seconds is None:
+        result = subprocess.run(cmd, env=env, cwd=resolve_cwd(args.cwd))
+        return result.returncode
+
+    popen_kwargs: dict = {"env": env, "cwd": resolve_cwd(args.cwd)}
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+    proc = subprocess.Popen(cmd, **popen_kwargs)
+    try:
+        return proc.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        target = args.skill if args.cmd == "skill" else "prompt"
+        emit_shadow_event(
+            "SkillSubprocessTimeout",
+            actor="edge-runner",
+            cycle_id=cycle_id,
+            payload={
+                "target": target,
+                "mode": args.cmd,
+                "timeout_seconds": timeout_seconds,
+                "pid": proc.pid,
+            },
+        )
+        _terminate_process_group(proc)
+        raise RunnerAbort("skill_subprocess_timeout", f"backend exceeded {timeout_seconds}s — process group killed")
+
+
+def _terminate_process_group(proc: subprocess.Popen) -> None:
+    if os.name != "posix":
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+        return
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, OSError):
+        return
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except (ProcessLookupError, OSError):
+        return
+    try:
+        proc.wait(timeout=10)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        return
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        pass
 
 
 def maybe_mark_skill_completion(skill: str, cycle_id: str | None, exit_code: int) -> None:


### PR DESCRIPTION
## Summary

Fixes #374. When a `claude -p <skill>` subprocess emits self-matching `pgrep -f` wait loops, it never terminates; the heartbeat lockfile stays held forever and every cron tick SKIPs silently. This PR adds defense in depth so that case bounds at 90 minutes instead of 12+ hours.

## Changes

- **F1 — `tools/edge-runner` watchdog (HIGH).** Wraps the backend subprocess in `Popen` + `wait(timeout=...)`, default 5400s, env override `EDGE_RUNNER_SKILL_TIMEOUT_SEC` (0 disables). On timeout: SIGTERM the process group → 10s grace → SIGKILL → emit `SkillSubprocessTimeout` → close cycle as `skill_subprocess_timeout`. Uses `start_new_session=True` on POSIX so the subprocess gets its own pgid for clean group-kill.
- **F2 — `config/heartbeat.sh.tpl` stale-lock recovery (HIGH).** When `flock` fails, inspect `current-dispatch.json::state.updated_at`. If older than `EDGE_HEARTBEAT_STALE_LOCK_SEC` (default 5400s), kill the lock holders, force-close the cycle via `edge-dispatch close --status failed --reason stale_lock`, remove the lockfile, and re-acquire.
- **F3 — `skills/_shared/workflow-conventions.md` (MEDIUM, defensive).** Documents the `pgrep -f` self-match anti-pattern and points to `wait <pid>`, marker files, or the `[r]egex-bracket` trick.

## Why both F1 and F2

The original failure observed in #374 was a `claude -p` subprocess hung on a self-matching `pgrep -f` loop after `consolidate-state` had already exited. F1 alone would have killed that subprocess at 90 min. F2 alone would have unblocked the next cron tick at 90 min even if F1 had failed. Either fix in isolation closes the symptom; both together close it twice. F3 attacks the upstream cause but is fragile (the inner agent can still emit the bad pattern), so F1+F2 are load-bearing.

## Test plan
- [x] `bash tests/test_edge_runner.sh` (8/8 PASS) — new Test 8 exercises the watchdog with `EDGE_RUNNER_SKILL_TIMEOUT_SEC=2` against a 10s sleep, asserts `close_status=failed`, `close_reason=skill_subprocess_timeout`, `SkillSubprocessTimeout` event emitted.
- [x] `bash tests/test_heartbeat_entrypoints.sh` (5/5 PASS) — new Test 0 renders the template and confirms it parses and wires the recovery function.
- [x] `bash tests/test_heartbeat_routing.sh` (3/3 PASS), `tests/test_edge_dispatch.sh` (12/12 PASS), `tests/test_edge_close.sh` (5/5 PASS) — adjacent suites green, no regressions.
- [ ] Post-merge: propagate via `edge-apply` to all fleet hosts (ed, drucker, roberto, bracis, gauss, bobmarley); verify on bobmarley that an artificially-stale `current-dispatch.json` triggers recovery on the next beat.

## Compatibility note

Existing tests `test_edge_runner.sh::Test 7` deliberately ignore the legacy `EDGE_HEARTBEAT_DISPATCH_TIMEOUT_SECONDS` env var — that path was removed earlier so heartbeats can run long. The new `EDGE_RUNNER_SKILL_TIMEOUT_SEC` is a different lever with a generous default (90 min ≫ any healthy beat) and an explicit `=0` escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)