### PR TITLE
[codex] make report review gates single-owner

### DIFF
--- a/skills/_shared/report-template.md
+++ b/skills/_shared/report-template.md
@@ -52,6 +52,13 @@ with Lineage, Gaps, Glossary, Bibliography, ≥1 SVG all MANDATORY.
    entry without a YAML spec skips Phase 2 (content report), producing no
    HTML. That path is forbidden by the uniform rite.
 
+   **Single review owner:** do not run standalone `edge-consult` or
+   `review-gate` before this command during the normal publication path.
+   `consolidate-state` owns the mandatory adversarial, Feynman, review-gate,
+   publication, meta-report, and state-commit phases. If a gate blocks, address
+   the emitted feedback and rerun `consolidate-state`; do not build a parallel
+   pre-publication review loop in the skill backend.
+
    Useful flags: `--scratchpad PATH`, `--reason TEXT`
    (Enforcement #218: bypass flags `--skip-review`, `--no-adversarial`, `--no-meta` were removed — all phases run unconditionally.)
 6. **Read meta-report** (`~/edge/meta-reports/<slug>-meta.md`) BEFORE editing status
@@ -181,46 +188,30 @@ SVG is not just for numbers — any information that communicates better as an i
 
 ---
 
-## Adversarial Sanity Check (edge-consult — MANDATORY in EVERY skill)
+## Review Ownership (MANDATORY)
 
-BEFORE generating the report YAML, submit the conclusions/recommendations to `edge-consult` for cross-model deliberation. GPT-5.4 (different model from the author) finds flaws, biases, weak premises.
+`consolidate-state` is the single owner of publication review. It runs:
 
-```bash
-# Adversarial (default) — synthesize conclusions in 2-3 sentences
-edge-consult "Summary: [conclusions]. Where is this reasoning weakest?" --context /tmp/spec.yaml
+- Phase 0.3: adversarial review;
+- Phase 0.45: Feynman judge;
+- Phase 0.5: review gate;
+- Phase 1-6: publication, report materialization, verification, meta-report,
+  state commit, audit, and git trail.
 
-# Collaborative (when stuck on direction)
-edge-consult --mode collab "I'm stuck on X, what angles to explore?"
-```
+Do not call `edge-consult` or `review-gate` manually before publishing in the
+normal skill backend. Manual review calls are allowed only for a genuinely
+decision-blocking research question, and their output must be summarized
+compactly rather than pasted into the prompt. Routine report quality gates
+belong to `consolidate-state`.
 
-**Response protocol:**
-1. Read the critique honestly
-2. If the argument is valid → adjust conclusions/YAML
-3. If maintaining position → record in the report as `callout` variant=info: "Sanity check GPT-5.4: [objection]. Response: [why I maintain my position]."
-
-**In the report:** include a block showing what was challenged and how you responded. Tested conviction > unchallenged conviction.
-
-**Cost:** ~$0.02/query. **Log:** ~/edge/logs/consult/ (for /ed-reflection to review).
+If `consolidate-state` blocks on review feedback, fix the specific YAML issues
+it reports and rerun `consolidate-state`. Do not regenerate the whole report
+or run a second standalone review loop unless the gate explicitly needs a new
+draft.
 
 ---
 
 ## Post-Report Steps (MANDATORY)
-
-### Review Gate (LLM-as-judge — RUN BEFORE publishing)
-
-Before calling `consolidate-state`, run the review gate for semantic validation:
-
-```bash
-# Standalone review (refinement loop)
-review-gate /tmp/spec-[skill]-[slug].yaml --skill [skill]
-
-# If FAIL: adjust YAML based on feedback, re-run until PASS
-# If PASS: publish
-```
-
-The review gate evaluates structural completeness, content depth, storytelling, Feynman reasoning, writing quality, visualization, intellectual honesty, internal consistency, and didactic clarity via the configured review router. Cost depends on the configured provider. Threshold: 3.5/5.
-
-**IMPORTANT:** `consolidate-state` runs the review gate automatically (Phase 0.5). If the YAML doesn't pass, publication is blocked — fix the YAML and re-run. (Enforcement #218: there is no bypass flag anymore — address the feedback.)
 
 ### Validation Gate (DO NOT SKIP)
 

--- a/skills/_shared/workflow-conventions.md
+++ b/skills/_shared/workflow-conventions.md
@@ -20,12 +20,12 @@ A workflow is a normal blog entry with `workflow` in the tags. edge-search detec
 
 ```yaml
 ---
-title: "workflow: sources → research → consult → report"
+title: "workflow: sources → research → report pipeline"
 date: 2026-03-24
-tags: [workflow, research, sources, edge-consult]
-keywords: [edge-sources, ed-research, edge-consult, exa, openai, pipeline]
+tags: [workflow, research, sources, consolidate-state]
+keywords: [edge-sources, ed-research, consolidate-state, exa, pipeline]
 claims:
-  - "Combining sources + consult before the report improves output quality"
+  - "Combining source lookup with the consolidate-state report pipeline improves output quality without duplicating review loops"
 secrets: [exa.env, openai.env]
 cost_estimate: "~$0.15/execution"
 ---
@@ -36,12 +36,12 @@ Heartbeat identifies relevant topic, or user requests /ed-research.
 ## Steps
 1. `edge-sources "topic" --intent research` → source collection (Exa + X + HN)
 2. LLM curation → filter signal from noise
-3. `edge-consult` → adversarial review of draft (GPT-5.4)
-4. Blog entry + HTML report
+3. Draft YAML spec + light blog entry
+4. `consolidate-state` → adversarial/Feynman/review gates + blog entry + HTML report + meta-report
 
 ## Secrets
 - `exa.env` — semantic search in step 1
-- `openai.env` — adversarial review in step 3
+- `openai.env` — review gates inside `consolidate-state`
 
 ## When it works
 Technical-scientific topics with good coverage in sources.
@@ -124,7 +124,7 @@ Beyond workflow-specific fields, **every blog entry** (research, discovery, stra
 
 ```yaml
 procedure:
-  - "When researching a new topic, run edge-sources BEFORE edge-consult -- external context strengthens adversarial review"
+  - "When researching a new topic, run edge-sources BEFORE drafting the report -- external context strengthens the report and the consolidate-state gates"
   - "When review-gate scores below threshold, fix section titles and inline acronyms first -- cheapest structural points"
   - "!When edge-search returns empty for workflows, log it as evidence the system needs seeding"
 ```
@@ -156,9 +156,9 @@ claims:
 threads: [agent-security]
 procedure:
   - "When researching a new topic, search internal corpus first (edge-search) -- prevents rediscovery"
-  - "When edge-consult returns valid criticism, adjust conclusions BEFORE building report YAML -- retrofitting is harder"
+  - "When consolidate-state returns valid gate criticism, adjust conclusions in the YAML before rerunning -- retrofitting is harder"
   - "!When review-gate fails, do NOT regenerate entire YAML -- fix specific issues for cheaper recovery"
-workflows_used: [sources-research-consult-report]
+workflows_used: [sources-research-report-pipeline]
 workflows_broken: [playwright-screenshot-validation]
 ---
 ```

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -25,6 +25,11 @@ If the answer fits cleanly in a few paragraphs, do not inflate it into a report.
 ## Boundary
 
 Do not manage lifecycle, publication, postflight, adversarial review, or generic artifact rites inside this skill.
+Do not call `edge-consult` or `review-gate` manually as part of the normal report path.
+Draft the YAML and staging entry, then let `consolidate-state` own the adversarial,
+Feynman, review-gate, publication, meta-report, and post-state phases. If
+`consolidate-state` blocks on feedback, address that feedback and rerun the
+pipeline; do not create a separate pre-publication review loop inside this skill.
 
 Follow the shared source lookup protocol when external evidence, current information, examples, papers, repositories, or public discussion are relevant.
 

--- a/tests/test_report_review_ownership.sh
+++ b/tests/test_report_review_ownership.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPORT_SKILL="$EDGE_DIR/skills/report/SKILL.md"
+TEMPLATE="$EDGE_DIR/skills/_shared/report-template.md"
+WORKFLOWS="$EDGE_DIR/skills/_shared/workflow-conventions.md"
+EDGE_APPLY="$EDGE_DIR/tools/edge-apply"
+
+echo "=== report review ownership contract test ==="
+
+grep -q "Do not call \`edge-consult\` or \`review-gate\` manually" "$REPORT_SKILL"
+grep -q "Single review owner" "$TEMPLATE"
+grep -q "consolidate-state.*single owner of publication review" "$TEMPLATE"
+grep -q "Do not call \`edge-consult\` or \`review-gate\` manually before publishing" "$TEMPLATE"
+
+if grep -q "BEFORE generating the report YAML, submit" "$TEMPLATE"; then
+  echo "FAIL: report template still asks skills to run standalone edge-consult before YAML" >&2
+  exit 1
+fi
+
+if grep -q "review-gate /tmp/spec" "$TEMPLATE"; then
+  echo "FAIL: report template still asks skills to run standalone review-gate" >&2
+  exit 1
+fi
+
+if grep -q "edge-consult.*adversarial review of draft" "$WORKFLOWS"; then
+  echo "FAIL: workflow conventions still duplicate adversarial review before consolidate-state" >&2
+  exit 1
+fi
+
+grep -q "consolidate-state.*adversarial/Feynman/review gates" "$WORKFLOWS"
+grep -q "consolidate-state.*adversarial/Feynman/review gates" "$EDGE_APPLY"
+
+echo "ALL TESTS PASSED"

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -1846,9 +1846,9 @@ Threads should be concrete workstreams (e.g. 'competitive-landscape', 'positioni
     workflow_entries = [
         {
             "slug": "workflow-research-pipeline",
-            "title": "workflow: sources → consult → report",
-            "tags": ["workflow", "research", "sources", "edge-consult"],
-            "keywords": ["edge-sources", "edge-consult", "research", "pipeline"],
+            "title": "workflow: sources → research → report pipeline",
+            "tags": ["workflow", "research", "sources", "consolidate-state"],
+            "keywords": ["edge-sources", "consolidate-state", "research", "pipeline"],
             "secrets": ["openai.env"],
             "cost_estimate": "~$0.15/execution",
             "body": (
@@ -1857,10 +1857,10 @@ Threads should be concrete workstreams (e.g. 'competitive-landscape', 'positioni
                 "## Steps\n"
                 '1. `edge-sources "topic" --intent research` → source collection\n'
                 "2. LLM curation → filter signal from noise\n"
-                "3. `edge-consult` → adversarial review of draft\n"
-                "4. Blog entry + HTML report via `consolidate-state`\n\n"
+                "3. Draft YAML spec + light blog entry\n"
+                "4. `consolidate-state` → adversarial/Feynman/review gates + blog entry + HTML report + meta-report\n\n"
                 "## Secrets\n"
-                "- `openai.env` — adversarial review in step 3\n\n"
+                "- `openai.env` — review gates inside `consolidate-state`\n\n"
                 "## When it works\n"
                 "Technical-scientific topics with good coverage in sources.\n\n"
                 "## When it fails\n"
@@ -1871,21 +1871,21 @@ Threads should be concrete workstreams (e.g. 'competitive-landscape', 'positioni
         },
         {
             "slug": "workflow-adversarial-review",
-            "title": "workflow: adversarial review before publishing",
-            "tags": ["workflow", "quality", "edge-consult", "review-gate"],
-            "keywords": ["edge-consult", "review-gate", "adversarial", "quality"],
+            "title": "workflow: consolidate-state review gates before publishing",
+            "tags": ["workflow", "quality", "consolidate-state", "review-gate"],
+            "keywords": ["consolidate-state", "review-gate", "adversarial", "quality"],
             "secrets": ["openai.env"],
             "cost_estimate": "~$0.10/execution",
             "body": (
                 "## Trigger\n"
-                "Every blog entry and report before publication.\n\n"
+                "Every blog entry and report before publication, via `consolidate-state`.\n\n"
                 "## Steps\n"
                 "1. Draft blog entry with claims, threads, procedures\n"
-                "2. `edge-consult` with entry content → adversarial critique\n"
-                "3. If valid criticism found → adjust conclusions before building report\n"
-                "4. Build report YAML → `consolidate-state` publishes\n\n"
+                "2. Draft report YAML\n"
+                "3. `consolidate-state` runs adversarial/Feynman/review gates\n"
+                "4. Address valid gate critique and rerun `consolidate-state` if blocked\n\n"
                 "## Secrets\n"
-                "- `openai.env` — adversarial model (GPT)\n\n"
+                "- `openai.env` — review models used by `consolidate-state`\n\n"
                 "## When it works\n"
                 "Always. The adversarial catch rate justifies the cost.\n\n"
                 "## When it fails\n"


### PR DESCRIPTION
## Summary

Make `consolidate-state` the single owner of report publication review gates.

## Root Cause

`skills/report/SKILL.md` told `/ed-report` not to manage lifecycle or adversarial review, but the shared report template and workflow seeds still instructed skills to run standalone `edge-consult` and `review-gate` before publication. In the runtime loop, `/ed-report` followed those older instructions, expanded context with a manual adversarial review, and the Claude backend failed with `API Error: Stream idle timeout - partial response received` before publication.

## What Changed

- Clarified `ed-report` must not call `edge-consult` or `review-gate` manually on the normal path.
- Replaced the shared standalone review loop instructions with a `consolidate-state` ownership section.
- Updated workflow conventions and `edge-apply` seeded workflows to route review through `consolidate-state`.
- Added a contract test for report review ownership.

## Validation

- `tests/test_report_review_ownership.sh`
- `tests/test_blog_entry_voice_contract.sh`
- `python3 -m py_compile tools/edge-apply`