### PR TITLE
[codex] Allow notes on gap tables

### DIFF
--- a/tools/test_yaml_to_html.py
+++ b/tools/test_yaml_to_html.py
@@ -589,6 +589,17 @@ class TestGapTable:
         assert_renders(block, "Gap one", "Gap two", "ABERTO", "RESOLVIDO")
         assert_validates_clean(block)
 
+    def test_with_note(self):
+        block = {
+            "type": "gap-table",
+            "gaps": [
+                {"id": 1, "description": "Gap one", "need": "Data", "status": "open"},
+            ],
+            "note": "This table records validation gaps.",
+        }
+        assert_renders(block, "Gap one", "This table records validation gaps")
+        assert_validates_clean(block)
+
     def test_table_fallback(self):
         """gap-table with headers/rows delegates to table renderer."""
         block = {

--- a/tools/yaml_to_html.py
+++ b/tools/yaml_to_html.py
@@ -790,6 +790,8 @@ def render_gap_table(b):
         parts.append(f'<td><span class="{cls}">{html.escape(status.upper())}</span></td>')
         parts.append('</tr>')
     parts.append('</tbody></table></div>')
+    if b.get("note"):
+        parts.append(f'<p class="chart-note">{render_text(b["note"])}</p>')
     return "\n".join(parts)
 
 
@@ -1022,7 +1024,7 @@ BLOCK_SCHEMAS = {
     },
     "gap-table": {
         "required": [],
-        "optional": ["gaps", "headers", "rows"],
+        "optional": ["gaps", "headers", "rows", "note"],
         "synonyms": {},
         "container_field": ("gaps", "headers"),
     },


### PR DESCRIPTION
## Summary

- Allow `note` on `gap-table` blocks in the YAML renderer schema.
- Render the note below the gap table using the existing chart-note styling.
- Add coverage for `gap-table` notes.

## Root Cause

The Ed `/ed-report` feedback loop generated a valid-looking `gap-table` with a top-level `note`, but `yaml_to_html` treated that field as an unknown typo and blocked report materialization before blog publish.

## Validation

- `python3 tools/generate_report.py --yaml /tmp/spec-report-pressure-classifier-noise-diagnosis.yaml --output /tmp/test-pressure-classifier.html`
- `python3 -m py_compile tools/yaml_to_html.py tools/generate_report.py`
- Inline Python check: `gap-table` with `note` renders without `ERRO bloco`

Note: `python3 tools/test_yaml_to_html.py` could not run in this environment because `pytest` is not installed, but the new assertion was exercised directly with the inline check above.