### PR TITLE
[codex] Add dispatch queue ack contract

### DIFF
--- a/tests/test_edge_dispatch.sh
+++ b/tests/test_edge_dispatch.sh
@@ -342,6 +342,95 @@ fi
 
 EDGE_CYCLE_ID=cycle-mismatch "$DISPATCH_TOOL" close --status aborted >/dev/null
 
+echo "--- Test 4e: ack removes an exact dispatch queue entry ---"
+cat >"$TMP_EDGE/state/dispatch-queue.json" <<'JSON'
+[
+  {
+    "skill": "reflection",
+    "source": "state-anchor-monitor",
+    "entry_id": "state-anchor-monitor:abc123",
+    "reason": "state anchor changed",
+    "created_at": "2026-04-29T00:00:00+00:00",
+    "payload": {"changed_files": [{"path": "memory/MEMORY.md"}]}
+  },
+  {
+    "skill": "strategy",
+    "source": "reflection",
+    "entry_id": "reflection:def456",
+    "reason": "handoff",
+    "created_at": "2026-04-29T00:01:00+00:00",
+    "payload": {}
+  }
+]
+JSON
+
+ACK_OUTPUT=$("$DISPATCH_TOOL" ack \
+    --skill reflection \
+    --source state-anchor-monitor \
+    --entry-id state-anchor-monitor:abc123 \
+    --cycle-id cycle-queue-ack \
+    --reason test_ack)
+
+if python3 - <<'PY' "$TMP_EDGE/state/dispatch-queue.json" "$TMP_EDGE/state/events/log.jsonl" "$ACK_OUTPUT"
+import json
+import sys
+
+queue = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+ack = json.loads(sys.argv[3])
+
+assert ack["removed"] is True
+assert ack["entry_id"] == "state-anchor-monitor:abc123"
+assert len(queue) == 1
+assert queue[0]["skill"] == "strategy"
+event = [item for item in events if item["type"] == "DispatchQueueEntryAcknowledged"][-1]
+assert event["cycle_id"] == "cycle-queue-ack"
+assert event["payload"]["reason"] == "test_ack"
+PY
+then
+    pass "ack removes an exact dispatch queue entry"
+else
+    fail "ack removes an exact dispatch queue entry"
+fi
+
+echo "--- Test 4f: completed cycle auto-acks the captured queue head ---"
+cat >"$TMP_EDGE/state/dispatch-queue.json" <<'JSON'
+[
+  {
+    "skill": "reflection",
+    "source": "state-anchor-monitor",
+    "entry_id": "state-anchor-monitor:autoack",
+    "reason": "state anchor changed",
+    "created_at": "2026-04-29T00:00:00+00:00",
+    "payload": {"changed_files": [{"path": "config/CLAUDE.md"}]}
+  }
+]
+JSON
+
+"$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-queue-autoack >/dev/null
+"$DISPATCH_TOOL" dispatch --skill reflection >/dev/null
+"$DISPATCH_TOOL" close --status completed >/dev/null
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/dispatch-queue.json" "$TMP_EDGE/state/events/log.jsonl"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+queue = json.load(open(sys.argv[2], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[3], encoding="utf-8") if line.strip()]
+acks = [item for item in events if item["type"] == "DispatchQueueEntryAcknowledged" and item.get("cycle_id") == "cycle-queue-autoack"]
+
+assert queue == []
+assert dispatch["state"]["dispatch_queue_ack"]["removed"] is True
+assert dispatch["state"]["dispatch_queue_ack"]["entry_id"] == "state-anchor-monitor:autoack"
+assert acks[-1]["payload"]["reason"] == "completed_cycle"
+PY
+then
+    pass "completed cycle auto-acks the captured queue head"
+else
+    fail "completed cycle auto-acks the captured queue head"
+fi
+
 echo "--- Test 5: operator cycle suppresses legacy heartbeat guard fallback ---"
 python3 - <<'PY' "$TMP_EDGE/state/current-beat.json"
 import json

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -7,7 +7,9 @@ import os
 import re
 import subprocess
 import sys
+import fcntl
 from collections import deque
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -109,11 +111,20 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _write_json(path: Path, payload: dict[str, Any]) -> None:
+def _write_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     tmp.replace(path)
+
+
+@contextmanager
+def _dispatch_queue_lock():
+    lock_path = DISPATCH_QUEUE_FILE.parent / ".dispatch-queue.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        yield
 
 
 def read_dispatch_state() -> dict[str, Any]:
@@ -161,6 +172,112 @@ def _normalize_skill_name(skill: str | None) -> str:
     if EDGE_INSTANCE and raw.startswith(f"{EDGE_INSTANCE}-"):
         return raw[len(EDGE_INSTANCE) + 1 :]
     return raw
