### PR TITLE
[codex] Scope publish guard to dispatch cycles

### DIFF
--- a/tests/test_edge_cmd_boundary.sh
+++ b/tests/test_edge_cmd_boundary.sh
@@ -81,7 +81,7 @@ cat >"$TMP_STATE/state/current-dispatch.json" <<JSON
 }
 JSON
 set +e
-EDGE_CONSOLIDATE_ACTIVE=1 "$TOOL" validate-write \
+EDGE_CONSOLIDATE_ACTIVE=1 EDGE_CYCLE_ID=cycle-cmd-heartbeat "$TOOL" validate-write \
   --tool Write \
   --path "$ENTRY_PATH" \
   --source test \
@@ -95,7 +95,54 @@ else
     fail "edge-cmd keeps heartbeat dispatch invariant at the command boundary"
 fi
 
-echo "--- Test 5: write-guard delegates to edge-cmd ---"
+echo "--- Test 5: heartbeat dispatch invariant allows different or unscoped cycles ---"
+EDGE_CONSOLIDATE_ACTIVE=1 "$TOOL" validate-write \
+  --tool Write \
+  --path "$ENTRY_PATH" \
+  --source test \
+  --require-dispatched-heartbeat \
+  --json >/tmp/edge-cmd-unscoped.out
+EDGE_CONSOLIDATE_ACTIVE=1 EDGE_CYCLE_ID=cycle-operator-work "$TOOL" validate-write \
+  --tool Write \
+  --path "$ENTRY_PATH" \
+  --source test \
+  --require-dispatched-heartbeat \
+  --json >/tmp/edge-cmd-different.out
+if grep -q "different_or_unscoped_cycle" /tmp/edge-cmd-unscoped.out && grep -q "different_or_unscoped_cycle" /tmp/edge-cmd-different.out; then
+    pass "edge-cmd does not block operator or unscoped publications for another heartbeat cycle"
+else
+    cat /tmp/edge-cmd-unscoped.out /tmp/edge-cmd-different.out
+    fail "edge-cmd does not block operator or unscoped publications for another heartbeat cycle"
+fi
+
+echo "--- Test 6: expired heartbeat dispatch invariant is ignored ---"
+PAST_EXPIRES_AT="$(python3 - <<'PY'
+from datetime import datetime, timedelta, timezone
+print((datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat())
+PY
+)"
+python3 - <<'PY' "$TMP_STATE/state/current-dispatch.json" "$PAST_EXPIRES_AT"
+import json
+import sys
+path, expires_at = sys.argv[1:3]
+payload = json.load(open(path, encoding="utf-8"))
+payload["state"]["expires_at"] = expires_at
+json.dump(payload, open(path, "w", encoding="utf-8"), indent=2)
+PY
+EDGE_CONSOLIDATE_ACTIVE=1 EDGE_CYCLE_ID=cycle-cmd-heartbeat "$TOOL" validate-write \
+  --tool Write \
+  --path "$ENTRY_PATH" \
+  --source test \
+  --require-dispatched-heartbeat \
+  --json >/tmp/edge-cmd-expired.out
+if grep -q "expired_heartbeat_cycle" /tmp/edge-cmd-expired.out; then
+    pass "edge-cmd ignores expired heartbeat cycles"
+else
+    cat /tmp/edge-cmd-expired.out
+    fail "edge-cmd ignores expired heartbeat cycles"
+fi
+
+echo "--- Test 7: write-guard delegates to edge-cmd ---"
 set +e
 printf '{"tool_name":"Write","tool_input":{"file_path":"%s"}}\n' "$ENTRY_PATH" | "$WRITE_GUARD" >/tmp/write-guard.out 2>/tmp/write-guard.err
 STATUS=$?
@@ -107,16 +154,25 @@ else
     fail "write-guard delegates protected write rejection to edge-cmd"
 fi
 
-echo "--- Test 6: heartbeat-dispatch-guard delegates to edge-cmd ---"
+echo "--- Test 8: heartbeat-dispatch-guard delegates same-cycle rejection to edge-cmd ---"
+python3 - <<'PY' "$TMP_STATE/state/current-dispatch.json" "$NOW_ISO"
+import json
+import sys
+path, opened_at = sys.argv[1:3]
+payload = json.load(open(path, encoding="utf-8"))
+payload["state"]["opened_at"] = opened_at
+payload["state"].pop("expires_at", None)
+json.dump(payload, open(path, "w", encoding="utf-8"), indent=2)
+PY
 set +e
