### PR TITLE
Require autonomous continuation after explicit skill dispatch

### DIFF
--- a/skills/_shared/state-protocol.md
+++ b/skills/_shared/state-protocol.md
@@ -97,6 +97,34 @@ Rules:
 
 ---
 
+## Autonomous Continuation After Explicit Dispatch (MANDATORY)
+
+An explicit skill dispatch is authorization to complete that skill's own
+contract. Do not stop mid-skill to ask whether to continue, whether to run the
+next internal loop, or whether to finish the method the operator already
+invoked.
+
+Rules:
+- If the operator invoked a concrete skill (`/ed-research`, `/ed-planner`,
+  `/ed-reflection`, etc.), infer reasonable scope from the request and current
+  context, state assumptions in the final output, and continue through the
+  skill contract.
+- If a method has bounded internal loops, run those loops autonomously within
+  the skill budget. Remaining uncertainty belongs in the output as open gaps,
+  not as a mid-cycle permission question.
+- Ask the operator only when the target cannot be inferred enough to begin, a
+  destructive or external mutation needs approval, required access is missing,
+  or the next step truly depends on a human judgment rather than agent work.
+- A question to the operator is not a substitute for doing available research,
+  probing local state, checking read models, or trying the next non-mutating
+  step.
+
+For research skills specifically: Feynman gap-resolution loops are part of the
+contract. Complete them autonomously, then publish remaining
+`[STILL DON'T UNDERSTAND: ...]` gaps if they remain.
+
+---
+
 ## Workflow Lookup (MANDATORY, before execution)
 
 Before starting any skill, look up relevant workflows and save the results:

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -32,6 +32,13 @@ Feynman cycle:
 
 Run at most two gap-resolution loops before publishing the remaining uncertainty.
 
+Do not pause after the first gap pass to ask whether to continue. A direct
+`/ed-research` dispatch already authorizes the bounded Feynman cycle. If the
+topic is underspecified, infer a reasonable scope from current context and say
+what you assumed in the final artifact. Ask the operator only when the target
+cannot be inferred enough to begin, required access is missing, or the next
+step requires an external/destructive mutation rather than research.
+
 ## Boundary
 
 Do not manage lifecycle, publication, postflight, or generic artifact rites inside this skill.

--- a/tests/test_autonomous_skill_continuation.sh
+++ b/tests/test_autonomous_skill_continuation.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PROTOCOL="$EDGE_DIR/skills/_shared/state-protocol.md"
+RESEARCH="$EDGE_DIR/skills/research/SKILL.md"
+
+echo "=== autonomous skill continuation test ==="
+
+grep -q "Autonomous Continuation After Explicit Dispatch" "$PROTOCOL"
+grep -q "Do not stop mid-skill to ask whether to continue" "$PROTOCOL"
+grep -q "bounded internal loops" "$PROTOCOL"
+grep -q "Feynman gap-resolution loops are part of the" "$PROTOCOL"
+
+grep -q "Do not pause after the first gap pass" "$RESEARCH"
+grep -q "/ed-research.*already authorizes" "$RESEARCH"
+grep -q "infer a reasonable scope" "$RESEARCH"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary
- add shared protocol guidance that an explicit skill dispatch authorizes completing the skill contract without mid-cycle permission questions
- clarify that bounded loops, especially research/Feynman gap-resolution loops, should run autonomously and publish remaining uncertainty in the output
- update `ed-research` to prohibit stopping after the first gap pass to ask whether to continue
- add a regression test for the shared protocol and research skill wording

## Validation
- `bash tests/test_autonomous_skill_continuation.sh`
- `bash tests/test_runtime_decision_protocol.sh`
- `git diff --check`

Fixes #395