+
+
+def ack_dispatch_queue_entry(
+    *,
+    skill: str,
+    source: str,
+    entry_id: str | None = None,
+    cycle_id: str | None = None,
+    reason: str = "manual_ack",
+) -> dict[str, Any]:
+    """Remove one dispatch-queue entry through an explicit command contract."""
+    normalized_skill = _normalize_skill_name(skill)
+    normalized_source = str(source or "").strip()
+    expected_entry_id = str(entry_id or "").strip()
+
+    with _dispatch_queue_lock():
+        queue = _read_json(DISPATCH_QUEUE_FILE, [])
+        if not isinstance(queue, list):
+            queue = []
+
+        before_total = len(queue)
+        removed_entry: dict[str, Any] | None = None
+        kept: list[Any] = []
+        for item in queue:
+            if not isinstance(item, dict) or removed_entry is not None:
+                kept.append(item)
+                continue
+
+            item_skill = _normalize_skill_name(item.get("skill"))
+            item_source = str(item.get("source") or "").strip()
+            item_entry_id = str(item.get("entry_id") or "").strip()
+            skill_matches = item_skill == normalized_skill
+            source_matches = item_source == normalized_source
+            id_matches = not expected_entry_id or item_entry_id == expected_entry_id
+            if skill_matches and source_matches and id_matches:
+                removed_entry = item
+            else:
+                kept.append(item)
+
+        if removed_entry is not None:
+            _write_json(DISPATCH_QUEUE_FILE, kept)
+
+    result = {
+        "ok": True,
+        "removed": removed_entry is not None,
+        "skill": normalized_skill,
+        "source": normalized_source,
+        "entry_id": expected_entry_id or (removed_entry or {}).get("entry_id"),
+        "reason": reason,
+        "cycle_id": cycle_id,
+        "before_total": before_total,
+        "after_total": len(kept) if removed_entry is not None else before_total,
+        "queue_path": str(DISPATCH_QUEUE_FILE),
+        "removed_entry": removed_entry,
+    }
+    if removed_entry is not None:
+        emit_shadow_event(
+            "DispatchQueueEntryAcknowledged",
+            actor="edge-dispatch",
+            cycle_id=cycle_id,
+            payload={
+                "skill": normalized_skill,
+                "source": normalized_source,
+                "entry_id": result.get("entry_id"),
+                "reason": reason,
+                "before_total": before_total,
+                "after_total": result["after_total"],
+            },
+        )
+        log_event(
+            "dispatch_queue",
+            actor="edge-dispatch",
+            cycle_id=cycle_id,
+            action="acknowledged",
+            skill=normalized_skill,
+            source=normalized_source,
+            entry_id=result.get("entry_id") or "",
+            reason=reason,
+        )
+    return result
+
+
+def ack_dispatch_queue_for_completed_cycle(state: dict[str, Any]) -> dict[str, Any] | None:
+    """Ack the queue head captured by preflight when the selected skill completed."""
+    request = state.get("request", {}) or {}
+    queue_summary = request.get("dispatch_queue_summary") or {}
+    head = queue_summary.get("head") if isinstance(queue_summary, dict) else None
+    if not isinstance(head, dict):
+        return None
+
+    selected_skill = _normalize_skill_name(request.get("skill"))
+    queued_skill = _normalize_skill_name(head.get("skill"))
+    if not selected_skill or selected_skill != queued_skill:
+        return None
+
+    source = str(head.get("source") or "").strip()
+    if not source:
+        return None
+
+    return ack_dispatch_queue_entry(
+        skill=selected_skill,
+        source=source,
+        entry_id=str(head.get("entry_id") or "").strip() or None,
+        cycle_id=state.get("cycle_id"),
+        reason="completed_cycle",
+    )
 
 
 def _heartbeat_skill_active(state: dict[str, Any], skill: str | None = None) -> bool:

--- a/tools/edge-dispatch
+++ b/tools/edge-dispatch
@@ -6,6 +6,7 @@ Usage:
   edge-dispatch open --trigger operator --skill reflection --arg topic=enforcement
   edge-dispatch dispatch --skill research
   edge-dispatch close --status completed