-printf '{"tool_name":"Write","tool_input":{"file_path":"%s"}}\n' "$ENTRY_PATH" | env EDGE_CONSOLIDATE_ACTIVE=1 "$HEARTBEAT_GUARD" >/tmp/heartbeat-guard.out 2>/tmp/heartbeat-guard.err
+printf '{"tool_name":"Write","tool_input":{"file_path":"%s"}}\n' "$ENTRY_PATH" | env EDGE_CONSOLIDATE_ACTIVE=1 EDGE_CYCLE_ID=cycle-cmd-heartbeat "$HEARTBEAT_GUARD" >/tmp/heartbeat-guard.out 2>/tmp/heartbeat-guard.err
 STATUS=$?
 set -e
 if [[ "$STATUS" -eq 2 ]] && grep -q "heartbeat is active" /tmp/heartbeat-guard.err; then
-    pass "heartbeat-dispatch-guard delegates heartbeat rejection to edge-cmd"
+    pass "heartbeat-dispatch-guard delegates same-cycle heartbeat rejection to edge-cmd"
 else
     cat /tmp/heartbeat-guard.out /tmp/heartbeat-guard.err
-    fail "heartbeat-dispatch-guard delegates heartbeat rejection to edge-cmd"
+    fail "heartbeat-dispatch-guard delegates same-cycle heartbeat rejection to edge-cmd"
 fi
 
 echo ""

--- a/tests/test_edge_dispatch.sh
+++ b/tests/test_edge_dispatch.sh
@@ -106,6 +106,7 @@ assert dispatch["request"]["args"]["thread_id"] == "ops-visibility"
 assert dispatch["request"]["preflight_profile"] == "heartbeat_default"
 assert dispatch["state"]["active"] is True
 assert dispatch["state"]["skill_dispatched"] is False
+assert dispatch["state"]["expires_at"]
 assert legacy["active"] is True
 assert legacy["skill_dispatched"] is False
 PY
@@ -128,13 +129,13 @@ PY
 )
 
 set +e
-EDGE_ROOT="$TMP_EDGE" bash "$GUARD_TOOL" <<<"$BLOCK_PAYLOAD" >/dev/null 2>/dev/null
+EDGE_ROOT="$TMP_EDGE" EDGE_CYCLE_ID=cycle-test-heartbeat bash "$GUARD_TOOL" <<<"$BLOCK_PAYLOAD" >/dev/null 2>/dev/null
 STATUS=$?
 set -e
 if [[ "$STATUS" -eq 2 ]]; then
-    pass "guard blocks heartbeat writes before skill dispatch"
+    pass "guard blocks same-cycle heartbeat writes before skill dispatch"
 else
-    fail "guard blocks heartbeat writes before skill dispatch (exit=$STATUS)"
+    fail "guard blocks same-cycle heartbeat writes before skill dispatch (exit=$STATUS)"
 fi
 
 echo "--- Test 3: dispatch marks skill and unblocks guard ---"

--- a/tests/test_edge_publish_guard.sh
+++ b/tests/test_edge_publish_guard.sh
@@ -37,6 +37,11 @@ else
 fi
 
 echo "--- Test 2: active heartbeat before dispatch is blocked and emits event ---"
+FUTURE_EXPIRES_AT="$(python3 - <<'PY'
+from datetime import datetime, timedelta, timezone
+print((datetime.now(timezone.utc) + timedelta(hours=2)).isoformat())
+PY
+)"
 cat >"$DISPATCH_FILE" <<'JSON'
 {
   "cycle_id": "cycle-heartbeat-inline",
@@ -46,13 +51,19 @@ cat >"$DISPATCH_FILE" <<'JSON'
   },
   "state": {
     "active": true,
-    "skill_dispatched": false
+    "skill_dispatched": false,
+    "expires_at": "__FUTURE_EXPIRES_AT__"
   }
 }
 JSON
+python3 - <<'PY' "$DISPATCH_FILE" "$FUTURE_EXPIRES_AT"
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+path.write_text(path.read_text().replace("__FUTURE_EXPIRES_AT__", sys.argv[2]), encoding="utf-8")
+PY
 
 set +e
