### PR TITLE
[codex] Fix edge-runner prompt transport

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -98,17 +98,19 @@ RUNNER_TOOL="$EDGE_DIR/tools/edge-runner"
 cat >"$TMP_HOME/.local/bin/claude" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+PROMPT="$(cat)"
 printf '%s\n' "$EDGE_CYCLE_ID" >> "${MOCK_CLAUDE_ENV_OUT:?}"
 printf '__INVOCATION__\n' >> "${MOCK_CLAUDE_ARGS_OUT:?}"
-printf '%s\n' "$*" >> "${MOCK_CLAUDE_ARGS_OUT:?}"
+printf 'ARGS: %s\n' "$*" >> "${MOCK_CLAUDE_ARGS_OUT:?}"
+printf 'STDIN:\n%s\n' "$PROMPT" >> "${MOCK_CLAUDE_ARGS_OUT:?}"
 printf '__END__\n' >> "${MOCK_CLAUDE_ARGS_OUT:?}"
 if [ -n "${MOCK_CLAUDE_SLEEP_SECONDS:-}" ]; then
   sleep "${MOCK_CLAUDE_SLEEP_SECONDS}"
 fi
 if [ "${MOCK_CLAUDE_HEARTBEAT_FLOW:-0}" = "1" ]; then
-  if [[ "$*" == *"/ed-heartbeat"* ]]; then
+  if [[ "$PROMPT" == *"/ed-heartbeat"* ]]; then
     "${EDGE_REPO_DIR:?}/tools/edge-dispatch" dispatch --skill discovery >/dev/null
-  elif [[ "$*" == *"/discovery"* ]]; then
+  elif [[ "$PROMPT" == *"/discovery"* ]]; then
     "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery start >/dev/null
     "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery end >/dev/null
   fi
@@ -244,6 +246,8 @@ assert any(event["type"] == "ExplorationPackPublished" for event in events)
 assert any(event["type"] == "SkillRunCompleted" for event in events)
 assert any(event["type"] == "CycleClosed" for event in events)
 assert len(invocations) == 2
+assert invocations[0].splitlines()[0] == "ARGS: -p -"
+assert invocations[1].splitlines()[0] == "ARGS: -p -"
 assert "/ed-heartbeat" in invocations[0]
 assert "/discovery" in invocations[1]
 assert "Dispatch runtime context below" in invocations[0]
@@ -484,6 +488,75 @@ then
     pass "watchdog kills hung backend and closes cycle as skill_subprocess_timeout"
 else
     fail "watchdog kills hung backend and closes cycle as skill_subprocess_timeout"
+fi
+
+echo "--- Test 9: backend prompt is delivered through stdin, not argv ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import argparse
+import importlib.machinery
+import importlib.util
+import os
+import sys
+
+edge_dir = sys.argv[1]
+loader = importlib.machinery.SourceFileLoader("edge_runner", f"{edge_dir}/tools/edge-runner")
+spec = importlib.util.spec_from_loader("edge_runner", loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+large_prompt = "prompt-line\n" + ("x" * (3 * 1024 * 1024))
+args = argparse.Namespace(
+    cmd="prompt",
+    prompt=large_prompt,
+    skill="",
+    backend="claude",
+    cwd=None,
+    max_turns=2,
+    allowed_tools="Bash",
+    output_format="json",
+    dangerously_skip_permissions=True,
+)
+captured = {}
+
+class Result:
+    returncode = 0
+
+def fake_run(cmd, *, env, cwd, input, text):
+    captured["cmd"] = cmd
+    captured["input"] = input
+    captured["text"] = text
+    captured["cwd"] = cwd
+    return Result()
+
+module.resolve_claude_bin = lambda: "/mock/claude"
+module.subprocess.run = fake_run
+os.environ["EDGE_RUNNER_SKILL_TIMEOUT_SEC"] = "0"
+try:
+    status = module.invoke_backend(args, {"EDGE_REPO_DIR": edge_dir}, cycle_id=None)
+finally:
+    os.environ.pop("EDGE_RUNNER_SKILL_TIMEOUT_SEC", None)
+
+assert status == 0
+assert captured["cmd"] == [
+    "/mock/claude",
+    "-p",
+    "-",
+    "--max-turns",
+    "2",
+    "--allowedTools",
+    "Bash",
+    "--output-format",
+    "json",
+    "--dangerously-skip-permissions",
+]
+assert captured["input"] == large_prompt
+assert large_prompt not in captured["cmd"]
+assert captured["text"] is True
+PY
+then
+    pass "large backend prompt is streamed through stdin"
+else
+    fail "large backend prompt is streamed through stdin"
 fi
 
 echo ""

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -87,8 +87,7 @@ def build_backend_command(args: argparse.Namespace) -> list[str]:
     if args.backend != "claude":
         raise ValueError(f"unsupported backend: {args.backend}")
 
-    content = args.skill if args.cmd == "skill" else args.prompt
-    cmd = [resolve_claude_bin(), "-p", content]
+    cmd = [resolve_claude_bin(), "-p", "-"]
     if args.max_turns is not None:
         cmd.extend(["--max-turns", str(args.max_turns)])
     if args.allowed_tools:
@@ -492,28 +491,25 @@ def resolve_skill_timeout_seconds() -> int | None:
 
 def invoke_backend(args: argparse.Namespace, env: dict[str, str], *, cycle_id: str | None = None) -> int:
     content = build_backend_content(args, cycle_id)
-    original = args.skill if args.cmd == "skill" else args.prompt
-    if content != original:
-        backend_args = argparse.Namespace(**vars(args))
-        if args.cmd == "skill":
-            backend_args.skill = content
-        else:
-            backend_args.prompt = content
-        cmd = build_backend_command(backend_args)
-    else:
-        cmd = build_backend_command(args)
+    cmd = build_backend_command(args)
 
     timeout_seconds = resolve_skill_timeout_seconds()
     if timeout_seconds is None:
-        result = subprocess.run(cmd, env=env, cwd=resolve_cwd(args.cwd))
+        result = subprocess.run(cmd, env=env, cwd=resolve_cwd(args.cwd), input=content, text=True)
         return result.returncode
 
-    popen_kwargs: dict = {"env": env, "cwd": resolve_cwd(args.cwd)}
+    popen_kwargs: dict = {
+        "env": env,
+        "cwd": resolve_cwd(args.cwd),
+        "stdin": subprocess.PIPE,
+        "text": True,
+    }
     if os.name == "posix":
         popen_kwargs["start_new_session"] = True
     proc = subprocess.Popen(cmd, **popen_kwargs)
     try:
-        return proc.wait(timeout=timeout_seconds)
+        proc.communicate(input=content, timeout=timeout_seconds)
+        return proc.returncode
     except subprocess.TimeoutExpired:
         target = args.skill if args.cmd == "skill" else "prompt"
         emit_shadow_event(


### PR DESCRIPTION
## Summary

- Changes `edge-runner` to invoke Claude as `claude -p -` and stream the rendered backend prompt through stdin instead of argv.
- Keeps Claude flags in argv while removing large runtime context from the process argument list.
- Updates the edge-runner smoke test mock to read stdin and adds a regression case for a 3MB prompt.

Fixes #406.

## Validation

- `python3 -m py_compile tools/edge-runner`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_edge_dispatch.sh`
- `python3 tools/audit-cqrs-migration.py --json`
- `git diff --check`

## Note

I also ran `bash tests/test_heartbeat_entrypoints.sh` as an extra check. It still fails on the existing direct `/ed-heartbeat` entrypoint contract, which is unrelated to this prompt transport fix and was not changed here.