### PR TITLE
[codex] Compile source intents into runtime bindings

### DIFF
--- a/config/preflight.yaml
+++ b/config/preflight.yaml
@@ -15,6 +15,8 @@ procedures:
     kind: primitives.status
   - id: capabilities
     kind: capabilities.status
+  - id: source-bindings
+    kind: source.bindings
   - id: corpus
     kind: corpus.lookup
   - id: workflows

--- a/tests/test_edge_cap_status.sh
+++ b/tests/test_edge_cap_status.sh
@@ -87,6 +87,10 @@ assert names["repo.status"]["effective_status"] == "available"
 assert names["repo.sync"]["effective_status"] == "available"
 assert names["storage.sync"]["effective_status"] == "degraded"
 assert names["source.arxiv"]["effective_status"] in {"active", "probed"}
+source_bindings = payload["source_bindings"]
+assert source_bindings["summary"]["source_total"] == 1
+assert source_bindings["bindings"][0]["source"] == "arxiv"
+assert source_bindings["bindings"][0]["binding_status"] == "present"
 recommended = {item["name"] for item in payload["recommended"]}
 assert "search.corpus" in recommended
 assert "sources.aggregate" in recommended
@@ -95,6 +99,21 @@ then
   pass "status merges static and primitive capabilities"
 else
   fail "status merges static and primitive capabilities"
+fi
+
+SOURCE_BINDINGS_OUTPUT=$(PATH="$TMP_BIN" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="captest" \
+  /usr/bin/python3 "$EDGE_DIR/tools/edge-cap" source-bindings --json --skill research)
+if python3 - <<'PY' "$SOURCE_BINDINGS_OUTPUT"
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["summary"]["source_total"] == 1
+assert payload["summary"]["bound_total"] == 1
+assert payload["bindings"][0]["capability"] == "sources.aggregate"
+PY
+then
+  pass "source binding surface resolves manifest sources"
+else
+  fail "source binding surface resolves manifest sources"
 fi
 
 if [[ -f "$TMP_STATE/state/capabilities-status.json" ]]; then

--- a/tests/test_edge_dispatch.sh
+++ b/tests/test_edge_dispatch.sh
@@ -41,6 +41,8 @@ procedures:
     kind: primitives.status
   - id: capabilities
     kind: capabilities.status
+  - id: source-bindings
+    kind: source.bindings
   - id: corpus
     kind: corpus.lookup
   - id: workflows
@@ -75,6 +77,17 @@ YAML
 export EDGE_REPO_DIR="$EDGE_DIR"
 export EDGE_STATE_DIR="$TMP_EDGE"
 export EDGE_CODENAME="test-agent"
+
+cat >"$TMP_EDGE/state/sources-manifest.yaml" <<'YAML'
+sources:
+  - name: exa
+    description: Web search
+    roles: [search]
+    primary: true
+  - name: meta
+    description: Campaign state
+    roles: [signals]
+YAML
 
 DISPATCH_TOOL="$EDGE_DIR/tools/edge-dispatch"
 GUARD_TOOL="$EDGE_DIR/bin/heartbeat-dispatch-guard.sh"
@@ -178,6 +191,18 @@ assert "raw_chat" in request["delta_prerequisite"]["inputs"]
 assert "surface_baselines" in request["delta_prerequisite"]["inputs"]["surfaces"]
 assert "configured_integrations" in request
 assert "unbound_integrations" in request
+assert "source_bindings" in request
+assert "unbound_source_bindings" in request
+assert "source_binding_warnings" in request
+source_bindings = {item["source"]: item for item in request["source_bindings"]}
+assert source_bindings["exa"]["binding_status"] == "present"
+assert source_bindings["exa"]["binding_mode"] == "sources.aggregate"
+assert source_bindings["meta"]["binding_status"] == "absent"
+assert request["unbound_source_bindings"][0]["source"] == "meta"
+assert request["source_binding_warnings"][0]["warning"] == "configured_integration_without_binding"
+source_step = next(item for item in request["preflight_evidence"] if item["kind"] == "source.bindings")
+assert source_step["satisfied"] is False
+assert source_step["unbound_total"] == 1
 corpus_step = next(item for item in request["preflight_evidence"] if item["kind"] == "corpus.lookup")
 assert corpus_step["satisfied"] is False
 assert corpus_step["missing_required_types"] == ["workflow", "memory"]

--- a/tests/test_protocol_runtime.sh
+++ b/tests/test_protocol_runtime.sh
@@ -17,7 +17,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$TMP_REPO/config" "$TMP_REPO/tools" "$TMP_STATE" "$TMP_HOME"
+mkdir -p "$TMP_REPO/config" "$TMP_REPO/tools" "$TMP_STATE/state" "$TMP_HOME"
 
 cat >"$TMP_REPO/config/preflight.yaml" <<'YAML'
 version: 1
@@ -36,6 +36,8 @@ procedures:
   - id: capability-probe
     kind: capability.probe
     capability: storage.sync
+  - id: source-bindings
+    kind: source.bindings
 YAML
 
 cat >"$TMP_REPO/config/postflight.yaml" <<'YAML'
