### PR TITLE
[codex] Sync report frontmatter before publish

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -508,7 +508,7 @@ fi
 emit_run_step_event "phase-0a" "completed" "state_snapshot" ""
 echo ""
 
-# ─── PHASE 0: Inject report: in frontmatter if needed ───
+# ─── PHASE 0: Sync report: in staging frontmatter before publish ───
 if [[ -n "$REPORT_INPUT" ]]; then
     # Determine report filename
     if [[ "$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.yml ]]; then
@@ -518,46 +518,19 @@ if [[ -n "$REPORT_INPUT" ]]; then
     fi
 
     if [[ -n "$REPORT_FILENAME" ]]; then
-        # Check if frontmatter already has report: field
-        HAS_REPORT=$(python3 -c "
-import yaml
-raw = open('$ENTRY_PATH').read()
-parts = raw.split('---', 2)
-if len(parts) >= 3:
-    fm = yaml.safe_load(parts[1]) or {}
-    print('yes' if fm.get('report') else 'no')
-else:
-    print('no')
-" 2>/dev/null)
-
-        if [[ "$HAS_REPORT" == "no" ]]; then
-            echo "── Phase 0: Frontmatter ──"
-            emit_run_step_event "phase-0" "started" "frontmatter_injection" ""
-            # Inject report: field after the last frontmatter field (before closing ---)
-            if python3 -c "
-try:
-    raw = open('$ENTRY_PATH').read()
-    parts = raw.split('---', 2)
-    if len(parts) >= 3:
-        fm_text = parts[1].rstrip()
-        fm_text += '\nreport: $REPORT_FILENAME\n'
-        result = '---' + fm_text + '---' + parts[2]
-        open('$ENTRY_PATH', 'w').write(result)
-        print('  OK: report: $REPORT_FILENAME injected into frontmatter')
-    else:
-        print('  WARN: frontmatter not found (no --- delimiters)')
-        exit(1)
-except Exception as e:
-    print(f'  FAIL: frontmatter injection: {e}')
-    exit(1)
-" 2>&1; then
-                :
-            else
-                log_failure "0" "frontmatter_injection" "Failed to inject report: field"
-            fi
-            emit_run_step_event "phase-0" "completed" "frontmatter_injection" ""
-            echo ""
+        echo "── Phase 0: Frontmatter ──"
+        emit_run_step_event "phase-0" "started" "frontmatter_report_sync" ""
+        if REPORT_SYNC_OUTPUT=$(python3 "$TOOLS_DIR/sync-report-frontmatter.py" "$ENTRY_PATH" "$REPORT_FILENAME" 2>&1); then
+            ok "report: $REPORT_SYNC_OUTPUT"
+        else
+            fail "Failed to sync report field"
+            echo "$REPORT_SYNC_OUTPUT" >&2
+            log_failure "0" "frontmatter_report_sync" "Failed to sync report: field"
+            emit_run_step_event "phase-0" "failed" "frontmatter_report_sync" "Failed to sync report: field"
+            exit 1
         fi
+        emit_run_step_event "phase-0" "completed" "frontmatter_report_sync" ""
+        echo ""
     fi
 fi
 
@@ -879,9 +852,11 @@ fi
 
 # Report linked in frontmatter?
 if [[ -n "$REPORT_FILENAME" ]]; then
+    VERIFY_ENTRY_PATH="$ENTRIES_DIR/$SLUG.md"
+    [[ -f "$VERIFY_ENTRY_PATH" ]] || VERIFY_ENTRY_PATH="$ENTRY_PATH"
     HAS_REPORT=$(python3 -c "
 import yaml
-raw = open('$ENTRY_PATH').read()
+raw = open('$VERIFY_ENTRY_PATH').read()
 parts = raw.split('---', 2)
 fm = yaml.safe_load(parts[1]) or {}
 r = fm.get('report', '')
@@ -891,8 +866,11 @@ print('OK' if r == '$REPORT_FILENAME' else f'MISMATCH: {r}')
         ok "Frontmatter report: $REPORT_FILENAME"
     else
         warn "Frontmatter report: $HAS_REPORT"
-        # Auto-fix: update frontmatter report field to match actual generated filename
-        sed -i "s|^report: .*|report: $REPORT_FILENAME|" "$ENTRY_PATH"
+        # Auto-fix both the staging file and the already-published entry.
+        python3 "$TOOLS_DIR/sync-report-frontmatter.py" "$ENTRY_PATH" "$REPORT_FILENAME" >/dev/null 2>&1 || true
+        if [[ "$VERIFY_ENTRY_PATH" != "$ENTRY_PATH" ]]; then
+            python3 "$TOOLS_DIR/sync-report-frontmatter.py" "$VERIFY_ENTRY_PATH" "$REPORT_FILENAME" >/dev/null 2>&1 || true
+        fi
         ok "FIXED: report: $REPORT_FILENAME"
     fi
 fi

--- a/tests/test_consolidate_report_frontmatter_sync.sh
+++ b/tests/test_consolidate_report_frontmatter_sync.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TOOL="$EDGE_DIR/tools/sync-report-frontmatter.py"
+SCRIPT="$EDGE_DIR/blog/consolidate-state.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ENTRY="$TMP_DIR/entry-research-contract.md"
+OUT="$TMP_DIR/out.txt"
+
+cat >"$ENTRY" <<'EOF'
+---
+title: "Research Contract"
+date: 2026-05-02
+tags: [research]
+report: "research-contract.html"
+claims:
+  - "Claim: quoted because YAML punctuation matters"
+---
+
+Body.
+EOF
+
+python3 "$TOOL" "$ENTRY" "entry-research-contract.html" >"$OUT"
+grep -q "updated:research-contract.html->entry-research-contract.html" "$OUT"
+grep -q "^report: entry-research-contract.html$" "$ENTRY"
+
+python3 - "$ENTRY" <<'PY'
+from pathlib import Path
+import sys
+
+import yaml
+
+raw = Path(sys.argv[1]).read_text(encoding="utf-8")
+fm = yaml.safe_load(raw.split("---", 2)[1]) or {}
+assert fm["report"] == "entry-research-contract.html"
+assert fm["claims"] == ["Claim: quoted because YAML punctuation matters"]
+PY
+
+cat >"$ENTRY" <<'EOF'
+---
+title: "Research Contract"
+date: 2026-05-02
+tags: [research]
+claims:
+  - "Still valid"
+---
+
+Body.
+EOF
+
+python3 "$TOOL" "$ENTRY" "entry-research-contract.html" >"$OUT"
+grep -q "updated:<missing>->entry-research-contract.html" "$OUT"
+grep -q "^report: entry-research-contract.html$" "$ENTRY"
+
+grep -q 'sync-report-frontmatter.py" "$ENTRY_PATH" "$REPORT_FILENAME"' "$SCRIPT"
+grep -q 'VERIFY_ENTRY_PATH="$ENTRIES_DIR/$SLUG.md"' "$SCRIPT"
+
+echo "PASS: consolidate-state synchronizes report frontmatter before and after publish"

--- a/tools/sync-report-frontmatter.py
+++ b/tools/sync-report-frontmatter.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Synchronize a blog entry's frontmatter report field."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def sync_report(entry_path: Path, expected_report: str) -> str:
+    raw = entry_path.read_text(encoding="utf-8")
+    parts = raw.split("---", 2)
+    if len(parts) < 3:
+        raise ValueError(f"missing frontmatter in {entry_path}")
+
+    try:
+        parsed = yaml.safe_load(parts[1]) or {}
+    except Exception as exc:  # pragma: no cover - exact yaml message varies
+        raise ValueError(f"invalid frontmatter YAML in {entry_path}: {exc}") from exc
+
+    current = str(parsed.get("report") or "").strip()
+    if current == expected_report:
+        return f"matched:{expected_report}"
+
+    lines = parts[1].splitlines()
+    updated_lines: list[str] = []
+    replaced = False
+    for line in lines:
+        if line.startswith("report:"):
+            if not replaced:
+                updated_lines.append(f"report: {expected_report}")
+                replaced = True
+            continue
+        updated_lines.append(line)
+
+    if not replaced:
+        while updated_lines and not updated_lines[-1].strip():
+            updated_lines.pop()
+        updated_lines.append(f"report: {expected_report}")
+
+    new_frontmatter = "\n".join(updated_lines).strip("\n")
+    entry_path.write_text(
+        f"{parts[0]}---\n{new_frontmatter}\n---{parts[2]}",
+        encoding="utf-8",
+    )
+    previous = current or "<missing>"
+    return f"updated:{previous}->{expected_report}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("entry", type=Path)
+    parser.add_argument("expected_report")
+    args = parser.parse_args()
+
+    try:
+        result = sync_report(args.entry, args.expected_report)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 65
+
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add `tools/sync-report-frontmatter.py` to normalize a blog entry's `report:` frontmatter field to the canonical generated report filename.
- Run that sync in `consolidate-state` before `blog-publish`, so already-published entries cannot retain stale draft report names.
- Make final verification read and repair the published entry as well as the staging file.
- Add a regression test for stale and missing `report:` values.

## Root Cause

`consolidate-state` derived the correct report filename from the staging entry slug, but only injected `report:` when the field was missing. If a research staging entry supplied a stale value like `research-foo.html`, `blog-publish` copied that stale value into `blog/entries/`. Phase 3 then repaired only the `/tmp` staging file, leaving the published entry broken.

## Validation

- `bash tests/test_consolidate_report_frontmatter_sync.sh`
- `bash tests/test_research_publication_completion.sh`
- `bash tests/test_consolidate_frontmatter_errors.sh`
- `python3 -m py_compile tools/sync-report-frontmatter.py`