### PR TITLE
[codex] Complete CQRS enforcement migration

### DIFF
--- a/bin/heartbeat-dispatch-guard.sh
+++ b/bin/heartbeat-dispatch-guard.sh
@@ -47,6 +47,29 @@ DISPATCH_FILE="${EDGE_ROOT}/state/current-dispatch.json"
 
 # Read PreToolUse payload from stdin
 TOOL_INPUT=$(cat)
+TOOL_NAME=$(python3 -c 'import json,sys; print((json.loads(sys.stdin.read() or "{}").get("tool_name") or ""))' <<<"$TOOL_INPUT" 2>/dev/null || true)
+PATH_ARG=$(python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read() or "{}").get("tool_input", {}) or {}
+    print(d.get("file_path") or d.get("notebook_path") or "")
+except Exception:
+    print("")
+' <<<"$TOOL_INPUT" 2>/dev/null || true)
+
+EDGE_CMD="${EDGE_REPO_DIR:-$EDGE_ROOT}/tools/edge-cmd"
+if [ -n "$PATH_ARG" ] && [ -x "$EDGE_CMD" ]; then
+  set +e
+  "$EDGE_CMD" validate-write \
+    --tool "${TOOL_NAME:-unknown}" \
+    --path "$PATH_ARG" \
+    --source heartbeat-dispatch-guard \
+    --require-dispatched-heartbeat \
+    --heartbeat-only
+  STATUS=$?
+  set -e
+  exit "$STATUS"
+fi
 
 # Fast path: if neither state file exists, not in heartbeat → allow immediately
 if [ ! -f "$STATE_FILE" ] && [ ! -f "$DISPATCH_FILE" ]; then

--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -88,7 +88,7 @@ tools_dir = Path(
 )
 sys.path.insert(0, str(tools_dir))
 try:
-    from _shared.telemetry import log_run_step
+    from _shared.telemetry import emit_shadow_event, log_run_step
 except Exception:
     sys.exit(0)
 
@@ -106,6 +106,32 @@ log_run_step(
     run_id=os.environ.get("EDGE_CONSOLIDATE_RUN_ID"),
     **fields,
 )
+
+if status in {"completed", "failed", "degraded"} and (phase == "pipeline" or phase.startswith("phase-")):
+    slug = os.environ.get("EDGE_PUBLISH_SLUG", "").strip()
+    if slug and slug != "unknown":
+        normalized_phase = phase[6:] if phase.startswith("phase-") else phase
+        payload = {
+            "pipeline": "consolidate-state",
+            "phase": normalized_phase,
+            "status": status,
+            "slug": slug,
+        }
+        if status == "completed":
+            payload["ok"] = True
+        elif status == "failed":
+            payload["ok"] = False
+        if operation:
+            payload["operation"] = operation
+        if error_text:
+            payload["reason"] = error_text[:240]
+        emit_shadow_event(
+            "PhaseCompleted",
+            actor="consolidate-state",
+            artifact=f"blog/entries/{slug}.md",
+            cycle_id=os.environ.get("EDGE_CYCLE_ID") or None,
+            payload=payload,
+        )
 PYEOF
 }
 

--- a/config/postflight.yaml
+++ b/config/postflight.yaml
@@ -7,6 +7,8 @@ procedures:
     kind: validate.recent
   - id: claims
     kind: claims.refresh
+  - id: pipeline-state
+    kind: pipeline_state.refresh
   - id: primitives
     kind: primitives.status
   - id: capabilities

--- a/docs/event-sourced-enforcement-migration.md
+++ b/docs/event-sourced-enforcement-migration.md
@@ -171,6 +171,8 @@ Current implementation path:
 - `tools/rollup-pipeline-state.py` builds `state/projections/pipeline-state.json`
 - `edge-replay pipeline-state` exposes the projection from the canonical ledger
 - `ArtifactPublished` without matching `PhaseCompleted` is surfaced as `orphaned_publish` until pipeline phase emission is complete
+- `consolidate-state` emits `PhaseCompleted` for every completed/failed/degraded phase, including a terminal `phase=pipeline`
+- `edge-doctor` and `edge-postflight` now read `pipeline-state` in advisory/soft-gate mode
 
 ### `render-install-drift`
 
@@ -219,6 +221,7 @@ Turn on narrow projection reads in the highest-value binary checkpoints:
 
 - dispatch-cycle close
 - pipeline completion summary
+- postflight projection refresh
 
 Do not yet block arbitrary writes. The purpose here is to force the cycle semantics, not to redesign every command path at once.
 
@@ -231,6 +234,13 @@ Only after this is stable should the following legacy pieces start disappearing:
 - prose-only "ABSOLUTE RULE" enforcement that duplicates binary invariants
 - primitive-specific write hooks
 - state-only audits that can now be replayed from events
+
+Current implementation path:
+
+- `tools/edge-cmd validate-write` validates protected artifact writes and emits `ArtifactWriteAuthorized` / `ArtifactWriteRejected`
+- `hooks/write-guard.sh` delegates protected write decisions to `edge-cmd`
+- `bin/heartbeat-dispatch-guard.sh` delegates heartbeat dispatch enforcement to `edge-cmd` while retaining its legacy fallback when the command boundary is unavailable
+- `tools/audit-cqrs-migration.py` audits the migration surface and reports remaining shim/fallback residue
 
 ## Legacy Retirement Order
 

--- a/hooks/write-guard.sh
+++ b/hooks/write-guard.sh
@@ -45,6 +45,7 @@ except Exception:
 [[ -z "$PATH_ARG" ]] && exit 0
 
 EDGE_ROOT="${EDGE_DIR:-$HOME/edge}"
+EDGE_CMD="${EDGE_REPO_DIR:-$EDGE_ROOT}/tools/edge-cmd"
 
 # Canonicalize
 ABS_PATH="$PATH_ARG"
