### PR TITLE
[codex] Reduce skill step registry to semantic checkpoints

### DIFF
--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -195,7 +195,7 @@ Edit the `HEARTBEAT_PROMPT` section in `heartbeat.sh` (or rerun the relevant par
 1. Place the tool script in `tools/`
 2. Make it executable: `chmod +x tools/my-tool`
 3. Add a description to `CLAUDE.md` under the Tools section
-4. If the tool has steps to track, add them to `tools/skill-steps-registry.yaml`
+4. If a skill has semantic checkpoints to track, add them to `tools/skill-steps-registry.yaml`
 5. Create a wrapper in `~/.local/bin/` if you want it available globally:
 ```bash
 cat > ~/.local/bin/my-tool << 'EOF'
@@ -213,18 +213,21 @@ Skills are Claude Code slash commands in `~/.claude/skills/PREFIX-NAME/SKILL.md`
 
 ### Core Skills (installed by template)
 - `heartbeat` — autonomous dispatcher
-- `pesquisa` — deep research
-- `descoberta` — lateral exploration
-- `lazer` — creative break
-- `reflexao` — self-reflection
-- `estrategia` — strategic planning
-- `planejar` — concrete proposals
-- `executar` — implementation (manual only)
+- `research` — directed deep research
+- `discovery` — lateral exploration and practical discoveries
+- `reflection` — operational learning loop
+- `strategy` — cross-project strategic curation
+- `planner` — concrete development-cycle proposals
+- `autonomy` — operational substrate improvement
+- `report` — structured analytical reports
+- `sources` — source/signal workflow curation
+- `map` — internal relationship mapping
+- `loader` — manual session resume
 
 ### Creating New Skills
 1. Create directory: `mkdir -p ~/.claude/skills/PREFIX-newskill/`
 2. Create `SKILL.md` with the skill instructions
-3. Register in `tools/skill-steps-registry.yaml` if it has trackable steps
+3. Register in `tools/skill-steps-registry.yaml` only if it has semantic checkpoints worth measuring
 
 ---
 
@@ -264,5 +267,5 @@ Cost: ~$0.02-0.05 per review.
 | `edge-consult` fails | OPENAI_API_KEY invalid or missing | Check secrets/*.env |
 | `edge-fontes` no Exa results | EXA_API_KEY invalid | Check secrets/exa.env |
 | Heartbeat repeats same topic | Anti-saturation not working | Check daily log: if >3 beats on same topic, force change |
-| Skills silently skipping steps | Missing `edge-skill-step` calls | Check skill-steps-registry.yaml |
+| Skills silently skipping semantic checkpoints | Missing `edge-skill-step` calls for registered checkpoints | Check skill-steps-registry.yaml |
 | `heartbeat-preflight.sh` always PREFLIGHT_CLEAN | Blog chat API not responding | Check blog server is running |

--- a/skills/_shared/state-protocol.md
+++ b/skills/_shared/state-protocol.md
@@ -5,14 +5,19 @@ Each skill references this file instead of having its own state management instr
 
 **Autonomy decisions:** see `~/edge/autonomy/autonomy-policy.md` (when to execute vs ask).
 **Audit tool:** `edge-state-audit` (snapshot, propose, audit, scan).
-**Step tracking:** `edge-skill-step` (records steps executed/skipped per skill).
+**Semantic checkpoint tracking:** `edge-skill-step` (records skill-specific checkpoints only).
 **Status consistency:** `edge-state-lint` (detects drift between memory files).
 
 ---
 
-## Step Tracking (MANDATORY in skills with protocol)
+## Semantic Checkpoint Tracking
 
-When executing a skill with numbered steps, log each executed step:
+Runtime/CQRS owns lifecycle evidence: preflight, dispatch, inbox capture,
+exploration pack, publication/review gates, postflight, and cycle close. Do not
+mirror those rites with `edge-skill-step`.
+
+When a skill has semantic checkpoints in `tools/skill-steps-registry.yaml`, log
+the checkpoints it actually completes:
 
 ```bash
 edge-skill-step <skill> <step_id>              # step executed
@@ -20,9 +25,17 @@ edge-skill-step <skill> skip <step_id> [reason]  # step explicitly skipped
 edge-skill-step <skill> end                     # summary (detects silent skips)
 ```
 
-**Rule:** call `edge-skill-step <skill> end` when finishing the skill. The tool compares logged steps against the registry (`~/edge/tools/skill-steps-registry.yaml`) and reports silently skipped steps.
+**Rule:** call `edge-skill-step <skill> end` when finishing the skill. The tool
+emits completion evidence for the runtime close path. If the skill has semantic
+checkpoints in the registry, it also compares logged checkpoints and reports
+silently skipped semantic work. Skills without a registry contract are allowed;
+they emit completion evidence without registry warnings.
 
-If a step is skipped for a valid reason (e.g.: cache hit, already ran this session), use `skip` with a reason. A step not logged as either executed or skipped = **silent skip** = /ed-reflection will flag it.
+If a checkpoint is skipped for a valid reason, use `skip` with a reason. A
+registered checkpoint not logged as either executed or skipped = **silent
+skip** = /ed-reflection will flag it. Do not add preflight, postflight, corpus,
+health, or dispatch checks to the registry; those belong to runtime events and
+projections.
 
 ---
 

--- a/tests/test_edge_close.sh
+++ b/tests/test_edge_close.sh
@@ -116,7 +116,9 @@ fi
 echo "--- Test 1b: edge-close refuses to close a different EDGE_CYCLE_ID ---"
 "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-mismatch --force >/dev/null
 "$DISPATCH_TOOL" dispatch --skill discovery >/dev/null
-EDGE_CYCLE_ID=cycle-close-mismatch "$STEP_TOOL" discovery start >/dev/null
+for step in direction explore application persistence; do
+    EDGE_CYCLE_ID=cycle-close-mismatch "$STEP_TOOL" discovery "$step" >/dev/null
+done
 EDGE_CYCLE_ID=cycle-close-mismatch "$STEP_TOOL" discovery end >/dev/null
 set +e
 EDGE_CYCLE_ID=cycle-other "$CLOSE_TOOL" --status completed >/dev/null 2>/dev/null
@@ -146,7 +148,9 @@ EDGE_CYCLE_ID=cycle-close-mismatch "$DISPATCH_TOOL" close --status aborted >/dev
 echo "--- Test 2: completed close succeeds with skill end evidence and postflight ---"
 "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-complete --force >/dev/null
 "$DISPATCH_TOOL" dispatch --skill discovery >/dev/null
-EDGE_CYCLE_ID=cycle-close-complete "$STEP_TOOL" discovery start >/dev/null
+for step in direction explore application persistence; do
+    EDGE_CYCLE_ID=cycle-close-complete "$STEP_TOOL" discovery "$step" >/dev/null
+done
 EDGE_CYCLE_ID=cycle-close-complete "$STEP_TOOL" discovery end >/dev/null
 "$CLOSE_TOOL" --status completed >/dev/null
 
@@ -189,7 +193,9 @@ cat >"$TMP_EDGE/reports/2026-04-22-warning.html" <<'EOF'
 EOF
 "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-warning --force >/dev/null
 "$DISPATCH_TOOL" dispatch --skill discovery >/dev/null
-EDGE_CYCLE_ID=cycle-close-warning "$STEP_TOOL" discovery start >/dev/null
+for step in direction explore application persistence; do
+    EDGE_CYCLE_ID=cycle-close-warning "$STEP_TOOL" discovery "$step" >/dev/null
+done
 EDGE_CYCLE_ID=cycle-close-warning "$STEP_TOOL" discovery end >/dev/null
 "$CLOSE_TOOL" --status completed >/dev/null
 

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -111,7 +111,9 @@ if [ "${MOCK_CLAUDE_HEARTBEAT_FLOW:-0}" = "1" ]; then
   if [[ "$PROMPT" == *"/ed-heartbeat"* ]]; then
     "${EDGE_REPO_DIR:?}/tools/edge-dispatch" dispatch --skill discovery >/dev/null
   elif [[ "$PROMPT" == *"/discovery"* ]]; then
-    "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery start >/dev/null
+    for step in direction explore application persistence; do
+      "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery "$step" >/dev/null
+    done
     "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery end >/dev/null
   fi
 fi

--- a/tests/test_edge_skill_step.sh
+++ b/tests/test_edge_skill_step.sh
@@ -28,8 +28,11 @@ echo "=== edge-skill-step Smoke Test ==="
 echo "Temp state: $TMP_EDGE"
 echo ""
 
-echo "--- Test 1: English skill alias resolves to registry skill and writes log ---"
-"$STEP_TOOL" discovery start >/dev/null
+echo "--- Test 1: English skill alias resolves to modern semantic registry skill ---"
+"$STEP_TOOL" discovery direction >/dev/null
+"$STEP_TOOL" discovery explore >/dev/null
+"$STEP_TOOL" discovery application >/dev/null
+"$STEP_TOOL" discovery persistence >/dev/null
 "$STEP_TOOL" discovery end >"$TMP_BASE/discovery-end.txt"
 
 if python3 - <<'PY' "$TMP_EDGE/logs/skill-steps.jsonl" "$TMP_EDGE/state/events/log.jsonl" "$TMP_BASE/discovery-end.txt"
@@ -41,22 +44,27 @@ events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if li
 output = open(sys.argv[3], encoding="utf-8").read()
 
 assert steps[0]["skill"] == "discovery"
-assert steps[0]["registry_skill"] == "ed-descoberta"
-assert steps[1]["skill"] == "discovery"
-assert steps[1]["registry_skill"] == "ed-descoberta"
-assert "warning" not in steps[1]
-assert "ed-descoberta" in output
+assert steps[0]["registry_skill"] == "ed-discovery"
+end = steps[4]
+assert end["skill"] == "discovery"
+assert end["registry_skill"] == "ed-discovery"
+assert end["contract"] == "semantic_checkpoints"
+assert end["expected"] == 4
+assert end["done"] == 4
+assert end["silent_skips"] == []
+assert "warning" not in end
+assert "ed-discovery" in output
 assert any(event["type"] == "SkillStepObserved" for event in events)
 assert any(event["type"] == "SkillRunCompleted" for event in events)
 PY
 then
-    pass "English discovery skill resolves to registry and emits logs/events"
+    pass "English discovery skill resolves to semantic registry and emits logs/events"
 else
-    fail "English discovery skill resolves to registry and emits logs/events"
+    fail "English discovery skill resolves to semantic registry and emits logs/events"
 fi
 
-echo "--- Test 2: prefixed runtime skill alias resolves to same registry skill ---"
-"$STEP_TOOL" /gauss-autonomy start >/dev/null
+echo "--- Test 2: prefixed runtime skill alias resolves and reports semantic skips ---"
+"$STEP_TOOL" /gauss-autonomy diagnosis >/dev/null
 "$STEP_TOOL" /gauss-autonomy end >"$TMP_BASE/autonomy-end.txt"
 
 if python3 - <<'PY' "$TMP_EDGE/logs/skill-steps.jsonl" "$TMP_BASE/autonomy-end.txt"
@@ -68,14 +76,88 @@ output = open(sys.argv[2], encoding="utf-8").read()
 last = steps[-1]
 
 assert last["skill"] == "/gauss-autonomy"
-assert last["registry_skill"] == "ed-autonomia"
+assert last["registry_skill"] == "ed-autonomy"
+assert last["expected"] == 4
+assert last["done"] == 1
+assert last["silent_skips"] == ["decision", "change", "verification"]
 assert "warning" not in last
-assert "ed-autonomia" in output
+assert "ed-autonomy" in output
+assert "decision:" in output
 PY
 then
-    pass "prefixed autonomy skill resolves to registry"
+    pass "prefixed autonomy skill resolves and reports semantic skips"
 else
-    fail "prefixed autonomy skill resolves to registry"
+    fail "prefixed autonomy skill resolves and reports semantic skips"
+fi
+
+echo "--- Test 3: unregistered skills are optional and still emit completion ---"
+"$STEP_TOOL" /gauss-prototype end >"$TMP_BASE/prototype-end.txt"
+
+if python3 - <<'PY' "$TMP_EDGE/logs/skill-steps.jsonl" "$TMP_EDGE/state/events/log.jsonl" "$TMP_BASE/prototype-end.txt"
+import json
+import sys
+
+steps = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8") if line.strip()]
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+output = open(sys.argv[3], encoding="utf-8").read()
+last = steps[-1]
+
+assert last["skill"] == "/gauss-prototype"
+assert last["registry_status"] == "unregistered"
+assert last["expected"] == 0
+assert last["completion_pct"] == 100
+assert "warning" not in last
+assert "sem contrato" in output
+assert any(event["type"] == "SkillRunCompleted" and event["payload"].get("registry_status") == "unregistered" for event in events)
+PY
+then
+    pass "unregistered skill completion is optional but observable"
+else
+    fail "unregistered skill completion is optional but observable"
+fi
+
+echo "--- Test 4: legacy Portuguese registry aliases remain compatible during migration ---"
+"$STEP_TOOL" ed-descoberta direction >/dev/null
+"$STEP_TOOL" ed-descoberta skip explore already-covered >/dev/null
+"$STEP_TOOL" ed-descoberta end >"$TMP_BASE/legacy-end.txt"
+
+if python3 - <<'PY' "$TMP_EDGE/logs/skill-steps.jsonl" "$TMP_BASE/legacy-end.txt"
+import json
+import sys
+
+steps = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8") if line.strip()]
+output = open(sys.argv[2], encoding="utf-8").read()
+last = steps[-1]
+
+assert last["skill"] == "ed-descoberta"
+assert last["registry_skill"] == "ed-discovery"
+assert last["done"] == 1
+assert last["explicit_skips"] == 1
+assert last["skip_details"] == {"explore": "already-covered"}
+assert last["silent_skips"] == ["application", "persistence"]
+assert "ed-discovery" in output
+PY
+then
+    pass "legacy Portuguese alias resolves to modern semantic registry"
+else
+    fail "legacy Portuguese alias resolves to modern semantic registry"
+fi
+
+echo "--- Test 5: reports ignore optional unregistered completion entries ---"
+"$STEP_TOOL" report --last 10 >"$TMP_BASE/report.txt"
+
+if python3 - <<'PY' "$TMP_BASE/report.txt"
+import sys
+
+output = open(sys.argv[1], encoding="utf-8").read()
+assert "ed-discovery" in output
+assert "ed-autonomy" in output
+assert "/gauss-prototype" not in output
+PY
+then
+    pass "report focuses on registered semantic checkpoint contracts"
+else
+    fail "report focuses on registered semantic checkpoint contracts"
 fi
 
 echo ""

--- a/tools/edge-skill-step
+++ b/tools/edge-skill-step
@@ -27,25 +27,13 @@ from _shared.telemetry import current_cycle_id, emit_shadow_event
 
 LOG = LOGS_DIR / "skill-steps.jsonl"
 REGISTRY = Path(__file__).resolve().parent / "skill-steps-registry.yaml"
-SKILL_ALIASES = {
-    "research": "ed-pesquisa",
-    "pesquisa": "ed-pesquisa",
-    "discovery": "ed-descoberta",
-    "descoberta": "ed-descoberta",
-    "heartbeat": "ed-heartbeat",
-    "strategy": "ed-estrategia",
-    "estrategia": "ed-estrategia",
-    "autonomy": "ed-autonomia",
-    "autonomia": "ed-autonomia",
-    "report": "ed-relatorio",
-    "relatorio": "ed-relatorio",
-    "planner": "ed-planejar",
-    "planejar": "ed-planejar",
-    "plan": "ed-planejar",
-    "reflection-hn": "ed-reflexao-HN",
-    "reflexao-hn": "ed-reflexao-HN",
-    "reflection-m": "ed-reflexao-M",
-    "reflexao-m": "ed-reflexao-M",
+REGISTRY_META_KEYS = {
+    "version",
+    "contract",
+    "default_unregistered",
+    "runtime_owned_lifecycle",
+    "aliases",
+    "skills",
 }
 
 
@@ -54,6 +42,60 @@ def _load_registry():
         with open(REGISTRY) as f:
             return yaml.safe_load(f) or {}
     return {}
+
+
+def _registry_skill_map(reg=None):
+    reg = reg if reg is not None else _load_registry()
+    if not isinstance(reg, dict):
+        return {}
+    skills = reg.get("skills")
+    if isinstance(skills, dict):
+        return skills
+    return {
+        key: value
+        for key, value in reg.items()
+        if key not in REGISTRY_META_KEYS and isinstance(value, list)
+    }
+
+
+def _registry_alias_map(reg=None):
+    reg = reg if reg is not None else _load_registry()
+    aliases = reg.get("aliases") if isinstance(reg, dict) else {}
+    if not isinstance(aliases, dict):
+        return {}
+    return {
+        str(key).strip().lower(): str(value).strip()
+        for key, value in aliases.items()
+        if str(key).strip() and str(value).strip()
+    }
+
+
+def _registry_contract(reg=None):
+    reg = reg if reg is not None else _load_registry()
+    if not isinstance(reg, dict):
+        return "legacy_steps"
+    return str(reg.get("contract") or "legacy_steps").strip() or "legacy_steps"
+
+
+def _unregistered_optional(reg=None):
+    reg = reg if reg is not None else _load_registry()
+    if not isinstance(reg, dict):
+        return False
+    return str(reg.get("default_unregistered") or "").strip().lower() == "optional"
+
+
+def _parse_step_entry(entry):
+    if isinstance(entry, dict):
+        step_id = str(entry.get("id") or "").strip()
+        label = str(entry.get("label") or entry.get("description") or step_id).strip()
+        return step_id, label
+    text = str(entry or "").strip()
+    if not text:
+        return "", ""
+    if ":" in text:
+        step_id, label = text.split(":", 1)
+        return step_id.strip(), label.strip()
+    return text, text
 
 
 def _log(data):
@@ -72,10 +114,16 @@ def _read_log():
 def _candidate_skill_names(skill):
     raw = (skill or "").strip()
     normalized = raw.lstrip("/")
-    candidates = [raw, normalized, normalized.lower()]
+    normalized_lower = normalized.lower()
+    candidates = [raw, normalized, normalized_lower]
+    if normalized_lower.startswith("ed-"):
+        candidates.append(normalized_lower[3:])
+    elif normalized_lower:
+        candidates.append(f"ed-{normalized_lower}")
     if "-" in normalized:
         _, suffix = normalized.split("-", 1)
-        candidates.extend([suffix, suffix.lower()])
+        suffix_lower = suffix.lower()
+        candidates.extend([suffix, suffix_lower, f"ed-{suffix_lower}"])
     seen = set()
     ordered = []
     for candidate in candidates:
@@ -87,12 +135,18 @@ def _candidate_skill_names(skill):
 
 def _resolve_registry_skill(skill):
     reg = _load_registry()
+    skills = _registry_skill_map(reg)
+    aliases = _registry_alias_map(reg)
     raw = (skill or "").strip()
     for candidate in _candidate_skill_names(raw):
-        if candidate in reg:
-            return raw, candidate
-        alias = SKILL_ALIASES.get(candidate.lower())
-        if alias and alias in reg:
+        candidate_key = candidate.strip()
+        candidate_lower = candidate_key.lower()
+        if candidate_key in skills:
+            return raw, candidate_key
+        if candidate_lower in skills:
+            return raw, candidate_lower
+        alias = aliases.get(candidate_lower)
+        if alias and alias in skills:
             return raw, alias
     return raw, None
 
@@ -100,11 +154,18 @@ def _resolve_registry_skill(skill):
 def _registry_steps(skill):
     """Get expected step IDs for a skill from registry."""
     reg = _load_registry()
+    skills = _registry_skill_map(reg)
     raw_skill, registry_skill = _resolve_registry_skill(skill)
     if not registry_skill:
         return [], {}, raw_skill, None
-    entries = reg.get(registry_skill, [])
-    return [s.split(":")[0] for s in entries], {s.split(":")[0]: s for s in entries}, raw_skill, registry_skill
+    parsed = [_parse_step_entry(entry) for entry in skills.get(registry_skill, [])]
+    parsed = [(step_id, label) for step_id, label in parsed if step_id]
+    return (
+        [step_id for step_id, _ in parsed],
+        {step_id: f"{step_id}:{label}" for step_id, label in parsed},
+        raw_skill,
+        registry_skill,
+    )
 
 
 def _entry_for_skill(skill, *, event, **extra):
@@ -158,20 +219,15 @@ def cmd_end(skill):
     """End a skill run. Compare logged steps against registry."""
     expected_ids, step_names, raw_skill, registry_skill = _registry_steps(skill)
 
-    if not expected_ids:
-        entry = _entry_for_skill(skill, event="end", warning=f"skill '{raw_skill}' not in registry")
-        _log(entry)
-        print(f"⚠ Skill '{raw_skill}' não está no registry. Nada para comparar.")
-        return
-
     # Read log backwards to find steps for this skill since last 'end' event
     all_entries = _read_log()
     recorded_done = set()
     recorded_skip = {}
+    target_skill = registry_skill or raw_skill
 
     for entry in reversed(all_entries):
         entry_skill = entry.get("registry_skill") or entry.get("skill")
-        if entry_skill != registry_skill:
+        if entry_skill != target_skill:
             continue
         if entry.get("event") == "end":
             break  # stop at previous end
@@ -182,7 +238,41 @@ def cmd_end(skill):
             elif entry.get("status") == "skipped":
                 recorded_skip[sid] = entry.get("reason", "")
 
-    all_accounted = recorded_done | set(recorded_skip.keys())
+    reg = _load_registry()
+    contract = _registry_contract(reg)
+    if not expected_ids:
+        summary = {
+            "skill": raw_skill,
+            "event": "end",
+            "expected": 0,
+            "done": len(recorded_done),
+            "explicit_skips": len(recorded_skip),
+            "silent_skips": [],
+            "completion_pct": 100,
+            "registry_status": "unregistered" if not registry_skill else "empty_contract",
+            "contract": contract,
+        }
+        if registry_skill:
+            summary["registry_skill"] = registry_skill
+        if recorded_skip:
+            summary["skip_details"] = recorded_skip
+        _log(summary)
+        emit_shadow_event(
+            "SkillRunCompleted",
+            actor="edge-skill-step",
+            cycle_id=current_cycle_id(),
+            payload=summary,
+        )
+        if _unregistered_optional(reg):
+            print(f"✓ {raw_skill}: sem contrato semântico no registry; lifecycle é medido pelo runtime")
+        else:
+            print(f"⚠ Skill '{raw_skill}' não está no registry. Nada para comparar.")
+        return
+
+    expected_set = set(expected_ids)
+    expected_done = recorded_done & expected_set
+    expected_skip = {sid: reason for sid, reason in recorded_skip.items() if sid in expected_set}
+    all_accounted = expected_done | set(expected_skip.keys())
     silent_skips = [s for s in expected_ids if s not in all_accounted]
 
     summary = {
@@ -190,13 +280,17 @@ def cmd_end(skill):
         "registry_skill": registry_skill,
         "event": "end",
         "expected": len(expected_ids),
-        "done": len(recorded_done),
-        "explicit_skips": len(recorded_skip),
+        "done": len(expected_done),
+        "explicit_skips": len(expected_skip),
         "silent_skips": silent_skips,
-        "completion_pct": round(len(recorded_done) / len(expected_ids) * 100) if expected_ids else 0,
+        "completion_pct": round(len(expected_done) / len(expected_ids) * 100) if expected_ids else 0,
+        "contract": contract,
     }
-    if recorded_skip:
-        summary["skip_details"] = recorded_skip
+    extra_steps = sorted((recorded_done | set(recorded_skip.keys())) - expected_set)
+    if expected_skip:
+        summary["skip_details"] = expected_skip
+    if extra_steps:
+        summary["extra_steps"] = extra_steps
     _log(summary)
     emit_shadow_event(
         "SkillRunCompleted",
@@ -211,8 +305,8 @@ def cmd_end(skill):
         print(f"⚠ {raw_skill}: {len(silent_skips)} passos silenciosamente pulados:")
         for s in named:
             print(f"  - {s}")
-    if recorded_skip:
-        print(f"  ({len(recorded_skip)} skip(s) explícito(s))")
+    if expected_skip:
+        print(f"  ({len(expected_skip)} skip(s) explícito(s))")
     display_skill = raw_skill if raw_skill == registry_skill else f"{raw_skill} -> {registry_skill}"
     print(f"✓ {display_skill}: {summary['done']}/{summary['expected']} passos "
           f"({summary['completion_pct']}%)")
@@ -221,7 +315,14 @@ def cmd_end(skill):
 def cmd_report(last_n=20):
     """Summary report for /ed-reflexao."""
     entries = _read_log()
-    ends = [e for e in entries if e.get("event") == "end" and "expected" in e]
+    ends = [
+        e
+        for e in entries
+        if e.get("event") == "end"
+        and "expected" in e
+        and e.get("registry_status") != "unregistered"
+        and int(e.get("expected", 0) or 0) > 0
+    ]
 
     if not ends:
         print("Sem dados de execução de skills.")

--- a/tools/skill-steps-registry.yaml
+++ b/tools/skill-steps-registry.yaml
@@ -1,127 +1,120 @@
-# Registry de passos esperados por skill.
-# Formato: "id:Nome curto"
-# edge-skill-step usa isso pra detectar passos silenciosamente pulados.
+# Semantic checkpoint registry for edge-skill-step.
+#
+# CQRS/runtime owns lifecycle evidence: preflight, dispatch, exploration pack,
+# postflight, cycle close, and health/capability projections. This registry is
+# intentionally small and measures only the semantic responsibility of a skill.
+version: 2
+contract: semantic_checkpoints
+default_unregistered: optional
 
-ed-pesquisa:
-  - "1:Retomar estado"
-  - "2:Absorver contexto"
-  - "2.5:Busca semantica corpus"
-  - "3:Identificar alvo"
-  - "4:Pesquisar (ultrathink)"
-  - "4.5:Fontes externas"
-  - "4.7:Sanity check adversarial"
-  - "5:Salvar notas"
-  - "6:Break journal"
-  - "7:Blog + report HTML"
-  - "9:Relatorio usuario"
+runtime_owned_lifecycle:
+  - preflight
+  - dispatch
+  - async inbox capture
+  - corpus/workflow/health projections
+  - exploration pack
+  - publication/review gates
+  - postflight
+  - cycle close
 
-ed-descoberta:
-  - "0:Absorver contexto"
-  - "0.5:Busca semantica corpus"
-  - "1:Explorar"
-  - "2:Buscar fontes"
-  - "3:Pesquisar profundidade"
-  - "3.5:Sanity check adversarial"
-  - "4:Salvar notas"
-  - "5:Registrar descoberta"
-  - "6:Break journal"
-  - "7:Blog + report HTML"
-  - "9:Relatorio usuario"
+aliases:
+  research: ed-research
+  pesquisa: ed-research
+  ed-pesquisa: ed-research
+  discovery: ed-discovery
+  descoberta: ed-discovery
+  ed-descoberta: ed-discovery
+  strategy: ed-strategy
+  estrategia: ed-strategy
+  ed-estrategia: ed-strategy
+  autonomy: ed-autonomy
+  autonomia: ed-autonomy
+  ed-autonomia: ed-autonomy
+  report: ed-report
+  relatorio: ed-report
+  ed-relatorio: ed-report
+  planner: ed-planner
+  plan: ed-planner
+  planejar: ed-planner
+  ed-planejar: ed-planner
+  reflection: ed-reflection
+  reflexao: ed-reflection
+  ed-reflexao-HN: ed-reflection
+  ed-reflexao-M: ed-reflection
+  sources: ed-sources
+  fontes: ed-sources
+  heartbeat: ed-heartbeat
+  loader: ed-loader
+  map: ed-map
+  delta: ed-delta
 
-ed-lazer:
-  - "1:Retomar estado"
-  - "2:Absorver contexto"
-  - "2.5:Busca semantica corpus"
-  - "3:Escolher tema"
-  - "3.5:Buscar fontes"
-  - "4:Atividades livres"
-  - "4.5:Sanity check adversarial"
-  - "5:Salvar"
-  - "6:Break journal"
-  - "7:Blog + report HTML"
-  - "9:Relatorio usuario"
+skills:
+  ed-research:
+    - "scope:Define the research question, assumptions, and useful stopping point"
+    - "model:Build or revise the core explanation/mechanism"
+    - "evidence:Resolve important gaps with relevant evidence"
+    - "synthesis:Return conclusions, uncertainty, and next actions"
 
-ed-heartbeat:
-  - "0:Preflight"
-  - "1a:Ler sessoes"
-  - "1b:Chat assincrono"
-  - "1b2:Ler insights"
-  - "1c:Beats anteriores"
-  - "1d:Debugging.md"
-  - "1e:Contexto projeto"
-  - "1e2:Fios investigacao"
-  - "1f:Task ledger"
-  - "1g:Corpus check"
-  - "1.5:Classificar beat"
-  - "2:Despachar skill"
-  - "2.5:Sanity check"
-  - "3:Registrar"
+  ed-discovery:
+    - "direction:Choose a starting direction or friction to explore"
+    - "explore:Find a non-obvious tool, model, pattern, or analogy"
+    - "application:Explain what changes because of the discovery"
+    - "persistence:Record or route the discovery when it should affect future work"
 
-ed-reflexao-HN:
-  - "HN-1:Ler ops-hotspots"
-  - "HN-1b:Render log"
-  - "HN-2:Git archaeology"
-  - "HN-3:Crossref debugging"
-  - "HN-4:Divida usuario"
-  - "HN-5:State drift"
-  - "HN-6:Corpus probe"
+  ed-strategy:
+    - "state:Review active projects, claims, threads, and constraints"
+    - "classify:Classify work as move, block, merge, park, archive, or route"
+    - "decision:Produce an action queue with ownership and rationale"
+    - "handoff:Update or route the strategic digest when needed"
 
-ed-reflexao-M:
-  - "M-1:Full git archaeology"
-  - "M-2:Full ledger"
-  - "M-3:Debug crossref"
-  - "M-4:Curadoria"
-  - "M-5:Decisoes curadoria"
-  - "M-6:Feedback"
-  - "M-7:Descobertas"
-  - "M-8:Busca semantica"
-  - "M-9:Sanity check"
-  - "M-10:Atualizar arquivos"
-  - "M-11:Blog + relatorio"
+  ed-autonomy:
+    - "diagnosis:Identify a substrate capability, primitive, workflow, or friction gap"
+    - "decision:Classify each finding as act, probe, workflow, blocked, or route"
+    - "change:Apply or attempt reachable reversible substrate improvements"
+    - "verification:Read back evidence, residual risk, and next route"
 
-ed-estrategia:
-  - "1:Absorver contexto"
-  - "1.5:Consultar relatorios"
-  - "2:Analise por projeto"
-  - "3:Conexoes"
-  - "3.5:Buscar fontes"
-  - "4:Definir direcoes"
-  - "4.5:Sanity check adversarial"
-  - "5:Propor atualizacoes"
-  - "6:Blog + relatorio"
-  - "7b:Registrar observacoes"
-  - "8:Relatorio usuario"
+  ed-report:
+    - "scope:Define the report question, audience, and minimum useful evidence"
+    - "evidence:Gather enough evidence or examples for the report claim"
+    - "structure:Organize analysis into a durable report shape"
+    - "delivery:Produce the artifact or explain why a smaller answer is sufficient"
 
-ed-autonomia:
-  - "0:Ler estado"
-  - "0.5:Contexto operacional"
-  - "1:Diagnostico uso"
-  - "2:Identificar gaps"
-  - "3:Formular propostas"
-  - "3.5:Sanity check adversarial"
-  - "4:Registrar workflows"
-  - "5:Atualizar arquivos"
-  - "6:Blog + relatorio"
-  - "7:Relatorio usuario"
+  ed-planner:
+    - "target:Define project target, constraints, and success criteria"
+    - "decomposition:Break the work into executable phases or tasks"
+    - "risks:Name dependencies, risks, and validation gates"
+    - "handoff:Produce a proposal/action handoff without executing the plan"
 
-ed-relatorio:
-  - "1:Definir escopo"
-  - "2:Pesquisar"
-  - "2.5:Buscar fontes"
-  - "3:Estruturar YAML"
-  - "3.5:Sanity check adversarial"
-  - "4:Registrar blog"
-  - "5:Publicar HTML"
-  - "6:Verificar"
+  ed-reflection:
+    - "evidence:Inspect repeated failures, feedback, stale rules, or contradictory state"
+    - "diagnosis:Identify the operational lesson or root cause"
+    - "correction:Apply, route, archive, or monitor the correction explicitly"
+    - "learning:Persist the durable rule or no-op rationale in the right place"
 
-ed-planejar:
-  - "1:Definir escopo"
-  - "1.5:Consultar relatorios"
-  - "2:Absorver estado"
-  - "2.5:Buscar fontes"
-  - "3:Elaborar proposta"
-  - "3.5:Sanity check adversarial"
-  - "4:Registrar proposta"
-  - "5:Break journal"
-  - "6:Blog + relatorio"
-  - "8:Relatorio usuario"
+  ed-sources:
+    - "history:Inspect source/search/signal evidence or feedback"
+    - "assessment:Grade channel/query/workflow usefulness and failure modes"
+    - "curation:Merge, archive, repair, or add source workflows within the active limit"
+    - "verification:Verify the source surface or record why it remains blocked"
+
+  ed-heartbeat:
+    - "routing:Choose exactly one internal skill or explicit no-op route"
+    - "dispatch:Dispatch the selected skill through edge-dispatch"
+    - "stop:Stop without doing the selected skill's substantive work"
+
+  ed-loader:
+    - "briefing:Regenerate/read the current briefing or equivalent persisted summary"
+    - "inbox:Inspect loader-relevant operator input"
+    - "summary:Return compact current context and active threads"
+
+  ed-map:
+    - "nodes:Identify relevant internal nodes"
+    - "edges:Extract evidence-backed relationships and inferred links separately"
+    - "view:Surface paths, clusters, conflicts, duplicates, or gaps"
+    - "route:Route stale, missing, or strategic follow-up work"
+
+  ed-delta:
+    - "inputs:Load previous digest, raw chat, preflight state, events, and surfaces"
+    - "probe:Probe only surfaces needed to classify real deltas"
+    - "classify:Mark checked surfaces as delta, non_delta, or unverified"
+    - "frame:Produce delta_frame and persistence instructions for the owning skill"


### PR DESCRIPTION
## Summary

- Replaces the old ritual/lifecycle-heavy `skill-steps-registry.yaml` with a v2 semantic checkpoint contract.
- Renames canonical registry keys to current skill names like `ed-research`, `ed-discovery`, and `ed-autonomy`, while preserving old Portuguese aliases during migration.
- Updates `edge-skill-step` to read the structured registry, treat unregistered skills as optional while still emitting `SkillRunCompleted`, and count only registered semantic checkpoints for `silent_skips`.
- Updates shared skill/docs language and tests so lifecycle evidence stays owned by runtime/CQRS instead of the skill-step checklist.

Closes #383.

## Validation

- `python3 -m py_compile tools/edge-skill-step`
- `git diff --check`
- `bash tests/test_edge_skill_step.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_edge_runner.sh`

## Notes

Attempted dashboard runtime tests too, but this checkout has no blog venv and system Python lacks Flask:

- `bash tests/test_dashboard_runtime.sh` -> missing `blog/.venv/bin/python3`
- `EDGE_BLOG_VENV=/usr/bin/python3 bash tests/test_dashboard_runtime.sh` -> `ModuleNotFoundError: No module named 'flask'`
- same result for `tests/test_dashboard_runtime_interventions.sh`