### PR TITLE
[codex] fix consolidate zero render errors

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -868,7 +868,7 @@ fi
 if [[ -n "$REPORT_HTML" && "$REPORT_RESULT" == "ok" ]]; then
     if [[ -f "$REPORT_HTML" ]]; then
         SIZE=$(du -h "$REPORT_HTML" | cut -f1)
-        RENDER_ERRORS=$(grep -c 'ERRO bloco' "$REPORT_HTML" 2>/dev/null)
+        RENDER_ERRORS=$(grep -c 'ERRO bloco' "$REPORT_HTML" 2>/dev/null || true)
         RENDER_ERRORS=${RENDER_ERRORS:-0}
         if [[ "$RENDER_ERRORS" -gt 0 ]]; then
             fail "Report has $RENDER_ERRORS render error(s). Fix the YAML and regenerate."

--- a/tests/test_consolidate_phase6_paths.sh
+++ b/tests/test_consolidate_phase6_paths.sh
@@ -28,6 +28,7 @@ partial_degraded = first_index('emit_run_step_event "pipeline" "degraded" "pipel
 report_materialization = first_index('emit_run_step_event "phase-0.9" "started" "report_materialization"')
 blog_publish = first_index('emit_run_step_event "phase-1" "started" "blog_publish"')
 report_confirmation = first_index('emit_run_step_event "phase-2" "started" "report_generation"')
+render_error_count = first_index("RENDER_ERRORS=$(grep -c 'ERRO bloco' \"$REPORT_HTML\" 2>/dev/null || true)")
 materialize_function = first_index('materialize_report_before_publish()')
 index_function = first_index('index_materialized_report()')
 
@@ -47,6 +48,9 @@ assert materialize_function < report_materialization < blog_publish, (
 )
 assert index_function < report_confirmation and blog_publish < report_confirmation, (
     "phase-2 should confirm/index the already materialized report after blog publish"
+)
+assert report_confirmation < render_error_count, (
+    "render-error counting must tolerate zero matches under set -e during phase-3 verification"
 )
 PY
 


### PR DESCRIPTION
## Summary

Fix `consolidate-state` phase 3 so a clean HTML report with zero `ERRO bloco` matches does not abort under `set -e`.

## Root Cause

`grep -c` prints `0` when there are no matches, but exits with status 1. Because the command ran inside an assignment while `set -e` was active, phase 3 exited before recording verification completion and before reaching the meta-report/publish terminal events.

## Validation

- `tests/test_consolidate_phase6_paths.sh`
- `bash -n blog/consolidate-state.sh`