@@ -57,6 +59,14 @@ YAML
 
 cat >"$TMP_REPO/config/capabilities.yaml" <<'YAML'
 capabilities:
+  - name: sources.aggregate
+    kind: external_cli
+    command: [edge-sources]
+    probe: [edge-sources, --help]
+    passthrough: true
+    required: true
+    roles: [search, source]
+    skills: [research]
   - name: storage.sync
     kind: external_cli
     command: [echo]
@@ -66,12 +76,35 @@ capabilities:
     skills: [report]
 YAML
 
-cat >"$TMP_REPO/tools/edge-primitives" <<'SH'
+cat >"$TMP_STATE/state/sources-manifest.yaml" <<'YAML'
+sources:
+  - name: exa
+    description: Web search
+    roles: [search]
+    primary: true
+  - name: meta
+    description: Campaign state
+    roles: [signals]
+YAML
+
+cat >"$TMP_REPO/tools/edge-sources" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' '{"summary":{},"sources":[]}'
+echo "edge-sources $*"
 SH
-chmod +x "$TMP_REPO/tools/edge-primitives"
+cat >"$TMP_REPO/tools/edge-primitives" <<'PY'
+#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+
+payload = {"summary": {}, "sources": []}
+path = Path(os.environ["EDGE_STATE_DIR"]) / "state" / "primitives-status.json"
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(payload), encoding="utf-8")
+print(json.dumps(payload))
+PY
+chmod +x "$TMP_REPO/tools/edge-primitives" "$TMP_REPO/tools/edge-sources"
 
 export HOME="$TMP_HOME"
 export EDGE_REPO_DIR="$TMP_REPO"
@@ -101,10 +134,21 @@ compiled_path = Path(state_dir) / "state" / "runtime" / "preflight.compiled.json
 assert compiled_path.exists()
 saved = json.loads(compiled_path.read_text(encoding="utf-8"))
 assert saved["source_hash"] == compiled["source_hash"]
-assert len(saved["procedures"]) == 3
+assert len(saved["procedures"]) == 4
 signal_step = next(item for item in saved["procedures"] if item["kind"] == "signals.context")
 assert signal_step["scope"] == "routing"
 assert signal_step["limit"] == 5
+source_step = next(item for item in saved["procedures"] if item["kind"] == "source.bindings")
+bindings = {item["source"]: item for item in source_step["source_bindings"]}
+assert bindings["exa"]["binding_status"] == "present"
+assert bindings["exa"]["binding_mode"] == "sources.aggregate"
+assert bindings["exa"]["capability"] == "sources.aggregate"
+assert bindings["meta"]["binding_status"] == "absent"
+assert bindings["meta"]["warning"] == "configured_integration_without_binding"
+assert any("meta: configured_integration_without_binding" in item for item in saved["warnings"])
+assert saved["dependency_hashes"]
+primitive_hash = saved["dependency_hashes"][str(Path(state_dir) / "state" / "primitives-status.json")]
+assert primitive_hash.startswith("sha256:")
 PY
 then
     pass "ensure_compiled_protocol writes compiled JSON with hashes"
@@ -164,7 +208,59 @@ else
     fail "source edits trigger automatic recompilation on next ensure"
 fi
 
-echo "--- Test 4: unknown protocol kinds fail compilation ---"
+echo "--- Test 4: volatile primitive timestamps do not force recompilation ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_STATE/state/primitives-status.json"
+import json
+import sys
+from pathlib import Path
+
+edge_dir, status_path = sys.argv[1:]
+sys.path.insert(0, f"{edge_dir}/tools")
+from _shared.protocol_runtime import ensure_compiled_protocol
+
+first = ensure_compiled_protocol("preflight")
+path = Path(status_path)
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["generated_at"] = "2026-05-01T00:00:00+00:00"
+payload.setdefault("summary", {})["generated_at"] = "2026-05-01T00:00:00+00:00"
+path.write_text(json.dumps(payload), encoding="utf-8")
+second = ensure_compiled_protocol("preflight")
+payload["generated_at"] = "2026-05-01T00:01:00+00:00"
+payload["summary"]["generated_at"] = "2026-05-01T00:01:00+00:00"
+path.write_text(json.dumps(payload), encoding="utf-8")
+third = ensure_compiled_protocol("preflight")
+assert first["compiled_hash"] == second["compiled_hash"] == third["compiled_hash"]
+PY
+then
+    pass "volatile primitive timestamps do not force recompilation"
+else
+    fail "volatile primitive timestamps do not force recompilation"
+fi
+
+echo "--- Test 5: manifest edits trigger automatic recompilation on next ensure ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_STATE/state/sources-manifest.yaml"
+import sys
+from pathlib import Path
+
+edge_dir, manifest_path = sys.argv[1:]
+sys.path.insert(0, f"{edge_dir}/tools")
+from _shared.protocol_runtime import ensure_compiled_protocol
+
+first = ensure_compiled_protocol("preflight")
+path = Path(manifest_path)
+raw = path.read_text(encoding="utf-8")
+path.write_text(raw + "  - name: reddit\n    description: Community search\n    roles: [search]\n", encoding="utf-8")
+second = ensure_compiled_protocol("preflight")
+assert first["dependency_hashes"] != second["dependency_hashes"]
+assert first["compiled_hash"] != second["compiled_hash"]
+PY
+then
+    pass "manifest edits trigger automatic recompilation on next ensure"
+else
+    fail "manifest edits trigger automatic recompilation on next ensure"
+fi
+
+echo "--- Test 6: unknown protocol kinds fail compilation ---"
 if python3 - <<'PY' "$EDGE_DIR" "$TMP_REPO/config/preflight.yaml"
 import sys
 from pathlib import Path

