### PR TITLE
[codex] Preserve primary source search metadata

### DIFF
--- a/agent.yaml.example
+++ b/agent.yaml.example
@@ -66,6 +66,17 @@ blog_auth_pass: ""              # default for new agents: generate a password
 # the description + docs/TOOL_CONTRACT.md and creates the primitive on the
 # spot. Autonomy reviews and deepens it later based on usage evidence.
 #
+# Web/open-search preference is also declared here. Do NOT add a separate
+# `search:` block just to pick a provider. If this agent has a preferred
+# open-web source, mark that source with `primary: true`; render/apply will
+# carry that into state/sources-manifest.yaml for the runtime to use. If no
+# source is primary, open-web lookup still goes through edge-sources so source
+# usage is visible in telemetry instead of bypassing the substrate through
+# direct Claude WebSearch.
+#
+# `edge-search` is different: it searches the agent's internal corpus and is
+# always framework infrastructure. Do not list it under `sources:`.
+#
 # Edge-native tools (edge-consult, edge-signal, edge-search, review-gate,
 # etc) are framework infrastructure — always available, NEVER listed here.
 #
@@ -81,8 +92,10 @@ blog_auth_pass: ""              # default for new agents: generate a password
 sources:
   - name: arxiv
     description: "Search for recent preprints — describe what this source does for YOUR agent"
+    # primary: true              # Optional: preferred open-web/search source.
   # - name: semscholar
   #   description: "Citation tracking and paper metadata"
+  #   primary: true
   # - name: overleaf
   #   description: "Read LaTeX projects via git clone; writes live in prose, not here"
 

--- a/config/features.yaml.tpl
+++ b/config/features.yaml.tpl
@@ -7,7 +7,7 @@ review:
   review_gate: auto         # LLM-as-judge no pipeline de publicação (precisa: OPENAI_API_KEY)
 
 search:
-  builtin_web_search: false  # bloqueia WebSearch/WebFetch por default; hook libera so no fallback
+  builtin_web_search: false  # bloqueia Claude WebSearch direto; WebFetch continua permitido para URLs conhecidas
   web_provider: exa          # provider primario para busca web aberta
   web_fallback: claude_web   # fallback de runtime se o provider primario falhar/zerar
   exa: auto                 # busca semântica via Exa (precisa: EXA_API_KEY)

--- a/docs/TOOL_CONTRACT.md
+++ b/docs/TOOL_CONTRACT.md
@@ -30,6 +30,11 @@ Install-time seeding registers declared source intent in
 `state/sources-manifest.yaml` with `status: declared`. That is runtime intent,
 not a built primitive.
 
