### PR TITLE
Persist curated delta digest from strategy and reflection

### DIFF
--- a/skills/delta/SKILL.md
+++ b/skills/delta/SKILL.md
@@ -16,7 +16,7 @@ The delta pass runs inside the same backend invocation as the dispatched skill. 
 
 Use `request.delta_prerequisite` as the contract. It contains:
 
-- `previous_delta_digest`: prior surface baselines and curated open work.
+- `previous_delta_digest`: curated `work`, `learning`, and `handoff` state from prior strategy/reflection runs.
 - `raw_chat`: recent operator messages and source refs.
 - `strategic_context`: beat launch context, operator pressure, claims, queue, and open gaps.
 - `surfaces`: configured integrations, capabilities, previous baselines, and open work.
@@ -24,6 +24,8 @@ Use `request.delta_prerequisite` as the contract. It contains:
 - `events`: recent edge runtime events.
 
 Structured state is authoritative for what was persisted. Raw chat is authoritative for what the operator actually said. Reconcile the two before acting.
+
+If `previous_delta_digest` is missing from runtime context, use `edge-delta show --json` as the fallback source. The CLI only reads persisted JSON; it does not call a model.
 
 ## Method
 
@@ -33,7 +35,7 @@ Structured state is authoritative for what was persisted. Raw chat is authoritat
 4. Probe only as much as needed to establish whether a real delta exists.
 5. Classify each checked surface as `delta`, `non_delta`, or `unverified`.
 6. Curate open work: keep, create, merge, block, complete, or archive.
-7. Produce `delta_frame` for the next skill and `new_delta_digest` for continuity.
+7. Produce `delta_frame` for the next skill. Strategy/reflection own persistence through `edge-delta update`.
 
 ## Delta Rules
 
@@ -49,6 +51,12 @@ Every real delta must include:
 Do not call something a delta just because context exists. If a surface was checked and nothing relevant changed, put it in `non_deltas`. If it matters but was not checked, put it in `unverified`.
 
 ## Open Work Curation
+
+The digest has three curated sections:
+
+- `work`: open work, archived work, priority threads, and surface baselines. Strategy owns this.
+- `learning`: recent failures, durable rules, protocol gaps, and skill patch candidates. Reflection owns this.
+- `handoff`: short guidance to inject into the next skill. Strategy and reflection may both update this.
 
 Open work may contain many entries, but it is not a passive backlog.
 
@@ -90,12 +98,7 @@ Return or carry forward this shape:
       "inject_to_next_skill": []
     }
   },
