### PR TITLE
edge-doctor: resolve commands against ~/.local/bin fallback (#376)

### DIFF
--- a/tests/test_edge_doctor_check_command.sh
+++ b/tests/test_edge_doctor_check_command.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d /tmp/edge-doctor-XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== edge-doctor check_command (issue #376) ==="
+
+mkdir -p "$TMP/home/.local/bin"
+cat >"$TMP/home/.local/bin/edge-runner" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$TMP/home/.local/bin/edge-runner"
+
+run_check() {
+    local home="$1"
+    local extra_path="$2"
+    HOME="$home" PATH="$extra_path:/usr/bin:/bin" python3 - <<PY "$EDGE_DIR" 2>&1
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(sys.argv[1]) / "tools" / "_shared"))
+import telemetry
+telemetry.log_install_check = lambda *a, **kw: None  # silence
+
+import importlib.util
+from importlib.machinery import SourceFileLoader
+loader = SourceFileLoader("edge_doctor", str(Path(sys.argv[1]) / "tools" / "edge-doctor"))
+spec = importlib.util.spec_from_loader("edge_doctor", loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+
+mod.CHECKS_PASSED = 0
+mod.CHECKS_WARNED = 0
+mod.CHECKS_FAILED = 0
+mod.check_command("edge-runner", "Edge runner CLI")
+print(f"PASSED={mod.CHECKS_PASSED} WARNED={mod.CHECKS_WARNED} FAILED={mod.CHECKS_FAILED}")
+PY
+}
+
+echo "--- Test 1: edge-runner on PATH → ok ---"
+out=$(run_check "$TMP/home" "$TMP/home/.local/bin")
+if echo "$out" | grep -q "PASSED=1 WARNED=0 FAILED=0"; then
+    pass "PATH hit increments PASSED, no warn/fail"
+else
+    fail "expected PASSED=1, got: $out"
+fi
+
+echo "--- Test 2: edge-runner only at ~/.local/bin (PATH stale) → warn, not fail ---"
+out=$(run_check "$TMP/home" "/nonexistent")
+if echo "$out" | grep -q "PASSED=0 WARNED=1 FAILED=0"; then
+    pass "stale PATH but binary present → WARNED, not FAILED"
+else
+    fail "expected WARNED=1, got: $out"
+fi
+if echo "$out" | grep -q "source ~/.edge-env"; then
+    pass "warn message tells user to source ~/.edge-env"
+else
+    fail "warn message missing source hint: $out"
+fi
+
+echo "--- Test 3: edge-runner truly missing → fail ---"
+out=$(run_check "$TMP/empty-home" "/nonexistent")
+if echo "$out" | grep -q "PASSED=0 WARNED=0 FAILED=1"; then
+    pass "binary genuinely absent → FAILED"
+else
+    fail "expected FAILED=1, got: $out"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -2202,11 +2202,12 @@ def main():
     if failed == 0:
         prefix = cfg.get("skill_prefix", codename)
         print(f"\n{GREEN}✓{RESET} Installation complete. Next steps:")
-        print(f"  1. Verify:     python3 tools/edge-doctor")
-        print(f"  2. Blog:       systemctl --user enable --now blog-server")
-        print(f"  3. Heartbeat:  systemctl --user enable --now agent-heartbeat.timer")
-        print("  4. Test:       ~/.local/bin/heartbeat.sh")
-        print(f"  5. Doctor:     python3 tools/edge-doctor")
+        print(f"  1. Reload PATH: source ~/.edge-env  (or open a new shell)")
+        print(f"  2. Verify:      python3 tools/edge-doctor")
+        print(f"  3. Blog:        systemctl --user enable --now blog-server")
+        print(f"  4. Heartbeat:   systemctl --user enable --now agent-heartbeat.timer")
+        print(f"  5. Test:        ~/.local/bin/heartbeat.sh")
+        print(f"  6. Doctor:      python3 tools/edge-doctor")
     else:
         print(f"\n{RED}✗{RESET} {failed} phase(s) failed.")
 

--- a/tools/edge-doctor
+++ b/tools/edge-doctor
@@ -129,13 +129,38 @@ def check_dir(path: Path, label: str):
 
 
 def check_command(cmd: str, label: str):
+    """Resolve `cmd` via PATH first, then fall back to known install paths.
+
+    Issue #376: when edge-apply has just installed symlinks to ~/.local/bin/
+    but the current shell has not refreshed PATH (.edge-env not sourced yet),
+    `shutil.which(cmd)` returns None and the install looks broken. Treat the
+    binary as installed if it exists at a known location, but warn so the
+    user knows to source ~/.edge-env or open a new shell.
+    """
     check_id = f"command:{_slug(cmd)}"
-    if shutil.which(cmd):
+    resolved = shutil.which(cmd)
+    if resolved:
         ok(f"{label}: {cmd}")
-        _record_check(check_id, "ok", f"{label}: {cmd}", artifact=cmd, label=label)
-    else:
-        fail(f"{label}: {cmd} — NÃO INSTALADO")
-        _record_check(check_id, "fail", f"{label}: {cmd} — NÃO INSTALADO", artifact=cmd, label=label)
+        _record_check(check_id, "ok", f"{label}: {cmd}", artifact=resolved, label=label)
+        return
+    fallback_paths = [
+        Path.home() / ".local" / "bin" / cmd,
+        Path.home() / "bin" / cmd,
+    ]
+    for candidate in fallback_paths:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            warn(f"{label}: {candidate} (encontrado, mas fora do PATH — rode `source ~/.edge-env` ou abra um novo shell)")
+            _record_check(
+                check_id,
+                "warn",
+                f"{label}: {candidate} fora do PATH",
+                artifact=str(candidate),
+                label=label,
+                resolution="path_not_active",
+            )
+            return
+    fail(f"{label}: {cmd} — NÃO INSTALADO")
+    _record_check(check_id, "fail", f"{label}: {cmd} — NÃO INSTALADO", artifact=cmd, label=label)
 
 
 def check_port(port: int, host: str = "127.0.0.1"):


### PR DESCRIPTION
## Summary

Fixes #376. `edge-doctor` was depending on transient shell state (PATH) to validate a finished install — so when `edge-apply` ran in a fresh shell that hadn't sourced `~/.edge-env` yet, every command check (including `edge-runner`) failed even though the symlinks were correctly placed.

## Changes

- **Primary — `tools/edge-doctor`.** `check_command` now falls back to `~/.local/bin/<cmd>` and `~/bin/<cmd>` when `shutil.which` misses. If the binary is found there but not on PATH, the check warns (not fails) and tells the user to `source ~/.edge-env` or open a new shell. The fail path stays for genuinely missing commands.
- **Defense in depth — `tools/edge-apply`.** Post-install "Next steps" now lists `source ~/.edge-env` as step 1 before the doctor invocation.

## Test plan

- [x] New `tests/test_edge_doctor_check_command.sh` (4/4 PASS):
  - PATH hit → `ok`
  - Stale PATH + binary at `~/.local/bin/` → `warn` with `source ~/.edge-env` hint, not `fail`
  - Truly absent → `fail`
- [x] Adjacent suites green: `test_edge_apply_bookkeeping_drift.sh` (3/3), `test_edge_apply_tools_recursive.sh` (4/4), `test_edge_runner.sh` (8/8), `test_heartbeat_entrypoints.sh` (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)