### PR TITLE
web-search-policy-guard: stop blocking WebFetch (#378)

### DIFF
--- a/hooks/web-search-policy-guard.sh
+++ b/hooks/web-search-policy-guard.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# web-search-policy-guard.sh — Claude Code PreToolUse hook for WebSearch/WebFetch
+# web-search-policy-guard.sh — Claude Code PreToolUse hook for WebSearch
 #
 # Blocks builtin Claude web search unless runtime policy allows it. The normal
 # path is: edge-search for corpus, edge-sources for external search, and only
 # then a temporary builtin fallback window if the configured web provider fails.
+#
+# WebFetch is intentionally NOT blocked — it is the legitimate read-path for
+# URLs returned by edge-sources. Blocking it forces ad hoc curl bypasses
+# (issue #378).
 
 set -euo pipefail
 
@@ -22,7 +26,7 @@ except Exception:
     raise SystemExit(0)
 
 tool_name = str(payload.get("tool_name") or "").strip()
-if tool_name not in {"WebSearch", "WebFetch"}:
+if tool_name != "WebSearch":
     raise SystemExit(0)
 
 repo_root = Path(edge_root)

--- a/tests/test_web_search_policy_guard.sh
+++ b/tests/test_web_search_policy_guard.sh
@@ -90,6 +90,23 @@ else
   fail "hook allows WebSearch when builtin policy is enabled"
 fi
 
+echo "--- Test 4: WebFetch is always allowed regardless of policy (issue #378) ---"
+cat >"$FEATURES_FILE" <<'YAML'
+search:
+  builtin_web_search: false
+  web_provider: exa
+  web_fallback: claude_web
+  exa: auto
+YAML
+rm -f "$TMP_STATE/state/runtime/web-search-fallback.json"
+
+WEBFETCH_INPUT='{"tool_name":"WebFetch","tool_input":{"url":"https://arxiv.org/abs/2602.17913","prompt":"summarize"}}'
+if EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" bash "$HOOK" <<<"$WEBFETCH_INPUT" >/dev/null 2>&1; then
+  pass "hook allows WebFetch even when WebSearch is blocked"
+else
+  fail "hook should allow WebFetch but blocked it"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"


### PR DESCRIPTION
Fixes #378.

## Summary

WebSearch and WebFetch are different tools. The hook was conflating them:

- **WebSearch** issues a query → results. edge-sources replaces it; blocking is correct.
- **WebFetch** reads a specific URL the agent already has — typically a URL just returned by edge-sources. Blocking forces ad hoc `curl` bypasses to read what edge-sources pointed to, which is the opposite of what the policy intends.

## Change

`hooks/web-search-policy-guard.sh` now matches `WebSearch` only. WebFetch passes through unconditionally. The fallback-allowance machinery (`read_builtin_web_search_allowance`) is untouched — it was always WebSearch-shaped anyway.

## Test plan

- [x] `bash tests/test_web_search_policy_guard.sh` — 4/4 PASS, including new Test 4 asserting WebFetch passes through under a blocking policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)