-"$GUARD_TOOL" --operation consolidate-state --target "$TMP_EDGE/blog/entries/test.md" >/dev/null 2>/dev/null
+EDGE_CYCLE_ID=cycle-heartbeat-inline "$GUARD_TOOL" --operation consolidate-state --target "$TMP_EDGE/blog/entries/test.md" >/dev/null 2>/dev/null
 STATUS=$?
 set -e
 
@@ -67,14 +78,31 @@ event = [item for item in events if item["type"] == "HeartbeatInlineWorkDetected
 assert event["payload"]["operation"] == "consolidate-state"
 assert event["payload"]["skill"] == "bob-heartbeat"
 assert event["payload"]["skill_dispatched"] is False
+assert event["payload"]["publisher_cycle_id"] == "cycle-heartbeat-inline"
 PY
 then
-    pass "guard blocks inline publish before dispatch and emits event"
+    pass "guard blocks same-cycle inline publish before dispatch and emits event"
 else
-    fail "guard blocks inline publish before dispatch and emits event"
+    fail "guard blocks same-cycle inline publish before dispatch and emits event"
 fi
 
-echo "--- Test 3: dispatched substantive skill allows publish ---"
+echo "--- Test 3: active heartbeat without publisher cycle allows manual publish ---"
+if "$GUARD_TOOL" --operation consolidate-state --target "$TMP_EDGE/blog/entries/manual.md" >/tmp/edge-publish-guard-manual.out; then
+    pass "guard allows unscoped manual publish while heartbeat is active"
+else
+    cat /tmp/edge-publish-guard-manual.out
+    fail "guard allows unscoped manual publish while heartbeat is active"
+fi
+
+echo "--- Test 4: different publisher cycle allows parallel operator publish ---"
+if EDGE_CYCLE_ID=cycle-operator-work "$GUARD_TOOL" --operation consolidate-state --target "$TMP_EDGE/blog/entries/operator.md" >/tmp/edge-publish-guard-operator.out; then
+    pass "guard allows different-cycle operator publish while heartbeat is active"
+else
+    cat /tmp/edge-publish-guard-operator.out
+    fail "guard allows different-cycle operator publish while heartbeat is active"
+fi
+
+echo "--- Test 5: dispatched substantive skill allows publish ---"
 cat >"$DISPATCH_FILE" <<'JSON'
 {
   "cycle_id": "cycle-heartbeat-dispatched",
@@ -93,6 +121,66 @@ if "$GUARD_TOOL" --operation blog-publish --target "$TMP_EDGE/blog/entries/test.
     pass "guard allows publish after substantive dispatch"
 else
     fail "guard allows publish after substantive dispatch"
+fi
+
+echo "--- Test 6: expired heartbeat cycle does not block same-cycle publish ---"
+PAST_EXPIRES_AT="$(python3 - <<'PY'
+from datetime import datetime, timedelta, timezone
+print((datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat())
+PY
+)"
+cat >"$DISPATCH_FILE" <<JSON
+{
+  "cycle_id": "cycle-heartbeat-expired",
+  "request": {
+    "trigger": "heartbeat",
+    "skill": "bob-heartbeat"
+  },
+  "state": {
+    "active": true,
+    "skill_dispatched": false,
+    "expires_at": "$PAST_EXPIRES_AT"
+  }
+}
+JSON
+
+if EDGE_CYCLE_ID=cycle-heartbeat-expired "$GUARD_TOOL" --operation consolidate-state --target "$TMP_EDGE/blog/entries/expired.md" --json >/tmp/edge-publish-guard-expired.out; then
+    if grep -q "expired_heartbeat_cycle" /tmp/edge-publish-guard-expired.out; then
+        pass "guard ignores expired heartbeat cycles"
+    else
+        cat /tmp/edge-publish-guard-expired.out
+        fail "guard reports expired heartbeat cycles"
+    fi
+else
+    cat /tmp/edge-publish-guard-expired.out
+    fail "guard ignores expired heartbeat cycles"
+fi
+
+echo "--- Test 7: active operator cycle never blocks publish ---"
+cat >"$DISPATCH_FILE" <<'JSON'
+{
+  "cycle_id": "cycle-operator",
+  "request": {
+    "trigger": "operator",
+    "skill": "research"
+  },
+  "state": {
+    "active": true,
+    "skill_dispatched": false
+  }
+}
+JSON
+
+if EDGE_CYCLE_ID=cycle-operator "$GUARD_TOOL" --operation consolidate-state --target "$TMP_EDGE/blog/entries/operator-active.md" --json >/tmp/edge-publish-guard-active-operator.out; then
+    if grep -q "non_heartbeat_cycle" /tmp/edge-publish-guard-active-operator.out; then
+        pass "guard allows active operator cycles"
+    else
+        cat /tmp/edge-publish-guard-active-operator.out
+        fail "guard reports active operator cycles"
+    fi
+else
+    cat /tmp/edge-publish-guard-active-operator.out
+    fail "guard allows active operator cycles"
 fi
 
 echo ""

--- a/tools/edge-cmd
+++ b/tools/edge-cmd
@@ -12,7 +12,7 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +45,7 @@ PROTECTED_ROOTS = (
     LOGS_DIR,
 )
 PUBLISH_ROOTS = (ENTRIES_DIR, REPORTS_DIR)
+DEFAULT_DISPATCH_TTL_SECONDS = 7200
 
 
 def _now_iso() -> str:
@@ -89,16 +90,39 @@ def _read_json(path: Path) -> dict[str, Any] | None:
         return None
 
 
-def _is_stale(started_at: str | None, *, max_age_s: int = 3600) -> bool:
-    if not started_at:
-        return False
+def _parse_time(value: Any) -> datetime | None:
+    if not value:
+        return None
     try:
-        started = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
     except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _dispatch_ttl_seconds() -> int | None:
+    raw = os.environ.get("EDGE_DISPATCH_TTL_SEC", str(DEFAULT_DISPATCH_TTL_SECONDS))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_DISPATCH_TTL_SECONDS
+    if value <= 0:
+        return None
+    return value
+
+
+def _is_stale(heartbeat: dict[str, Any]) -> bool:
+    expires_at = _parse_time(heartbeat.get("expires_at"))
+    if expires_at is not None:
+        return datetime.now(timezone.utc) > expires_at
+
+    ttl = _dispatch_ttl_seconds()
+    started = _parse_time(heartbeat.get("started_at"))
+    if ttl is None or started is None:
         return False
-    if started.tzinfo is None:
-        started = started.replace(tzinfo=timezone.utc)
-    return (datetime.now(timezone.utc) - started).total_seconds() > max_age_s
+    return datetime.now(timezone.utc) > started + timedelta(seconds=ttl)
 
 
 def _active_heartbeat_state() -> tuple[dict[str, Any] | None, str]:
@@ -114,6 +138,7 @@ def _active_heartbeat_state() -> tuple[dict[str, Any] | None, str]:
                     "skill_dispatched": state.get("skill_dispatched"),
                     "skill": request.get("skill"),
                     "cycle_id": dispatch.get("cycle_id"),
+                    "expires_at": state.get("expires_at"),
                 },
                 "current-dispatch.json",
             )