@@ -54,6 +55,11 @@ ABS_PATH="$PATH_ARG"
 case "$ABS_PATH" in
     "$HOME/.claude/projects/"*/memory/*) exit 0 ;;
 esac
+
+if [[ -x "$EDGE_CMD" ]]; then
+    "$EDGE_CMD" validate-write --tool "$TOOL_NAME" --path "$PATH_ARG" --source write-guard
+    exit $?
+fi
 
 for sub in blog/entries state reports meta-reports threads health logs; do
     prefix="$EDGE_ROOT/$sub"

--- a/memory/events.md
+++ b/memory/events.md
@@ -124,6 +124,10 @@ trigger came from heartbeat or operator intent.
 ```
 
 Represents the outcome of one pipeline phase. This is enough to build the first `pipeline-state` projection.
+`consolidate-state` also emits a terminal `PhaseCompleted` with
+`payload.phase = "pipeline"` when the whole publication pipeline completes,
+fails, or degrades. The `pipeline-state` projection treats a published artifact
+as `complete` only when the terminal pipeline phase is OK.
 
 ### `ArtifactPublished`
 
@@ -139,6 +143,40 @@ Represents the outcome of one pipeline phase. This is enough to build the first 
 ```
 
 Represents the canonical publish fact for an artifact.
+
+### `ArtifactWriteAuthorized`
+
+```json
+{
+  "type": "ArtifactWriteAuthorized",
+  "artifact": "blog/entries/2026-04-19-example.md",
+  "payload": {
+    "tool": "Write",
+    "operation": "write",
+    "source": "write-guard",
+    "reason": "consolidate_state_active"
+  }
+}
+```
+
+Represents a command-boundary decision allowing a protected artifact write.
+
+### `ArtifactWriteRejected`
+
+```json
+{
+  "type": "ArtifactWriteRejected",
+  "artifact": "blog/entries/2026-04-19-example.md",
+  "payload": {
+    "tool": "Write",
+    "operation": "write",
+    "source": "edge-cmd",
+    "reason": "protected_write_requires_command_boundary"
+  }
+}
+```
+
+Represents a command-boundary decision rejecting a protected artifact write.
 
 ### `ClaimObserved`
 
@@ -513,6 +551,10 @@ or remained incomplete without changing runtime behavior.
 `complete`, `partial`, `blocked`, `failed`, or `orphaned_publish` from
 `PhaseCompleted` and `ArtifactPublished` facts without changing publication
 behavior.
+
+`edge-cmd validate-write` is the command-boundary validator for protected
+artifact writes. Legacy hooks may remain installed, but their authoritative
+decision is delegated to `edge-cmd` during the migration.
 
 ## Compatibility Rule
 

--- a/tests/test_cqrs_audit.sh
+++ b/tests/test_cqrs_audit.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_STATE="$(mktemp -d /tmp/edge-cqrs-audit-XXXXXX)"
+trap 'rm -rf "$TMP_STATE"' EXIT
+
+mkdir -p "$TMP_STATE/state/events" "$TMP_STATE/state/projections"
+cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
+{"ts":"2026-04-26T10:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-audit","artifact":"blog/entries/audit.md","payload":{"pipeline":"consolidate-state","phase":"pipeline","ok":true},"prev_hash":"sha256:root"}
+{"ts":"2026-04-26T10:01:00+00:00","type":"ArtifactPublished","actor":"continuity","cycle_id":"cycle-audit","artifact":"blog/entries/audit.md","payload":{"source_skill":"research"},"prev_hash":"sha256:a"}
+JSONL
+
+echo "=== CQRS migration audit Smoke Test ==="
+
+EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$EDGE_DIR/tools/audit-cqrs-migration.py" --json >/tmp/cqrs-audit.json
+
+python3 - <<'PY' /tmp/cqrs-audit.json
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+assert payload["ok"] is True, payload
+checks = {item["check_id"]: item for item in payload["checks"]}
+for required in [
+    "publisher:phase-completed",
+    "command-boundary:edge-cmd",
+    "hook:write-guard-shim",
+    "hook:heartbeat-guard-shim",
+    "postflight:pipeline-state",
+    "doctor:pipeline-state",
+    "backfill:pipeline-phase-events",
+    "projection:pipeline-state-replay",
+    "repo:fleet-grafana-absent",
+]:
+    assert checks[required]["status"] == "ok", checks[required]
+assert payload["legacy_residuals"], "expected shim/fallback residuals to be reported"
+PY
+
+echo "ALL TESTS PASSED"

--- a/tests/test_edge_cmd_boundary.sh
+++ b/tests/test_edge_cmd_boundary.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-cmd-boundary-XXXXXX)"
+TMP_STATE="$TMP_BASE/state"
+TMP_HOME="$TMP_BASE/home"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE/blog/entries" "$TMP_STATE/reports" "$TMP_STATE/state/events" "$TMP_STATE/state" "$TMP_HOME"
+
+export HOME="$TMP_HOME"
+export EDGE_REPO_DIR="$EDGE_DIR"
+export EDGE_STATE_DIR="$TMP_STATE"
+export EDGE_CODENAME="cmd-boundary-test"
+
+TOOL="$EDGE_DIR/tools/edge-cmd"
+WRITE_GUARD="$EDGE_DIR/hooks/write-guard.sh"
+HEARTBEAT_GUARD="$EDGE_DIR/bin/heartbeat-dispatch-guard.sh"
+ENTRY_PATH="$TMP_STATE/blog/entries/protected.md"
+UNPROTECTED_PATH="$TMP_BASE/free.md"
+
+echo "=== edge-cmd boundary Smoke Test ==="
+echo "Temp state: $TMP_STATE"
+echo ""
+
+echo "--- Test 1: protected writes are rejected outside command-owned context ---"
+set +e
+"$TOOL" validate-write --tool Write --path "$ENTRY_PATH" --source test >/tmp/edge-cmd-reject.out 2>/tmp/edge-cmd-reject.err
+STATUS=$?
+set -e
+if [[ "$STATUS" -eq 2 ]] && grep -q "protected_write_requires_command_boundary" "$TMP_STATE/state/events/log.jsonl"; then
+    pass "edge-cmd rejects protected writes and emits a canonical rejection"
+else
+    cat /tmp/edge-cmd-reject.out /tmp/edge-cmd-reject.err
+    fail "edge-cmd rejects protected writes and emits a canonical rejection"
+fi
+
+echo "--- Test 2: consolidate-state context authorizes protected writes ---"
+EDGE_CONSOLIDATE_ACTIVE=1 "$TOOL" validate-write --tool Write --path "$ENTRY_PATH" --source test >/tmp/edge-cmd-authorize.out
+if grep -q "ArtifactWriteAuthorized" "$TMP_STATE/state/events/log.jsonl"; then
+    pass "edge-cmd authorizes consolidate-state protected writes"
+else
+    cat /tmp/edge-cmd-authorize.out
+    fail "edge-cmd authorizes consolidate-state protected writes"
+fi
+
+echo "--- Test 3: unprotected writes pass without command ceremony ---"
+"$TOOL" validate-write --tool Write --path "$UNPROTECTED_PATH" --source test --json >/tmp/edge-cmd-free.out
+if grep -q "unprotected_path" /tmp/edge-cmd-free.out; then
+    pass "edge-cmd allows unprotected writes"
+else
+    cat /tmp/edge-cmd-free.out
+    fail "edge-cmd allows unprotected writes"
+fi
+
+echo "--- Test 4: heartbeat dispatch invariant still blocks even during consolidate-state ---"
+NOW_ISO="$(python3 - <<'PY'
+from datetime import datetime, timezone
+print(datetime.now(timezone.utc).isoformat())
+PY
+)"
+cat >"$TMP_STATE/state/current-dispatch.json" <<JSON
+{
+  "cycle_id": "cycle-cmd-heartbeat",
+  "request": {"trigger": "heartbeat", "skill": null},
+  "state": {
+    "active": true,
+    "opened_at": "$NOW_ISO",
+    "skill_dispatched": false
+  }
+}
+JSON
+set +e
+EDGE_CONSOLIDATE_ACTIVE=1 "$TOOL" validate-write \
+  --tool Write \
+  --path "$ENTRY_PATH" \
+  --source test \
+  --require-dispatched-heartbeat >/tmp/edge-cmd-heartbeat.out 2>/tmp/edge-cmd-heartbeat.err
+STATUS=$?
+set -e
+if [[ "$STATUS" -eq 2 ]] && grep -q "heartbeat_dispatch_required" "$TMP_STATE/state/events/log.jsonl"; then
+    pass "edge-cmd keeps heartbeat dispatch invariant at the command boundary"
+else
+    cat /tmp/edge-cmd-heartbeat.out /tmp/edge-cmd-heartbeat.err
+    fail "edge-cmd keeps heartbeat dispatch invariant at the command boundary"
+fi
+
+echo "--- Test 5: write-guard delegates to edge-cmd ---"
+set +e
+printf '{"tool_name":"Write","tool_input":{"file_path":"%s"}}\n' "$ENTRY_PATH" | "$WRITE_GUARD" >/tmp/write-guard.out 2>/tmp/write-guard.err
+STATUS=$?
+set -e
+if [[ "$STATUS" -eq 2 ]] && grep -q "edge-cmd" /tmp/write-guard.err; then
+    pass "write-guard delegates protected write rejection to edge-cmd"
+else
+    cat /tmp/write-guard.out /tmp/write-guard.err
+    fail "write-guard delegates protected write rejection to edge-cmd"
+fi
+
+echo "--- Test 6: heartbeat-dispatch-guard delegates to edge-cmd ---"
+set +e
+printf '{"tool_name":"Write","tool_input":{"file_path":"%s"}}\n' "$ENTRY_PATH" | env EDGE_CONSOLIDATE_ACTIVE=1 "$HEARTBEAT_GUARD" >/tmp/heartbeat-guard.out 2>/tmp/heartbeat-guard.err
+STATUS=$?
+set -e
+if [[ "$STATUS" -eq 2 ]] && grep -q "heartbeat is active" /tmp/heartbeat-guard.err; then
+    pass "heartbeat-dispatch-guard delegates heartbeat rejection to edge-cmd"
+else
+    cat /tmp/heartbeat-guard.out /tmp/heartbeat-guard.err
+    fail "heartbeat-dispatch-guard delegates heartbeat rejection to edge-cmd"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tests/test_pipeline_state_backfill.sh
+++ b/tests/test_pipeline_state_backfill.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_STATE="$(mktemp -d /tmp/edge-pipeline-backfill-XXXXXX)"
+trap 'rm -rf "$TMP_STATE"' EXIT
+
+mkdir -p "$TMP_STATE/state/events" "$TMP_STATE/state/projections"
+cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
+{"ts":"2026-04-26T10:00:00+00:00","type":"ArtifactPublished","actor":"continuity","cycle_id":"cycle-legacy","artifact":"blog/entries/legacy.md","payload":{"source_skill":"research"},"prev_hash":"sha256:root"}
+JSONL
+
+echo "=== pipeline-state backfill Smoke Test ==="
+
+EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$EDGE_DIR/tools/backfill-pipeline-phase-events.py" --dry-run --json >/tmp/pipeline-backfill-dry.json
+python3 - <<'PY' /tmp/pipeline-backfill-dry.json
+import json
+import sys
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+assert payload["candidate_total"] == 1, payload
+assert payload["emitted_total"] == 0, payload
+PY
+
+EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$EDGE_DIR/tools/backfill-pipeline-phase-events.py" --json >/tmp/pipeline-backfill.json
+EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$EDGE_DIR/tools/rollup-pipeline-state.py" --json >/tmp/pipeline-after-backfill.json
+
+python3 - <<'PY' /tmp/pipeline-backfill.json /tmp/pipeline-after-backfill.json
+import json
+import sys
+backfill = json.load(open(sys.argv[1], encoding="utf-8"))
+projection = json.load(open(sys.argv[2], encoding="utf-8"))
+assert backfill["emitted_total"] == 1, backfill
+counts = projection["summary"]["counts_by_status"]
+assert counts["complete"] == 1, projection["summary"]
+assert projection["summary"]["artifacts_attention"] == 0, projection["summary"]
+PY
+
+echo "ALL TESTS PASSED"

--- a/tests/test_pipeline_state_projection.sh
+++ b/tests/test_pipeline_state_projection.sh
@@ -10,6 +10,7 @@ cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
 {"ts":"2026-04-26T10:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-complete","artifact":"blog/entries/complete.md","payload":{"pipeline":"consolidate-state","phase":"1","ok":true},"prev_hash":"sha256:root"}
 {"ts":"2026-04-26T10:02:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-complete","artifact":"blog/entries/complete.md","payload":{"pipeline":"consolidate-state","phase":"4","ok":true},"prev_hash":"sha256:a"}
 {"ts":"2026-04-26T10:03:00+00:00","type":"ArtifactPublished","actor":"continuity","cycle_id":"cycle-complete","artifact":"blog/entries/complete.md","payload":{"hash":"sha256:complete","source_skill":"research"},"prev_hash":"sha256:b"}
+{"ts":"2026-04-26T10:04:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-complete","artifact":"blog/entries/complete.md","payload":{"pipeline":"consolidate-state","phase":"pipeline","ok":true},"prev_hash":"sha256:b2"}
 {"ts":"2026-04-26T11:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-partial","artifact":"blog/entries/partial.md","payload":{"pipeline":"consolidate-state","phase":"1","ok":true},"prev_hash":"sha256:c"}
 {"ts":"2026-04-26T12:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-blocked","artifact":"blog/entries/blocked.md","payload":{"pipeline":"consolidate-state","phase":"3","ok":false,"reason":"review_gate_failed"},"prev_hash":"sha256:d"}
 {"ts":"2026-04-26T13:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-failed","artifact":"blog/entries/failed.md","payload":{"pipeline":"consolidate-state","phase":"4","ok":false,"reason":"meta_report_failed"},"prev_hash":"sha256:e"}
@@ -44,7 +45,8 @@ assert summary["counts_by_status"]["orphaned_publish"] == 1, summary
 complete = by_artifact["blog/entries/complete.md"]
 assert complete["status"] == "complete"
 assert complete["published"] is True
-assert complete["phase_counts"]["ok"] == 2
+assert complete["phase_counts"]["ok"] == 3
+assert complete["terminal_phase_status"] == "ok"
 assert complete["source_skill"] == "research"
 
 partial = by_artifact["blog/entries/partial.md"]

--- a/tests/test_postflight_pipeline_state.sh
+++ b/tests/test_postflight_pipeline_state.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-postflight-pipeline-XXXXXX)"
+TMP_STATE="$TMP_BASE/state"
+TMP_HOME="$TMP_BASE/home"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE/state/events" "$TMP_STATE/state/projections" "$TMP_STATE/logs" "$TMP_HOME"
+
+export HOME="$TMP_HOME"
+export EDGE_REPO_DIR="$EDGE_DIR"
+export EDGE_STATE_DIR="$TMP_STATE"
+export EDGE_CODENAME="postflight-pipeline-test"
+
+cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
+{"ts":"2026-04-26T10:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-ok","artifact":"blog/entries/ok.md","payload":{"pipeline":"consolidate-state","phase":"pipeline","ok":true},"prev_hash":"sha256:root"}
+{"ts":"2026-04-26T10:01:00+00:00","type":"ArtifactPublished","actor":"continuity","cycle_id":"cycle-ok","artifact":"blog/entries/ok.md","payload":{"source_skill":"research"},"prev_hash":"sha256:a"}
+{"ts":"2026-04-26T11:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-bad","artifact":"blog/entries/bad.md","payload":{"pipeline":"consolidate-state","phase":"3","ok":false,"reason":"verification failed"},"prev_hash":"sha256:b"}
+JSONL
+
+echo "=== postflight pipeline-state Smoke Test ==="
+echo "Temp state: $TMP_STATE"
+echo ""
+
+echo "--- Test 1: clean cycle satisfies pipeline-state step ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+loader = importlib.machinery.SourceFileLoader("edge_postflight", str(edge_dir / "tools" / "edge-postflight"))
+spec = importlib.util.spec_from_loader("edge_postflight", loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+result = module._execute_postflight_step(
+    {"id": "pipeline-state", "kind": "pipeline_state.refresh"},
+    {"cycle_id": "cycle-ok", "request": {}, "state": {}},
+)
+assert result["status"] == "ok", result
+assert result["satisfied"] is True, result
+assert result["payload"]["summary"]["counts_by_status"]["complete"] == 1
+PY
+then
+    pass "postflight pipeline-state step is OK for a complete cycle"
+else
+    fail "postflight pipeline-state step is OK for a complete cycle"
+fi
+
+echo "--- Test 2: current-cycle pipeline attention becomes a soft warning ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+loader = importlib.machinery.SourceFileLoader("edge_postflight", str(edge_dir / "tools" / "edge-postflight"))
+spec = importlib.util.spec_from_loader("edge_postflight", loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+result = module._execute_postflight_step(
+    {"id": "pipeline-state", "kind": "pipeline_state.refresh"},
+    {"cycle_id": "cycle-bad", "request": {}, "state": {}},
+)
+assert result["status"] == "warning", result
+assert result["satisfied"] is False, result
+assert result["current_attention"][0]["artifact"] == "blog/entries/bad.md"
+PY
+then
+    pass "postflight pipeline-state step warns on current-cycle blocked artifacts"
+else
+    fail "postflight pipeline-state step warns on current-cycle blocked artifacts"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tests/test_protocol_runtime.sh
+++ b/tests/test_protocol_runtime.sh
@@ -47,6 +47,8 @@ operator_notes:
 procedures:
   - id: source-affordances
     kind: source_affordance.digest
+  - id: pipeline-state
+    kind: pipeline_state.refresh
   - id: briefing-refresh
     kind: briefing.refresh
   - id: async-inbox-response
@@ -124,11 +126,13 @@ compiled = ensure_compiled_protocol("postflight")
 assert compiled["protocol"] == "postflight"
 kinds = [item["kind"] for item in compiled["procedures"]]
 assert "source_affordance.digest" in kinds
+assert "pipeline_state.refresh" in kinds
 assert "async_inbox.respond" in kinds
 compiled_path = Path(state_dir) / "state" / "runtime" / "postflight.compiled.json"
 assert compiled_path.exists()
 saved = json.loads(compiled_path.read_text(encoding="utf-8"))
 assert any(item["kind"] == "source_affordance.digest" for item in saved["procedures"])
+assert any(item["kind"] == "pipeline_state.refresh" for item in saved["procedures"])
 assert any(item["kind"] == "async_inbox.respond" for item in saved["procedures"])
 PY
 then

--- a/tests/test_runtime_router_config.sh
+++ b/tests/test_runtime_router_config.sh
@@ -81,11 +81,12 @@ assert payload["routers"]["review"]["base_url"] == "https://api.x.ai/v1"
 assert payload["routers"]["chat"]["model"] == "gpt-5.4"
 postflight = yaml.safe_load((repo / "config" / "postflight.yaml").read_text(encoding="utf-8"))
 assert any(item["kind"] == "source_affordance.digest" for item in postflight["procedures"])
+assert any(item["kind"] == "pipeline_state.refresh" for item in postflight["procedures"])
 PY
 then
-    pass "edge-render materializes runtime routers and source affordance postflight"
+    pass "edge-render materializes runtime routers and projection postflight"
 else
-    fail "edge-render materializes runtime routers and source affordance postflight"
+    fail "edge-render materializes runtime routers and projection postflight"
 fi
 
 echo "--- Test 2: router_client reads runtime routers without agent.yaml ---"

--- a/tools/_shared/protocol_runtime.py
+++ b/tools/_shared/protocol_runtime.py
@@ -43,6 +43,7 @@ _ALLOWED_KINDS: dict[str, set[str]] = {
     "postflight": {
         "validate.recent",
         "claims.refresh",
+        "pipeline_state.refresh",
         "primitives.status",
         "capabilities.status",
         "workflow.status",

--- a/tools/audit-cqrs-migration.py
+++ b/tools/audit-cqrs-migration.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Audit CQRS/event-sourced enforcement migration coverage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+
+
+@dataclass
+class Check:
+    check_id: str
+    status: str
+    detail: str
+    artifact: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "check_id": self.check_id,
+            "status": self.status,
+            "detail": self.detail,
+            "artifact": self.artifact,
+        }
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        return ""
+
+
+def _check_contains(check_id: str, path: Path, needles: list[str], detail: str) -> Check:
+    content = _read(path)
+    missing = [needle for needle in needles if needle not in content]
+    if missing:
+        return Check(check_id, "fail", f"missing: {', '.join(missing)}", str(path.relative_to(REPO_ROOT)))
+    return Check(check_id, "ok", detail, str(path.relative_to(REPO_ROOT)))
+
+
+def _run_projection() -> Check:
+    tool = SCRIPT_DIR / "rollup-pipeline-state.py"
+    result = subprocess.run(
+        [sys.executable, str(tool), "--json", "--no-write"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        return Check("projection:pipeline-state-replay", "fail", result.stderr.strip() or result.stdout.strip(), str(tool.relative_to(REPO_ROOT)))
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return Check("projection:pipeline-state-replay", "fail", f"invalid JSON: {exc}", str(tool.relative_to(REPO_ROOT)))
+    summary = payload.get("summary") or {}
+    counts = summary.get("counts_by_status") or {}
+    detail = (
+        f"artifacts={summary.get('artifacts_total', 0)} "
+        f"attention={summary.get('artifacts_attention', 0)} "
+        f"complete={counts.get('complete', 0)} "
+        f"blocked={counts.get('blocked', 0)} "
+        f"failed={counts.get('failed', 0)} "
+        f"orphaned_publish={counts.get('orphaned_publish', 0)}"
+    )
+    if counts.get("blocked", 0) or counts.get("failed", 0):
+        return Check("projection:pipeline-state-replay", "fail", detail, str(tool.relative_to(REPO_ROOT)))
+    if summary.get("artifacts_attention", 0):
+        return Check("projection:pipeline-state-replay", "warn", detail, str(tool.relative_to(REPO_ROOT)))
+    return Check("projection:pipeline-state-replay", "ok", detail, str(tool.relative_to(REPO_ROOT)))
+
+
+def _fleet_canonical_check() -> Check:
+    path = REPO_ROOT / "observability" / "fleet"
+    if path.exists():
+        return Check("repo:fleet-grafana-absent", "fail", "canonical repo still contains observability/fleet", str(path.relative_to(REPO_ROOT)))
+    return Check("repo:fleet-grafana-absent", "ok", "Grafana fleet overlay is absent from canonical repo", "observability/fleet")
+
+
+def _legacy_residuals() -> list[dict[str, str]]:
+    patterns = {
+        "write-guard": "legacy hook remains as edge-cmd shim",
+        "heartbeat-dispatch-guard": "legacy heartbeat hook remains as edge-cmd shim/fallback",
+        "current-beat.json": "legacy beat sentinel remains as compatibility fallback",
+        "EDGE_CONSOLIDATE_ACTIVE": "legacy env authorization remains as adapter into command boundary",
+    }
+    scan_paths = [
+        REPO_ROOT / "bin",
+        REPO_ROOT / "hooks",
+        REPO_ROOT / "tools",
+        REPO_ROOT / "docs",
+        REPO_ROOT / "config",
+    ]
+    residuals: list[dict[str, str]] = []
+    for root in scan_paths:
+        if not root.exists():
+            continue
+        for file_path in root.rglob("*"):
+            if not file_path.is_file() or file_path.suffix in {".pyc", ".png", ".jpg", ".db"}:
+                continue
+            text = _read(file_path)
+            for pattern, interpretation in patterns.items():
+                if pattern in text:
+                    residuals.append(
+                        {
+                            "pattern": pattern,
+                            "artifact": str(file_path.relative_to(REPO_ROOT)),
+                            "interpretation": interpretation,
+                        }
+                    )
+                    break
+    return residuals
+
+
+def build_audit() -> dict[str, Any]:
+    checks = [
+        _check_contains(
+            "publisher:phase-completed",
+            REPO_ROOT / "blog" / "consolidate-state.sh",
+            ["PhaseCompleted", "emit_shadow_event"],
+            "consolidate-state emits canonical PhaseCompleted facts",
+        ),
+        _check_contains(
+            "command-boundary:edge-cmd",
+            REPO_ROOT / "tools" / "edge-cmd",
+            ["validate-write", "ArtifactWriteRejected", "ArtifactWriteAuthorized"],
+            "edge-cmd validates protected writes and emits command-boundary facts",
+        ),
+        _check_contains(
+            "hook:write-guard-shim",
+            REPO_ROOT / "hooks" / "write-guard.sh",
+            ["edge-cmd", "validate-write"],
+            "write-guard delegates protected writes to edge-cmd",
+        ),
+        _check_contains(
+            "hook:heartbeat-guard-shim",
+            REPO_ROOT / "bin" / "heartbeat-dispatch-guard.sh",
+            ["edge-cmd", "--require-dispatched-heartbeat", "--heartbeat-only"],
+            "heartbeat dispatch guard delegates heartbeat invariant to edge-cmd",
+        ),
+        _check_contains(
+            "postflight:pipeline-state",
+            REPO_ROOT / "tools" / "edge-postflight",
+            ["pipeline_state.refresh", "refresh_pipeline_state"],
+            "postflight consults pipeline-state projection",
+        ),
+        _check_contains(
+            "protocol:pipeline-state",
+            REPO_ROOT / "tools" / "_shared" / "protocol_runtime.py",
+            ["pipeline_state.refresh"],
+            "runtime protocol compiler accepts pipeline-state postflight step",
+        ),
+        _check_contains(
+            "doctor:pipeline-state",
+            REPO_ROOT / "tools" / "edge-doctor",
+            ["projection:pipeline-state", "check_pipeline_state"],
+            "edge-doctor exposes pipeline-state projection health",
+        ),
+        _check_contains(
+            "backfill:pipeline-phase-events",
+            REPO_ROOT / "tools" / "backfill-pipeline-phase-events.py",
+            ["orphaned_publish", "PhaseCompleted"],
+            "legacy ArtifactPublished facts have an idempotent PhaseCompleted backfill path",
+        ),
+        _check_contains(
+            "config:pipeline-state",
+            REPO_ROOT / "config" / "postflight.yaml",
+            ["pipeline_state.refresh"],
+            "default postflight protocol includes pipeline-state refresh",
+        ),
+        _run_projection(),
+        _fleet_canonical_check(),
+    ]
+    return {
+        "ok": all(check.status != "fail" for check in checks),
+        "checks": [check.as_dict() for check in checks],
+        "legacy_residuals": _legacy_residuals(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audit CQRS/event-sourced enforcement migration coverage")
+    parser.add_argument("--json", action="store_true", help="Print JSON")
+    parser.add_argument("--strict-residuals", action="store_true", help="Treat legacy shim/fallback residuals as failures")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    payload = build_audit()
+    if args.strict_residuals and payload["legacy_residuals"]:
+        payload["ok"] = False
+
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        for check in payload["checks"]:
+            label = "OK" if check["status"] == "ok" else "FAIL"
+            print(f"{label}: {check['check_id']} — {check['detail']} ({check['artifact']})")
+        if payload["legacy_residuals"]:
+            print("")
+            print("Legacy residuals still present as shims/fallbacks:")
+            for item in payload["legacy_residuals"][:20]:
+                print(f"- {item['pattern']} in {item['artifact']}: {item['interpretation']}")
+            if len(payload["legacy_residuals"]) > 20:
+                print(f"- ... {len(payload['legacy_residuals']) - 20} more")
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/backfill-pipeline-phase-events.py
+++ b/tools/backfill-pipeline-phase-events.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Backfill terminal pipeline PhaseCompleted facts for legacy publishes."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import STATE_EVENTS_FILE  # noqa: E402
+
+sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.telemetry import emit_shadow_event  # noqa: E402
+
+
+def _load_pipeline_module():
+    path = SCRIPT_DIR / "rollup-pipeline-state.py"
+    spec = importlib.util.spec_from_file_location("rollup_pipeline_state", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_backfill(limit: int) -> list[dict[str, Any]]:
+    module = _load_pipeline_module()
+    projection = module.build_projection(limit=max(1, limit))
+    return [
+        item
+        for item in (projection.get("attention_artifacts") or [])
+        if item.get("status") == "orphaned_publish"
+    ]
+
+
+def emit_backfills(items: list[dict[str, Any]], *, reason: str) -> list[dict[str, Any]]:
+    emitted: list[dict[str, Any]] = []
+    for item in items:
+        artifact = str(item.get("artifact") or "").strip()
+        if not artifact:
+            continue
+        payload = {
+            "pipeline": "consolidate-state",
+            "phase": "pipeline",
+            "status": "completed",
+            "ok": True,
+            "reason": reason,
+            "backfill": True,
+            "source": "backfill-pipeline-phase-events",
+            "source_event_lines": item.get("event_lines") or [],
+        }
+        emit_shadow_event(
+            "PhaseCompleted",
+            actor="pipeline-state-backfill",
+            artifact=artifact,
+            cycle_id=item.get("cycle_id") or None,
+            payload=payload,
+        )
+        emitted.append({"artifact": artifact, "cycle_id": item.get("cycle_id") or "", "payload": payload})
+    return emitted
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Backfill terminal PhaseCompleted facts for legacy ArtifactPublished events")
+    parser.add_argument("--limit", type=int, default=500)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--reason",
+        default="legacy ArtifactPublished before PhaseCompleted instrumentation",
+        help="Reason stored in the backfill event payload",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    items = build_backfill(args.limit)
+    emitted = [] if args.dry_run else emit_backfills(items, reason=args.reason)
+    payload = {
+        "ok": True,
+        "events_path": str(STATE_EVENTS_FILE),
+        "dry_run": bool(args.dry_run),
+        "candidate_total": len(items),
+        "emitted_total": len(emitted),
+        "candidates": items,
+        "emitted": emitted,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        action = "would backfill" if args.dry_run else "backfilled"
+        print(f"{action}: {payload['emitted_total'] if not args.dry_run else payload['candidate_total']} legacy pipeline publish event(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/edge-cmd
+++ b/tools/edge-cmd
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""edge-cmd — command boundary for protected runtime operations.
+
+This starts the CQRS migration at the write boundary: hooks and tools ask this
+validator whether a protected artifact write is allowed, and this command emits
+canonical facts for accepted/rejected decisions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import (  # noqa: E402
+    CURRENT_BEAT_FILE,
+    CURRENT_DISPATCH_FILE,
+    EDGE_REPO_DIR,
+    EDGE_STATE_DIR,
+    ENTRIES_DIR,
+    HEALTH_DIR,
+    LOGS_DIR,
+    META_DIR,
+    REPORTS_DIR,
+    STATE_DIR,
+    THREADS_DIR,
+)
+
+sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.telemetry import emit_shadow_event  # noqa: E402
+
+PROTECTED_ROOTS = (
+    ENTRIES_DIR,
+    STATE_DIR,
+    REPORTS_DIR,
+    META_DIR,
+    THREADS_DIR,
+    HEALTH_DIR,
+    LOGS_DIR,
+)
+PUBLISH_ROOTS = (ENTRIES_DIR, REPORTS_DIR)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _resolve_path(value: str) -> Path:
+    path = Path(os.path.expanduser(value))
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return path.resolve(strict=False)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root.resolve(strict=False))
+        return True
+    except ValueError:
+        return False
+
+
+def _protected_root(path: Path, roots: tuple[Path, ...] = PROTECTED_ROOTS) -> Path | None:
+    for root in roots:
+        if _is_relative_to(path, root):
+            return root
+    return None
+
+
+def _artifact_for(path: Path) -> str:
+    for root in (EDGE_STATE_DIR, EDGE_REPO_DIR):
+        try:
+            return str(path.relative_to(root.resolve(strict=False)))
+        except ValueError:
+            continue
+    return str(path)
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _is_stale(started_at: str | None, *, max_age_s: int = 3600) -> bool:
+    if not started_at:
+        return False
+    try:
+        started = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - started).total_seconds() > max_age_s
+
+
+def _active_heartbeat_state() -> tuple[dict[str, Any] | None, str]:
+    dispatch = _read_json(CURRENT_DISPATCH_FILE)
+    if dispatch:
+        request = dispatch.get("request", {}) or {}
+        state = dispatch.get("state", {}) or {}
+        if state.get("active") and request.get("trigger") == "heartbeat":
+            return (
+                {
+                    "active": state.get("active"),
+                    "started_at": state.get("opened_at"),
+                    "skill_dispatched": state.get("skill_dispatched"),
+                    "skill": request.get("skill"),
+                    "cycle_id": dispatch.get("cycle_id"),
+                },
+                "current-dispatch.json",
+            )
+        if state.get("active"):
+            return None, ""
+
+    legacy = _read_json(CURRENT_BEAT_FILE)
+    if legacy:
+        return legacy, "current-beat.json"
+    return None, ""
+
+
+def _emit_decision(event_type: str, *, artifact: str, payload: dict[str, Any]) -> None:
+    emit_shadow_event(
+        event_type,
+        actor="edge-cmd",
+        artifact=artifact,
+        cycle_id=os.environ.get("EDGE_CYCLE_ID") or None,
+        payload=payload,
+    )
+
+
+def validate_write(args: argparse.Namespace) -> int:
+    path = _resolve_path(args.path)
+    artifact = _artifact_for(path)
+    protected_root = _protected_root(path)
+    publish_root = _protected_root(path, PUBLISH_ROOTS)
+    payload = {
+        "path": str(path),
+        "artifact": artifact,
+        "tool": args.tool,
+        "operation": args.operation,
+        "source": args.source,
+        "checked_at": _now_iso(),
+    }
+
+    if protected_root is None:
+        result = {"ok": True, "reason": "unprotected_path", **payload}
+        if args.json:
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    payload["protected_root"] = _artifact_for(protected_root.resolve(strict=False))
+
+    if args.require_dispatched_heartbeat and publish_root is not None:
+        heartbeat, state_source = _active_heartbeat_state()
+        if heartbeat and heartbeat.get("active") and not _is_stale(heartbeat.get("started_at")) and not heartbeat.get("skill_dispatched"):
+            reason = "heartbeat_dispatch_required"
+            payload.update({"reason": reason, "state_source": state_source, "skill": heartbeat.get("skill") or ""})
+            _emit_decision("ArtifactWriteRejected", artifact=artifact, payload=payload)
+            message = (
+                "BLOCK(edge-cmd): heartbeat is active but no skill has been dispatched yet.\n"
+                f"  target: {path}\n"
+                f"  state: {state_source}\n"
+                "  fix: run `edge-dispatch dispatch --skill <skill>` before writing artifacts.\n"
+            )
+            if args.json:
+                print(json.dumps({"ok": False, **payload}, indent=2, ensure_ascii=False), file=sys.stderr)
+            else:
+                print(message, file=sys.stderr, end="")
+            return 2
+
+    if args.heartbeat_only:
+        result = {"ok": True, "reason": "heartbeat_invariant_satisfied", **payload}
+        if args.json:
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    if os.environ.get("EDGE_CONSOLIDATE_ACTIVE", "0") == "1":
+        payload["reason"] = "consolidate_state_active"
+        _emit_decision("ArtifactWriteAuthorized", artifact=artifact, payload=payload)
+        if args.json:
+            print(json.dumps({"ok": True, **payload}, indent=2, ensure_ascii=False))
+        return 0
+
+    reason = "protected_write_requires_command_boundary"
+    payload["reason"] = reason
+    _emit_decision("ArtifactWriteRejected", artifact=artifact, payload=payload)
+    message = (
+        f"[edge-cmd] BLOCKED: {args.tool} on {path}\n"
+        "Protected artifact paths are writable only through consolidate-state or a command-owned writer.\n"
+        "Run: consolidate-state <entry.md> <report.yaml|report.html>\n"
+    )
+    if args.json:
+        print(json.dumps({"ok": False, **payload}, indent=2, ensure_ascii=False), file=sys.stderr)
+    else:
+        print(message, file=sys.stderr, end="")
+    return 2
+
+
+def query_pipeline_state(args: argparse.Namespace) -> int:
+    import importlib.util
+
+    path = SCRIPT_DIR / "rollup-pipeline-state.py"
+    spec = importlib.util.spec_from_file_location("rollup_pipeline_state", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    payload = module.build_projection(limit=max(1, args.limit)) if args.no_write else module.write_projection(limit=max(1, args.limit))
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Command boundary for protected Edge operations")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser("validate-write", help="Validate a pending protected artifact write")
+    validate.add_argument("--path", required=True)
+    validate.add_argument("--tool", default="unknown")
+    validate.add_argument("--operation", default="write")
+    validate.add_argument("--source", default="edge-cmd")
+    validate.add_argument("--require-dispatched-heartbeat", action="store_true")
+    validate.add_argument("--heartbeat-only", action="store_true", help="Only enforce heartbeat dispatch, not the general protected-write boundary")
+    validate.add_argument("--json", action="store_true")
+    validate.set_defaults(func=validate_write)
+
+    query = sub.add_parser("query", help="Read a command-side projection")
+    query_sub = query.add_subparsers(dest="query", required=True)
+    pipeline = query_sub.add_parser("pipeline-state", help="Build/read the pipeline-state projection")
+    pipeline.add_argument("--limit", type=int, default=50)
+    pipeline.add_argument("--no-write", action="store_true")
+    pipeline.set_defaults(func=query_pipeline_state)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/edge-doctor
+++ b/tools/edge-doctor
@@ -440,6 +440,60 @@ def check_render_install_drift():
         _record_check("projection:render-install-drift", "ok", detail, artifact=artifact)
 
 
+def check_pipeline_state():
+    """Build and summarize the publication pipeline projection."""
+    tool = Path(__file__).resolve().parent / "rollup-pipeline-state.py"
+    if not tool.exists():
+        warn("pipeline-state projection tool não encontrado")
+        _record_check("projection:pipeline-state", "warn", "pipeline-state projection tool não encontrado", artifact=tool)
+        return
+    try:
+        result = subprocess.run(
+            [sys.executable, str(tool), "--json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        warn(f"pipeline-state projection indisponível: {exc}")
+        _record_check("projection:pipeline-state", "warn", f"pipeline-state projection indisponível: {exc}", artifact=tool)
+        return
+
+    if result.returncode != 0:
+        warn(f"pipeline-state projection falhou: {result.stderr.strip() or result.stdout.strip()}")
+        _record_check(
+            "projection:pipeline-state",
+            "warn",
+            f"pipeline-state projection falhou: {result.stderr.strip() or result.stdout.strip()}",
+            artifact=tool,
+        )
+        return
+
+    payload = json.loads(result.stdout) if result.stdout.strip() else {}
+    summary = payload.get("summary", {}) or {}
+    counts = summary.get("counts_by_status", {}) or {}
+    detail = (
+        "pipeline-state: "
+        f"artifacts={summary.get('artifacts_total', 0)}, "
+        f"attention={summary.get('artifacts_attention', 0)}, "
+        f"complete={counts.get('complete', 0)}, "
+        f"partial={counts.get('partial', 0)}, "
+        f"blocked={counts.get('blocked', 0)}, "
+        f"failed={counts.get('failed', 0)}, "
+        f"orphaned_publish={counts.get('orphaned_publish', 0)}"
+    )
+    artifact = payload.get("output_path") or tool
+    if counts.get("blocked", 0) or counts.get("failed", 0):
+        fail(detail)
+        _record_check("projection:pipeline-state", "fail", detail, artifact=artifact)
+    elif summary.get("artifacts_attention", 0):
+        warn(detail)
+        _record_check("projection:pipeline-state", "warn", detail, artifact=artifact)
+    else:
+        ok(detail)
+        _record_check("projection:pipeline-state", "ok", detail, artifact=artifact)
+
+
 def check_primitives_status():
     tool = Path(__file__).resolve().parent / "edge-primitives"
     if not tool.exists():
@@ -637,6 +691,7 @@ def main():
     CURRENT_SECTION = "projection"
     print("\033[1m[8/8] Projection\033[0m")
     check_primitives_status()
+    check_pipeline_state()
     check_render_install_drift()
     print()
 

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -239,6 +239,40 @@ def refresh_claims_status() -> dict[str, Any]:
     return {"ok": True, "detail": detail, "payload": projections}
 
 
+def refresh_pipeline_state(cycle_id: str | None = None) -> dict[str, Any]:
+    code, stdout, stderr = run_subprocess([sys.executable, str(EDGE_REPO_DIR / "tools" / "rollup-pipeline-state.py"), "--json"])
+    if code != 0:
+        detail = (stderr or stdout or f"exit={code}").splitlines()[-1]
+        append_postskill_log("pipeline_state", "FAIL", detail)
+        return {"ok": False, "status": "failed", "detail": detail, "payload": {}, "current_attention": []}
+
+    payload = json.loads(stdout) if stdout else {}
+    summary = payload.get("summary") or {}
+    counts = summary.get("counts_by_status") or {}
+    attention = [
+        item
+        for item in (payload.get("attention_artifacts") or [])
+        if cycle_id and item.get("cycle_id") == cycle_id
+    ]
+    detail = (
+        f"artifacts={summary.get('artifacts_total', 0)} "
+        f"attention={summary.get('artifacts_attention', 0)} "
+        f"complete={counts.get('complete', 0)} "
+        f"blocked={counts.get('blocked', 0)} "
+        f"failed={counts.get('failed', 0)} "
+        f"current_attention={len(attention)}"
+    )
+    ok = len(attention) == 0
+    append_postskill_log("pipeline_state", "OK" if ok else "WARN", detail)
+    return {
+        "ok": ok,
+        "status": "ok" if ok else "warning",
+        "detail": detail,
+        "payload": payload,
+        "current_attention": attention[:5],
+    }
+
+
 def refresh_briefing() -> dict[str, Any]:
     code, stdout, stderr = run_subprocess([sys.executable, str(EDGE_REPO_DIR / "tools" / "edge-digest")])
     if code != 0:
@@ -313,6 +347,19 @@ def _execute_postflight_step(step: dict[str, Any], state: dict[str, Any]) -> dic
     if kind == "claims.refresh":
         refreshed = refresh_claims_status()
         return _protocol_step(step, status="ok", satisfied=bool(refreshed.get("ok", False)), detail=str(refreshed.get("detail") or ""), extra={"payload": refreshed.get("payload") or {}})
+
+    if kind == "pipeline_state.refresh":
+        refreshed = refresh_pipeline_state(cycle_id=state.get("cycle_id"))
+        return _protocol_step(
+            step,
+            status=str(refreshed.get("status") or ("ok" if refreshed.get("ok") else "warning")),
+            satisfied=bool(refreshed.get("ok", False)),
+            detail=str(refreshed.get("detail") or ""),
+            extra={
+                "payload": refreshed.get("payload") or {},
+                "current_attention": refreshed.get("current_attention") or [],
+            },
+        )
 
     if kind == "primitives.status":
         refreshed = refresh_primitives_status()
@@ -461,6 +508,8 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
     primitives_payload: dict[str, Any] = {}
     workflows_payload: dict[str, Any] = {}
     capabilities_payload: dict[str, Any] = {}
+    pipeline_state_payload: dict[str, Any] = {}
+    pipeline_state_attention: list[dict[str, Any]] = []
     curation_payload: dict[str, Any] = {}
     async_inbox_payload: dict[str, Any] = {}
     warning_seen = False
@@ -495,6 +544,9 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
         kind = str(step.get("kind") or "")
         if kind == "claims.refresh" and isinstance(payload, dict):
             claims_payload = payload
+        elif kind == "pipeline_state.refresh" and isinstance(payload, dict):
+            pipeline_state_payload = payload
+            pipeline_state_attention = list(result.get("current_attention") or [])
         elif kind == "primitives.status" and isinstance(payload, dict):
             primitives_payload = payload
         elif kind == "workflow.status" and isinstance(payload, dict):
@@ -570,6 +622,14 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
             "top_used": workflow_summary.get("top_used", []),
             "top_broken": workflow_summary.get("top_broken", []),
         }
+    if pipeline_state_payload:
+        pipeline_summary = pipeline_state_payload.get("summary") or {}
+        request["pipeline_state_summary"] = {
+            "artifacts_total": pipeline_summary.get("artifacts_total", 0),
+            "artifacts_attention": pipeline_summary.get("artifacts_attention", 0),
+            "counts_by_status": pipeline_summary.get("counts_by_status", {}),
+            "current_attention": pipeline_state_attention,
+        }
     if curation_payload:
         request["curation_digest"] = curation_payload
     if async_inbox_payload:
@@ -595,6 +655,11 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
         "protocol_compiled_hash": request["post_skill_context"].get("compiled_hash"),
         "failed_steps": failed_steps,
         "delta": delta,
+        "pipeline_state": {
+            "artifacts_total": int(((pipeline_state_payload.get("summary") or {}).get("artifacts_total", 0)) or 0),
+            "artifacts_attention": int(((pipeline_state_payload.get("summary") or {}).get("artifacts_attention", 0)) or 0),
+            "current_attention": len(pipeline_state_attention),
+        } if pipeline_state_payload else {},
         "curation": {
             "topics_total": int((curation_payload.get("topics") or {}).get("total", 0) or 0),
             "stale_candidates": int((curation_payload.get("corpus") or {}).get("stale_candidates", 0) or 0),

--- a/tools/edge-render
+++ b/tools/edge-render
@@ -144,6 +144,7 @@ def _render_postflight_protocol(cfg: dict) -> str:
         "procedures": [
             {"id": "validate-recent", "kind": "validate.recent"},
             {"id": "claims-refresh", "kind": "claims.refresh"},
+            {"id": "pipeline-state", "kind": "pipeline_state.refresh"},
             {"id": "primitives-status", "kind": "primitives.status"},
             {"id": "capabilities-status", "kind": "capabilities.status"},
             {"id": "workflow-status", "kind": "workflow.status"},

--- a/tools/rollup-pipeline-state.py
+++ b/tools/rollup-pipeline-state.py
@@ -21,6 +21,7 @@ from paths import PIPELINE_STATE_FILE, STATE_EVENTS_FILE  # noqa: E402
 PIPELINE_EVENT_TYPES = {"PhaseCompleted", "ArtifactPublished"}
 TRUE_VALUES = {"1", "true", "yes", "ok", "success", "succeeded", "completed", "pass", "passed"}
 FALSE_VALUES = {"0", "false", "no", "fail", "failed", "error", "blocked", "aborted"}
+TERMINAL_PHASES = {"pipeline", "pipeline-end", "pipeline_end"}
 
 
 def iter_events(path: Path = STATE_EVENTS_FILE):
@@ -85,6 +86,8 @@ def _build_empty_artifact(artifact: str) -> dict[str, Any]:
         "last_event_at": "",
         "published_at": "",
         "published": False,
+        "terminal_phase_status": "",
+        "terminal_phase_at": "",
         "phase_counts": {"ok": 0, "failed": 0, "unknown": 0},
         "phases": [],
         "event_counts": {"PhaseCompleted": 0, "ArtifactPublished": 0},
@@ -137,6 +140,10 @@ def _apply_phase_completed(record: dict[str, Any], event: dict[str, Any], payloa
             "line": int(event.get("_line") or 0),
         }
     )
+    phase_name = str(payload.get("phase") or "").strip().lower()
+    if phase_name in TERMINAL_PHASES:
+        record["terminal_phase_status"] = phase_status
+        record["terminal_phase_at"] = _timestamp(event)
 
 
 def _apply_artifact_published(record: dict[str, Any], event: dict[str, Any], payload: dict[str, Any]) -> None:
@@ -153,13 +160,18 @@ def _classify(record: dict[str, Any]) -> str:
     phase_total = int(record["event_counts"].get("PhaseCompleted") or 0)
     published = bool(record.get("published"))
     failed = int((record.get("phase_counts") or {}).get("failed") or 0) > 0
+    terminal = str(record.get("terminal_phase_status") or "").strip()
 
     if published and phase_total == 0:
         return "orphaned_publish"
+    if terminal == "ok":
+        return "complete" if published else "partial"
+    if terminal == "failed":
+        return "failed" if published else "blocked"
     if published and failed:
         return "failed"
     if published and phase_total > 0:
-        return "complete"
+        return "partial"
     if failed:
         return "blocked"
     if phase_total > 0:


### PR DESCRIPTION
## Summary

Closes #248.

This PR moves the event-sourced enforcement migration from observer/advisory slices into a complete command-boundary architecture:

- `consolidate-state` now emits canonical `PhaseCompleted` facts, including a terminal `phase=pipeline` event.
- `pipeline-state` now requires a terminal pipeline phase before classifying a published artifact as complete.
- `edge-postflight` and `edge-doctor` consume `pipeline-state` as a projection readout and soft gate.
- `edge-cmd` is introduced as the protected-write command boundary and emits `ArtifactWriteAuthorized` / `ArtifactWriteRejected` facts.
- `write-guard` and `heartbeat-dispatch-guard` are reduced to shims that delegate authority to `edge-cmd`.
- `backfill-pipeline-phase-events.py` idempotently appends terminal `PhaseCompleted` facts for legacy `ArtifactPublished` events.
- `audit-cqrs-migration.py` verifies the migration surface and reports remaining shim/fallback residue explicitly.

## Runtime / Fleet Note

The Fleet Grafana overlay remains outside the canonical repository, per the local-fleet decision. I instrumented it locally at:

- `/home/vboxuser/observability/fleet/publish_dispatch_projection.py`
- `/home/vboxuser/fleet-observe/publish_dispatch_projection.py`
- `/home/vboxuser/observability/fleet/grafana/dashboards/fleet-dispatch-cycles.json`

The local publisher now emits `PipelineStateProjectionPublished` and related metric/status events in addition to dispatch-cycle events. The canonical repo still has no `observability/fleet` directory.

## Validation

- `python3 -m py_compile tools/edge-cmd tools/audit-cqrs-migration.py tools/backfill-pipeline-phase-events.py tools/edge-postflight tools/rollup-pipeline-state.py tools/edge-doctor tools/_shared/protocol_runtime.py`
- `bash -n blog/consolidate-state.sh hooks/write-guard.sh bin/heartbeat-dispatch-guard.sh`
- `bash tests/test_pipeline_state_projection.sh`
- `bash tests/test_pipeline_state_backfill.sh`
- `bash tests/test_edge_cmd_boundary.sh`
- `bash tests/test_postflight_pipeline_state.sh`
- `bash tests/test_edge_dispatch.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_dispatch_cycle_projection.sh`
- `bash tests/test_render_install_drift.sh`
- `bash tests/test_postflight_resilience.sh`
- `bash tests/test_protocol_runtime.sh`
- `bash tests/test_runtime_router_config.sh`
- `bash tests/test_cqrs_audit.sh`
- `./tools/audit-cqrs-migration.py`
- `/home/vboxuser/observability/fleet/publish_dispatch_projection.py --dry-run --limit 5`

## Backfill Applied Locally

After dry-run reported 15 legacy orphaned publishes, I ran the new backfill against `/home/vboxuser/edge/state/events/log.jsonl`. The current local projection is now:

`pipeline-state: artifacts=15 attention=0 complete=15 partial=0 blocked=0 failed=0 orphaned_publish=0`