### PR TITLE
Fix blog entry voice guidance

### DIFF
--- a/skills/_shared/report-template.md
+++ b/skills/_shared/report-template.md
@@ -16,7 +16,11 @@ with Lineage, Gaps, Glossary, Bibliography, ≥1 SVG all MANDATORY.
 
 1. **Generate YAML** with the sections from the calling skill, using the block types below
 2. **Write YAML** to `/tmp/spec-[skill]-[slug].yaml`
-3. **Include claims in the blog entry frontmatter** (compaction — MANDATORY):
+3. **Write the blog entry as a light invitation, then include claims in
+   frontmatter** (compaction — MANDATORY). The entry body should be only a few
+   concise paragraphs: lead with what changed or what was learned, invite the
+   reader into the work, and leave implementation depth to the report. Do not
+   duplicate the YAML/report structure in the blog body.
    ```yaml
    claims:
      - "Verified fact I learned"

--- a/skills/_shared/state-protocol.md
+++ b/skills/_shared/state-protocol.md
@@ -217,6 +217,23 @@ If during editing you realize you need to change a file NOT proposed:
 
 ### Step 5: Create blog entry + claims + procedures
 
+#### Blog Entry Voice Contract
+
+The blog entry body is the invitation, not the report. Write it as a short,
+light read that helps the operator remember why this work matters and decide
+whether to open the attached report.
+
+Required voice:
+- Keep the body to a few concise paragraphs; default to 2-4 paragraphs.
+- Lead with what changed, what was learned, or what door this opens.
+- Use plain language and an exploratory tone; avoid implementation dumps,
+  acronyms, long lists, stack traces, and dense protocol detail in the body.
+- Put technical depth in the report, notes, claims, procedures, and metadata.
+- End by pointing toward the reader-visible report or next question when useful.
+
+If a publication needs heavy detail, the entry should summarize the shape of the
+finding and let the content report carry the technical load.
+
 ```yaml
 claims:
   - "Verified fact I learned"

--- a/tests/test_blog_entry_voice_contract.sh
+++ b/tests/test_blog_entry_voice_contract.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PROTOCOL="$EDGE_DIR/skills/_shared/state-protocol.md"
+TEMPLATE="$EDGE_DIR/skills/_shared/report-template.md"
+
+echo "=== blog entry voice contract test ==="
+
+grep -q "Blog Entry Voice Contract" "$PROTOCOL"
+grep -q "The blog entry body is the invitation, not the report" "$PROTOCOL"
+grep -q "default to 2-4 paragraphs" "$PROTOCOL"
+grep -q "Put technical depth in the report" "$PROTOCOL"
+grep -q "Write the blog entry as a light invitation" "$TEMPLATE"
+grep -q "duplicate the YAML/report structure" "$TEMPLATE"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #388.

## Summary
- Adds a shared Blog Entry Voice Contract to keep blog entries short, light, and inviting.
- Clarifies that technical depth belongs in reports, notes, claims, procedures, and metadata.
- Adds a regression test to keep the voice guidance present in shared publication docs.

## Tests
- `tests/test_blog_entry_voice_contract.sh`
- `tests/test_blog_publish_branding.sh`
- `bash tests/test_protocol_runtime.sh`