### PR TITLE
[codex] Guard report publication and heartbeat handoff

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -16,8 +16,9 @@
 #   0.3 Adversarial review enforcement (edge-consult --gate; YAML or HTML)
 #   0.45 Feynman judge (YAML or HTML)
 #   0.5 Review gate (LLM-as-judge, content report only; YAML or HTML)
+#   0.9 Content report materialization before publish (mandatory — #245)
 #   1.  Blog entry (blog-publish.sh)
-#   2.  Content report (generate_report.py, mandatory — #245)
+#   2.  Content report indexing/confirmation
 #   3.  Verificação (API, frontmatter, files)
 #   3.4 LLM cost injection
 #   4.  Meta-report (state delta + scratchpad + adversarial → cognitive mirror)
@@ -241,6 +242,80 @@ NC='\033[0m'
 ok()   { echo -e "  ${GREEN}OK${NC}: $1"; }
 warn() { echo -e "  ${YELLOW}WARN${NC}: $1"; }
 fail() { echo -e "  ${RED}FAIL${NC}: $1"; }
+
+materialize_report_before_publish() {
+    if [[ -z "$REPORT_INPUT" ]]; then
+        REPORT_RESULT="skip"
+        return 0
+    fi
+    if [[ ! -f "$REPORT_INPUT" ]]; then
+        fail "Report not found: $REPORT_INPUT"
+        REPORT_RESULT="fail"
+        return 1
+    fi
+    if [[ -z "$REPORT_FILENAME" ]]; then
+        fail "Unsupported report format: $REPORT_INPUT"
+        REPORT_RESULT="fail"
+        return 1
+    fi
+
+    REPORT_HTML="$REPORTS_DIR/$REPORT_FILENAME"
+    mkdir -p "$REPORTS_DIR"
+
+    if [[ "$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.yml ]]; then
+        local render_output=""
+        echo "  Generating HTML from $(basename "$REPORT_INPUT") before publishing entry..."
+        if render_output=$(python3 "$TOOLS_DIR/generate_report.py" --yaml "$REPORT_INPUT" --output "$REPORT_HTML" 2>&1); then
+            [[ -n "$render_output" ]] && echo "$render_output"
+            ok "Report generated: $REPORT_FILENAME"
+            REPORT_RESULT="ok"
+            return 0
+        fi
+        [[ -n "$render_output" ]] && echo "$render_output"
+        fail "generate_report.py failed"
+        REPORT_RESULT="fail"
+        return 1
+    fi
+
+    if [[ "$REPORT_INPUT" == *.html ]]; then
+        if [[ "$(dirname "$REPORT_INPUT")" != "$REPORTS_DIR" ]]; then
+            cp "$REPORT_INPUT" "$REPORT_HTML"
+        fi
+        if [[ -f "$REPORT_HTML" ]]; then
+            ok "Report HTML: $REPORT_FILENAME"
+            REPORT_RESULT="ok"
+            return 0
+        fi
+        fail "Report HTML not found"
+        REPORT_RESULT="fail"
+        return 1
+    fi
+
+    fail "Unsupported report format: $REPORT_INPUT"
+    REPORT_RESULT="fail"
+    return 1
+}
+
+index_materialized_report() {
+    if [[ "$REPORT_RESULT" != "ok" || -z "$REPORT_HTML" || ! -f "$REPORT_HTML" ]]; then
+        fail "Report was not materialized before publish"
+        REPORT_RESULT="fail"
+        return 1
+    fi
+
+    ok "Report ready before publish: $REPORT_FILENAME"
+    echo "  Indexing report..."
+    if command -v edge-index &>/dev/null; then
+        if edge-index "$REPORT_HTML" 2>/dev/null; then
+            ok "Report indexed"
+        else
+            warn "edge-index returned error (non-fatal)"
+        fi
+    else
+        warn "edge-index not found"
+    fi
+    return 0
+}
 
 # Log pipeline failure to JSONL (bash phases)
 FAILURES_LOG="$LOGS_DIR/pipeline-failures.jsonl"
@@ -701,6 +776,21 @@ if suggestions:
     echo ""
 fi
 
+# ─── PHASE 0.9: Report materialization before publishing entry ───
+if [[ -n "$REPORT_INPUT" ]]; then
+    echo "── Phase 0.9: Report Materialization ──"
+    ledger_record "phase-0.9" "ok"
+    emit_run_step_event "phase-0.9" "started" "report_materialization" ""
+    if materialize_report_before_publish; then
+        emit_run_step_event "phase-0.9" "completed" "report_materialization" ""
+    else
+        log_failure "0.9" "report_materialization" "report materialization failed before blog publish"
+        emit_run_step_event "phase-0.9" "failed" "report_materialization" "report materialization failed before blog publish"
+        exit 1
+    fi
+    echo ""
+fi
+
 # ─── PHASE 1: Blog entry ───
 echo "── Phase 1: Blog Entry ──"
 ledger_record "phase-1" "ok"
@@ -720,50 +810,8 @@ if [[ -n "$REPORT_INPUT" ]]; then
     echo "── Phase 2: Report ──"
     emit_run_step_event "phase-2" "started" "report_generation" ""
 
-    if [[ ! -f "$REPORT_INPUT" ]]; then
-        fail "Report not found: $REPORT_INPUT"
-        REPORT_RESULT="fail"
-    elif [[ "$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.yml ]]; then
-        # Generate HTML from YAML
-        REPORT_HTML="$REPORTS_DIR/$REPORT_FILENAME"
-        echo "  Generating HTML from $(basename "$REPORT_INPUT")..."
-        if python3 "$TOOLS_DIR/generate_report.py" --yaml "$REPORT_INPUT" --output "$REPORT_HTML" 2>&1; then
-            ok "Report generated: $REPORT_FILENAME"
-            REPORT_RESULT="ok"
-        else
-            fail "generate_report.py failed"
-            REPORT_RESULT="fail"
-        fi
-    elif [[ "$REPORT_INPUT" == *.html ]]; then
-        # Pre-generated HTML — copy to reports dir if not already there
-        if [[ "$(dirname "$REPORT_INPUT")" != "$REPORTS_DIR" ]]; then
-            cp "$REPORT_INPUT" "$REPORTS_DIR/$REPORT_FILENAME"
-        fi
-        REPORT_HTML="$REPORTS_DIR/$REPORT_FILENAME"
-        if [[ -f "$REPORT_HTML" ]]; then
-            ok "Report HTML: $REPORT_FILENAME"
-            REPORT_RESULT="ok"
-        else
-            fail "Report HTML not found"
-            REPORT_RESULT="fail"
-        fi
-    else
-        warn "Unrecognized report format: $REPORT_INPUT"
-        REPORT_RESULT="fail"
-    fi
-
-    # Index report
-    if [[ "$REPORT_RESULT" == "ok" && -n "$REPORT_HTML" ]]; then
-        echo "  Indexing report..."
-        if command -v edge-index &>/dev/null; then
-            if edge-index "$REPORT_HTML" 2>/dev/null; then
-                ok "Report indexed"
-            else
-                warn "edge-index returned error (non-fatal)"
-            fi
-        else
-            warn "edge-index not found"
-        fi
+    if ! index_materialized_report; then
+        log_failure "2" "report_generation" "report was not materialized before publish"
     fi
     if [[ "$REPORT_RESULT" == "ok" ]]; then
         emit_run_step_event "phase-2" "completed" "report_generation" ""

--- a/tests/test_consolidate_phase6_paths.sh
+++ b/tests/test_consolidate_phase6_paths.sh
@@ -25,6 +25,11 @@ audit_use = first_index('if audit_path.exists():')
 non_git_diff_guard = first_index('skipping scoped diff')
 non_git_commit_guard = first_index('skipping git commit')
 partial_degraded = first_index('emit_run_step_event "pipeline" "degraded" "pipeline_end" "partial publication"')
+report_materialization = first_index('emit_run_step_event "phase-0.9" "started" "report_materialization"')
+blog_publish = first_index('emit_run_step_event "phase-1" "started" "blog_publish"')
+report_confirmation = first_index('emit_run_step_event "phase-2" "started" "report_generation"')
+materialize_function = first_index('materialize_report_before_publish()')
+index_function = first_index('index_materialized_report()')
 
 assert phase6_start < definition < first_use, (
     f"proposal_path must be defined before phase-6 allowlist use "
@@ -37,6 +42,12 @@ assert phase6_start < audit_definition < audit_use, (
 assert phase6_start < non_git_diff_guard, "non-git EDGE_REPO_DIR must skip scoped diff in phase 6"
 assert phase6_start < non_git_commit_guard, "non-git EDGE_REPO_DIR must skip git commit in phase 6"
 assert phase6_start < partial_degraded, "partial publication must be degraded, not a hard pipeline failure"
+assert materialize_function < report_materialization < blog_publish, (
+    "report materialization must happen before blog publish so entries cannot be published without reports"
+)
+assert index_function < report_confirmation and blog_publish < report_confirmation, (
+    "phase-2 should confirm/index the already materialized report after blog publish"
+)
 PY
 
 echo "PASS: consolidate-state phase-6 paths are initialized before use"

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -110,6 +110,24 @@ fi
 if [ "${MOCK_CLAUDE_HEARTBEAT_FLOW:-0}" = "1" ]; then
   if [[ "$PROMPT" == *"/ed-heartbeat"* ]]; then
     "${EDGE_REPO_DIR:?}/tools/edge-dispatch" dispatch --skill discovery >/dev/null
+    if [ "${MOCK_CLAUDE_HEARTBEAT_INLINE_DONE:-0}" = "1" ]; then
+      python3 - <<'PY'
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+path = Path(os.environ["EDGE_STATE_DIR"]) / "state" / "current-dispatch.json"
+state = json.loads(path.read_text(encoding="utf-8"))
+now = datetime.now(timezone.utc).isoformat()
+state_block = state.setdefault("state", {})
+state_block["postflight_status"] = "warning"
+state_block["postflight_reason"] = "inline_substantive_work"
+state_block["postflight_checked_at"] = now
+state_block["updated_at"] = now
+path.write_text(json.dumps(state, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+PY
+    fi
   elif [[ "$PROMPT" == *"/discovery"* ]]; then
     for step in direction explore application persistence; do
       "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery "$step" >/dev/null
@@ -259,6 +277,73 @@ then
     pass "heartbeat run dispatches and executes the follow-on skill before closing the cycle"
 else
     fail "heartbeat run dispatches and executes the follow-on skill before closing the cycle"
+fi
+
+echo "--- Test 1b: inline heartbeat work skips duplicate follow-on invocation ---"
+export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id-inline.txt"
+export MOCK_CLAUDE_ARGS_OUT="$TMP_BASE/args-inline.txt"
+rm -f "$MOCK_CLAUDE_ENV_OUT" "$MOCK_CLAUDE_ARGS_OUT"
+export MOCK_CLAUDE_HEARTBEAT_FLOW=1
+export MOCK_CLAUDE_HEARTBEAT_INLINE_DONE=1
+"$RUNNER_TOOL" skill \
+    --skill /ed-heartbeat \
+    --dispatch-trigger heartbeat \
+    --dispatch-policy autonomous \
+    --dispatch-routing-mode auto \
+    --dispatch-preflight-profile heartbeat_default \
+    --dispatch-postflight-profile standard \
+    --dispatch-force >/dev/null
+unset MOCK_CLAUDE_HEARTBEAT_INLINE_DONE || true
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$TMP_EDGE/logs/events.jsonl" "$TMP_BASE/cycle-id-inline.txt" "$TMP_BASE/args-inline.txt"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+run_events = [json.loads(line) for line in open(sys.argv[3], encoding="utf-8") if line.strip()]
+cycle_ids = [line.strip() for line in open(sys.argv[4], encoding="utf-8") if line.strip()]
+invocations = []
+current = []
+for raw_line in open(sys.argv[5], encoding="utf-8"):
+    line = raw_line.rstrip("\n")
+    if line == "__INVOCATION__":
+        current = []
+        continue
+    if line == "__END__":
+        invocations.append("\n".join(current))
+        current = []
+        continue
+    current.append(line)
+
+assert len(cycle_ids) == 1
+assert len(invocations) == 1
+assert "/ed-heartbeat" in invocations[0]
+assert dispatch["request"]["skill"] == "discovery"
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "completed"
+assert dispatch["state"]["postflight_status"] in {"completed", "warning"}
+completion_events = [
+    e for e in events
+    if e.get("type") == "SkillRunCompleted"
+    and e.get("cycle_id") == dispatch["cycle_id"]
+]
+assert completion_events
+assert completion_events[-1]["payload"]["skill"] == "discovery"
+handoff_events = [
+    e for e in run_events
+    if e.get("type") == "run_step"
+    and e.get("run_kind") == "edge-runner"
+    and e.get("phase") == "handoff"
+    and e.get("status") == "completed"
+    and e.get("close_reason") == "follow_on_already_progressed"
+]
+assert handoff_events
+PY
+then
+    pass "inline heartbeat work skips duplicate follow-on invocation"
+else
+    fail "inline heartbeat work skips duplicate follow-on invocation"
 fi
 
 echo "--- Test 2: success without skill completion evidence closes as failed ---"

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -467,6 +467,31 @@ def dispatched_follow_on_skill(args: argparse.Namespace, cycle_id: str | None) -
     return dispatched_skill
 
 
+def cycle_progressed_beyond_router(cycle_id: str | None) -> bool:
+    """Return true when the heartbeat backend already did substantive work.
+
+    Heartbeat is supposed to route only, but the model can still execute the
+    dispatched skill inline. If postflight or close state already exists after
+    the heartbeat backend returns, starting the follow-on skill again would
+    duplicate publication in the same cycle.
+    """
+    if not cycle_id:
+        return False
+    state = dispatch_state_matches(cycle_id)
+    if not state:
+        return False
+    state_block = state.get("state", {}) or {}
+    postflight_status = str(state_block.get("postflight_status") or "").strip().lower()
+    close_status = str(state_block.get("close_status") or "").strip().lower()
+    if postflight_status and postflight_status != "pending":
+        return True
+    if close_status:
+        return True
+    if state_block.get("active") is False:
+        return True
+    return False
+
+
 def make_follow_on_skill_args(args: argparse.Namespace, skill_name: str) -> argparse.Namespace:
     follow_on = argparse.Namespace(**vars(args))
     follow_on.skill = f"/{normalize_skill_name(skill_name)}"
@@ -672,35 +697,49 @@ def main() -> int:
 
         follow_on_skill = dispatched_follow_on_skill(args, cycle_id)
         if follow_on_skill and exit_code == 0:
-            maybe_run_exploration(args, env, cycle_id, follow_on_skill)
-            maybe_run_autonomy_primitive_checkup(args, env, cycle_id, follow_on_skill)
-            log_run_step(
-                "edge-runner",
-                "handoff",
-                "started",
-                run_id=cycle_id,
-                backend=args.backend,
-                mode=args.cmd,
-                target=follow_on_skill,
-            )
-            follow_on_args = make_follow_on_skill_args(args, follow_on_skill)
-            follow_on_exit = invoke_backend(follow_on_args, env, cycle_id=cycle_id)
-            maybe_mark_skill_completion(follow_on_skill, cycle_id, follow_on_exit)
-            final_status = "completed" if follow_on_exit == 0 else "failed"
-            log_run_step(
-                "edge-runner",
-                "handoff",
-                final_status,
-                run_id=cycle_id,
-                backend=args.backend,
-                mode="skill",
-                target=follow_on_skill,
-                exit_code=follow_on_exit,
-            )
-            if follow_on_exit != 0:
-                exit_code = follow_on_exit
-                close_status = "failed"
-                close_reason = f"dispatched_backend_exit_{follow_on_exit}"
+            if cycle_progressed_beyond_router(cycle_id):
+                maybe_mark_skill_completion(follow_on_skill, cycle_id, 0)
+                log_run_step(
+                    "edge-runner",
+                    "handoff",
+                    "completed",
+                    run_id=cycle_id,
+                    backend=args.backend,
+                    mode="skill",
+                    target=follow_on_skill,
+                    exit_code=0,
+                    close_reason="follow_on_already_progressed",
+                )
+            else:
+                maybe_run_exploration(args, env, cycle_id, follow_on_skill)
+                maybe_run_autonomy_primitive_checkup(args, env, cycle_id, follow_on_skill)
+                log_run_step(
+                    "edge-runner",
+                    "handoff",
+                    "started",
+                    run_id=cycle_id,
+                    backend=args.backend,
+                    mode=args.cmd,
+                    target=follow_on_skill,
+                )
+                follow_on_args = make_follow_on_skill_args(args, follow_on_skill)
+                follow_on_exit = invoke_backend(follow_on_args, env, cycle_id=cycle_id)
+                maybe_mark_skill_completion(follow_on_skill, cycle_id, follow_on_exit)
+                final_status = "completed" if follow_on_exit == 0 else "failed"
+                log_run_step(
+                    "edge-runner",
+                    "handoff",
+                    final_status,
+                    run_id=cycle_id,
+                    backend=args.backend,
+                    mode="skill",
+                    target=follow_on_skill,
+                    exit_code=follow_on_exit,
+                )
+                if follow_on_exit != 0:
+                    exit_code = follow_on_exit
+                    close_status = "failed"
+                    close_reason = f"dispatched_backend_exit_{follow_on_exit}"
         if exit_code != 0:
             close_status = "failed"
             close_reason = close_reason or f"backend_exit_{exit_code}"


### PR DESCRIPTION
## Summary

- Materialize mandatory content reports before publishing blog entries in `consolidate-state`.
- Change report phase 2 to confirm/index the already materialized report instead of generating it after publication.
- Guard `edge-runner` heartbeat handoff so a follow-on skill is not executed again when the heartbeat backend already advanced postflight/close state.
- Add regression coverage for report-before-blog ordering and inline heartbeat work.

## Root Cause

A content report could fail during phase 2 after phase 1 had already published the blog entry, leaving a blog-only artifact. Separately, a heartbeat backend could do substantive follow-on work inline; the runner then interpreted the dispatch as still pending and attempted the follow-on again.

## Validation

- `tests/test_edge_runner.sh`
- `tests/test_consolidate_phase6_paths.sh`
- `tests/test_consolidate_adversarial_phase.sh`
- `git diff --check HEAD~1 HEAD`