### PR TITLE
[codex] Require ed-report publication completion

### DIFF
--- a/skills/_shared/report-template.md
+++ b/skills/_shared/report-template.md
@@ -52,6 +52,14 @@ with Lineage, Gaps, Glossary, Bibliography, ≥1 SVG all MANDATORY.
    entry without a YAML spec skips Phase 2 (content report), producing no
    HTML. That path is forbidden by the uniform rite.
 
+   **Staging is not completion.** A skill invocation must not close with only
+   `/tmp/spec-*` and `/tmp/entry-*` files. Do not ask the operator whether to
+   publish, recommend a later `consolidate-state` run as the final answer, or
+   hand off because older drafts are blocked. Run `consolidate-state` in this
+   invocation, fix gate feedback if it blocks, and verify the generated report.
+   If publication cannot complete, report the concrete failing command and
+   failure reason rather than presenting the run as successful.
+
    **Single review owner:** do not run standalone `edge-consult` or
    `review-gate` before this command during the normal publication path.
    `consolidate-state` owns the mandatory adversarial, Feynman, review-gate,

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -31,6 +31,16 @@ Feynman, review-gate, publication, meta-report, and post-state phases. If
 `consolidate-state` blocks on feedback, address that feedback and rerun the
 pipeline; do not create a separate pre-publication review loop inside this skill.
 
+Publishing is not optional once `/ed-report` has chosen a topic. Files staged in
+`/tmp` are drafts, not the report artifact. Do not close by asking the operator
+whether to publish, by recommending a future `consolidate-state` run, or by
+handing off because earlier drafts are blocked. Prior blocked drafts are evidence
+for the report and may justify a tighter scope, but they do not authorize a
+staging-only exit. The skill is complete only after `consolidate-state` succeeds
+and the generated HTML report, blog entry, and meta-report have been verified; if
+that cannot be achieved, surface the concrete failing command and reason instead
+of reporting success.
+
 Follow the shared source lookup protocol when external evidence, current information, examples, papers, repositories, or public discussion are relevant.
 
 ## Method

--- a/tests/test_report_publication_completion.sh
+++ b/tests/test_report_publication_completion.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPORT_SKILL="$EDGE_DIR/skills/report/SKILL.md"
+TEMPLATE="$EDGE_DIR/skills/_shared/report-template.md"
+
+echo "=== report publication completion contract ==="
+
+grep -q "Publishing is not optional once \`/ed-report\` has chosen a topic" "$REPORT_SKILL"
+grep -q "Files staged in" "$REPORT_SKILL"
+grep -q "staging-only exit" "$REPORT_SKILL"
+grep -q "concrete failing command and reason" "$REPORT_SKILL"
+
+grep -q "Staging is not completion" "$TEMPLATE"
+grep -q "must not close with only" "$TEMPLATE"
+grep -q "Run \`consolidate-state\` in this" "$TEMPLATE"
+grep -q "concrete failing command and" "$TEMPLATE"
+
+echo "PASS: ed-report cannot treat /tmp staging as a completed report"


### PR DESCRIPTION
## Summary

- Tighten `/ed-report` so staging files in `/tmp` are explicitly not a completed report.
- Require the skill to run `consolidate-state`, fix gate feedback, and verify generated HTML/blog/meta artifacts before closing.
- Add a shell contract test for the publication-completion invariant.

## Root Cause

A bare `/ed-report` could draft YAML and a blog entry, then decide not to publish because earlier drafts were blocked. The runner reported success even though no durable report artifact was produced.

## Validation

- `tests/test_report_publication_completion.sh`
- `tests/test_report_review_ownership.sh`
- `git diff --check`