@@ -147,6 +172,7 @@ def validate_write(args: argparse.Namespace) -> int:
         "tool": args.tool,
         "operation": args.operation,
         "source": args.source,
+        "publisher_cycle_id": (args.cycle_id or os.environ.get("EDGE_CYCLE_ID") or None),
         "checked_at": _now_iso(),
     }
 
@@ -160,9 +186,39 @@ def validate_write(args: argparse.Namespace) -> int:
 
     if args.require_dispatched_heartbeat and publish_root is not None:
         heartbeat, state_source = _active_heartbeat_state()
-        if heartbeat and heartbeat.get("active") and not _is_stale(heartbeat.get("started_at")) and not heartbeat.get("skill_dispatched"):
+        if heartbeat and heartbeat.get("active"):
+            current_cycle_id = str(heartbeat.get("cycle_id") or "")
+            publisher_cycle_id = str(args.cycle_id or os.environ.get("EDGE_CYCLE_ID") or "").strip()
+            if _is_stale(heartbeat):
+                result = {"ok": True, "reason": "expired_heartbeat_cycle", "state_source": state_source, **payload}
+                if args.json:
+                    print(json.dumps(result, indent=2, ensure_ascii=False))
+                return 0
+            if not current_cycle_id or not publisher_cycle_id or publisher_cycle_id != current_cycle_id:
+                result = {
+                    "ok": True,
+                    "reason": "different_or_unscoped_cycle",
+                    "state_source": state_source,
+                    "current_cycle_id": current_cycle_id or None,
+                    **payload,
+                }
+                if args.json:
+                    print(json.dumps(result, indent=2, ensure_ascii=False))
+                return 0
+            if heartbeat.get("skill_dispatched"):
+                result = {"ok": True, "reason": "heartbeat_skill_dispatched", "state_source": state_source, **payload}
+                if args.json:
+                    print(json.dumps(result, indent=2, ensure_ascii=False))
+                return 0
             reason = "heartbeat_dispatch_required"