+  edge-dispatch ack --skill reflection --source state-anchor-monitor
   edge-dispatch status
 """
 
@@ -27,7 +28,12 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import CURRENT_BEAT_FILE, CURRENT_DISPATCH_FILE, THREADS_DIR  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
-from _shared.dispatch_runtime import acknowledge_heartbeat_routing, enrich_dispatch_state  # noqa: E402
+from _shared.dispatch_runtime import (  # noqa: E402
+    ack_dispatch_queue_entry,
+    ack_dispatch_queue_for_completed_cycle,
+    acknowledge_heartbeat_routing,
+    enrich_dispatch_state,
+)
 from _shared.telemetry import current_actor, emit_shadow_event, log_event  # noqa: E402
 from _shared.skill_inbox import attach_snapshot_to_dispatch  # noqa: E402
 
@@ -519,6 +525,17 @@ def cmd_close(args: argparse.Namespace) -> int:
     state_block["updated_at"] = timestamp
     if state_block.get("skill_status") == "running":
         state_block["skill_status"] = "completed" if args.status == "completed" else args.status
+    if args.status == "completed":
+        ack_result = ack_dispatch_queue_for_completed_cycle(state)
+        if ack_result is not None:
+            state_block["dispatch_queue_ack"] = {
+                "removed": ack_result.get("removed", False),
+                "skill": ack_result.get("skill"),
+                "source": ack_result.get("source"),
+                "entry_id": ack_result.get("entry_id"),
+                "reason": ack_result.get("reason"),
+                "after_total": ack_result.get("after_total"),
+            }
 
     write_json(CURRENT_DISPATCH_FILE, state)
     mirror_heartbeat_guard(state)
@@ -558,6 +575,18 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_ack(args: argparse.Namespace) -> int:
+    result = ack_dispatch_queue_entry(
+        skill=args.skill,
+        source=args.source,
+        entry_id=args.entry_id,
+        cycle_id=args.cycle_id,
+        reason=args.reason,
+    )
+    print_json(result)
+    return 0 if result.get("removed") else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Dispatch-cycle envelope for heartbeat and operator runs")
     sub = parser.add_subparsers(dest="cmd")
@@ -584,6 +613,13 @@ def build_parser() -> argparse.ArgumentParser:
     p_close.add_argument("--status", default="completed", choices=["completed", "failed", "aborted"])
     p_close.add_argument("--reason", help="Optional close reason")
 
+    p_ack = sub.add_parser("ack", help="Acknowledge and remove a dispatch-queue entry")
+    p_ack.add_argument("--skill", required=True, help="Queued skill to acknowledge")
+    p_ack.add_argument("--source", required=True, help="Queue producer/source to acknowledge")
+    p_ack.add_argument("--entry-id", help="Optional stable queue entry id to guard against stale acks")
+    p_ack.add_argument("--cycle-id", help="Cycle that consumed the queue entry")
+    p_ack.add_argument("--reason", default="manual_ack", help="Ack reason label")
+
     sub.add_parser("status", help="Print the current dispatch state")
     return parser
 
@@ -591,7 +627,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    if args.cmd in {"open", "dispatch", "close"}:
+    if args.cmd in {"open", "dispatch", "close", "ack"}:
         with dispatch_lock():
             if args.cmd == "open":
                 return cmd_open(args)
@@ -599,6 +635,8 @@ def main() -> int:
                 return cmd_dispatch(args)
             if args.cmd == "close":
                 return cmd_close(args)
+            if args.cmd == "ack":
+                return cmd_ack(args)
     if args.cmd == "status":
         return cmd_status(args)
     parser.print_help()

--- a/tools/edge-state-dispatch
+++ b/tools/edge-state-dispatch
@@ -53,6 +53,11 @@ def sha256_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+def dispatch_entry_id(source: str, payload: dict) -> str:
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return f"{source}:{hashlib.sha256(raw.encode('utf-8')).hexdigest()[:16]}"
+
+
 def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
@@ -168,9 +173,11 @@ def run_lint() -> dict:
 
 def upsert_dispatch(reason: str, payload: dict, created_at: str) -> str:
     queue = load_json(QUEUE_PATH, [])
+    source = "state-anchor-monitor"
+    entry_id = dispatch_entry_id(source, payload)
     existing = None
     for item in queue:
-        if item.get("skill") == "reflection" and item.get("source") == "state-anchor-monitor":
+        if item.get("skill") == "reflection" and item.get("source") == source:
             existing = item
             break
 
@@ -178,7 +185,8 @@ def upsert_dispatch(reason: str, payload: dict, created_at: str) -> str:
         queue.append(
             {
                 "skill": "reflection",
-                "source": "state-anchor-monitor",
+                "source": source,
+                "entry_id": entry_id,
                 "reason": reason,
                 "created_at": created_at,
                 "payload": payload,
@@ -186,6 +194,8 @@ def upsert_dispatch(reason: str, payload: dict, created_at: str) -> str:
         )
         status = "queued"
     else:
+        existing.setdefault("created_at", created_at)
+        existing["entry_id"] = entry_id
         existing["reason"] = reason
         existing["payload"] = payload
         existing["updated_at"] = created_at


### PR DESCRIPTION
## Summary
- add `edge-dispatch ack` to explicitly remove a dispatch queue entry by skill/source and optional stable `entry_id`
- stamp `state-anchor-monitor` queue entries with a deterministic `entry_id`
- auto-ack the captured queue head when a completed cycle closes with the queued skill
- emit `DispatchQueueEntryAcknowledged` shadow events for queue consumption

## Why
`state/dispatch-queue.json` had producers and priority-hint readers but no consumer contract. A state-anchor reflection entry could persist indefinitely, pin heartbeat routing to reflection, and starve the round-robin lane.

This is a small CQRS-aligned slice: queue consumption becomes an explicit command/event instead of implicit JSON mutation or skill prose.

## Validation
- `python3 -m py_compile tools/_shared/dispatch_runtime.py tools/edge-dispatch tools/edge-state-dispatch`
- `bash tests/test_edge_dispatch.sh`
- `bash tests/test_heartbeat_routing.sh`
- `bash tests/test_edge_close.sh`
- `git diff --check`

## Note
`bash tests/test_edge_runner.sh` currently fails on its first scenario because its operator-pressure fixture uses fixed timestamps from 2026-04-23, which have aged outside the recent-pressure window by 2026-04-30. I did not change that unrelated fixture in this PR.