### PR TITLE
edge-sources: query corpus first, surface in dedicated section (#381)

### DIFF
--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -72,6 +72,8 @@ edge-search "[technical facet]" -k 5 --type note
 edge-search "[conceptual facet]" -k 5 --type report
 ```
 
+> **Note (issue #381):** `edge-sources` (Step 3.5) now always runs the corpus as its first source and renders a `### Corpus (internal)` section at the top of its output. Step 1 is still the right place for *targeted, multi-facet* exploration; but if you skip it, you still cannot escape corpus consultation downstream — the report must reflect what that section returned (or document an empty result).
+
 For each relevant result, read the original:
 ```bash
 cat ~/edge/notes/[file].md | head -60    # Notes — more detailed

--- a/tests/test_edge_sources_corpus.sh
+++ b/tests/test_edge_sources_corpus.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d /tmp/edge-sources-corpus-XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== edge-sources corpus integration (issue #381) ==="
+
+# Stub edge-search so the test does not require a built corpus index.
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/edge-search" <<'SH'
+#!/usr/bin/env bash
+# Mimic the JSON shape edge-search emits.
+cat <<'JSON'
+{
+  "mode": "hybrid",
+  "query": "stubbed",
+  "results": [
+    {"id":"r1","path":"/edge/notes/prior-research.md","type":"note","title":"Prior research on the topic","score":0.0167,"snippet":"This note already covered most of it."},
+    {"id":"r2","path":"/edge/blog/entries/2026-01-01.md","type":"blog","title":"Earlier exploration","score":0.0142,"snippet":"Open gap: dimension X never validated."}
+  ],
+  "workflows": [],
+  "coverage": {}
+}
+JSON
+SH
+chmod +x "$TMP/bin/edge-search"
+
+PATH_OVERRIDE="$TMP/bin:/usr/bin:/bin"
+
+run_with_stub() {
+    local args=("$@")
+    EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP/state" PATH="$PATH_OVERRIDE" \
+        python3 - "$EDGE_DIR" "${args[@]}" <<'PY' 2>&1
+import sys
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+import importlib.util
+
+edge_dir = Path(sys.argv[1])
+script_args = sys.argv[2:]
+loader = SourceFileLoader("edge_sources", str(edge_dir / "tools" / "edge-sources"))
+spec = importlib.util.spec_from_loader("edge_sources", loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+
+# Drive the corpus source directly.
+items = mod.search_corpus("stubbed topic")
+print("CORPUS_COUNT=", len(items))
+for it in items:
+    print("CORPUS_ITEM=", it["source"], "|", it["title"])
+print("ALL_SOURCES=", mod.ALL_SOURCES)
+print("CORPUS_IN_SOURCE_FN=", "corpus" in mod.SOURCE_FN)
+print("WILDCARD_EXCLUDES_CORPUS=", "corpus" not in (mod.pick_wildcard(["x"]) or "x"))
+PY
+}
+
+echo "--- Test 1: search_corpus parses edge-search JSON into source-shaped items ---"
+out=$(run_with_stub)
+if echo "$out" | grep -q "CORPUS_COUNT= 2"; then
+    pass "search_corpus returns 2 items from stubbed edge-search"
+else
+    echo "$out"
+    fail "expected 2 items, got: $out"
+fi
+if echo "$out" | grep -qE "CORPUS_ITEM= Corpus \| \[note\] Prior research"; then
+    pass "title prefixed with doc type"
+else
+    echo "$out"
+    fail "title format incorrect: $out"
+fi
+if echo "$out" | grep -q "CORPUS_IN_SOURCE_FN= True"; then
+    pass "corpus is registered in SOURCE_FN"
+else
+    fail "corpus missing from SOURCE_FN"
+fi
+if echo "$out" | grep -q "WILDCARD_EXCLUDES_CORPUS= True"; then
+    pass "pick_wildcard never selects corpus"
+else
+    fail "pick_wildcard might pick corpus: $out"
+fi
+
+echo "--- Test 2: edge-sources main() always prepends corpus to selected sources ---"
+out=$(EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP/state" PATH="$PATH_OVERRIDE" python3 - "$EDGE_DIR" <<'PY' 2>&1
+import sys, argparse
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+import importlib.util
+
+edge_dir = Path(sys.argv[1])
+loader = SourceFileLoader("edge_sources", str(edge_dir / "tools" / "edge-sources"))
+spec = importlib.util.spec_from_loader("edge_sources", loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+
+# Simulate the source-selection block from main() with default args.
+class A: pass
+args = A()
+args.sources = ""
+args.intent = "research"
+args.no_corpus = False
+
+route = mod.ROUTING.get(args.intent, mod.ROUTING["research"])
+sources = route["primary"] + route["secondary"]
+if not args.no_corpus and "corpus" not in sources:
+    sources = ["corpus"] + sources
+print("FIRST_SOURCE=", sources[0])
+print("HAS_CORPUS=", "corpus" in sources)
+
+args.no_corpus = True
+sources = route["primary"] + route["secondary"]
+if not args.no_corpus and "corpus" not in sources:
+    sources = ["corpus"] + sources
+print("OPTOUT_HAS_CORPUS=", "corpus" in sources)
+PY
+)
+if echo "$out" | grep -q "FIRST_SOURCE= corpus"; then
+    pass "default selection puts corpus first"
+else
+    echo "$out"
+    fail "corpus not first: $out"
+fi
+if echo "$out" | grep -q "HAS_CORPUS= True"; then
+    pass "default selection includes corpus"
+else
+    fail "corpus missing by default: $out"
+fi
+if echo "$out" | grep -q "OPTOUT_HAS_CORPUS= False"; then
+    pass "--no-corpus opts out cleanly"
+else
+    fail "--no-corpus did not opt out: $out"
+fi
+
+echo "--- Test 3: format_markdown surfaces a Corpus section above External sources ---"
+out=$(EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP/state" PATH="$PATH_OVERRIDE" python3 - "$EDGE_DIR" <<'PY' 2>&1
+import sys
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+import importlib.util
+
+edge_dir = Path(sys.argv[1])
+loader = SourceFileLoader("edge_sources", str(edge_dir / "tools" / "edge-sources"))
+spec = importlib.util.spec_from_loader("edge_sources", loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+
+results_by_source = {
+    "corpus": [
+        {"title": "[note] Prior research", "url": "/edge/notes/prior-research.md", "source": "Corpus", "detail": "Already covered.", "score": 16},
+    ],
+    "exa": [
+        {"title": "External hit", "url": "https://example.com", "source": "Exa", "detail": "External text.", "score": 80},
+    ],
+}
+md = mod.format_markdown("test topic", "research", results_by_source)
+corpus_idx = md.find("### Corpus (internal)")
+external_idx = md.find("### High Relevance")
+print("CORPUS_FIRST=", corpus_idx >= 0 and corpus_idx < external_idx)
+print("CORPUS_RENDERED=", "Prior research" in md)
+PY
+)
+if echo "$out" | grep -q "CORPUS_FIRST= True"; then
+    pass "Corpus section rendered above High Relevance"
+else
+    echo "$out"
+    fail "Corpus not first in markdown: $out"
+fi
+if echo "$out" | grep -q "CORPUS_RENDERED= True"; then
+    pass "Corpus item rendered in section"
+else
+    fail "Corpus item missing: $out"
+fi
+
+echo "--- Test 4: empty corpus produces an explicit 'no prior matches' note ---"
+out=$(EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP/state" PATH="$PATH_OVERRIDE" python3 - "$EDGE_DIR" <<'PY' 2>&1
+import sys
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+import importlib.util
+
+edge_dir = Path(sys.argv[1])
+loader = SourceFileLoader("edge_sources", str(edge_dir / "tools" / "edge-sources"))
+spec = importlib.util.spec_from_loader("edge_sources", loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+
+md = mod.format_markdown("test", "research", {"corpus": []})
+print("HAS_HEADER=", "### Corpus (internal)" in md)
+print("HAS_EMPTY_NOTE=", "No prior corpus matches" in md)
+PY
+)
+if echo "$out" | grep -q "HAS_HEADER= True"; then
+    pass "header still rendered when corpus empty"
+else
+    fail "missing header: $out"
+fi
+if echo "$out" | grep -q "HAS_EMPTY_NOTE= True"; then
+    pass "explicit empty-corpus note shown"
+else
+    fail "empty-corpus note missing: $out"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tools/edge-sources
+++ b/tools/edge-sources
@@ -12,7 +12,7 @@ Runs all sources concurrently, curates by signal, outputs structured markdown.
 Sources that can't be scripted (WebSearch/WebFetch) are noted in output.
 """
 
-import sys, os, json, argparse, subprocess, random, uuid
+import sys, os, json, argparse, subprocess, random, shutil, uuid
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.request import urlopen, Request
@@ -22,7 +22,7 @@ import xml.etree.ElementTree as ET
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 sys.path.insert(0, str(SCRIPT_DIR.parent / "tools"))
-from paths import TOOLS_DIR, SECRETS_DIR
+from paths import EDGE_REPO_DIR, TOOLS_DIR, SECRETS_DIR
 from _shared.telemetry import make_odi_id, log_odi_observed, log_primitive_call, log_run_step, log_source_query
 from _shared.search_runtime import (
     clear_builtin_web_search_allowance,
@@ -280,9 +280,52 @@ def search_exa(topic):
         return [{"title": f"Exa error: {e}", "url": "", "source": "Exa", "detail": "", "score": 0}]
 
 
+# --- Internal corpus (issue #381) ---
+
+def search_corpus(topic):
+    """Hybrid search the internal edge-memory corpus via edge-search.
+
+    Always included as a source unless --no-corpus is passed (issue #381),
+    so research/discovery/etc. cannot silently skip prior knowledge.
+    Returns the same shape as external sources; URL field carries the local
+    file path for follow-up reads.
+    """
+    bin_path = shutil.which("edge-search") or str(EDGE_REPO_DIR / "search" / "edge-search")
+    try:
+        proc = subprocess.run(
+            [bin_path, topic, "-k", "8", "--json", "--no-telemetry"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except Exception as exc:
+        return [{"title": f"corpus error: {exc}", "url": "", "source": "Corpus", "detail": "", "score": 0}]
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "")[:200]
+        return [{"title": f"corpus error: {detail}", "url": "", "source": "Corpus", "detail": "", "score": 0}]
+    try:
+        payload = json.loads(proc.stdout) if proc.stdout.strip() else {}
+    except json.JSONDecodeError:
+        return [{"title": "corpus error: invalid JSON from edge-search", "url": "", "source": "Corpus", "detail": "", "score": 0}]
+    items = []
+    for entry in (payload.get("results") or []):
+        score_val = int(float(entry.get("score") or 0) * 1000)
+        title = str(entry.get("title") or entry.get("id") or "")[:200]
+        snippet = str(entry.get("snippet") or "")[:240]
+        doc_type = str(entry.get("type") or "")
+        path = str(entry.get("path") or "")
+        items.append({
+            "title": f"[{doc_type}] {title}" if doc_type else title,
+            "url": path,
+            "source": "Corpus",
+            "detail": snippet,
+            "score": score_val,
+        })
+    return items
+
+
 # --- Dispatcher ---
 
 SOURCE_FN = {
+    'corpus': search_corpus,
     'x': search_x,
     'hn': search_hn,
     'arxiv': search_arxiv,
@@ -295,8 +338,11 @@ SOURCE_FN = {
 
 
 def pick_wildcard(selected_sources):
-    """Pick one source NOT in the selected set (forced serendipity)."""
-    candidates = [s for s in ALL_SOURCES if s not in selected_sources]
+    """Pick one source NOT in the selected set (forced serendipity).
+
+    `corpus` is excluded — it is mandatory by design, not serendipitous.
+    """
+    candidates = [s for s in ALL_SOURCES if s not in selected_sources and s != 'corpus']
     return random.choice(candidates) if candidates else None
 
 
@@ -412,9 +458,29 @@ def format_markdown(topic, intent, results_by_source, wildcard_src=None):
     """Format results as structured markdown."""
     lines = [f"## External Sources — \"{topic}\" (intent: {intent})\n"]
 
-    # Flatten and sort by score
+    # Corpus section (issue #381) — surfaced first so prior internal knowledge
+    # is read before any external source. If corpus was queried but returned
+    # nothing, the section says so explicitly so the report can record that.
+    corpus_items = results_by_source.get('corpus') or []
+    corpus_clean = [item for item in corpus_items if 'error' not in item.get('title', '').lower()]
+    if 'corpus' in results_by_source:
+        lines.append("### Corpus (internal)\n")
+        if corpus_clean:
+            for item in corpus_clean:
+                lines.append(f"- **[{item['source']}]** {item['title']}")
+                if item.get('detail'):
+                    lines.append(f"  {item['detail'][:200]}")
+                if item.get('url'):
+                    lines.append(f"  Path: {item['url']}")
+                lines.append("")
+        else:
+            lines.append("- _No prior corpus matches — record \"Corpus: not consulted before this run\" in the report only if edge-search itself failed; an empty corpus is a valid finding._\n")
+
+    # External: flatten everything except corpus and sort by score
     all_items = []
     for src, items in results_by_source.items():
+        if src == 'corpus':
+            continue
         for item in items:
             if item.get("url") or "error" not in item.get("title", "").lower():
                 all_items.append(item)
@@ -513,6 +579,8 @@ def main():
     parser.add_argument("--front-page", action="store_true", help="Headlines-only mode (HN front page)")
     parser.add_argument("--json", action="store_true", help="JSON output")
     parser.add_argument("--no-wildcard", action="store_true", help="Skip wildcard source")
+    parser.add_argument("--no-corpus", action="store_true",
+                        help="Skip the mandatory internal corpus (edge-search) source — issue #381")
     args = parser.parse_args()
 
     if args.front_page:
@@ -534,6 +602,12 @@ def main():
     else:
         route = ROUTING.get(args.intent, ROUTING['research'])
         sources = route['primary'] + route['secondary']
+
+    # Corpus is always queried first unless explicitly opted out (issue #381).
+    # This removes the possibility of skipping prior knowledge before going
+    # external — the failure mode that triggered #381.
+    if not args.no_corpus and 'corpus' not in sources:
+        sources = ['corpus'] + sources
 
     # Wildcard: one random source outside the routing (forced serendipity)
     wildcard_src = None


### PR DESCRIPTION
Fixes #381.

## Summary

The research skill defines Step 1 (edge-search corpus) as mandatory, but the protocol is markdown — there is no mechanical gate, and it was being silently skipped. Per **Option C** in the issue: make corpus consultation a property of the tool, not the protocol.

## Changes

- **`tools/edge-sources`** registers `corpus` as a source backed by `edge-search` and prepends it to every selection by default. `--no-corpus` opts out. The wildcard picker excludes `corpus` (mandatory, not serendipitous). `format_markdown` renders a `### Corpus (internal)` section above external results, with an explicit "no prior matches" note when empty so the report can record that finding instead of pretending corpus was never consulted.
- **`skills/research/SKILL.md`** Step 1 gains a callout: even if Step 1 is skipped, edge-sources at Step 3.5 will still surface corpus matches and the report must reflect them.

## Acceptance criteria mapping

| Criterion | Met by |
|---|---|
| Research skill cannot produce a report without corpus search evidence | `edge-sources` always queries corpus first; the markdown the agent reads always contains the section |
| If corpus search is empty (no results), that's documented in the report | `format_markdown` emits an explicit empty-corpus note |
| If corpus search finds relevant prior work, the report builds on it | Corpus section is at the top of edge-sources output, ahead of external results |

## Test plan

- [x] `bash tests/test_edge_sources_corpus.sh` (11/11 PASS): source function parses edge-search JSON, doc-type prefix in title, registered in `SOURCE_FN`, `pick_wildcard` excludes corpus, default selection prepends corpus, `--no-corpus` opts out, markdown puts corpus first, empty-corpus note rendered.
- [x] Adjacent suites green: `test_source_affordance_digest.sh` (1/1), `test_web_search_policy_guard.sh` (4/4), `test_edge_runner.sh` (8/8), `test_edge_search_coverage.sh` (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)