### PR TITLE
[codex] Improve report communication and chart blocks

### DIFF
--- a/skills/_shared/report-template.md
+++ b/skills/_shared/report-template.md
@@ -16,11 +16,11 @@ with Lineage, Gaps, Glossary, Bibliography, ≥1 SVG all MANDATORY.
 
 1. **Generate YAML** with the sections from the calling skill, using the block types below
 2. **Write YAML** to `/tmp/spec-[skill]-[slug].yaml`
-3. **Write the blog entry as a light invitation, then include claims in
-   frontmatter** (compaction — MANDATORY). The entry body should be only a few
-   concise paragraphs: lead with what changed or what was learned, invite the
-   reader into the work, and leave implementation depth to the report. Do not
-   duplicate the YAML/report structure in the blog body.
+3. **Write the blog entry as a light strategic invitation, then include claims
+   in frontmatter** (compaction — MANDATORY). The entry body should be only a
+   few concise paragraphs: frame why this matters now, explain what the
+   operator gains by opening the report, and leave implementation depth to the
+   report. Do not duplicate the YAML/report structure in the blog body.
    ```yaml
    claims:
      - "Verified fact I learned"
@@ -103,6 +103,8 @@ bibliography:
 | `template-block` | Example template | title, description?, content, note? |
 | `next-steps-grid` | Visual roadmap | steps[{number,title,description}] |
 | `metrics-grid` | Inline KPIs | items[{value,label}] |
+| `bar-chart` | Quantitative comparison with SVG + table | title?, unit?, items[{label,value,variant?}] |
+| `line-chart` | Trend/sequence with SVG + table | title?, unit?, points[{label,value,variant?}] |
 | `list` | ul/ol list | items, ordered? |
 | `diff-block` | Before/after diff | header?, lines[{type(insert/delete/context),text}] |
 | `raw-html` | HTML passthrough | content |
@@ -130,7 +132,7 @@ If there is no relevant prior work, state explicitly: "First work on this topic.
 
 SVG is not just for numbers — any information that communicates better as an image deserves SVG. Rule: if the reader would need to draw on paper to understand, generate SVG.
 
-**When to generate SVG:**
+**When to generate SVG/chart blocks:**
 - Comparison of 3+ values: horizontal/vertical bars
 - Statistical distribution: box plot (whiskers + median + mean)
 - Trend over time: bars grouped by period
@@ -142,7 +144,7 @@ SVG is not just for numbers — any information that communicates better as an i
 - Hierarchy/taxonomy: tree diagram
 - Cycle/loop: circular diagram (feedback loops, iterative cycles)
 
-**SVG standard:** fixed viewBox (`700 280` charts, `700 400` diagrams), `font-family:'Segoe UI',sans-serif`, semantic colors (`#e53e3e` danger, `#2b6cb0` normal, `#38a169` success, `#ed8936` warning, `#805ad5` highlight, `#718096` neutral), inline legend, `max-width:100%`, `<title>` for accessibility. Numerical data: SVG + table = mandatory pair. Relationship/flow diagrams do not need a table. Minimum 1 SVG per report.
+**SVG standard:** fixed viewBox (`700 280` charts, `700 400` diagrams), `font-family:'Segoe UI',sans-serif`, semantic colors (`#e53e3e` danger, `#2b6cb0` normal, `#38a169` success, `#ed8936` warning, `#805ad5` highlight, `#718096` neutral), inline legend, `max-width:100%`, `<title>` for accessibility. Numerical data: SVG + table = mandatory pair. Relationship/flow diagrams do not need a table. Minimum 1 SVG per report; for reports with multiple comparisons, trends, risks, or operational trade-offs, default to 2+ visual encodings. Prefer the structured `bar-chart` and `line-chart` blocks for routine numerical comparisons, and `raw-html` SVG for diagrams that need custom layout.
 
 ---
 