+Optional source search preference also materializes there. In `agent.yaml`,
+mark a preferred open-web/search source with `primary: true`; render/apply
+preserves it in `state/sources-manifest.yaml` as runtime metadata. If no source
+is primary, open-web lookup still routes through `edge-sources` for telemetry.
+
 Agent hits exit 127 (primitive doesn't exist). Before writing code:
 
 1. Read the source's `description` from `state/sources-manifest.yaml` or

--- a/tests/test_primitives_status.sh
+++ b/tests/test_primitives_status.sh
@@ -34,6 +34,7 @@ sources:
     description: Recent preprints
   - name: exa
     description: Web search
+    primary: true
 YAML
 
 export HOME="$TMP_HOME"
@@ -51,7 +52,31 @@ echo "=== primitives status Smoke Test ==="
 echo "Temp state: $TMP_EDGE"
 echo ""
 
-echo "--- Test 1: phase_seed seeds manifest from declared sources ---"
+echo "--- Test 1: edge-render preserves source search primary metadata ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_CONFIG"
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+edge_dir, config_path = sys.argv[1:]
+loader = importlib.machinery.SourceFileLoader("edge_render_mod", f"{edge_dir}/tools/edge-render")
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+cfg = mod.load_agent_yaml(Path(config_path))
+sources = {item["name"]: item for item in cfg["sources"]}
+assert sources["exa"]["primary"] is True
+assert sources["exa"]["roles"] == ["search"]
+assert sources["arxiv"]["primary"] is False
+PY
+then
+    pass "edge-render preserves source search primary metadata"
+else
+    fail "edge-render preserves source search primary metadata"
+fi
+
+echo "--- Test 2: phase_seed seeds manifest from declared sources ---"
 if python3 - <<'PY' "$EDGE_DIR" "$TMP_CONFIG"
 import importlib.machinery
 import importlib.util
@@ -78,6 +103,9 @@ entries = {item["name"]: item for item in manifest["sources"]}
 assert set(entries) == {"arxiv", "exa"}
 assert entries["arxiv"]["status"] == "declared"
 assert entries["exa"]["status"] == "declared"
+assert entries["exa"]["primary"] is True
+assert entries["exa"]["roles"] == ["search"]
+assert entries["arxiv"]["primary"] is False
 PY
     then
         pass "phase_seed seeds declared sources into manifest"
@@ -88,7 +116,7 @@ else
     fail "phase_seed seeds declared sources into manifest"
 fi
 
-echo "--- Test 2: edge-primitives status reports declared sources and writes snapshot ---"
+echo "--- Test 3: edge-primitives status reports declared sources and writes snapshot ---"
 if python3 - <<'PY' "$STATUS_TOOL" "$STATUS_FILE"
 import json
 import subprocess
@@ -103,6 +131,9 @@ assert payload["summary"]["degraded_total"] == 0
 rows = {row["name"]: row for row in payload["sources"]}
 assert rows["arxiv"]["effective_status"] == "unknown"
 assert rows["exa"]["effective_status"] == "unknown"
+assert rows["arxiv"]["primary"] is False
+assert rows["exa"]["primary"] is True
+assert rows["exa"]["roles"] == ["search"]
 assert "declared_unbound" in rows["arxiv"]["problems"]
 assert "declared_unbound" in rows["exa"]["problems"]
 assert Path(status_file).exists()
@@ -113,7 +144,7 @@ else
     fail "edge-primitives status reports declared sources"
 fi
 
-echo "--- Test 3: lifecycle transitions update the read model ---"
+echo "--- Test 4: lifecycle transitions update the read model ---"
 mkdir -p "$LIBEXEC_DIR"
 cat >"$LIBEXEC_DIR/arxiv" <<'SH'
 #!/usr/bin/env bash
@@ -145,7 +176,7 @@ else
     fail "lifecycle transitions update status to probed"
 fi
 
-echo "--- Test 4: missing active binary is reported as degraded ---"
+echo "--- Test 5: missing active binary is reported as degraded ---"
 rm -f "$LIBEXEC_DIR/arxiv"
 if python3 - <<'PY' "$STATUS_TOOL"
 import json
@@ -165,7 +196,7 @@ else
     fail "status reports degraded when active binary disappears"
 fi
 
-echo "--- Test 5: checkup probes capabilities and reports candidate actions without aborting ---"
+echo "--- Test 6: checkup probes capabilities and reports candidate actions without aborting ---"
 if OUTPUT=$("$STATUS_TOOL" status --json --checkup --skill autonomy --skip-primitive-probes); then
     if python3 - <<'PY' "$OUTPUT"
 import json

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -1210,7 +1210,7 @@ def _search_protocol(skill: str | None, request: dict[str, Any]) -> dict[str, An
                 "fallback_provider": runtime_search.get("web_fallback", "claude_web"),
                 "unlocked": runtime_search.get("builtin_web_search_unlocked", False),
             },
-            "when": "Use edge-search as often as needed. If corpus coverage is still missing and external source fan-out fails or returns nothing useful, use the configured web provider first. When builtin web search is policy-disabled, do not call WebSearch/WebFetch directly unless runtime has explicitly unlocked the fallback window.",
+            "when": "Use edge-search as often as needed. If corpus coverage is still missing and external source fan-out fails or returns nothing useful, use the configured web provider first. When builtin web search is policy-disabled, do not call WebSearch directly unless runtime has explicitly unlocked the fallback window. WebFetch is allowed for URLs already surfaced by sources.",
             "must_record": [
                 "why_corpus_or_external_search_was_insufficient",
                 "which_gap_the_web_search_is_covering",

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -290,18 +290,40 @@ def _normalize_sources(raw_sources) -> list[dict]:
     if not isinstance(raw_sources, list):
         raw_sources = [raw_sources]
     normalized = []
+
+    def normalize_roles(value) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        return []
+
+    def normalize_primary(value) -> bool:
+        if isinstance(value, bool):
+            return value
+        text = str(value or "").strip().lower()
+        return text in {"1", "true", "yes", "on"}
+
     for src in raw_sources:
         if isinstance(src, dict) and src.get("name"):
             name = str(src["name"]).strip()
             description = str(src.get("description", "")).strip()
+            roles = normalize_roles(src.get("roles"))
+            primary = normalize_primary(src.get("primary"))
         elif isinstance(src, str) and src.strip():
             name = src.strip()
             description = ""
+            roles = []
+            primary = False
         else:
             continue
         if not name or name.startswith("edge-"):
             continue
-        normalized.append({"name": name, "description": description})
+        if primary and "search" not in roles:
+            roles.append("search")
+        normalized.append({"name": name, "description": description, "roles": roles, "primary": primary})
     return normalized
 
 
@@ -1773,6 +1795,8 @@ Threads should be concrete workstreams (e.g. 'competitive-landscape', 'positioni
                 {
                     "name": src["name"],
                     "description": src.get("description", ""),
+                    "roles": list(src.get("roles") or []),
+                    "primary": bool(src.get("primary")),
                     "status": "declared",
                     "created_at": now_iso,
                     "updated_at": now_iso,
@@ -1785,6 +1809,14 @@ Threads should be concrete workstreams (e.g. 'competitive-landscape', 'positioni
             continue
         if src.get("description") and not entry.get("description"):
             entry["description"] = src["description"]
+            changed = True
+        desired_roles = list(src.get("roles") or [])
+        if entry.get("roles") != desired_roles:
+            entry["roles"] = desired_roles
+            changed = True
+        desired_primary = bool(src.get("primary"))
+        if bool(entry.get("primary")) != desired_primary:
+            entry["primary"] = desired_primary
             changed = True
         if not entry.get("status"):
             entry["status"] = "declared"

--- a/tools/edge-fontes
+++ b/tools/edge-fontes
@@ -9,7 +9,8 @@ Usage:
     edge-fontes "topic" --json                   # JSON output
 
 Runs all sources concurrently, curates by signal, outputs structured markdown.
-Sources that can't be scripted (WebSearch/WebFetch) are noted in output.
+Claude WebSearch is treated as a managed fallback path, not a direct source
+bypass. WebFetch remains the read path for URLs returned by sources.
 """
 
 import sys, os, json, argparse, subprocess, random
@@ -409,7 +410,7 @@ def format_markdown(topic, intent, results_by_source, wildcard_src=None):
 
     # Note about builtin web search policy
     lines.append("### Nota")
-    lines.append("Use esta ferramenta antes de Claude WebSearch/WebFetch. O runtime so libera a busca builtin quando o provider web primario falha ou volta vazio.\n")
+    lines.append("Use esta ferramenta antes de Claude WebSearch. O runtime so libera WebSearch builtin quando o provider web primario falha ou volta vazio. WebFetch continua valido para URLs ja encontradas pelas fontes.\n")
 
     return "\n".join(lines)
 
@@ -491,7 +492,7 @@ def main():
     allowance = _maybe_unlock_builtin_web_search(args.topic, sources, results)
     if allowance is not None:
         print(
-            "Exa falhou ou voltou vazio; fallback temporario para Claude WebSearch/WebFetch foi liberado.",
+            "Exa falhou ou voltou vazio; fallback temporario para Claude WebSearch foi liberado.",
             file=sys.stderr,
         )
 

--- a/tools/edge-primitives
+++ b/tools/edge-primitives
@@ -71,18 +71,40 @@ def _normalize_sources(raw_sources) -> dict[str, dict]:
     if not isinstance(raw_sources, list):
         raw_sources = [raw_sources]
     normalized: dict[str, dict] = {}
+
+    def normalize_roles(value) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        return []
+
+    def normalize_primary(value) -> bool:
+        if isinstance(value, bool):
+            return value
+        text = str(value or "").strip().lower()
+        return text in {"1", "true", "yes", "on"}
+
     for src in raw_sources:
         if isinstance(src, dict) and src.get("name"):
             name = str(src["name"]).strip()
             description = str(src.get("description", "")).strip()
+            roles = normalize_roles(src.get("roles"))
+            primary = normalize_primary(src.get("primary"))
         elif isinstance(src, str) and src.strip():
             name = src.strip()
             description = ""
+            roles = []
+            primary = False
         else:
             continue
         if not name or name.startswith("edge-"):
             continue
-        normalized[name] = {"name": name, "description": description}
+        if primary and "search" not in roles:
+            roles.append("search")
+        normalized[name] = {"name": name, "description": description, "roles": roles, "primary": primary}
     return normalized
 
 
@@ -263,6 +285,8 @@ def build_status(config_path: Path | None = None) -> dict:
                 "declared": declared,
                 "description": declared_entry.get("description") or manifest_entry.get("description", ""),
                 "description_present": bool(declared_entry.get("description") or manifest_entry.get("description")),
+                "roles": list(declared_entry.get("roles") or manifest_entry.get("roles") or []),
+                "primary": bool(declared_entry.get("primary") or manifest_entry.get("primary")),
                 "manifest_exists": bool(manifest_entry),
                 "manifest_status": manifest_status or ("declared" if declared else ""),
                 "meta_path": str(meta_path),

--- a/tools/edge-render
+++ b/tools/edge-render
@@ -245,6 +245,21 @@ def load_agent_yaml(path: Path) -> dict:
             return [val] if val.strip() else []
         return list(val)
 
+    def _normalize_roles(val):
+        if val is None:
+            return []
+        if isinstance(val, str):
+            return [item.strip() for item in val.split(",") if item.strip()]
+        if isinstance(val, list):
+            return [str(item).strip() for item in val if str(item).strip()]
+        return []
+
+    def _normalize_primary(val):
+        if isinstance(val, bool):
+            return val
+        text = str(val or "").strip().lower()
+        return text in {"1", "true", "yes", "on"}
+
     pre_context = _normalize_list(cfg.get("pre_skill_context"))
     pre_procedure = _normalize_list(cfg.get("pre_skill_procedure"))
     pre_alias = _normalize_list(cfg.get("pre_skill"))
@@ -260,8 +275,10 @@ def load_agent_yaml(path: Path) -> dict:
     ]
 
     # Normalize `sources:` (capability manifest of external read primitives,
-    # #94). Each entry is {name, description} — the description is the spec
-    # the agent uses to create the primitive on first invocation (exit 127).
+    # #94). Each entry is {name, description, roles, primary} — the description
+    # is the spec the agent uses to create the primitive on first invocation
+    # (exit 127). `primary: true` marks the preferred open-web/search source
+    # and is carried through render/apply into state/sources-manifest.yaml.
     # No install-time resolution against a catalog. Primitives are born from
     # demand, not speculation.
     #
@@ -274,9 +291,13 @@ def load_agent_yaml(path: Path) -> dict:
         if isinstance(src, dict) and src.get("name"):
             name = src["name"].strip()
             desc = src.get("description", "").strip()
+            roles = _normalize_roles(src.get("roles"))
+            primary = _normalize_primary(src.get("primary"))
         elif isinstance(src, str) and src.strip():
             name = src.strip()
             desc = ""
+            roles = []
+            primary = False
         else:
             continue
         if name.startswith("edge-"):
@@ -286,7 +307,9 @@ def load_agent_yaml(path: Path) -> dict:
                 file=sys.stderr,
             )
             continue
-        cfg["sources"].append({"name": name, "description": desc})
+        if primary and "search" not in roles:
+            roles.append("search")
+        cfg["sources"].append({"name": name, "description": desc, "roles": roles, "primary": primary})
 
     # If only `pre_skill` is set, map it into procedure.
     if pre_alias and not pre_context and not pre_procedure:

--- a/tools/edge-sources
+++ b/tools/edge-sources
@@ -9,7 +9,8 @@ Usage:
     edge-sources "topic" --json                   # JSON output
 
 Runs all sources concurrently, curates by signal, outputs structured markdown.
-Sources that can't be scripted (WebSearch/WebFetch) are noted in output.
+Claude WebSearch is treated as a managed fallback path, not a direct source
+bypass. WebFetch remains the read path for URLs returned by sources.
 """
 
 import sys, os, json, argparse, subprocess, random, shutil, uuid
@@ -593,7 +594,7 @@ def format_markdown(topic, intent, results_by_source, wildcard_src=None, run_id=
 
     # Note about builtin web search policy
     lines.append("### Note")
-    lines.append("Use this tool before Claude WebSearch/WebFetch. Runtime may unlock builtin web search only after the primary web provider fails or returns nothing useful.\n")
+    lines.append("Use this tool before Claude WebSearch. Runtime may unlock builtin WebSearch only after the primary web provider fails or returns nothing useful. WebFetch remains valid for URLs already surfaced by sources.\n")
 
     return "\n".join(lines)
 
@@ -789,7 +790,7 @@ def main():
         allowance = _maybe_unlock_builtin_web_search(args.topic, sources, results)
         if allowance is not None:
             print(
-                "Exa failed or returned no usable hits; unlocked Claude WebSearch/WebFetch fallback temporarily.",
+                "Exa failed or returned no usable hits; unlocked Claude WebSearch fallback temporarily.",
                 file=sys.stderr,
             )
 


### PR DESCRIPTION
## Summary

- Document `agent.yaml` source search preference as `sources[].primary: true`, without adding a separate `search:` block.
- Preserve `sources[].primary` and `sources[].roles` through render/apply into `state/sources-manifest.yaml`.
- Expose source primary/roles in `edge-primitives status` and clarify WebSearch vs WebFetch wording.

## Validation

- `python3 -m py_compile tools/edge-render tools/edge-apply tools/edge-primitives tools/_shared/dispatch_runtime.py tools/edge-sources tools/edge-fontes`
- `bash tests/test_primitives_status.sh`
- `bash tests/test_web_search_policy_guard.sh`
- `bash tests/test_runtime_decision_protocol.sh`
- `bash tests/test_edge_sources_corpus.sh`
- `git diff --check`