### PR TITLE
[codex] Require ed-research publication completion

### DIFF
--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -42,6 +42,16 @@ step requires an external/destructive mutation rather than research.
 ## Boundary
 
 Do not manage lifecycle, publication, postflight, or generic artifact rites inside this skill.
+Do use the shared uniform report pipeline as the publication path for every
+research deliverable. A stdout-only research answer is not a completed
+`/ed-research` run. Before drafting, read `skills/_shared/report-template.md`
+from the active edge repo, write a YAML report spec and a light staging blog
+entry in `/tmp`, then run `consolidate-state` so the research becomes a durable
+blog entry, HTML report, and meta-report. If a gate blocks, address the specific
+feedback and rerun `consolidate-state`. Do not close by asking the operator
+whether to publish, by recommending a future publication pass, or by handing off
+with only prose or staging files. If publication cannot complete, surface the
+concrete failing command and reason instead of reporting success.
 
 ## Research Method
 
@@ -125,6 +135,10 @@ Synthesis must include:
 ## Output Contract
 
 Produce a research artifact suitable for the uniform report pipeline.
+The artifact is complete only after `consolidate-state` succeeds and the
+generated HTML report, blog entry, and meta-report have been verified. The final
+chat response should summarize the published paths and key finding; it must not
+be the only place where the research exists.
 
 Recommended sections:
 

--- a/tests/test_research_publication_completion.sh
+++ b/tests/test_research_publication_completion.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESEARCH_SKILL="$EDGE_DIR/skills/research/SKILL.md"
+
+echo "=== research publication completion contract ==="
+
+grep -q "stdout-only research answer is not a completed" "$RESEARCH_SKILL"
+grep -q "read \`skills/_shared/report-template.md\`" "$RESEARCH_SKILL"
+grep -q "run \`consolidate-state\`" "$RESEARCH_SKILL"
+grep -q "Do not close by asking the operator" "$RESEARCH_SKILL"
+grep -q "generated HTML report, blog entry, and meta-report have been verified" "$RESEARCH_SKILL"
+grep -q "only place where the research exists" "$RESEARCH_SKILL"
+
+echo "PASS: ed-research cannot treat stdout prose as a completed artifact"


### PR DESCRIPTION
## Summary

- Tighten `/ed-research` so stdout prose is explicitly not a completed research run.
- Require the skill to read the shared report template, stage YAML/blog files, run `consolidate-state`, and verify blog/HTML/meta artifacts.
- Add a contract test covering the publication-completion invariant.

## Root Cause

A bare `/ed-research` could complete successfully after printing a full research memo to stdout, with no durable blog/report/meta artifacts. That regressed the expected artifact contract.

## Validation

- `tests/test_research_publication_completion.sh`
- `tests/test_report_publication_completion.sh`
- `git diff --check`