@@ -212,7 +214,7 @@ review-gate /tmp/spec-[skill]-[slug].yaml --skill [skill]
 # If PASS: publish
 ```
 
-The review gate evaluates 6 dimensions (structural_completeness, content_depth, writing_quality, visualization, intellectual_honesty, internal_consistency) via GPT-4o-mini. Cost: ~$0.002/review. Threshold: 3.5/5.
+The review gate evaluates structural completeness, content depth, storytelling, Feynman reasoning, writing quality, visualization, intellectual honesty, internal consistency, and didactic clarity via the configured review router. Cost depends on the configured provider. Threshold: 3.5/5.
 
 **IMPORTANT:** `consolidate-state` runs the review gate automatically (Phase 0.5). If the YAML doesn't pass, publication is blocked — fix the YAML and re-run. (Enforcement #218: there is no bypass flag anymore — address the feedback.)
 

--- a/skills/_shared/state-protocol.md
+++ b/skills/_shared/state-protocol.md
@@ -248,16 +248,20 @@ If during editing you realize you need to change a file NOT proposed:
 #### Blog Entry Voice Contract
 
 The blog entry body is the invitation, not the report. Write it as a short,
-light read that helps the operator remember why this work matters and decide
-whether to open the attached report.
+light strategic read that helps the operator remember why this work matters,
+what decision or leverage the report enables, and whether to open the attached
+report.
 
 Required voice:
 - Keep the body to a few concise paragraphs; default to 2-4 paragraphs.
 - Lead with what changed, what was learned, or what door this opens.
+- Explain the operator gain: the decision, risk reduction, context, or next
+  move the report makes easier.
 - Use plain language and an exploratory tone; avoid implementation dumps,
   acronyms, long lists, stack traces, and dense protocol detail in the body.
 - Put technical depth in the report, notes, claims, procedures, and metadata.
-- End by pointing toward the reader-visible report or next question when useful.
+- End by pointing toward the reader-visible report or next question when useful,
+  without turning the entry into a summary of every report section.
 
 If a publication needs heavy detail, the entry should summarize the shape of the
 finding and let the content report carry the technical load.

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -91,6 +91,8 @@ Use visual structure when it makes the report easier to reason about.
 Prefer:
 
 - tables for exact reference;
+- `bar-chart` blocks for 3+ comparable values, risks, options, costs, or scores;
+- `line-chart` blocks for trends, sequences, or before/during/after movement;
 - comparison blocks for before/after or option trade-offs;
 - flow examples for input -> output transformations;
 - diagrams for architecture, process, dependencies, or feedback loops;
@@ -98,6 +100,8 @@ Prefer:
 - charts for numeric comparison.
 
 If the reader would need to draw something on paper to understand it, include a visualization.
+When a report has more than one analytical comparison or operational trade-off,
+use more than one visualization instead of forcing the whole argument into prose.
 
 ## Output Contract
 
@@ -109,6 +113,7 @@ The artifact should include:
 - concise executive summary;
 - sections with narrative flow;
 - at least one structured element when useful: table, comparison, diagram, timeline, flow example, or chart;
+- SVG/table chart pairs for routine numerical comparisons;
 - references for external or non-obvious claims;
 - explicit risks and unknowns;
 - next steps.

--- a/tests/test_blog_entry_voice_contract.sh
+++ b/tests/test_blog_entry_voice_contract.sh
@@ -9,9 +9,11 @@ echo "=== blog entry voice contract test ==="
 
 grep -q "Blog Entry Voice Contract" "$PROTOCOL"
 grep -q "The blog entry body is the invitation, not the report" "$PROTOCOL"
+grep -q "operator gain" "$PROTOCOL"
 grep -q "default to 2-4 paragraphs" "$PROTOCOL"
 grep -q "Put technical depth in the report" "$PROTOCOL"
-grep -q "Write the blog entry as a light invitation" "$TEMPLATE"
+grep -q "Write the blog entry as a light strategic invitation" "$TEMPLATE"
+grep -q "operator gains by opening the report" "$TEMPLATE"
 grep -q "duplicate the YAML/report structure" "$TEMPLATE"
 
 echo "ALL TESTS PASSED"

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -298,13 +298,15 @@ DIMENSIONS = {
         "Titles are evocative, not descriptive."
     ),
     "visualization": (
-        "At least 1 SVG visualization (inline in raw-html block). "
-        "Data tables paired with charts when 3+ values compared. "
+        "At least 1 SVG visualization, either via structured chart blocks "
+        "(bar-chart, line-chart) or inline SVG in a raw-html block. "
+        "Data tables paired with charts when 3+ values are compared. "
         "Diagrams where relationships/flows communicate better visually. "
         "Prefer visual reasoning, not decorative charts: causal maps, funnels, timelines, "
         "state-transition diagrams, evidence matrices, uncertainty heatmaps, or before/after comparisons. "
         "If a report compares 3+ items, steps, metrics, risks, or alternatives, it should contain a visual encoding "
-        "of that comparison, not only prose/table. SVG follows standards: viewBox, font-family, semantic colors, "
+        "of that comparison, not only prose/table. If it has multiple analytical comparisons, trends, or operational "
+        "trade-offs, expect 2+ visual encodings. SVG follows standards: viewBox, font-family, semantic colors, "
         "labels that explain the insight, and enough whitespace to be readable."
     ),
     "intellectual_honesty": (
@@ -318,7 +320,9 @@ DIMENSIONS = {
         "Metrics match what's reported in sections. "
         "Title matches actual scope. Numbers consistent throughout. "
         "Linhagem references real prior work, not generic placeholders. "
-        "Blog entry (if provided) is consistent with report content."
+        "Blog entry (if provided) is consistent with report content and acts as a light strategic invitation: "
+        "it contextualizes why the work matters, states what the operator gains by opening the report, and leaves "
+        "technical depth to the report instead of duplicating it."
     ),
     "didactic_clarity": (
         "Every concept, acronym, and technical term is explained on first use. "
@@ -433,8 +437,10 @@ Flag as critical_issues if ANY of these:
 - Required section completely missing (linhagem, "O que Nao Sei", glossario)
 - executive_summary or metrics missing at top level, or no reader-visible equivalent in HTML
 - Empty sections (title present but no blocks/content)
-- Zero SVG visualizations in entire spec
+- Zero SVG-capable visualizations in entire spec (no bar-chart, line-chart, or raw-html inline SVG)
 - A report compares 3+ items/steps/metrics/risks/alternatives but has no chart, flow, matrix, timeline, or diagram representing that comparison visually
+- A report has multiple quantitative/trade-off comparisons but only one visual encoding and no clear reason for keeping the rest textual
+- Associated blog entry duplicates the report structure or does not explain the operator gain from opening the report (if blog entry provided)
 - "O que Nao Sei" is clearly boilerplate (vague generic text, not specific to this report's topic)
 - Sections reference data/events not present elsewhere in the spec (internal contradiction)
 - Blog entry says one thing, report says another (if blog entry provided)
@@ -479,15 +485,17 @@ Language: Portuguese (PT-BR). Output: ONLY the complete, corrected YAML. No mark
 - Do NOT remove existing good content — only add, improve, or restructure
 - Preserve the YAML structure (title, subtitle, date, executive_summary, metrics, sections, bibliography)
 - If the reviewer says a section is shallow, DEEPEN it with concrete content (not lorem ipsum)
-- If an SVG is missing and the reviewer flagged it, add a simple but real SVG visualization
-- If the report compares 3+ things, add a visual encoding of the comparison: timeline, funnel, matrix, causal map, risk heatmap, before/after, or flow diagram
+- If an SVG/chart is missing and the reviewer flagged it, add a simple but real visualization; use `bar-chart` or `line-chart` for routine numerical data, and raw-html SVG for custom diagrams
+- If the report compares 3+ things, add a visual encoding of the comparison: bar-chart, line-chart, timeline, funnel, matrix, causal map, risk heatmap, before/after, or flow diagram
+- If the report has several analytical comparisons or operational trade-offs, add multiple visual encodings rather than one decorative chart
 - If "O que Nao Sei" is flagged as boilerplate, rewrite with genuine, specific gaps
 - Keep all existing metadata intact (title, date, etc.)
 
 ## Report Template Rules (summary)
 - Required sections: linhagem (first), "O que Nao Sei" (penultimate), glossario (last)
 - Required top-level keys: executive_summary, metrics, bibliography
-- At least 1 SVG visualization (inline raw-html block); comparisons with 3+ values need a chart/diagram, not only a table
+- At least 1 SVG visualization (`bar-chart`, `line-chart`, or inline raw-html SVG); comparisons with 3+ values need a chart/diagram, not only a table
+- Reports with multiple comparisons/trends/trade-offs should use 2+ visual encodings when useful
 - Tables paired with charts when 3+ values compared
 """
 

--- a/tools/test_yaml_to_html.py
+++ b/tools/test_yaml_to_html.py
@@ -443,6 +443,61 @@ class TestMetricsGrid:
         assert any("desconhecido" in w for w in warnings)
 
 
+class TestBarChart:
+    def test_basic(self):
+        block = {
+            "type": "bar-chart",
+            "title": "Comparacao de risco",
+            "unit": "%",
+            "items": [
+                {"label": "A", "value": 20, "variant": "success"},
+                {"label": "B", "value": 80, "variant": "danger"},
+            ],
+        }
+        assert_renders(block, "<svg", "Comparacao de risco", "A", "80%", "<table")
+        assert_validates_clean(block)
+
+    def test_data_synonym(self):
+        block = {
+            "type": "bar-chart",
+            "data": [{"label": "Latencia", "value": "42ms"}],
+        }
+        assert_renders(block, "Latencia", "42")
+        assert_validates_clean(block)
+
+    def test_empty_items_warns(self):
+        warnings = _validate_block("bar-chart", {"type": "bar-chart", "items": []})
+        assert any("Container vazio" in w for w in warnings)
+
+
+class TestLineChart:
+    def test_basic(self):
+        block = {
+            "type": "line-chart",
+            "title": "Tendencia",
+            "unit": " ciclos",
+            "points": [
+                {"label": "D1", "value": 1},
+                {"label": "D2", "value": 3},
+                {"label": "D3", "value": 2},
+            ],
+        }
+        assert_renders(block, "<polyline", "Tendencia", "D2", "3 ciclos", "<table")
+        assert_validates_clean(block)
+
+    def test_items_synonym(self):
+        block = {
+            "type": "line-chart",
+            "items": [{"label": "antes", "value": 1}, {"label": "depois", "value": 2}],
+        }
+        assert_renders(block, "antes", "depois")
+        assert_validates_clean(block)
+
+    def test_empty_points_warns(self):
+        warnings = _validate_block("line-chart", {"type": "line-chart", "points": []})
+        assert any("Container vazio" in w for w in warnings)
+
+
 class TestList:
     def test_unordered(self):
         block = {"type": "list", "items": ["apple", "banana", "cherry"]}

--- a/tools/yaml_to_html.py
+++ b/tools/yaml_to_html.py
@@ -65,6 +65,41 @@ def badge_html(text: str, variant: str = "neutral") -> str:
     return f'<span class="badge badge-{variant}">{html.escape(str(text))}</span>'
 
 
+def _xml_text(value) -> str:
+    """Escape text for inline SVG nodes and attributes."""
+    return html.escape(str(value), quote=True)
+
+
+def _coerce_number(value, default: float = 0.0) -> float:
+    """Extract a float from common YAML scalar forms such as '42%' or '1,5'."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    match = re.search(r"-?\d+(?:[\.,]\d+)?", str(value or ""))
+    if not match:
+        return default
+    return float(match.group(0).replace(",", "."))
+
+
+def _format_number(value: float) -> str:
+    if float(value).is_integer():
+        return str(int(value))
+    return f"{value:.1f}".rstrip("0").rstrip(".")
+
+
+def _chart_color(item: dict, default: str = "#2b6cb0") -> str:
+    colors = {
+        "danger": "#e53e3e",
+        "warning": "#ed8936",
+        "success": "#38a169",
+        "highlight": "#805ad5",
+        "neutral": "#718096",
+        "info": "#2b6cb0",
+        "normal": "#2b6cb0",
+    }
+    raw = str(item.get("color") or item.get("variant") or item.get("status") or "").lower()
+    return colors.get(raw, item.get("color") or default)
+
+
 # ---------------------------------------------------------------------------
 # Block renderers
 # ---------------------------------------------------------------------------
@@ -480,6 +515,178 @@ def render_metrics_grid_block(b):
     return _render_metrics_items(b.get("items", []) or b.get("metrics", []))
 
 
+@renderer("bar-chart")
+def render_bar_chart(b):
+    items = b.get("items", []) or b.get("data", [])
+    if not items:
+        return ""
+
+    title = b.get("title", "Grafico de barras")
+    unit = str(b.get("unit", "") or "")
+    label_key = b.get("label_key", "label")
+    value_key = b.get("value_key", "value")
+    value_label = b.get("value_label", "Valor")
+    values = [_coerce_number(item.get(value_key, item.get("value", 0))) for item in items]
+    max_value = _coerce_number(b.get("max_value"), max(values) if values else 1.0)
+    max_value = max(max_value, max(values) if values else 1.0, 1.0)
+
+    width, height = 700, 280
+    plot_x, plot_w = 220, 410
+    top, bottom = 48, 238
+    rows = max(len(items), 1)
+    step = (bottom - top) / rows
+    bar_h = min(26, step * 0.58)
+
+    svg = [
+        f'<svg role="img" viewBox="0 0 {width} {height}" '
+        'xmlns="http://www.w3.org/2000/svg" '
+        'style="max-width:100%;height:auto;display:block;margin:8px 0 14px;">',
+        f"<title>{_xml_text(title)}</title>",
+        '<rect x="0" y="0" width="700" height="280" rx="8" fill="#ffffff"/>',
+        '<line x1="220" y1="238" x2="630" y2="238" stroke="#d1d5db" stroke-width="1"/>',
+        f'<text x="24" y="26" font-family="Segoe UI,sans-serif" font-size="16" '
+        f'font-weight="600" fill="#1a3560">{_xml_text(title)}</text>',
+        f'<text x="220" y="260" font-family="Segoe UI,sans-serif" font-size="11" '
+        f'fill="#718096">0</text>',
+        f'<text x="630" y="260" font-family="Segoe UI,sans-serif" font-size="11" '
+        f'text-anchor="end" fill="#718096">{_xml_text(_format_number(max_value) + unit)}</text>',
+    ]
+
+    for idx, item in enumerate(items):
+        label = str(item.get(label_key) or item.get("name") or item.get("title") or f"Item {idx + 1}")
+        value = values[idx]
+        bar_w = 0 if max_value <= 0 else max(2, (value / max_value) * plot_w)
+        y = top + idx * step + (step - bar_h) / 2
+        color = _chart_color(item)
+        svg.extend([
+            f'<text x="24" y="{y + bar_h * 0.72:.1f}" font-family="Segoe UI,sans-serif" '
+            f'font-size="12" fill="#374151">{_xml_text(label)}</text>',
+            f'<rect x="{plot_x}" y="{y:.1f}" width="{plot_w}" height="{bar_h:.1f}" '
+            f'rx="4" fill="#e5e7eb"/>',
+            f'<rect x="{plot_x}" y="{y:.1f}" width="{bar_w:.1f}" height="{bar_h:.1f}" '
+            f'rx="4" fill="{_xml_text(color)}"/>',
+            f'<text x="{min(plot_x + bar_w + 8, 672):.1f}" y="{y + bar_h * 0.72:.1f}" '
+            f'font-family="Segoe UI,sans-serif" font-size="12" fill="#111827">'
+            f'{_xml_text(_format_number(value) + unit)}</text>',
+        ])
+    svg.append("</svg>")
+
+    table_rows = "".join(
+        "<tr>"
+        f"<td>{render_text(str(item.get(label_key) or item.get('name') or item.get('title') or f'Item {idx + 1}'))}</td>"
+        f"<td>{render_text(_format_number(values[idx]) + unit)}</td>"
+        "</tr>"
+        for idx, item in enumerate(items)
+    )
+    table = (
+        '<div class="table-wrapper"><table><thead><tr>'
+        f'<th>{render_text(b.get("label_label", "Item"))}</th>'
+        f'<th>{render_text(value_label)}</th>'
+        f'</tr></thead><tbody>{table_rows}</tbody></table></div>'
+    )
+    note = ""
+    if b.get("note"):
+        note = (
+            f'<p style="font-size: 12px; color: var(--gray-500); margin-top: -8px;">'
+            f'{render_text(b["note"])}</p>'
+        )
+    return "\n".join(['<div class="chart-block">', *svg, table, note, '</div>'])
+
+
+@renderer("line-chart")
+def render_line_chart(b):
+    points = b.get("points", []) or b.get("items", []) or b.get("data", [])
+    if not points:
+        return ""
+
+    title = b.get("title", "Grafico de linha")
+    unit = str(b.get("unit", "") or "")
+    label_key = b.get("label_key", "label")
+    value_key = b.get("value_key", "value")
+    value_label = b.get("value_label", "Valor")
+    values = [_coerce_number(item.get(value_key, item.get("value", 0))) for item in points]
+    min_value = min(values) if values else 0.0
+    max_value = max(values) if values else 1.0
+    if b.get("min_value") is not None:
+        min_value = _coerce_number(b.get("min_value"), min_value)
+    if b.get("max_value") is not None:
+        max_value = _coerce_number(b.get("max_value"), max_value)
+    if min_value == max_value:
+        min_value -= 1
+        max_value += 1
+
+    width, height = 700, 280
+    left, right = 70, 650
+    top, bottom = 48, 226
+    span_x = max(right - left, 1)
+    span_y = max_value - min_value
+    denom = max(len(points) - 1, 1)
+
+    coords = []
+    for idx, value in enumerate(values):
+        x = left + (idx / denom) * span_x
+        y = bottom - ((value - min_value) / span_y) * (bottom - top)
+        coords.append((x, y))
+    polyline = " ".join(f"{x:.1f},{y:.1f}" for x, y in coords)
+
+    svg = [
+        f'<svg role="img" viewBox="0 0 {width} {height}" '
+        'xmlns="http://www.w3.org/2000/svg" '
+        'style="max-width:100%;height:auto;display:block;margin:8px 0 14px;">',
+        f"<title>{_xml_text(title)}</title>",
+        '<rect x="0" y="0" width="700" height="280" rx="8" fill="#ffffff"/>',
+        f'<text x="24" y="26" font-family="Segoe UI,sans-serif" font-size="16" '
+        f'font-weight="600" fill="#1a3560">{_xml_text(title)}</text>',
+        f'<line x1="{left}" y1="{bottom}" x2="{right}" y2="{bottom}" stroke="#d1d5db" stroke-width="1"/>',
+        f'<line x1="{left}" y1="{top}" x2="{left}" y2="{bottom}" stroke="#d1d5db" stroke-width="1"/>',
+        f'<text x="24" y="{top + 4}" font-family="Segoe UI,sans-serif" font-size="11" '
+        f'fill="#718096">{_xml_text(_format_number(max_value) + unit)}</text>',
+        f'<text x="24" y="{bottom}" font-family="Segoe UI,sans-serif" font-size="11" '
+        f'fill="#718096">{_xml_text(_format_number(min_value) + unit)}</text>',
+        f'<polyline points="{polyline}" fill="none" stroke="#2b6cb0" stroke-width="3" '
+        'stroke-linejoin="round" stroke-linecap="round"/>',
+    ]
+
+    for idx, item in enumerate(points):
+        label = str(item.get(label_key) or item.get("name") or item.get("title") or idx + 1)
+        value = values[idx]
+        x, y = coords[idx]
+        color = _chart_color(item, "#2b6cb0")
+        svg.extend([
+            f'<circle cx="{x:.1f}" cy="{y:.1f}" r="4" fill="{_xml_text(color)}"/>',
+            f'<text x="{x:.1f}" y="248" font-family="Segoe UI,sans-serif" font-size="10" '
+            f'text-anchor="middle" fill="#718096">{_xml_text(label)}</text>',
+        ])
+        if len(points) <= 8:
+            svg.append(
+                f'<text x="{x:.1f}" y="{max(y - 10, 38):.1f}" font-family="Segoe UI,sans-serif" '
+                f'font-size="11" text-anchor="middle" fill="#111827">'
+                f'{_xml_text(_format_number(value) + unit)}</text>'
+            )
+    svg.append("</svg>")
+
+    table_rows = "".join(
+        "<tr>"
+        f"<td>{render_text(str(item.get(label_key) or item.get('name') or item.get('title') or idx + 1))}</td>"
+        f"<td>{render_text(_format_number(values[idx]) + unit)}</td>"
+        "</tr>"
+        for idx, item in enumerate(points)
+    )
+    table = (
+        '<div class="table-wrapper"><table><thead><tr>'
+        f'<th>{render_text(b.get("label_label", "Ponto"))}</th>'
+        f'<th>{render_text(value_label)}</th>'
+        f'</tr></thead><tbody>{table_rows}</tbody></table></div>'
+    )
+    note = ""
+    if b.get("note"):
+        note = (
+            f'<p style="font-size: 12px; color: var(--gray-500); margin-top: -8px;">'
+            f'{render_text(b["note"])}</p>'
+        )
+    return "\n".join(['<div class="chart-block">', *svg, table, note, '</div>'])
+
+
 @renderer("list")
 def render_list(b):
     tag = "ol" if b.get("ordered") else "ul"
@@ -765,6 +972,24 @@ BLOCK_SCHEMAS = {
         "synonyms": {"metrics": "items"},
         "container_field": ("items", "metrics"),
     },
+    "bar-chart": {
+        "required": [],
+        "optional": [
+            "title", "unit", "max_value", "value_label", "label_label",
+            "label_key", "value_key", "note", "items", "data",
+        ],
+        "synonyms": {"data": "items"},
+        "container_field": ("items", "data"),
+    },
+    "line-chart": {
+        "required": [],
+        "optional": [
+            "title", "unit", "min_value", "max_value", "value_label",
+            "label_label", "label_key", "value_key", "note", "points", "items", "data",
+        ],
+        "synonyms": {"items": "points", "data": "points"},
+        "container_field": ("points", "items", "data"),
+    },
     "list": {
         "required": [],
         "optional": ["items", "ordered", "style"],
@@ -815,7 +1040,7 @@ BLOCK_SCHEMAS = {
     },
     "glossary": {
         "required": [],
-        "optional": ["context", "terms"],
+        "optional": ["context", "terms", "items"],
         "synonyms": {"items": "terms"},
         "container_field": ("terms", "items"),
     },
@@ -830,6 +1055,14 @@ def _validate_block(block_type: str, block: dict) -> list:
     warnings = []
     present = {k for k in block if k != "type"}
     known = set(schema["required"]) | set(schema["optional"]) | set(schema.get("synonyms", {}).keys())
+
+    if block_type == "comparison":
+        has_left = any(k in block for k in ("before", "left", "left_title", "left_items"))
+        has_right = any(k in block for k in ("after", "right", "right_title", "right_items"))
+        if not has_left:
+            warnings.append("Campo obrigatorio ausente: 'before'")
+        if not has_right:
+            warnings.append("Campo obrigatorio ausente: 'after'")
 
     # Missing required fields
     for field in schema["required"]:
@@ -913,6 +1146,14 @@ _BLOCK_TYPE_ALIASES = {
     "kpi-row": "metrics-grid",
     "kpi-grid": "metrics-grid",
     "stats": "metrics-grid",
+    # Chart aliases
+    "chart": "bar-chart",
+    "bar": "bar-chart",
+    "bars": "bar-chart",
+    "horizontal-bar": "bar-chart",
+    "line": "line-chart",
+    "trend": "line-chart",
+    "sparkline": "line-chart",
     # Card aliases
     "numbered-cards": "numbered-card",
     "step-card": "numbered-card",
@@ -1019,6 +1260,7 @@ def _normalize_section_blocks(section: dict) -> list:
     4. Next-steps shorthand: section has 'type: next-steps-grid' and 'steps'
     5. Table shorthand: section has 'type: table' and 'headers'/'rows'
     6. Callout shorthand: section has 'type: callout' and 'content'/'text'
+    7. Chart shorthand: section has 'type: bar-chart'/'line-chart' and items/data
     """
     if section.get("blocks"):
         return section["blocks"]
@@ -1047,19 +1289,24 @@ def _normalize_section_blocks(section: dict) -> list:
             block["highlight_rows"] = section["highlight_rows"]
     elif sec_type == "metrics-grid":
         block["items"] = section.get("metrics", section.get("items", []))
+    elif sec_type == "bar-chart":
+        block["items"] = section.get("items", section.get("data", []))
+    elif sec_type == "line-chart":
+        block["points"] = section.get("points", section.get("items", section.get("data", [])))
     elif sec_type == "next-steps-grid":
         block["steps"] = section.get("steps", section.get("items", []))
     elif content:
         block["text"] = content
 
     # Copy any extra keys the renderer might need
-    for key in ("items", "steps", "ordered", "variant",
-                "headers", "rows", "number", "badge", "badge_class"):
+    for key in ("items", "steps", "points", "ordered", "variant",
+                "headers", "rows", "number", "badge", "badge_class",
+                "unit", "max_value", "min_value", "value_label", "label_label"):
         if key in section and key not in block:
             block[key] = section[key]
 
     if block.get("text") or block.get("items") or block.get("steps") \
-       or block.get("headers") or block.get("content"):
+       or block.get("points") or block.get("headers") or block.get("content"):
         title = section.get("title", "(sem titulo)")
         print(f"AVISO: secao '{title}' usa formato shorthand (type/content no nivel da secao). "
               f"Formato correto: blocks: [{{type: ..., text: ...}}]. Convertido automaticamente.",


### PR DESCRIPTION
## Summary
- Tighten the blog/dashboard entry voice contract so posts stay light, strategic, and explain the operator gain from opening the report.
- Add structured `bar-chart` and `line-chart` YAML blocks that render accessible inline SVG charts with paired data tables.
- Update report and review guidance so complex reports default to more useful visual encodings and review checks catch weak post/report communication.

Closes #409.

## Validation
- `python3 -m py_compile tools/yaml_to_html.py tools/review-gate.py`
- `/tmp/edge-yaml-test-venv/bin/python -m pytest tools/test_yaml_to_html.py` (`86 passed`)
- `bash tests/test_blog_entry_voice_contract.sh`
- `git diff --check HEAD~1 HEAD`