-            payload.update({"reason": reason, "state_source": state_source, "skill": heartbeat.get("skill") or ""})
+            payload.update(
+                {
+                    "reason": reason,
+                    "state_source": state_source,
+                    "skill": heartbeat.get("skill") or "",
+                    "current_cycle_id": current_cycle_id or None,
+                }
+            )
             _emit_decision("ArtifactWriteRejected", artifact=artifact, payload=payload)
             message = (
                 "BLOCK(edge-cmd): heartbeat is active but no skill has been dispatched yet.\n"
@@ -227,6 +283,7 @@ def build_parser() -> argparse.ArgumentParser:
     validate.add_argument("--tool", default="unknown")
     validate.add_argument("--operation", default="write")
     validate.add_argument("--source", default="edge-cmd")
+    validate.add_argument("--cycle-id", default="", help="Publishing cycle id; defaults to EDGE_CYCLE_ID")
     validate.add_argument("--require-dispatched-heartbeat", action="store_true")
     validate.add_argument("--heartbeat-only", action="store_true", help="Only enforce heartbeat dispatch, not the general protected-write boundary")
     validate.add_argument("--json", action="store_true")

--- a/tools/edge-dispatch
+++ b/tools/edge-dispatch
@@ -21,7 +21,7 @@ import socket
 import sys
 import uuid
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -37,9 +37,22 @@ from _shared.dispatch_runtime import (  # noqa: E402
 from _shared.telemetry import current_actor, emit_shadow_event, log_event  # noqa: E402
 from _shared.skill_inbox import attach_snapshot_to_dispatch  # noqa: E402
 
+DEFAULT_DISPATCH_TTL_SECONDS = 7200
+
 
 def now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def dispatch_ttl_seconds() -> int | None:
+    raw = os.environ.get("EDGE_DISPATCH_TTL_SEC", str(DEFAULT_DISPATCH_TTL_SECONDS))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_DISPATCH_TTL_SECONDS
+    if value <= 0:
+        return None
+    return value
 
 
 def make_cycle_id() -> str:
@@ -282,7 +295,10 @@ def cmd_open(args: argparse.Namespace) -> int:
     postflight_profile = args.postflight_profile or "standard"
     request_args = parse_args_items(args.arg, args.args_json)
     primary_thread_id = resolve_primary_thread_id(request_args)
-    opened_at = now_iso()
+    opened = datetime.now(timezone.utc)
+    opened_at = opened.isoformat()
+    ttl = dispatch_ttl_seconds()
+    expires_at = (opened + timedelta(seconds=ttl)).isoformat() if ttl is not None else None
 
     state = {
         "version": 1,
@@ -311,6 +327,7 @@ def cmd_open(args: argparse.Namespace) -> int:
             "dispatched_at": None,
             "closed_at": None,
             "close_reason": None,
+            "expires_at": expires_at,
             **owner_metadata(),
         },
     }

--- a/tools/edge-publish-guard
+++ b/tools/edge-publish-guard
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -14,6 +15,8 @@ sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import CURRENT_DISPATCH_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
 from _shared.telemetry import emit_shadow_event  # noqa: E402
+
+DEFAULT_DISPATCH_TTL_SECONDS = 7200
 
 
 def read_dispatch_state() -> dict:
@@ -25,25 +28,76 @@ def read_dispatch_state() -> dict:
         return {}
 
 
-def should_block(dispatch: dict) -> tuple[bool, dict]:
+def _parse_time(value: object) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _dispatch_ttl_seconds() -> int | None:
+    raw = os.environ.get("EDGE_DISPATCH_TTL_SEC", str(DEFAULT_DISPATCH_TTL_SECONDS))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_DISPATCH_TTL_SECONDS
+    if value <= 0:
+        return None
+    return value
+
+
+def _is_expired(state: dict) -> bool:
+    expires_at = _parse_time(state.get("expires_at"))
+    if expires_at is not None:
+        return datetime.now(timezone.utc) > expires_at
+
+    ttl = _dispatch_ttl_seconds()
+    opened_at = _parse_time(state.get("opened_at"))
+    if ttl is None or opened_at is None:
+        return False
+    return datetime.now(timezone.utc) > opened_at + timedelta(seconds=ttl)
+
+
+def should_block(dispatch: dict, publisher_cycle_id: str | None) -> tuple[bool, dict]:
     request = dispatch.get("request", {}) or {}
     state = dispatch.get("state", {}) or {}
     trigger = str(request.get("trigger") or "")
     skill = str(request.get("skill") or "")
+    current_cycle_id = str(dispatch.get("cycle_id") or "")
+    publisher_cycle_id = str(publisher_cycle_id or "").strip()
     payload = {
+        "current_cycle_id": current_cycle_id or None,
+        "publisher_cycle_id": publisher_cycle_id or None,
         "trigger": trigger or None,
         "skill": skill or None,
         "active": bool(state.get("active")),
         "skill_dispatched": bool(state.get("skill_dispatched")),
+        "expires_at": state.get("expires_at"),
     }
     if not state.get("active"):
+        payload["reason"] = "no_active_cycle"
         return False, payload
     if trigger != "heartbeat":
+        payload["reason"] = "non_heartbeat_cycle"
+        return False, payload
+    if _is_expired(state):
+        payload["reason"] = "expired_heartbeat_cycle"
         return False, payload
     if state.get("skill_dispatched"):
+        payload["reason"] = "heartbeat_skill_dispatched"
         return False, payload
     if skill and not skill.endswith("heartbeat"):
+        payload["reason"] = "substantive_skill_selected"
         return False, payload
+    if not current_cycle_id or not publisher_cycle_id or publisher_cycle_id != current_cycle_id:
+        payload["reason"] = "different_or_unscoped_cycle"
+        return False, payload
+    payload["reason"] = "heartbeat_inline_publish_before_dispatch"
     return True, payload
 
 
@@ -51,6 +105,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--operation", default="", help="Logical operation name")
     parser.add_argument("--target", default="", help="Artifact path or label")
+    parser.add_argument("--cycle-id", default="", help="Publishing cycle id; defaults to EDGE_CYCLE_ID")
     parser.add_argument("--json", action="store_true", help="Print JSON response")
     return parser
 
@@ -58,7 +113,8 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = build_parser().parse_args()
     dispatch = read_dispatch_state()
-    blocked, payload = should_block(dispatch)
+    publisher_cycle_id = args.cycle_id or os.environ.get("EDGE_CYCLE_ID", "")
+    blocked, payload = should_block(dispatch, publisher_cycle_id)
     payload.update(
         {
             "operation": args.operation or None,


### PR DESCRIPTION
## Summary

Fixes #412.

This changes heartbeat publication enforcement from a global lock to a cycle-scoped guard:

- `edge-publish-guard` only blocks inline publication when the publishing `EDGE_CYCLE_ID` is the same active heartbeat cycle and that cycle has not dispatched a substantive skill.
- Manual/operator publications with no cycle id, a different cycle id, or an operator-triggered active cycle are allowed.
- Active heartbeat cycles now carry `state.expires_at` from `edge-dispatch open`; publish guards and command-boundary heartbeat validation ignore expired heartbeat cycles.
- `edge-cmd validate-write --require-dispatched-heartbeat` now uses the same cycle scoping and TTL behavior as `edge-publish-guard`.

## Validation

- `python3 -m py_compile tools/edge-publish-guard tools/edge-cmd tools/edge-dispatch`
- `bash tests/test_edge_publish_guard.sh`
- `bash tests/test_edge_cmd_boundary.sh`
- `bash tests/test_edge_dispatch.sh`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_edge_close.sh`
- `python3 tools/audit-cqrs-migration.py --json`
- `git diff --check`

Known pre-existing residual: `bash tests/test_heartbeat_entrypoints.sh` still fails on the direct `/ed-heartbeat` wrapper-delegation contract; this PR keeps that separate from the #412 publish guard fix.