### PR TITLE
Fix blog pending status semantics

### DIFF
--- a/blog/app.py
+++ b/blog/app.py
@@ -108,6 +108,21 @@ TAG_MAP = {
     "execution": "execucao", "calibration": "calibracao",
 }
 
+UNPUBLISHED_STATUSES = {"draft", "pending", "pendente", "unpublished", "private", "hidden"}
+UNPUBLISHED_TAGS = {"draft", "workflow-draft", "unpublished"}
+
+
+def _normalized_token(value):
+    return str(value or "").strip().lower()
+
+
+def is_entry_published(fm, tags):
+    status = _normalized_token(fm.get("status"))
+    if status in UNPUBLISHED_STATUSES:
+        return False
+    normalized_tags = {_normalized_token(tag) for tag in tags or []}
+    return not bool(normalized_tags & UNPUBLISHED_TAGS)
+
 SKILL_GROUPS = [
     {"name": "producao", "label": "producao", "tags": ["pesquisa", "descoberta", "lazer"]},
     {"name": "planejamento", "label": "planejamento", "tags": ["planejamento", "estrategia"]},
@@ -274,8 +289,8 @@ def load_entries():
         if audit_path.exists():
             state_audit = audit_path.name
 
-        # Pipeline enforcement: entry is "published" only if meta-report exists
-        published = bool(meta_report)
+        pipeline_complete = bool(meta_report)
+        published = is_entry_published(fm, tags_list)
 
         entries.append({
             "title": fm.get("title", fp.stem),
@@ -285,6 +300,8 @@ def load_entries():
             "context": fm.get("context", ""),
             "report": os.path.basename(fm.get("report", "")) if fm.get("report") else "",
             "meta_report": meta_report,
+            "pipeline_complete": pipeline_complete,
+            "pipeline_status": "complete" if pipeline_complete else "missing_meta_report",
             "published": published,
             "state_proposal": state_proposal,
             "state_audit": state_audit,
@@ -424,7 +441,8 @@ def filter_entries(entries, comments_data, cat=None, temp=None, status=None,
             fts_slugs = {r["slug"] for r in fts_results}
 
     for e in entries:
-        # Pipeline enforcement: hide unpublished entries unless explicitly requested
+        # Hide explicit drafts/unpublished entries unless explicitly requested.
+        # Missing meta-report is tracked separately as pipeline_status.
         if not show_pending and not e.get("published"):
             continue
 
@@ -777,6 +795,9 @@ def entries_json():
             "category_number": e["category_number"],
             "report": e.get("report", ""),
             "meta_report": e.get("meta_report", ""),
+            "pipeline_complete": e.get("pipeline_complete", False),
+            "pipeline_status": e.get("pipeline_status", ""),
+            "published": e.get("published", False),
             "state_proposal": e.get("state_proposal", ""),
             "state_audit": e.get("state_audit", ""),
             "llm_cost": e.get("llm_cost", ""),

--- a/blog/templates/partials/compact_card.html
+++ b/blog/templates/partials/compact_card.html
@@ -8,7 +8,7 @@
   <div class="compact-row">
     <span class="entry-number">#{{ entry.break_number }}</span>
     <span class="compact-title">{{ entry.title[:60] }}{{ '...' if entry.title|length > 60 }}</span>
-    {% if not entry.published %}<span class="entry-tag" style="background:#e74c3c;color:#fff;font-size:0.7em">SEM PIPELINE</span>{% endif %}
+    {% if not entry.pipeline_complete %}<span class="entry-tag" style="background:#e74c3c;color:#fff;font-size:0.7em">SEM PIPELINE</span>{% endif %}
     <span class="entry-tag tag-{{ entry.tag }}">{{ entry.tag }}</span>
     <span class="temp-badge temp-{{ entry.temperature or 'null' }}"
           data-path="{{ entry.path }}"

--- a/blog/templates/partials/entry_card.html
+++ b/blog/templates/partials/entry_card.html
@@ -11,7 +11,7 @@
       <span class="entry-number">#{{ entry.break_number }} | {{ entry.tag }} #{{ entry.category_number }}</span>
       <div class="entry-title">{{ entry.title }}</div>
     </div>
-    {% if not entry.published %}<span class="entry-tag" style="background:#e74c3c;color:#fff;font-weight:bold">SEM PIPELINE</span>{% endif %}
+    {% if not entry.pipeline_complete %}<span class="entry-tag" style="background:#e74c3c;color:#fff;font-weight:bold">SEM PIPELINE</span>{% endif %}
     <span class="entry-tag tag-{{ entry.tag }}">{{ entry.tag }}</span>
     <span class="temp-badge temp-{{ entry.temperature or 'null' }}"
           data-path="{{ entry.path }}"

--- a/tests/test_blog_pending_status_semantics.sh
+++ b/tests/test_blog_pending_status_semantics.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+APP="$EDGE_DIR/blog/app.py"
+ENTRY_CARD="$EDGE_DIR/blog/templates/partials/entry_card.html"
+COMPACT_CARD="$EDGE_DIR/blog/templates/partials/compact_card.html"
+
+echo "=== blog pending status semantics test ==="
+
+python3 - <<'PY' "$APP"
+import ast
+import sys
+
+path = sys.argv[1]
+source = open(path, encoding="utf-8").read()
+tree = ast.parse(source, filename=path)
+
+selected = []
+for node in tree.body:
+    if isinstance(node, ast.Assign):
+        names = {target.id for target in node.targets if isinstance(target, ast.Name)}
+        if names & {"UNPUBLISHED_STATUSES", "UNPUBLISHED_TAGS"}:
+            selected.append(node)
+    elif isinstance(node, ast.FunctionDef) and node.name in {"_normalized_token", "is_entry_published"}:
+        selected.append(node)
+
+namespace = {}
+module = ast.Module(body=selected, type_ignores=[])
+ast.fix_missing_locations(module)
+exec(compile(module, path, "exec"), namespace)
+
+is_entry_published = namespace["is_entry_published"]
+
+assert is_entry_published({}, ["workflow"]) is True
+assert is_entry_published({"status": "approved"}, ["workflow", "operator-authored"]) is True
+assert is_entry_published({"status": "draft"}, ["workflow"]) is False
+assert is_entry_published({"status": "pending"}, ["workflow"]) is False
+assert is_entry_published({"status": "pendente"}, ["workflow"]) is False
+assert is_entry_published({}, ["workflow-draft"]) is False
+
+assert "pipeline_complete = bool(meta_report)" in source
+assert '"pipeline_status": "complete" if pipeline_complete else "missing_meta_report"' in source
+assert "published = is_entry_published(fm, tags_list)" in source
+PY
+
+grep -q "entry.pipeline_complete" "$ENTRY_CARD"
+grep -q "entry.pipeline_complete" "$COMPACT_CARD"
+! grep -q "not entry.published.*SEM PIPELINE" "$ENTRY_CARD"
+! grep -q "not entry.published.*SEM PIPELINE" "$COMPACT_CARD"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #393\n\n## Summary\n- separate entry publication state from meta-report/pipeline completeness\n- keep missing meta-report visible as pipeline_status / SEM PIPELINE\n- expose published + pipeline fields in the entries JSON API\n- add a regression test for pending status semantics\n\n## Tests\n- tests/test_blog_pending_status_semantics.sh\n- python3 -m py_compile blog/app.py\n- git diff --check