--- a/tools/_shared/capability_runtime.py
+++ b/tools/_shared/capability_runtime.py
@@ -23,6 +23,7 @@ from paths import (  # noqa: E402
     PRIMITIVES_STATUS_FILE,
     SEARCH_DIR,
     SECRETS_DIR,
+    SOURCES_MANIFEST_FILE,
     STATE_EVENTS_FILE,
     TOOLS_DIR,
 )
@@ -95,6 +96,13 @@ INTEGRATION_CATALOG: dict[str, dict[str, Any]] = {
         "roles": ["publish"],
         "candidate_capabilities": [],
     },
+    "meta": {
+        "name": "meta",
+        "label": "Meta Marketing API",
+        "kind": "ads_platform",
+        "roles": ["signals", "search", "external_context"],
+        "candidate_capabilities": ["source.meta"],
+    },
     "netlify": {
         "name": "netlify",
         "label": "Netlify",
@@ -138,6 +146,32 @@ INTEGRATION_CATALOG: dict[str, dict[str, Any]] = {
         "candidate_capabilities": [],
     },
 }
+
+AGGREGATE_SOURCE_ALIASES = {
+    "claude-web": "claude_builtin",
+    "claude_web": "claude_builtin",
+    "claude": "claude_builtin",
+    "hackernews": "hn",
+    "hacker-news": "hn",
+    "semanticscholar": "semantic_scholar",
+    "semantic-scholar": "semantic_scholar",
+    "semscholar": "semantic_scholar",
+    "huggingface": "hf_papers",
+    "hf": "hf_papers",
+}
+AGGREGATE_SOURCE_PROVIDERS = {
+    "arxiv",
+    "claude_builtin",
+    "exa",
+    "github",
+    "hf_papers",
+    "hn",
+    "reddit",
+    "semantic_scholar",
+    "x",
+}
+BOUND_STATUSES = {"available", "active", "probed"}
+DEGRADED_STATUSES = {"degraded", "broken"}
 
 
 def _normalize_effective_status(value: Any) -> str:
@@ -220,6 +254,22 @@ def _parse_env_file(path: Path) -> list[str]:
         if key and value:
             vars_present.append(key)
     return sorted(set(vars_present))
