### PR TITLE
[codex] Bound review-gate router calls

### DIFF
--- a/tests/test_review_gate_timeout_contract.sh
+++ b/tests/test_review_gate_timeout_contract.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d /tmp/edge-review-gate-timeout-XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat >"$TMP_DIR/spec.yaml" <<'YAML'
+title: "Timeout contract"
+date: "2026-05-01"
+executive_summary: "Validate bounded review-gate router calls"
+sections:
+  - title: "linhagem"
+    content: "test"
+  - title: "O que Nao Sei"
+    content: "test"
+  - title: "glossario"
+    content: "test"
+YAML
+
+python3 - <<'PY' "$EDGE_DIR" "$TMP_DIR/spec.yaml"
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+edge_dir = Path(sys.argv[1])
+spec_path = Path(sys.argv[2])
+module_path = edge_dir / "tools" / "review-gate.py"
+
+spec = importlib.util.spec_from_file_location("review_gate_timeout_contract", module_path)
+review_gate = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(review_gate)
+
+calls = []
+
+
+class FakeUsage:
+    prompt_tokens = 7
+    completion_tokens = 11
+    total_tokens = 18
+
+
+class FakeChatCompletions:
+    def create(self, **kwargs):
+        if kwargs.get("response_format") == {"type": "json_object"}:
+            content = json.dumps(
+                {
+                    "dimensions": {
+                        name: {"score": 4, "feedback": "ok"}
+                        for name in review_gate.DIMENSIONS
+                    },
+                    "critical_issues": [],
+                    "suggestions": [],
+                }
+            )
+        elif kwargs.get("tools"):
+            content = json.dumps({"enrichments": []})
+        else:
+            content = spec_path.read_text(encoding="utf-8")
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content, tool_calls=None))],
+            usage=FakeUsage(),
+        )
+
+
+class FakeClient:
+    chat = SimpleNamespace(completions=FakeChatCompletions())
+
+
+def fake_make_client(**kwargs):
+    calls.append(kwargs)
+    return FakeClient(), "gpt-5.4"
+
+
+review_gate.make_client = fake_make_client
+
+review_gate.coauthor(str(spec_path))
+review_gate.review(str(spec_path))
+review_gate.refine(
+    str(spec_path),
+    {
+        "overall": 4,
+        "dimensions": {},
+        "critical_issues": [],
+        "suggestions": [],
+    },
+)
+
+assert len(calls) == 3, calls
+for call in calls:
+    assert call["timeout"] == review_gate.REVIEW_GATE_LLM_TIMEOUT, call
+    assert call["max_retries"] == 0, call
+
+print("PASS: review-gate router calls are timeout-bounded and non-retrying")
+PY

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -49,6 +49,7 @@ GROK_MODEL = "grok-4.20-multi-agent-beta-0309"
 # config/runtime-routers.yaml routers.<purpose>.model — respecting per-agent configuration (Azure, OpenAI,
 # xAI, etc.) instead of hardcoding a model slug.
 DEFAULT_PURPOSE = "chat"
+REVIEW_GATE_LLM_TIMEOUT = int(os.environ.get("EDGE_REVIEW_GATE_LLM_TIMEOUT_SEC", "120"))
 
 # Models that require the Responses API instead of Chat Completions
 RESPONSES_API_MODELS = {GROK_MODEL, "gpt-5.4-pro"}
@@ -546,7 +547,12 @@ def coauthor(yaml_path: str, skill: str = None, model: str = None,
              purpose: str = DEFAULT_PURPOSE,
              entry_path: str = None, brief: str = None) -> dict:
     """Run co-author phase with tool use. Returns enrichment suggestions."""
-    client, model = make_client(purpose=purpose, model=model)
+    client, model = make_client(
+        purpose=purpose,
+        model=model,
+        timeout=REVIEW_GATE_LLM_TIMEOUT,
+        max_retries=0,
+    )
 
     yaml_content = Path(yaml_path).read_text(encoding="utf-8")
 
@@ -697,7 +703,12 @@ def review(yaml_path: str, skill: str = None, model: str = None,
            threshold: float = 3.0, entry_path: str = None) -> dict:
     """Run review phase. Returns structured feedback dict."""
     try:
-        client, model = make_client(purpose=purpose, model=model)
+        client, model = make_client(
+            purpose=purpose,
+            model=model,
+            timeout=REVIEW_GATE_LLM_TIMEOUT,
+            max_retries=0,
+        )
     except Exception as e:
         raise RuntimeError(f"router setup failed for purpose={purpose} model={model}: {e}") from e
 
@@ -803,7 +814,12 @@ def review(yaml_path: str, skill: str = None, model: str = None,
 def refine(yaml_path: str, review_result: dict, model: str = None,
            purpose: str = DEFAULT_PURPOSE) -> dict:
     """Apply reviewer feedback to YAML. Rewrites the file in-place. Returns metadata."""
-    client, model = make_client(purpose=purpose, model=model)
+    client, model = make_client(
+        purpose=purpose,
+        model=model,
+        timeout=REVIEW_GATE_LLM_TIMEOUT,
+        max_retries=0,
+    )
 
     yaml_content = Path(yaml_path).read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- Add an explicit `EDGE_REVIEW_GATE_LLM_TIMEOUT_SEC`-controlled timeout for `review-gate` LLM calls.
- Disable provider retries in the coauthor, review, and refine phases so quota/rate failures degrade quickly to the existing fallback path.
- Add a contract test that asserts all three review-gate phases call the router with timeout bounds and `max_retries=0`.

## Root Cause

During the Ed `/ed-report` feedback loop, `review-gate` waited about 602s before surfacing an OpenAI quota failure because it created router clients without an explicit timeout or retry policy. `edge-consult` already has hard timeouts; `review-gate` did not.

## Validation

- `tests/test_review_gate_timeout_contract.sh`
- `bash tests/test_runtime_router_config.sh`
- `python3 -m py_compile tools/review-gate.py`