-  "new_delta_digest": {
-    "generated_at": "...",
-    "summary": "...",
-    "surface_baselines": {},
-    "open_work": []
-  }
+  "digest_update_needed": false
 }
 ```
 

--- a/skills/reflection/SKILL.md
+++ b/skills/reflection/SKILL.md
@@ -172,6 +172,52 @@ Routed / Monitoring:
 
 If no issue is found, say so directly and name the residual risk or next signal to watch.
 
+### 8. Curate The Delta Digest
+
+Every reflection run must update the curated delta digest, even if the update is an explicit no-op.
+
+Reflection owns the digest `learning` section:
+
+- `recent_failures`: live operational failures or repeated mistakes.
+- `rules_to_preserve`: durable lessons that should continue guiding dispatch.
+- `protocol_gaps`: missing or weak protocol support.
+- `skill_patch_candidates`: concrete skill changes that should be planned or implemented.
+- `archived_guidance_recent`: stale guidance removed from active attention.
+
+Reflection may also update `handoff.inject_to_next_skill`, `handoff.watch_next`, and `handoff.unverified_but_important` when the next skill needs short guidance.
+
+Persist with:
+
+```bash
+edge-delta update --skill reflection --payload-file <json>
+```
+
+If nothing should change:
+
+```bash
+edge-delta update --skill reflection --no-op --summary "<reason>"
+```
+
+The payload shape is:
+
+```json
+{
+  "summary": "short learning continuity summary",
+  "learning": {
+    "recent_failures": [],
+    "rules_to_preserve": [],
+    "protocol_gaps": [],
+    "skill_patch_candidates": [],
+    "archived_guidance_recent": []
+  },
+  "handoff": {
+    "inject_to_next_skill": [],
+    "watch_next": [],
+    "unverified_but_important": []
+  }
+}
+```
+
 ## Escalation Triggers
 
 Escalate from normal to escalated when any of these is true:
@@ -189,4 +235,5 @@ Escalate from normal to escalated when any of these is true:
 - Operator feedback outranks autonomous curiosity.
 - Reflection changes operating behavior or routes the work; it does not merely summarize.
 - Stale rules are liabilities. Archive them when no current work depends on them.
+- Do not finish without `edge-delta update` or an explicit `edge-delta update --no-op`.
 - Keep the output short enough to guide the next cycle.

--- a/skills/strategy/SKILL.md
+++ b/skills/strategy/SKILL.md
@@ -159,6 +159,50 @@ Strategic Actions
 
 The queue should be short enough to act on.
 
+### 6. Curate The Delta Digest
+
+Every strategy run must update the curated delta digest, even if the update is an explicit no-op.
+
+Strategy owns the digest `work` section:
+
+- `open_work`: active work that should affect future dispatch.
+- `archived_work_recent`: stale or completed work removed from active attention.
+- `priority_threads`: threads that should bias the next dispatch.
+- `surface_baselines`: checked work surfaces and their latest known refs.
+
+Strategy may also update `handoff.inject_to_next_skill`, `handoff.watch_next`, and `handoff.unverified_but_important` when the next skill needs short guidance.
+
+Persist with:
+
+```bash
+edge-delta update --skill strategy --payload-file <json>
+```
+
+If nothing should change:
+
+```bash
+edge-delta update --skill strategy --no-op --summary "<reason>"
+```
+
+The payload shape is:
+
+```json
+{
+  "summary": "short strategic continuity summary",
+  "work": {
+    "open_work": [],
+    "archived_work_recent": [],
+    "priority_threads": [],
+    "surface_baselines": {}
+  },
+  "handoff": {
+    "inject_to_next_skill": [],
+    "watch_next": [],
+    "unverified_but_important": []
+  }
+}
+```
+
 ## Quality Criteria
 
 - Strategy must be grounded in actual project, thread, and claim state.
@@ -170,6 +214,7 @@ The queue should be short enough to act on.
 - Priority means something else is not first; state the trade-off.
 - Do not turn strategy into implementation.
 - Do not edit operator-owned direction or priority files directly from this skill.
+- Do not finish without `edge-delta update` or an explicit `edge-delta update --no-op`.
 - Make stale assumptions visible.
 - Compare against prior strategy when available.
 
@@ -185,9 +230,10 @@ Recommended sections:
 4. Claim Curation
 5. Dependencies And Conflicts
 6. Strategic Action Queue
-7. Operator Decisions
-8. Risks
-9. References
+7. Delta Digest Update
+8. Operator Decisions
+9. Risks
+10. References
 
 Useful structures:
 

--- a/tests/test_edge_delta.sh
+++ b/tests/test_edge_delta.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-delta-XXXXXX)"
+TMP_STATE="$TMP_BASE/state"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE"
+
+export EDGE_REPO_DIR="$EDGE_DIR"
+export EDGE_STATE_DIR="$TMP_STATE"
+
+DELTA_TOOL="$EDGE_DIR/tools/edge-delta"
+
+echo "=== edge-delta Test ==="
+echo ""
+
+echo "--- Test 1: show returns an empty normalized digest ---"
+if "$DELTA_TOOL" show --json >"$TMP_BASE/empty.json" && python3 - <<'PY' "$TMP_BASE/empty.json"
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+assert payload["kind"] == "edge_delta_digest"
+assert payload["work"]["open_work"] == []
+assert payload["learning"]["recent_failures"] == []
+assert payload["handoff"]["inject_to_next_skill"] == []
+assert payload["digest_hash"].startswith("sha256:")
+PY
+then
+    pass "show normalizes an empty digest"
+else
+    fail "show normalizes an empty digest"
+fi
+
+echo "--- Test 2: strategy update persists work and handoff sections ---"
+cat >"$TMP_BASE/strategy.json" <<'JSON'
+{
+  "summary": "runtime delta work is active",
+  "work": {
+    "open_work": [
+      {
+        "id": "work-delta",
+        "title": "Curate delta digest",
+        "surface": "runtime",
+        "status": "active",
+        "priority": "high",
+        "evidence": ["issue #390"]
+      }
+    ],
+    "archived_work_recent": [
+      {"id": "old-work", "summary": "obsolete backlog", "status": "archived"}
+    ],
+    "priority_threads": [
+      {"id": "thread-runtime", "summary": "runtime continuity", "priority": "high"}
+    ],
+    "surface_baselines": {
+      "github:lucasrp/edge-of-chaos": {
+        "kind": "git",
+        "last_seen_ref": "abc123",
+        "summary": "baseline"
+      }
+    }
+  },
+  "handoff": {
+    "inject_to_next_skill": [
+      {"summary": "keep delta_frame in context", "priority": "high"}
+    ]
+  }
+}
+JSON
+
+if "$DELTA_TOOL" validate --payload-file "$TMP_BASE/strategy.json" >/dev/null \
+    && "$DELTA_TOOL" update --skill strategy --payload-file "$TMP_BASE/strategy.json" >"$TMP_BASE/strategy-update.json" \
+    && python3 - <<'PY' "$TMP_STATE/state/projections/continuity-deltas/runtime-latest.json"
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+assert payload["summary"] == "runtime delta work is active"
+assert payload["work"]["open_work"][0]["id"] == "work-delta"
+assert payload["open_work"][0]["id"] == "work-delta"
+assert payload["surface_baselines"]["github:lucasrp/edge-of-chaos"]["last_seen_ref"] == "abc123"
+assert payload["handoff"]["inject_to_next_skill"][0]["summary"] == "keep delta_frame in context"
+assert payload["updates"][-1]["skill"] == "strategy"
+assert payload["digest_hash"].startswith("sha256:")
+PY
+then
+    pass "strategy update persists work and handoff"
+else
+    fail "strategy update persists work and handoff"
+fi
+
+echo "--- Test 3: reflection update preserves work and updates learning ---"
+cat >"$TMP_BASE/reflection.json" <<'JSON'
+{
+  "summary": "learning digest updated",
+  "learning": {
+    "recent_failures": [
+      {"id": "failure-repeat", "summary": "operator had to repeat delta continuity", "status": "active"}
+    ],
+    "rules_to_preserve": [
+      {"id": "rule-delta", "summary": "delta digest updates are deterministic", "status": "active"}
+    ],
+    "protocol_gaps": [],
+    "skill_patch_candidates": [
+      {"id": "patch-strategy", "summary": "strategy must update work digest", "status": "active"}
+    ],
+    "archived_guidance_recent": []
+  }
+}
+JSON
+
+if "$DELTA_TOOL" update --skill reflection --payload-file "$TMP_BASE/reflection.json" >/dev/null \
+    && python3 - <<'PY' "$TMP_STATE/state/projections/continuity-deltas/runtime-latest.json"
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+assert payload["summary"] == "learning digest updated"
+assert payload["work"]["open_work"][0]["id"] == "work-delta"
+assert payload["learning"]["recent_failures"][0]["id"] == "failure-repeat"
+assert payload["learning"]["rules_to_preserve"][0]["id"] == "rule-delta"
+assert payload["updates"][-1]["skill"] == "reflection"
+PY
+then
+    pass "reflection update preserves work and updates learning"
+else
+    fail "reflection update preserves work and updates learning"
+fi
+
+echo "--- Test 4: invalid payload is rejected ---"
+cat >"$TMP_BASE/bad.json" <<'JSON'
+{"work": {"open_work": "not-a-list"}}
+JSON
+
+set +e
+"$DELTA_TOOL" validate --skill strategy --payload-file "$TMP_BASE/bad.json" >/dev/null 2>&1
+STATUS=$?
+set -e
+if [[ "$STATUS" -ne 0 ]]; then
+    pass "invalid payload is rejected"
+else
+    fail "invalid payload is rejected"
+fi
+
+echo "--- Test 5: skill ownership is enforced ---"
+cat >"$TMP_BASE/wrong-owner.json" <<'JSON'
+{"learning": {"recent_failures": []}}
+JSON
+
+set +e
+"$DELTA_TOOL" update --skill strategy --payload-file "$TMP_BASE/wrong-owner.json" >/dev/null 2>&1
+STATUS=$?
+set -e
+if [[ "$STATUS" -ne 0 ]]; then
+    pass "skill ownership is enforced"
+else
+    fail "skill ownership is enforced"
+fi
+
+echo "--- Test 6: no-op update records explicit continuity decision ---"
+if "$DELTA_TOOL" update --skill strategy --no-op --summary "no strategic digest changes" >/dev/null \
+    && python3 - <<'PY' "$TMP_STATE/state/projections/continuity-deltas/runtime-latest.json"
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+assert payload["updates"][-1]["no_op"] is True
+assert payload["updates"][-1]["summary"] == "no strategic digest changes"
+PY
+then
+    pass "no-op update records explicit continuity decision"
+else
+    fail "no-op update records explicit continuity decision"
+fi
+
+echo ""
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [[ $FAIL -ne 0 ]]; then
+    exit 1
+fi

--- a/tests/test_edge_dispatch.sh
+++ b/tests/test_edge_dispatch.sh
@@ -170,6 +170,7 @@ assert request["corpus_coverage"]["missing_required_types"] == ["topic", "workfl
 assert request["search_protocol"]["required"] is True
 assert request["epistemic_protocol"]["required"] is True
 assert request["delta_prerequisite"]["required"] is True
+assert request["delta_prerequisite"]["digest_update_required"] is False
 assert request["delta_prerequisite"]["skill_command"] == "ed-delta"
 assert "previous_delta_digest" in request["delta_prerequisite"]
 assert "raw_chat" in request["delta_prerequisite"]["inputs"]

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -197,6 +197,7 @@ assert any("Corpus coverage is missing required types" in item for item in reque
 assert request["search_protocol"]["required"] is True
 assert request["epistemic_protocol"]["required"] is True
 assert request["delta_prerequisite"]["required"] is True
+assert request["delta_prerequisite"]["digest_update_required"] is False
 assert request["delta_prerequisite"]["inputs"]["raw_chat"]["available"] is True
 assert request["delta_prerequisite"]["inputs"]["raw_chat"]["recent_items"]
 assert request["exploration_pack"]["skill"] == "discovery"

--- a/tests/test_runtime_decision_protocol.sh
+++ b/tests/test_runtime_decision_protocol.sh
@@ -69,6 +69,7 @@ state = {
         "delta_prerequisite": {
             "required": True,
             "skill_command": "ed-delta",
+            "digest_update_required": False,
             "previous_delta_digest": {"open_work": []},
             "inputs": {"raw_chat": {"available": False}},
         },
@@ -85,6 +86,7 @@ assert "delta_prerequisite" in prompt
 assert "DELTA PREREQUISITE" in prompt
 assert "ed-delta" in prompt
 assert "same backend invocation" in prompt
+assert "edge-delta update" in prompt
 assert "mandatory read-only exploration loop" in prompt
 assert "configured web provider" in prompt
 assert "policy-disabled" in prompt
@@ -93,6 +95,36 @@ then
     pass "substantive skills get explicit search/epistemic runtime protocol"
 else
     fail "substantive skills get explicit search/epistemic runtime protocol"
+fi
+
+echo "--- Test 1b: strategy/reflection own curated delta digest updates ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+sys.path.insert(0, str(edge_dir / "tools"))
+
+from _shared.dispatch_runtime import build_delta_prerequisite
+
+strategy = build_delta_prerequisite({"request": {"skill": "strategy"}}, skill="strategy", stage="dispatch")
+reflection = build_delta_prerequisite({"request": {"skill": "reflection"}}, skill="reflection", stage="dispatch")
+research = build_delta_prerequisite({"request": {"skill": "research"}}, skill="research", stage="dispatch")
+
+assert strategy["digest_update_required"] is True
+assert strategy["digest_update_owner"] == "work"
+assert strategy["digest_update_contract"]["cli"].startswith("edge-delta update")
+assert reflection["digest_update_required"] is True
+assert reflection["digest_update_owner"] == "learning"
+assert research["digest_update_required"] is False
+assert research["digest_update_owner"] is None
+assert "curated_learning" in strategy["inputs"]["surfaces"]
+assert "curated_handoff" in strategy["inputs"]["surfaces"]
+PY
+then
+    pass "strategy/reflection own curated delta digest updates"
+else
+    fail "strategy/reflection own curated delta digest updates"
 fi
 
 echo "--- Test 2: heartbeat is exempt from the substantive protocol ---"

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -651,19 +651,85 @@ def _compact_surface_baselines(payload: Any, *, limit: int = DELTA_OPEN_WORK_LIM
     return compact
 
 
+def _compact_digest_items(items: Any, *, limit: int = DELTA_OPEN_WORK_LIMIT) -> list[Any]:
+    if not isinstance(items, list):
+        return []
+    compact: list[Any] = []
+    for item in items[:limit]:
+        if isinstance(item, dict):
+            compact.append(
+                {
+                    str(key): value
+                    for key, value in item.items()
+                    if key in {"id", "title", "summary", "surface", "status", "priority", "reason", "next", "evidence", "skill", "thread_id"}
+                }
+            )
+        else:
+            text = str(item or "").strip()
+            if text:
+                compact.append(text[:260])
+    return compact
+
+
+def _compact_learning_section(payload: Any) -> dict[str, Any]:
+    payload = payload if isinstance(payload, dict) else {}
+    return {
+        "recent_failures": _compact_digest_items(payload.get("recent_failures")),
+        "rules_to_preserve": _compact_digest_items(payload.get("rules_to_preserve")),
+        "protocol_gaps": _compact_digest_items(payload.get("protocol_gaps")),
+        "skill_patch_candidates": _compact_digest_items(payload.get("skill_patch_candidates")),
+        "archived_guidance_recent": _compact_digest_items(payload.get("archived_guidance_recent"), limit=8),
+    }
+
+
+def _compact_handoff_section(payload: Any) -> dict[str, Any]:
+    payload = payload if isinstance(payload, dict) else {}
+    return {
+        "inject_to_next_skill": _compact_digest_items(payload.get("inject_to_next_skill")),
+        "watch_next": _compact_digest_items(payload.get("watch_next")),
+        "unverified_but_important": _compact_digest_items(payload.get("unverified_but_important")),
+    }
+
+
+def _delta_digest_update_owner(skill: str | None) -> str | None:
+    normalized = _normalize_skill_name(skill)
+    if normalized == "strategy":
+        return "work"
+    if normalized == "reflection":
+        return "learning"
+    return None
+
+
 def _previous_delta_digest() -> dict[str, Any]:
     payload = _read_json(DELTA_DIGEST_FILE, {})
     if not isinstance(payload, dict):
         payload = {}
+    work = payload.get("work") if isinstance(payload.get("work"), dict) else {}
+    learning = payload.get("learning") if isinstance(payload.get("learning"), dict) else {}
+    handoff = payload.get("handoff") if isinstance(payload.get("handoff"), dict) else {}
+    surface_baselines = payload.get("surface_baselines") or work.get("surface_baselines")
+    open_work = payload.get("open_work") or work.get("open_work")
+    archived_work = payload.get("archived_work_recent") or work.get("archived_work_recent") or payload.get("archived_work")
     return {
         "schema_version": payload.get("schema_version"),
+        "kind": payload.get("kind") or "edge_delta_digest",
         "generated_at": payload.get("generated_at"),
+        "updated_at": payload.get("updated_at"),
         "digest_hash": payload.get("digest_hash"),
         "source_hash": payload.get("source_hash"),
         "summary": payload.get("summary"),
-        "surface_baselines": _compact_surface_baselines(payload.get("surface_baselines")),
-        "open_work": _compact_open_work(payload.get("open_work")),
-        "archived_work_recent": _compact_open_work(payload.get("archived_work_recent") or payload.get("archived_work"), limit=6),
+        "surface_baselines": _compact_surface_baselines(surface_baselines),
+        "open_work": _compact_open_work(open_work),
+        "archived_work_recent": _compact_open_work(archived_work, limit=6),
+        "work": {
+            "open_work": _compact_open_work(open_work),
+            "archived_work_recent": _compact_open_work(archived_work, limit=6),
+            "priority_threads": _compact_digest_items(work.get("priority_threads")),
+            "surface_baselines": _compact_surface_baselines(surface_baselines),
+        },
+        "learning": _compact_learning_section(learning),
+        "handoff": _compact_handoff_section(handoff),
+        "recent_updates": _compact_digest_items(payload.get("updates"), limit=6),
         "source_path": str(DELTA_DIGEST_FILE),
     }
 
@@ -738,12 +804,15 @@ def build_delta_prerequisite(state: dict[str, Any], *, skill: str | None, stage:
     required = _delta_required_for_skill(normalized)
     previous = _previous_delta_digest()
     open_work = previous.get("open_work") or []
+    digest_update_owner = _delta_digest_update_owner(normalized)
     operator_digest = request.get("operator_pressure_digest") or {}
     return {
         "schema_version": DELTA_PREREQUISITE_SCHEMA_VERSION,
         "skill": normalized,
         "stage": stage,
         "required": required,
+        "digest_update_required": digest_update_owner is not None,
+        "digest_update_owner": digest_update_owner,
         "reason": (
             "substantive skill must load the current work delta before its own reasoning"
             if required
@@ -761,6 +830,13 @@ def build_delta_prerequisite(state: dict[str, Any], *, skill: str | None, stage:
             "mode": "same_backend_invocation",
             "visibility": "the delta pass runs inside the dispatched skill prompt; keep delta_frame in working context for the main skill",
             "handoff_field": "delta_frame.work_continuity.inject_to_next_skill",
+        },
+        "digest_update_contract": {
+            "required_for_current_skill": digest_update_owner is not None,
+            "owner_section": digest_update_owner,
+            "cli": "edge-delta update --skill <strategy|reflection> --payload-file <json>",
+            "policy": "strategy curates work; reflection curates learning; both may refresh short handoff guidance",
+            "no_op": "edge-delta update --skill <skill> --no-op --summary '<why nothing changed>'",
         },
         "inputs": {
             "current_request": {
@@ -788,6 +864,9 @@ def build_delta_prerequisite(state: dict[str, Any], *, skill: str | None, stage:
                 "search_runtime": request.get("search_runtime", {}),
                 "surface_baselines": previous.get("surface_baselines", {}),
                 "open_work": open_work,
+                "curated_work": previous.get("work", {}),
+                "curated_learning": previous.get("learning", {}),
+                "curated_handoff": previous.get("handoff", {}),
             },
             "preflight": {
                 "constraints": request.get("constraints", {}),
@@ -824,14 +903,16 @@ def build_delta_prerequisite(state: dict[str, Any], *, skill: str | None, stage:
                 },
             },
             "new_delta_digest": {
-                "surface_baselines": "updated only for probed surfaces",
-                "open_work": "curated open work registry",
+                "work": "strategy-owned open work, archives, priority threads, and surface baselines",
+                "learning": "reflection-owned recent failures, durable rules, protocol gaps, and skill patch candidates",
+                "handoff": "short guidance to inject into the next skill",
                 "summary": "short continuity digest for the next beat",
             },
         },
         "rules": [
             "Compare previous_delta_digest, structured preflight state, raw chat, and any probed surfaces before the main skill reasons.",
             "Do not discard the delta output; the same backend invocation must carry delta_frame into the dispatched skill's main reasoning.",
+            "Use curated work, learning, and handoff sections as the persistent continuity layer; keep the runtime delta_frame short.",
             "Use raw chat to recover work mentioned outside edge cycles; use structured state to avoid re-opening work that was already closed.",
             "Probe only surfaces relevant to the current request, high-priority open work, or explicit operator pressure.",
             "Represent every real delta with before, after, evidence, relevance, and confidence.",
@@ -1585,6 +1666,8 @@ def enrich_dispatch_state(
         "beat_launch_operator_signals": len((request.get("beat_launch_context") or {}).get("signal_from_operator_now") or []),
         "beat_launch_edge_state_signals": len((request.get("beat_launch_context") or {}).get("signal_from_edge_state_now") or []),
         "delta_prerequisite_required": bool((request.get("delta_prerequisite") or {}).get("required")),
+        "delta_digest_update_required": bool((request.get("delta_prerequisite") or {}).get("digest_update_required")),
+        "delta_digest_update_owner": (request.get("delta_prerequisite") or {}).get("digest_update_owner"),
         "delta_open_work": len(((request.get("delta_prerequisite") or {}).get("previous_delta_digest") or {}).get("open_work") or []),
         "open_claims": claims_summary.get("open_total", 0),
         "orphans": orphan_summary.get("orphan_total", 0),
@@ -1697,6 +1780,7 @@ def render_skill_runtime_prompt(skill: str, state: dict[str, Any]) -> str:
         "The `operator_pressure_digest` captures recent operator signal only. The `beat_launch_context` is the ephemeral composition of that operator signal with current edge-state signals and the exploration budget for this beat. Treat those two together as the launch frame for what matters now.\n\n"
         "DELTA PREREQUISITE:\n"
         "For substantive non-heartbeat skills, `request.delta_prerequisite.required` is true. Before the main skill performs substantive work, execute the internal `ed-delta` pass over `request.delta_prerequisite`: reconcile previous_delta_digest, raw chat, structured preflight state, events, and relevant work surfaces; produce a `delta_frame`; and carry `delta_frame.work_continuity.inject_to_next_skill` into the main skill. The delta pass runs in this same backend invocation, so its explored text and frame remain available to the dispatched skill. If no real delta is found, state that explicitly and continue with an empty delta frame.\n\n"
+        "If `request.delta_prerequisite.digest_update_required` is true, persist a compact curated update before closing the skill: `strategy` owns the digest `work` section, `reflection` owns the digest `learning` section, and both may update short `handoff` guidance. Use `edge-delta update --skill <skill> --payload-file <json>` or record an explicit no-op with `edge-delta update --skill <skill> --no-op --summary <reason>`.\n\n"
         "Prefer `edge-cap invoke <capability> -- ...` over direct CLI/tool calls when a capability exists in `capabilities_status`.\n\n"
         "Before any substantive decision, synthesis, or artifact drafting in non-heartbeat skills, read `exploration_pack` first. "
         "The runtime has already performed the mandatory read-only exploration loop: memory retrieval, source/signal fan-out, adversarial Feynman interpretation, and a targeted second round. "

--- a/tools/edge-delta
+++ b/tools/edge-delta
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""edge-delta - curated runtime delta digest store."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import CONTINUITY_DELTAS_DIR  # noqa: E402
+
+SCHEMA_VERSION = 1
+DIGEST_FILE = CONTINUITY_DELTAS_DIR / "runtime-latest.json"
+HISTORY_DIR = CONTINUITY_DELTAS_DIR / "runtime-history"
+MAX_ITEMS = 20
+MAX_TEXT = 700
+
+WORK_FIELDS = {
+    "open_work",
+    "archived_work_recent",
+    "priority_threads",
+    "surface_baselines",
+}
+LEARNING_FIELDS = {
+    "recent_failures",
+    "rules_to_preserve",
+    "protocol_gaps",
+    "skill_patch_candidates",
+    "archived_guidance_recent",
+}
+HANDOFF_FIELDS = {
+    "inject_to_next_skill",
+    "watch_next",
+    "unverified_but_important",
+}
+TOP_LEVEL_UPDATE_FIELDS = {
+    "summary",
+    "work",
+    "learning",
+    "handoff",
+    "surface_baselines",
+    "open_work",
+    "archived_work_recent",
+}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def stable_hash(payload: Any) -> str:
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return f"sha256:{hashlib.sha256(raw).hexdigest()}"
+
+
+def compact(value: Any, *, max_items: int = MAX_ITEMS) -> Any:
+    if isinstance(value, str):
+        return value.strip()[:MAX_TEXT]
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return [compact(item, max_items=max_items) for item in value[:max_items]]
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key in sorted(value.keys(), key=lambda item: str(item)):
+            text_key = str(key).strip()
+            if not text_key:
+                continue
+            out[text_key] = compact(value[key], max_items=max_items)
+        return out
+    return str(value)[:MAX_TEXT]
+
+
+def empty_digest() -> dict[str, Any]:
+    generated_at = now_iso()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "edge_delta_digest",
+        "generated_at": generated_at,
+        "updated_at": generated_at,
+        "summary": "",
+        "source_hash": "",
+        "digest_hash": "",
+        "surface_baselines": {},
+        "open_work": [],
+        "archived_work_recent": [],
+        "work": {
+            "open_work": [],
+            "archived_work_recent": [],
+            "priority_threads": [],
+            "surface_baselines": {},
+        },
+        "learning": {
+            "recent_failures": [],
+            "rules_to_preserve": [],
+            "protocol_gaps": [],
+            "skill_patch_candidates": [],
+            "archived_guidance_recent": [],
+        },
+        "handoff": {
+            "inject_to_next_skill": [],
+            "watch_next": [],
+            "unverified_but_important": [],
+        },
+        "updates": [],
+    }
+
+
+def normalize_section(raw: Any, fields: set[str]) -> dict[str, Any]:
+    section: dict[str, Any] = {}
+    raw = raw if isinstance(raw, dict) else {}
+    for field in fields:
+        default: Any = {} if field == "surface_baselines" else []
+        value = raw.get(field, default)
+        if field == "surface_baselines":
+            section[field] = compact(value if isinstance(value, dict) else {})
+        else:
+            section[field] = compact(value if isinstance(value, list) else [])
+    return section
+
+
+def normalize_digest(payload: Any) -> dict[str, Any]:
+    base = empty_digest()
+    if not isinstance(payload, dict):
+        refresh_hashes(base)
+        return base
+
+    base["schema_version"] = int(payload.get("schema_version") or SCHEMA_VERSION)
+    base["kind"] = str(payload.get("kind") or "edge_delta_digest")
+    base["generated_at"] = str(payload.get("generated_at") or base["generated_at"])
+    base["updated_at"] = str(payload.get("updated_at") or payload.get("generated_at") or base["updated_at"])
+    base["summary"] = str(payload.get("summary") or "")[:MAX_TEXT]
+
+    work = normalize_section(payload.get("work"), WORK_FIELDS)
+    if payload.get("open_work") and not work["open_work"]:
+        work["open_work"] = compact(payload.get("open_work") if isinstance(payload.get("open_work"), list) else [])
+    if payload.get("archived_work_recent") and not work["archived_work_recent"]:
+        work["archived_work_recent"] = compact(
+            payload.get("archived_work_recent") if isinstance(payload.get("archived_work_recent"), list) else []
+        )
+    if payload.get("surface_baselines") and not work["surface_baselines"]:
+        work["surface_baselines"] = compact(
+            payload.get("surface_baselines") if isinstance(payload.get("surface_baselines"), dict) else {}
+        )
+
+    base["work"] = work
+    base["learning"] = normalize_section(payload.get("learning"), LEARNING_FIELDS)
+    base["handoff"] = normalize_section(payload.get("handoff"), HANDOFF_FIELDS)
+    base["open_work"] = work["open_work"]
+    base["archived_work_recent"] = work["archived_work_recent"]
+    base["surface_baselines"] = work["surface_baselines"]
+    base["updates"] = compact(payload.get("updates") if isinstance(payload.get("updates"), list) else [])[-MAX_ITEMS:]
+    refresh_hashes(base)
+    return base
+
+
+def hashable_digest(digest: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in digest.items()
+        if key not in {"digest_hash", "source_hash", "generated_at", "updated_at"}
+    }
+
+
+def refresh_hashes(digest: dict[str, Any]) -> None:
+    source = hashable_digest(digest)
+    digest["source_hash"] = stable_hash(source)
+    digest["digest_hash"] = stable_hash({**source, "source_hash": digest["source_hash"]})
+
+
+def current_digest() -> dict[str, Any]:
+    return normalize_digest(read_json(DIGEST_FILE, {}))
+
+
+def unwrap_update(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a JSON object")
+    for key in ("delta_digest_update", "new_delta_digest"):
+        nested = payload.get(key)
+        if isinstance(nested, dict):
+            return nested
+    return payload
+
+
+def validate_update(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    unknown = sorted(set(payload.keys()) - TOP_LEVEL_UPDATE_FIELDS)
+    if unknown:
+        errors.append(f"unknown top-level field(s): {', '.join(unknown)}")
+    for section_name, fields in (("work", WORK_FIELDS), ("learning", LEARNING_FIELDS), ("handoff", HANDOFF_FIELDS)):
+        section = payload.get(section_name)
+        if section is None:
+            continue
+        if not isinstance(section, dict):
+            errors.append(f"{section_name} must be an object")
+            continue
+        unknown_section = sorted(set(section.keys()) - fields)
+        if unknown_section:
+            errors.append(f"{section_name} has unknown field(s): {', '.join(unknown_section)}")
+        for field, value in section.items():
+            if field == "surface_baselines":
+                if not isinstance(value, dict):
+                    errors.append("work.surface_baselines must be an object")
+            elif field in fields and not isinstance(value, list):
+                errors.append(f"{section_name}.{field} must be a list")
+    if "surface_baselines" in payload and not isinstance(payload["surface_baselines"], dict):
+        errors.append("surface_baselines must be an object")
+    for field in ("open_work", "archived_work_recent"):
+        if field in payload and not isinstance(payload[field], list):
+            errors.append(f"{field} must be a list")
+    if "summary" in payload and not isinstance(payload["summary"], str):
+        errors.append("summary must be a string")
+    return errors
+
+
+def normalized_skill(raw: str | None) -> str:
+    return str(raw or "").strip().lstrip("/").split("-")[-1]
+
+
+def validate_skill_scope(payload: dict[str, Any], *, skill: str | None) -> list[str]:
+    normalized = normalized_skill(skill)
+    errors: list[str] = []
+    if normalized == "strategy" and "learning" in payload:
+        errors.append("strategy may update work and handoff, not learning")
+    if normalized == "reflection":
+        work_fields = {"work", "open_work", "archived_work_recent", "surface_baselines"}
+        used = sorted(work_fields.intersection(payload.keys()))
+        if used:
+            errors.append(f"reflection may update learning and handoff, not work field(s): {', '.join(used)}")
+    return errors
+
+
+def load_update_payload(args: argparse.Namespace) -> dict[str, Any]:
+    if args.no_op:
+        return {"summary": args.summary or "no delta digest changes"}
+    if args.payload_json:
+        payload = json.loads(args.payload_json)
+    elif args.payload_file:
+        if args.payload_file == "-":
+            payload = json.loads(sys.stdin.read())
+        else:
+            payload = json.loads(Path(args.payload_file).read_text(encoding="utf-8"))
+    else:
+        raise ValueError("update requires --payload-file, --payload-json, or --no-op")
+    payload = unwrap_update(payload)
+    if args.summary:
+        payload["summary"] = args.summary
+    return payload
+
+
+def merge_section(target: dict[str, Any], update: dict[str, Any], fields: set[str]) -> None:
+    for field in fields:
+        if field not in update:
+            continue
+        if field == "surface_baselines":
+            existing = target.get(field) if isinstance(target.get(field), dict) else {}
+            incoming = update.get(field) if isinstance(update.get(field), dict) else {}
+            target[field] = compact({**existing, **incoming})
+        else:
+            target[field] = compact(update.get(field) if isinstance(update.get(field), list) else [])
+
+
+def apply_update(digest: dict[str, Any], payload: dict[str, Any], *, skill: str, no_op: bool = False) -> dict[str, Any]:
+    digest = normalize_digest(digest)
+    if "work" in payload and isinstance(payload["work"], dict):
+        merge_section(digest["work"], payload["work"], WORK_FIELDS)
+    if "learning" in payload and isinstance(payload["learning"], dict):
+        merge_section(digest["learning"], payload["learning"], LEARNING_FIELDS)
+    if "handoff" in payload and isinstance(payload["handoff"], dict):
+        merge_section(digest["handoff"], payload["handoff"], HANDOFF_FIELDS)
+
+    if "open_work" in payload:
+        digest["work"]["open_work"] = compact(payload.get("open_work") if isinstance(payload.get("open_work"), list) else [])
+    if "archived_work_recent" in payload:
+        digest["work"]["archived_work_recent"] = compact(
+            payload.get("archived_work_recent") if isinstance(payload.get("archived_work_recent"), list) else []
+        )
+    if "surface_baselines" in payload:
+        existing = digest["work"].get("surface_baselines") if isinstance(digest["work"].get("surface_baselines"), dict) else {}
+        incoming = payload.get("surface_baselines") if isinstance(payload.get("surface_baselines"), dict) else {}
+        digest["work"]["surface_baselines"] = compact({**existing, **incoming})
+
+    digest["open_work"] = digest["work"]["open_work"]
+    digest["archived_work_recent"] = digest["work"]["archived_work_recent"]
+    digest["surface_baselines"] = digest["work"]["surface_baselines"]
+
+    summary = str(payload.get("summary") or "").strip()
+    if summary:
+        digest["summary"] = summary[:MAX_TEXT]
+    digest["updated_at"] = now_iso()
+    update_record = {
+        "skill": skill,
+        "updated_at": digest["updated_at"],
+        "summary": summary or ("no-op" if no_op else "delta digest update"),
+        "sections": [key for key in ("work", "learning", "handoff") if key in payload],
+        "no_op": bool(no_op),
+    }
+    digest["updates"] = compact((digest.get("updates") or []) + [update_record])[-MAX_ITEMS:]
+    refresh_hashes(digest)
+    return digest
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    digest = current_digest()
+    if args.json:
+        print(json.dumps(digest, indent=2, ensure_ascii=False))
+    else:
+        print(f"path: {DIGEST_FILE}")
+        print(f"digest_hash: {digest.get('digest_hash')}")
+        print(f"summary: {digest.get('summary') or '(empty)'}")
+        print(f"open_work: {len(digest.get('open_work') or [])}")
+        print(f"learning_failures: {len((digest.get('learning') or {}).get('recent_failures') or [])}")
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    try:
+        payload = load_update_payload(args)
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+        return 1
+    errors = validate_update(payload)
+    if args.skill:
+        errors.extend(validate_skill_scope(payload, skill=args.skill))
+    result = {"ok": not errors, "errors": errors}
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0 if not errors else 1
+
+
+def cmd_update(args: argparse.Namespace) -> int:
+    try:
+        payload = load_update_payload(args)
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+        return 1
+    errors = validate_update(payload)
+    errors.extend(validate_skill_scope(payload, skill=args.skill))
+    if errors:
+        print(json.dumps({"ok": False, "errors": errors}, indent=2, ensure_ascii=False), file=sys.stderr)
+        return 1
+    digest = apply_update(current_digest(), payload, skill=args.skill, no_op=args.no_op)
+    if not args.dry_run:
+        write_json(DIGEST_FILE, digest)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        safe_skill = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in args.skill)
+        history_path = HISTORY_DIR / f"{stamp}-{safe_skill}.json"
+        write_json(history_path, digest)
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "path": str(DIGEST_FILE),
+                "digest_hash": digest.get("digest_hash"),
+                "summary": digest.get("summary"),
+                "dry_run": bool(args.dry_run),
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Curated runtime delta digest store")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_show = sub.add_parser("show", help="Show the current curated delta digest")
+    p_show.add_argument("--json", action="store_true")
+    p_show.set_defaults(func=cmd_show)
+
+    p_validate = sub.add_parser("validate", help="Validate a digest update payload")
+    p_validate.add_argument("--payload-file")
+    p_validate.add_argument("--payload-json")
+    p_validate.add_argument("--skill")
+    p_validate.add_argument("--summary")
+    p_validate.add_argument("--no-op", action="store_true")
+    p_validate.set_defaults(func=cmd_validate)
+
+    p_update = sub.add_parser("update", help="Merge and persist a curated digest update")
+    p_update.add_argument("--skill", required=True)
+    p_update.add_argument("--payload-file")
+    p_update.add_argument("--payload-json")
+    p_update.add_argument("--summary")
+    p_update.add_argument("--no-op", action="store_true")
+    p_update.add_argument("--dry-run", action="store_true")
+    p_update.set_defaults(func=cmd_update)
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add deterministic `edge-delta` CLI to show, validate, and persist curated runtime delta digests without making model calls
- model the digest as `work`, `learning`, and `handoff`, with ownership enforced for `strategy` and `reflection`
- update `ed-delta`, `ed-strategy`, and `ed-reflection` contracts so delta reads the digest and strategy/reflection curate it every run
- extend dispatch runtime context so strategy/reflection know when digest updates are required and what section they own
- add tests for CLI validation/merge behavior and runtime contract

## Tests
- `python3 -m py_compile tools/edge-delta tools/_shared/dispatch_runtime.py tools/edge-runner tools/edge-dispatch tools/edge-preflight`
- `bash tests/test_edge_delta.sh`
- `bash tests/test_runtime_decision_protocol.sh`
- `bash tests/test_edge_dispatch.sh`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_operator_pressure_layers.sh`
- `bash tests/test_edge_apply_tools_recursive.sh`

Fixes #390