+
+
+def _canonical_source_provider(name: str) -> str:
+    key = str(name or "").strip().lower().replace(" ", "_")
+    return AGGREGATE_SOURCE_ALIASES.get(key, key)
+
+
+def _load_sources_manifest() -> list[dict[str, Any]]:
+    if not SOURCES_MANIFEST_FILE.exists():
+        return []
+    try:
+        raw = yaml.safe_load(SOURCES_MANIFEST_FILE.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return []
+    items = raw.get("sources") if isinstance(raw, dict) else []
+    return [item for item in items if isinstance(item, dict) and str(item.get("name") or "").strip()] if isinstance(items, list) else []
 
 
 def _load_static_registry() -> list[dict[str, Any]]:
@@ -385,6 +435,9 @@ def _primitive_capability_row(item: dict[str, Any], *, invocations: dict[str, An
     invocation_event = invocations.get(name, {})
     effective_status = _normalize_effective_status(item.get("effective_status"))
     normalized_skill = _normalize_skill(skill)
+    roles = _normalize_roles(item.get("roles")) or ["search"]
+    if "source" not in roles:
+        roles.append("source")
     return {
         "name": name,
         "kind": "primitive",
@@ -392,7 +445,7 @@ def _primitive_capability_row(item: dict[str, Any], *, invocations: dict[str, An
         "primitive_name": item.get("name"),
         "description": str(item.get("description") or "").strip(),
         "required": False,
-        "roles": ["search", "source"],
+        "roles": roles,
         "skills": ["sources", "research", "discovery", "report", "strategy", "planner", "autonomy"],
         "recommended_for_skill": bool(normalized_skill and normalized_skill in {"sources", "research", "discovery", "report", "strategy", "planner", "autonomy"}),
         "configured_command": [str(item.get("binary_path") or "")] if item.get("binary_path") else [],
@@ -534,6 +587,112 @@ def build_configured_integrations(*, skill: str | None = None) -> dict[str, Any]
         "summary": summary,
         "configured_integrations": integrations,
         "unbound_integrations": unbound,
+    }
+
+
+def build_source_bindings(*, skill: str | None = None) -> dict[str, Any]:
+    """Resolve runtime-declared source intents into executable capability bindings."""
+    now = _now()
+    capability_payload = build_capability_status(skill=skill)
+    capability_rows = {
+        str(item.get("name") or "").strip(): item
+        for item in (capability_payload.get("capabilities") or [])
+        if isinstance(item, dict) and str(item.get("name") or "").strip()
+    }
+    aggregate = capability_rows.get("sources.aggregate") or {}
+    aggregate_status = str(aggregate.get("effective_status") or "unknown")
+    aggregate_available = aggregate_status in BOUND_STATUSES
+    sources = _load_sources_manifest()
+    bindings: list[dict[str, Any]] = []
+
+    for source in sources:
+        source_name = str(source.get("name") or "").strip()
+        if not source_name:
+            continue
+        roles = _normalize_roles(source.get("roles"))
+        primary = bool(source.get("primary", False))
+        primitive_name = f"source.{source_name}"
+        primitive = capability_rows.get(primitive_name) or {}
+        primitive_status = str(primitive.get("effective_status") or "unknown")
+        provider = _canonical_source_provider(source_name)
+        source_roles_search = not roles or "search" in roles or "source" in roles
+
+        binding_status = "absent"
+        binding_mode = "none"
+        capability = primitive_name
+        problems = list(primitive.get("problems") or [])
+        evidence: dict[str, Any] = {
+            "primitive_status": primitive_status,
+            "aggregate_status": aggregate_status,
+            "manifest_status": source.get("status") or "",
+        }
+
+        if source_roles_search and provider in AGGREGATE_SOURCE_PROVIDERS and aggregate_available:
+            binding_status = "present"
+            binding_mode = "sources.aggregate"
+            capability = "sources.aggregate"
+            evidence["aggregate_provider"] = provider
+        elif primitive_status in BOUND_STATUSES:
+            binding_status = "present"
+            binding_mode = "primitive"
+        elif primitive_status in DEGRADED_STATUSES:
+            binding_status = "degraded"
+            binding_mode = "primitive"
+        else:
+            binding_status = "absent"
+            binding_mode = "primitive" if primitive else "none"
+            if "declared_unbound" not in problems:
+                problems.append("declared_unbound")
+
+        warning = ""
+        if binding_status == "absent":
+            warning = "configured_integration_without_binding"
+        elif binding_status == "degraded":
+            warning = "configured_integration_binding_degraded"
+
+        bindings.append(
+            {
+                "source": source_name,
+                "description": str(source.get("description") or ""),
+                "roles": roles,
+                "primary": primary,
+                "capability": capability,
+                "binding_status": binding_status,
+                "binding_mode": binding_mode,
+                "problems": problems,
+                "warning": warning,
+                "evidence": evidence,
+            }
+        )
+
+    counts = Counter(item["binding_status"] for item in bindings)
+    unbound = [item for item in bindings if item.get("binding_status") == "absent"]
+    degraded = [item for item in bindings if item.get("binding_status") == "degraded"]
+    summary = {
+        "generated_at": now.isoformat(),
+        "source_total": len(bindings),
+        "bound_total": counts.get("present", 0),
+        "unbound_total": counts.get("absent", 0),
+        "degraded_total": counts.get("degraded", 0),
+        "counts_by_binding_status": dict(sorted(counts.items())),
+        "health_status": "fail" if unbound else "degraded" if degraded else "ok",
+        "source_path": str(SOURCES_MANIFEST_FILE),
+    }
+    return {
+        "summary": summary,
+        "bindings": bindings,
+        "unbound_source_bindings": unbound,
+        "degraded_source_bindings": degraded,
+        "warnings": [
+            {
+                "source": item["source"],
+                "warning": item["warning"],
+                "capability": item["capability"],
+                "problems": item.get("problems") or [],
+            }
+            for item in bindings
+            if item.get("warning")
+        ],
     }
 
 

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -39,7 +39,7 @@ from paths import (  # noqa: E402
     WORKFLOW_HEALTH_FILE,
 )
 from .continuity import refresh_continuity_projections  # noqa: E402
-from .capability_runtime import build_capability_status, build_configured_integrations, invoke_capability, probe_capability  # noqa: E402
+from .capability_runtime import build_capability_status, build_configured_integrations, build_source_bindings, invoke_capability, probe_capability  # noqa: E402
 from .operator_pressure import read_or_refresh_operator_pressure_projection  # noqa: E402
 from .protocol_runtime import emit_protocol_step_observed, ensure_compiled_protocol, protocol_context  # noqa: E402
 from .search_runtime import search_runtime_summary  # noqa: E402
@@ -989,6 +989,9 @@ def build_delta_prerequisite(state: dict[str, Any], *, skill: str | None, stage:
             "surfaces": {
                 "configured_integrations": request.get("configured_integrations", [])[:12],
                 "unbound_integrations": request.get("unbound_integrations", [])[:12],
+                "source_bindings": request.get("source_bindings", [])[:12],
+                "unbound_source_bindings": request.get("unbound_source_bindings", [])[:12],
+                "source_binding_warnings": request.get("source_binding_warnings", [])[:12],
                 "capabilities_status": request.get("capabilities_status", {}),
                 "search_runtime": request.get("search_runtime", {}),
                 "surface_baselines": previous.get("surface_baselines", {}),
@@ -1571,6 +1574,34 @@ def _execute_preflight_step(
         request["unbound_integrations"] = capabilities.get("unbound_integrations") or []
         return _step_result(step, status="ok", satisfied=True, detail=f"health={capabilities.get('health_status', 'unknown')}")
 
+    if kind == "source.bindings":
+        bindings = build_source_bindings(skill=skill)
+        summary = bindings.get("summary") or {}
+        request["source_bindings"] = bindings.get("bindings") or []
+        request["unbound_source_bindings"] = bindings.get("unbound_source_bindings") or []
+        request["degraded_source_bindings"] = bindings.get("degraded_source_bindings") or []
+        request["source_binding_warnings"] = bindings.get("warnings") or []
+        unbound_total = int(summary.get("unbound_total", 0) or 0)
+        degraded_total = int(summary.get("degraded_total", 0) or 0)
+        satisfied = unbound_total == 0 and degraded_total == 0
+        return _step_result(
+            step,
+            status="ok" if satisfied else "warning",
+            satisfied=satisfied,
+            detail=(
+                f"sources={summary.get('source_total', 0)} "
+                f"bound={summary.get('bound_total', 0)} "
+                f"unbound={unbound_total} degraded={degraded_total}"
+            ),
+            extra={
+                "source_total": int(summary.get("source_total", 0) or 0),
+                "bound_total": int(summary.get("bound_total", 0) or 0),
+                "unbound_total": unbound_total,
+                "degraded_total": degraded_total,
+                "warnings": bindings.get("warnings") or [],
+            },
+        )
+
     if kind == "signals.context":
         signal_query = str(step.get("query") or "").strip()
         if not signal_query:
@@ -1750,6 +1781,10 @@ def enrich_dispatch_state(
     request.setdefault("corpus_hits", [])
     request.setdefault("configured_integrations", [])
     request.setdefault("unbound_integrations", [])
+    request.setdefault("source_bindings", [])
+    request.setdefault("unbound_source_bindings", [])
+    request.setdefault("degraded_source_bindings", [])
+    request.setdefault("source_binding_warnings", [])
     request["search_runtime"] = search_runtime_summary()
     request.setdefault("operator_pressure", {"summary": {}, "digest": {}, "redigest": {}})
     request.setdefault("operator_pressure_digest", {})
@@ -1791,6 +1826,9 @@ def enrich_dispatch_state(
         "missing_required_corpus_types": list((request.get("corpus_coverage") or {}).get("missing_required_types") or []),
         "configured_integrations": len(request.get("configured_integrations") or []),
         "unbound_integrations": len(request.get("unbound_integrations") or []),
+        "source_bindings": len(request.get("source_bindings") or []),
+        "unbound_source_bindings": len(request.get("unbound_source_bindings") or []),
+        "source_binding_warnings": len(request.get("source_binding_warnings") or []),
         "builtin_web_search": (request.get("search_runtime") or {}).get("builtin_web_search"),
         "web_provider": (request.get("search_runtime") or {}).get("web_provider"),
         "operator_pressure_items": (request.get("operator_pressure_summary") or {}).get("item_total", 0),
@@ -1881,6 +1919,9 @@ def render_skill_runtime_prompt(skill: str, state: dict[str, Any]) -> str:
         "delta_prerequisite": delta_prerequisite,
         "configured_integrations": request.get("configured_integrations", [])[:12],
         "unbound_integrations": request.get("unbound_integrations", [])[:12],
+        "source_bindings": request.get("source_bindings", [])[:12],
+        "unbound_source_bindings": request.get("unbound_source_bindings", [])[:12],
+        "source_binding_warnings": request.get("source_binding_warnings", [])[:12],
         "search_runtime": request.get("search_runtime", {}),
         "search_protocol": request.get("search_protocol", {}),
         "epistemic_protocol": request.get("epistemic_protocol", {}),
@@ -1920,7 +1961,7 @@ def render_skill_runtime_prompt(skill: str, state: dict[str, Any]) -> str:
         "Before any substantive decision, synthesis, or artifact drafting in non-heartbeat skills, read `exploration_pack` first. "
         "The runtime has already performed the mandatory read-only exploration loop: memory retrieval, source/signal fan-out, adversarial Feynman interpretation, and a targeted second round. "
         "Use the pack as the minimum evidence base, surface its warnings, and only run additional search if the pack is missing, stale, or leaves a decision-blocking gap.\n"
-        "Configured integrations may exist without a capability binding; those are visible in `configured_integrations` / `unbound_integrations` and may be used ad hoc when explicitly needed, but they do not count as canonical capability use.\n\n"
+        "Configured integrations and source intents may exist without a capability binding; those are visible in `configured_integrations` / `unbound_integrations` and `source_bindings` / `source_binding_warnings`. Use bound capabilities as canonical; unbound entries are warning evidence, not completed substrate.\n\n"
         "```json\n"
         f"{json.dumps(summary, indent=2, ensure_ascii=False)}\n"
         "```"

--- a/tools/_shared/protocol_runtime.py
+++ b/tools/_shared/protocol_runtime.py
@@ -17,10 +17,13 @@ sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "config"))
 from paths import (  # noqa: E402
     POSTFLIGHT_COMPILED_FILE,
     POSTFLIGHT_PROTOCOL_FILE,
+    CAPABILITIES_CONFIG_FILE,
     PREFLIGHT_COMPILED_FILE,
     PREFLIGHT_PROTOCOL_FILE,
+    PRIMITIVES_STATUS_FILE,
+    SOURCES_MANIFEST_FILE,
 )
-from .capability_runtime import build_capability_status  # noqa: E402
+from .capability_runtime import build_capability_status, build_source_bindings  # noqa: E402
 from .telemetry import emit_shadow_event, log_event  # noqa: E402
 
 PROTOCOL_VERSION = 1
@@ -32,6 +35,7 @@ _ALLOWED_KINDS: dict[str, set[str]] = {
         "claims.refresh",
         "primitives.status",
         "capabilities.status",
+        "source.bindings",
         "signals.context",
         "corpus.lookup",
         "workflow.status",
@@ -68,6 +72,45 @@ def _now_iso() -> str:
 
 def _hash_text(content: str) -> str:
     return f"sha256:{hashlib.sha256(content.encode('utf-8')).hexdigest()}"
+
+
+def _hash_file(path: Path) -> str:
+    if not path.exists():
+        return "missing"
+    try:
+        return _hash_text(path.read_text(encoding="utf-8", errors="replace"))
+    except OSError:
+        return "unreadable"
+
+
+def _hash_primitives_binding_inputs(path: Path) -> str:
+    if not path.exists():
+        return "missing"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return _hash_file(path)
+    sources = payload.get("sources") if isinstance(payload, dict) else []
+    if not isinstance(sources, list):
+        sources = []
+    relevant = []
+    for item in sources:
+        if not isinstance(item, dict):
+            continue
+        relevant.append(
+            {
+                "name": item.get("name"),
+                "roles": list(item.get("roles") or []),
+                "primary": bool(item.get("primary")),
+                "effective_status": item.get("effective_status"),
+                "problems": list(item.get("problems") or []),
+                "manifest_status": item.get("manifest_status"),
+                "binary_exists": bool(item.get("binary_exists")),
+                "binary_path": item.get("binary_path"),
+            }
+        )
+    relevant.sort(key=lambda item: str(item.get("name") or ""))
+    return _hash_text(json.dumps({"sources": relevant}, sort_keys=True, ensure_ascii=False))
 
 
 def _protocol_paths(protocol: str) -> tuple[Path, Path]:
@@ -109,6 +152,26 @@ def _known_capability_rows() -> dict[str, dict[str, Any]]:
         for item in rows
         if isinstance(item, dict) and str(item.get("name") or "").strip()
     }
+
+
+def _dependency_hashes(protocol: str, payload: dict[str, Any]) -> dict[str, str]:
+    raw_steps = payload.get("procedures")
+    if raw_steps is None:
+        raw_steps = payload.get("steps")
+    if not isinstance(raw_steps, list):
+        raw_steps = []
+    kinds = {
+        str(item.get("kind") or "").strip()
+        for item in raw_steps
+        if isinstance(item, dict)
+    }
+    dependencies: dict[str, str] = {}
+    if kinds & {"capability.invoke", "capability.probe", "source.bindings"}:
+        dependencies[str(CAPABILITIES_CONFIG_FILE)] = _hash_file(CAPABILITIES_CONFIG_FILE)
+    if "source.bindings" in kinds:
+        dependencies[str(SOURCES_MANIFEST_FILE)] = _hash_file(SOURCES_MANIFEST_FILE)
+        dependencies[str(PRIMITIVES_STATUS_FILE)] = _hash_primitives_binding_inputs(PRIMITIVES_STATUS_FILE)
+    return dependencies
 
 
 def _normalize_step(
@@ -174,6 +237,28 @@ def _normalize_step(
             raise ProtocolCompileError(f"{protocol} procedures[{index}] signals.context limit must be an integer") from exc
         step["refresh"] = bool(raw_step.get("refresh", False))
 
+    if kind == "source.bindings":
+        payload = build_source_bindings()
+        step["source_bindings"] = [
+            {
+                "source": item.get("source"),
+                "capability": item.get("capability"),
+                "binding_status": item.get("binding_status"),
+                "binding_mode": item.get("binding_mode"),
+                "primary": bool(item.get("primary")),
+                "roles": list(item.get("roles") or []),
+                "warning": item.get("warning") or "",
+            }
+            for item in payload.get("bindings") or []
+            if isinstance(item, dict)
+        ]
+        for item in payload.get("warnings") or []:
+            source = str(item.get("source") or "").strip()
+            warning = str(item.get("warning") or "").strip()
+            capability = str(item.get("capability") or "").strip()
+            if source and warning:
+                warnings.append(f"{source}: {warning}{f' ({capability})' if capability else ''}")
+
     return step, warnings
 
 
@@ -224,12 +309,14 @@ def compile_protocol(protocol: str) -> dict[str, Any]:
         steps.append(step)
         warnings.extend(step_warnings)
 
+    dependency_hashes = _dependency_hashes(protocol, payload)
     compiled: dict[str, Any] = {
         "version": int(payload.get("version") or PROTOCOL_VERSION),
         "protocol": protocol,
         "source_path": str(source_path),
         "compiled_path": str(compiled_path),
         "source_hash": source_hash,
+        "dependency_hashes": dependency_hashes,
         "compiled_at": _now_iso(),
         "context_notes": context_notes,
         "operator_notes": operator_notes,
@@ -274,16 +361,32 @@ def ensure_compiled_protocol(protocol: str) -> dict[str, Any]:
     source_path, compiled_path = _protocol_paths(protocol)
     if not source_path.exists():
         raise ProtocolCompileError(f"{source_path} not found")
-    current_source_hash = _hash_text(source_path.read_text(encoding="utf-8"))
+    source_text = source_path.read_text(encoding="utf-8")
+    current_source_hash = _hash_text(source_text)
+    try:
+        payload = yaml.safe_load(source_text) or {}
+    except yaml.YAMLError:
+        payload = {}
+    current_dependency_hashes = _dependency_hashes(protocol, payload if isinstance(payload, dict) else {})
     compiled = _read_compiled(compiled_path)
-    if compiled and compiled.get("source_hash") == current_source_hash and compiled.get("protocol") == protocol:
+    if (
+        compiled
+        and compiled.get("source_hash") == current_source_hash
+        and compiled.get("protocol") == protocol
+        and (compiled.get("dependency_hashes") or {}) == current_dependency_hashes
+    ):
         return compiled
 
     reason = "missing_compiled"
     previous_source_hash = ""
     if compiled is not None:
         previous_source_hash = str(compiled.get("source_hash") or "")
-        reason = "source_hash_changed" if previous_source_hash and previous_source_hash != current_source_hash else "invalid_compiled"
+        if previous_source_hash and previous_source_hash != current_source_hash:
+            reason = "source_hash_changed"
+        elif (compiled.get("dependency_hashes") or {}) != current_dependency_hashes:
+            reason = "dependency_hash_changed"
+        else:
+            reason = "invalid_compiled"
 
     emit_shadow_event(
         "ProtocolDriftObserved",
@@ -375,6 +478,7 @@ def protocol_context(protocol: dict[str, Any]) -> dict[str, Any]:
         "compiled_at": protocol.get("compiled_at"),
         "context_notes": list(protocol.get("context_notes") or []),
         "operator_notes": list(protocol.get("operator_notes") or []),
+        "warnings": list(protocol.get("warnings") or []),
         "steps": [
             {
                 "id": step.get("id"),

--- a/tools/edge-cap
+++ b/tools/edge-cap
@@ -12,6 +12,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 from _shared.capability_runtime import (  # noqa: E402
     build_capability_status,
+    build_source_bindings,
     get_capability,
     invoke_capability,
     probe_capability,
@@ -40,14 +41,52 @@ def _print_status(payload: dict[str, object]) -> None:
             f"{row.get('effective_status'):16} "
             f"invoke30d={row.get('invoke_30d', row.get('usage_30d', 0))}"
         )
+    source_bindings = payload.get("source_bindings") or {}
+    source_summary = source_bindings.get("summary") if isinstance(source_bindings, dict) else {}
+    if source_summary:
+        print(
+            "source-bindings:"
+            f" sources={source_summary.get('source_total', 0)}"
+            f" bound={source_summary.get('bound_total', 0)}"
+            f" unbound={source_summary.get('unbound_total', 0)}"
+            f" degraded={source_summary.get('degraded_total', 0)}"
+            f" health={source_summary.get('health_status', 'unknown')}"
+        )
+        for item in (source_bindings.get("warnings") or [])[:10]:
+            print(f"  - {item.get('source')}: {item.get('warning')} ({item.get('capability')})")
 
 
 def cmd_status(args: argparse.Namespace) -> int:
     payload = build_capability_status(skill=args.skill)
+    payload["source_bindings"] = build_source_bindings(skill=args.skill)
     if args.json:
         print(json.dumps(payload, ensure_ascii=False))
         return 0
     _print_status(payload)
+    return 0
+
+
+def cmd_source_bindings(args: argparse.Namespace) -> int:
+    payload = build_source_bindings(skill=args.skill)
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False))
+        return 0
+    summary = payload.get("summary") or {}
+    print(
+        "source-bindings:"
+        f" sources={summary.get('source_total', 0)}"
+        f" bound={summary.get('bound_total', 0)}"
+        f" unbound={summary.get('unbound_total', 0)}"
+        f" degraded={summary.get('degraded_total', 0)}"
+        f" health={summary.get('health_status', 'unknown')}"
+    )
+    for item in payload.get("bindings") or []:
+        print(
+            f"{item.get('source'):24} "
+            f"{item.get('binding_status'):10} "
+            f"{item.get('binding_mode'):18} "
+            f"{item.get('capability')}"
+        )
     return 0
 
 
@@ -103,6 +142,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_status.add_argument("--skill", default="", help="Optional skill hint for recommendations")
     p_status.add_argument("--json", action="store_true")
 
+    p_sources = sub.add_parser("source-bindings", help="Resolve source manifest intents to capability bindings")
+    p_sources.add_argument("--skill", default="", help="Optional skill hint for recommendations")
+    p_sources.add_argument("--json", action="store_true")
+
     p_invoke = sub.add_parser("invoke", help="Invoke a capability by name")
     p_invoke.add_argument("name")
     p_invoke.add_argument("--skill", default="", help="Optional skill hint for telemetry")
@@ -119,6 +162,8 @@ def main() -> int:
     args = build_parser().parse_args()
     if args.cmd == "status":
         return cmd_status(args)
+    if args.cmd == "source-bindings":
+        return cmd_source_bindings(args)
     if args.cmd == "invoke":
         return cmd_invoke(args)
     if args.cmd == "probe":

--- a/tools/edge-doctor
+++ b/tools/edge-doctor
@@ -542,6 +542,49 @@ def check_primitives_status():
         _record_check("projection:primitives-status", "ok", detail, artifact=artifact)
 
 
+def check_source_bindings():
+    tool = Path(__file__).resolve().parent / "edge-cap"
+    if not tool.exists():
+        warn("source bindings indisponível: edge-cap não encontrado")
+        _record_check("projection:source-bindings", "warn", "source bindings indisponível: edge-cap não encontrado", artifact=tool)
+        return
+    try:
+        result = subprocess.run(
+            [sys.executable, str(tool), "source-bindings", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        warn(f"source bindings indisponível: {exc}")
+        _record_check("projection:source-bindings", "warn", f"source bindings indisponível: {exc}", artifact=tool)
+        return
+    if result.returncode != 0:
+        warn(f"source bindings falhou: {result.stderr.strip() or result.stdout.strip()}")
+        _record_check(
+            "projection:source-bindings",
+            "warn",
+            f"source bindings falhou: {result.stderr.strip() or result.stdout.strip()}",
+            artifact=tool,
+        )
+        return
+    payload = json.loads(result.stdout) if result.stdout.strip() else {}
+    summary = payload.get("summary", {}) or {}
+    detail = (
+        "source-bindings: "
+        f"sources={summary.get('source_total', 0)}, "
+        f"bound={summary.get('bound_total', 0)}, "
+        f"unbound={summary.get('unbound_total', 0)}, "
+        f"degraded={summary.get('degraded_total', 0)}"
+    )
+    if summary.get("unbound_total", 0) or summary.get("degraded_total", 0):
+        warn(detail)
+        _record_check("projection:source-bindings", "warn", detail, artifact=tool)
+    else:
+        ok(detail)
+        _record_check("projection:source-bindings", "ok", detail, artifact=tool)
+
+
 def main():
     global CURRENT_SECTION
 
@@ -691,6 +734,7 @@ def main():
     CURRENT_SECTION = "projection"
     print("\033[1m[8/8] Projection\033[0m")
     check_primitives_status()
+    check_source_bindings()
     check_pipeline_state()
     check_render_install_drift()
     print()

--- a/tools/edge-render
+++ b/tools/edge-render
@@ -126,6 +126,7 @@ def _render_preflight_protocol(cfg: dict) -> str:
             {"id": "claims-refresh", "kind": "claims.refresh"},
             {"id": "primitives-status", "kind": "primitives.status"},
             {"id": "capabilities-status", "kind": "capabilities.status"},
+            {"id": "source-bindings", "kind": "source.bindings"},
             {"id": "corpus-lookup", "kind": "corpus.lookup"},
             {"id": "workflow-status", "kind": "workflow.status"},
             {"id": "queue-status", "kind": "queue.status"},


### PR DESCRIPTION
## Summary

- Adds a `source.bindings` preflight step that resolves `state/sources-manifest.yaml` source intents into concrete capability bindings.
- Binds built-in source providers through `sources.aggregate`, binds materialized primitives through `source.<name>`, and emits explicit warnings for unbound or degraded configured sources.
- Exposes source binding evidence in compiled protocols, dispatch request context, delta inputs, `edge-cap status`, `edge-cap source-bindings`, and `edge-doctor` projection checks.
- Updates the rendered/canonical preflight so fresh installs get the binding step automatically.

Closes #321.

## Validation

- `python3 -m py_compile tools/_shared/capability_runtime.py tools/_shared/protocol_runtime.py tools/_shared/dispatch_runtime.py tools/edge-render tools/edge-cap tools/edge-doctor`
- `git diff --check`
- `bash tests/test_protocol_runtime.sh`
- `bash tests/test_edge_cap_status.sh`
- `bash tests/test_edge_dispatch.sh`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_primitives_status.sh`
- `bash tests/test_runtime_decision_protocol.sh`
- `bash tests/test_runtime_router_config.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_install_telemetry.sh`
- `bash tests/test_render_install_drift.sh`
- `bash tests/test_edge_apply_bookkeeping_drift.sh`