### PR TITLE
[codex] Make bare report infer scope

### DIFF
--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -41,6 +41,26 @@ Before researching or writing, answer:
 
 If user-invoked, the request provides the scope. If self-invoked, state why the report is being generated.
 
+### Bare Invocation / Missing Scope
+
+A bare `/ed-report` dispatch is already authorization to choose a useful
+report target. Do not end the skill by asking the operator what topic to use
+when runtime context contains enough signal to proceed.
+
+If no explicit topic, question, or args are present:
+
+1. Inspect the injected runtime frame: `delta_prerequisite`,
+   `beat_launch_context`, `operator_pressure_digest`, `health_snapshot`,
+   `claims_summary`, `exploration_pack`, recent pipeline failures, and current
+   git/runtime drift.
+2. Select the highest-leverage report target that would reduce operator
+   uncertainty or make the next engineering action clear.
+3. State the inferred target and why it was selected.
+4. Produce the report artifact.
+
+Ask the operator for a topic only when the runtime frame contains no reasonable
+candidate and any inferred report would be misleading. That should be rare.
+
 ### 2. Gather Evidence
 
 Use the right sources for the topic:

--- a/tests/test_report_skill_contract.sh
+++ b/tests/test_report_skill_contract.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL="$EDGE_DIR/skills/report/SKILL.md"
+
+echo "=== report skill contract ==="
+
+python3 - <<'PY' "$SKILL"
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+
+required = [
+    "Bare Invocation / Missing Scope",
+    "A bare `/ed-report` dispatch is already authorization to choose a useful",
+    "Do not end the skill by asking the operator what topic to use",
+    "If no explicit topic, question, or args are present:",
+    "`delta_prerequisite`",
+    "`beat_launch_context`",
+    "`operator_pressure_digest`",
+    "`health_snapshot`",
+    "`claims_summary`",
+    "`exploration_pack`",
+    "Select the highest-leverage report target",
+    "State the inferred target and why it was selected.",
+    "Produce the report artifact.",
+    "Ask the operator for a topic only when the runtime frame contains no reasonable",
+]
+for needle in required:
+    assert needle in text, needle
+PY
+
+echo "PASS: bare /ed-report must infer scope before asking"


### PR DESCRIPTION
## Summary

- Clarify the `ed-report` contract for bare `/ed-report` dispatches.
- Require the skill to infer a useful report target from runtime context instead of ending by asking for a topic when enough signal exists.
- Add a static contract test for the missing-scope behavior.

## Root Cause

During the Ed feedback loop, a bare `/ed-report` cycle closed mechanically but produced no artifact because the skill asked the operator to choose a topic. That violates autonomous operator-dispatch behavior for this loop.

## Validation

- `tests/test_report_skill_contract.sh`