### PR TITLE
[codex] Fix install hash and operator pressure context bleed

### DIFF
--- a/tests/test_edge_apply_bookkeeping_drift.sh
+++ b/tests/test_edge_apply_bookkeeping_drift.sh
@@ -207,6 +207,62 @@ else
     fail "phase_identity migrates legacy topics into state topics dir"
 fi
 
+echo "--- Test 4: _copy_file logs content hash when destination is symlink ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_HOME" "$TMP_REPO" "$TMP_STATE"
+import hashlib
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+edge_dir, home_dir, repo_dir, state_dir = sys.argv[1:]
+os.environ["HOME"] = home_dir
+os.environ["EDGE_STATE_DIR"] = state_dir
+os.environ["EDGE_CODENAME"] = "drift-test"
+os.environ["EDGE_CYCLE_ID"] = "install:test-copy-symlink-hash"
+
+loader = importlib.machinery.SourceFileLoader("edge_apply_mod", f"{edge_dir}/tools/edge-apply")
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+mod.REPO_ROOT = Path(repo_dir)
+
+src = Path(repo_dir) / "config" / "heartbeat.sh"
+src.write_text("#!/bin/sh\necho rendered-heartbeat\n", encoding="utf-8")
+target = Path(home_dir) / "actual-heartbeat.sh"
+target.write_text("stale\n", encoding="utf-8")
+dst = Path(home_dir) / ".local" / "bin" / "heartbeat.sh"
+dst.parent.mkdir(parents=True, exist_ok=True)
+dst.symlink_to(target)
+
+mod._copy_file(src, dst, phase="systemd", dry_run=False, chmod=0o755)
+
+expected_hash = "sha256:" + hashlib.sha256(src.read_bytes()).hexdigest()
+symlink_target_hash = "sha256:" + hashlib.sha256(os.readlink(dst).encode("utf-8")).hexdigest()
+events = [
+    json.loads(line)
+    for line in (Path(state_dir) / "state" / "events" / "log.jsonl").read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+match = next(
+    event for event in reversed(events)
+    if event.get("type") == "InstallApplied"
+    and event.get("cycle_id") == "install:test-copy-symlink-hash"
+    and event.get("artifact") == str(dst)
+)
+payload_hash = (match.get("payload") or {}).get("hash")
+assert payload_hash == expected_hash, payload_hash
+assert payload_hash != symlink_target_hash
+assert target.read_bytes() == src.read_bytes()
+PY
+then
+    pass "_copy_file logs content hash through symlink destinations"
+else
+    fail "_copy_file logs content hash through symlink destinations"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/tests/test_operator_pressure_layers.sh
+++ b/tests/test_operator_pressure_layers.sh
@@ -195,6 +195,145 @@ else
     fail "operator pressure projection supports no-write preview and materialized read model"
 fi
 
+echo "--- Test 4: runtime-injected user messages are excluded from pressure atoms ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_BASE"
+import json
+import sys
+from pathlib import Path
+
+edge_dir, tmp_base = sys.argv[1:]
+sys.path.insert(0, f"{edge_dir}/tools")
+
+from _shared.operator_pressure import build_operator_pressure_layers
+
+tmp_base = Path(tmp_base)
+project = tmp_base / "noise-project"
+state = tmp_base / "noise-state"
+project.mkdir(parents=True, exist_ok=True)
+state.mkdir(parents=True, exist_ok=True)
+session = project / "session-noise.jsonl"
+rows = [
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:00:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "-\n/ed-research\n\nDispatch runtime context below is authoritative for cross-cutting checks already handled by CLI."
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:01:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "Base directory for this skill: /home/vboxuser/.claude/skills/ed-report"
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:02:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "## System\n\nYou are a quality reviewer for report artifacts in this repository."
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:03:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "corrija o install do edge e rode heartbeat depois"
+        },
+    },
+]
+session.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+payload = build_operator_pressure_layers(
+    project_dir=project,
+    ledger_path=state / "operator-pressure" / "ledger.json",
+    hot_digest_path=state / "operator-pressure" / "hot-digest.json",
+    redigest_dir=state / "operator-pressure" / "redigests",
+    allow_llm=False,
+)
+ledger = payload["ledger"]
+assert ledger["message_total"] == 1, ledger["message_total"]
+assert ledger["item_total"] == 1, ledger["item_total"]
+content = ledger["items"][0]["content"]
+assert content == "corrija o install do edge e rode heartbeat depois", content
+assert "Dispatch runtime context below" not in content
+PY
+then
+    pass "runtime-injected user messages are excluded from pressure atoms"
+else
+    fail "runtime-injected user messages are excluded from pressure atoms"
+fi
+
+echo "--- Test 5: empty ledger skips LLM renderer even with sticky previous digest ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import sys
+
+edge_dir = sys.argv[1]
+sys.path.insert(0, f"{edge_dir}/tools")
+
+from _shared import operator_pressure as mod
+
+def fail_client(*_args, **_kwargs):
+    raise AssertionError("LLM should not be called for empty pressure input")
+
+mod.LLM_DISABLED = False
+mod.make_client = fail_client
+
+previous = {
+    "schema_version": mod.SCHEMA_VERSION,
+    "digest_hash": "sha256:previous",
+    "signal_from_operator_now": [
+        {"item_id": "pressure:sticky", "text": "sticky directive", "target": "workflow", "kind": "directive"}
+    ],
+    "operator_pains_resolvable_now": [
+        {"item_id": "pressure:pain", "text": "sticky pain", "target": "workflow", "kind": "failure"}
+    ],
+}
+ledger = {
+    "source_hash": "sha256:empty",
+    "item_total": 0,
+    "session_total": 0,
+    "items": [],
+}
+digest = mod._render_hot_digest_with_llm(
+    ledger,
+    previous_digest=previous,
+    delta_items=[
+        {"item_id": "pressure:sticky", "text": "sticky directive", "target": "workflow", "kind": "directive"}
+    ],
+)
+
+assert digest["render_mode"] == "deterministic", digest
+assert digest["summary"] == "no strong recent operator pressure detected", digest["summary"]
+for key in (
+    "signal_from_operator_now",
+    "operator_pains_resolvable_now",
+    "operator_toil_optimizable_now",
+    "mistakes_to_avoid_now",
+    "implicit_needs_hypotheses",
+    "workflow_candidates",
+    "capability_candidates",
+    "substrate_gap_requests",
+    "active_entities",
+    "item_ids",
+):
+    assert digest[key] == [], (key, digest[key])
+assert "render_warning" not in digest
+PY
+then
+    pass "empty ledger skips LLM renderer even with sticky previous digest"
+else
+    fail "empty ledger skips LLM renderer even with sticky previous digest"
+fi
+
 echo ""
 echo "Passed: $PASS"
 echo "Failed: $FAIL"

--- a/tools/_shared/operator_pressure.py
+++ b/tools/_shared/operator_pressure.py
@@ -168,6 +168,27 @@ _HOT_DIGEST_KEYS = {
     "item_ids",
 }
 
+_DIGEST_SECTION_KEYS = (
+    "signal_from_operator_now",
+    "operator_pains_resolvable_now",
+    "operator_toil_optimizable_now",
+    "mistakes_to_avoid_now",
+    "implicit_needs_hypotheses",
+    "workflow_candidates",
+    "capability_candidates",
+    "substrate_gap_requests",
+)
+
+_RUNTIME_PRESSURE_NOISE_RE = (
+    re.compile(
+        r"^\s*(?:-\s*\n\s*)?/[a-z0-9_.-]+\s*\n\s*\n"
+        r"Dispatch runtime context below is authoritative for\b",
+        re.I,
+    ),
+    re.compile(r"^\s*Base directory for this skill:\s+\S*\.claude/skills/", re.I),
+    re.compile(r"^\s*## System\s*\n\s*You are a quality reviewer for report artifacts\b", re.I),
+)
+
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
@@ -255,6 +276,10 @@ def _extract_user_text(message: dict[str, Any]) -> str:
     return str(content or "").strip()
 
 
+def _is_runtime_pressure_noise(text: str) -> bool:
+    return any(pattern.search(text) for pattern in _RUNTIME_PRESSURE_NOISE_RE)
+
+
 def _iter_recent_user_messages(
     *,
     project_dir: Path,
@@ -289,6 +314,8 @@ def _iter_recent_user_messages(
                     continue
                 text = _extract_user_text(payload)
                 if not text or len(text) < 8:
+                    continue
+                if _is_runtime_pressure_noise(text):
                     continue
                 ts = _parse_ts(str(payload.get("timestamp") or ""))
                 if ts and ts < cutoff:
@@ -756,16 +783,7 @@ def _extract_json_object(text: str) -> dict[str, Any] | None:
 def _coerce_digest_shape(candidate: dict[str, Any], fallback: dict[str, Any]) -> dict[str, Any]:
     digest = dict(fallback)
     digest["summary"] = str(candidate.get("summary") or fallback.get("summary") or "").strip()
-    for key in (
-        "signal_from_operator_now",
-        "operator_pains_resolvable_now",
-        "operator_toil_optimizable_now",
-        "mistakes_to_avoid_now",
-        "implicit_needs_hypotheses",
-        "workflow_candidates",
-        "capability_candidates",
-        "substrate_gap_requests",
-    ):
+    for key in _DIGEST_SECTION_KEYS:
         items = candidate.get(key)
         if isinstance(items, list):
             normalized: list[dict[str, Any]] = []
@@ -791,6 +809,13 @@ def _coerce_digest_shape(candidate: dict[str, Any], fallback: dict[str, Any]) ->
     return digest
 
 
+def _render_input_has_pressure(render_input: dict[str, Any]) -> bool:
+    for key in _DIGEST_SECTION_KEYS:
+        if render_input.get(key):
+            return True
+    return bool(render_input.get("active_entities"))
+
+
 def _render_hot_digest_with_llm(
     ledger: dict[str, Any],
     *,
@@ -814,6 +839,8 @@ def _render_hot_digest_with_llm(
         "substrate_gap_requests": fallback.get("substrate_gap_requests", []),
         "active_entities": fallback.get("active_entities", []),
     }
+    if int(ledger.get("item_total") or 0) == 0 and not _render_input_has_pressure(render_input):
+        return fallback
     prompt = _llm_prompt(render_input, previous_digest=previous_digest, delta_items=delta_items[:SECTION_LIMIT])
     try:
         client, model = make_client("chat", model=LLM_MODEL, timeout=90)

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -57,9 +57,9 @@ def _hash_text(content: str) -> str:
     return f"sha256:{hashlib.sha256(content.encode('utf-8')).hexdigest()}"
 
 
-def _hash_path(path: Path) -> str | None:
+def _hash_path(path: Path, *, follow_symlinks: bool = False) -> str | None:
     try:
-        if path.is_symlink():
+        if path.is_symlink() and not follow_symlinks:
             target = os.readlink(path)
             return f"sha256:{hashlib.sha256(target.encode('utf-8')).hexdigest()}"
         if path.is_file():
@@ -163,7 +163,9 @@ def _copy_file(
         source_template=_repo_relative(src),
         action="copy",
         kind="file",
-        hash_value=_hash_path(dst),
+        # shutil.copy2 follows an existing destination symlink; the install
+        # event must match the bytes edge-doctor reads from the artifact path.
+        hash_value=_hash_path(dst, follow_symlinks=True),
         phase=phase,
         dry_run=False,
         executable=bool(chmod),


### PR DESCRIPTION
## Summary

Fixes #437.
Fixes #439.

This PR lands two genotype fixes needed before rerunning the roberto fresh-install feedback loop:

- `edge-apply` records the content hash of an installed copy target even when the destination path is an existing symlink.
- operator-pressure ingestion drops known runtime-injected preambles before they become pressure atoms, and the hot-digest renderer skips the LLM when the current ledger is empty so sticky `previous_digest` cannot repopulate phantom pressure.

## Root Cause

For #437, `shutil.copy2(src, dst)` follows an existing destination symlink and writes bytes to the symlink target, while `_hash_path(dst)` previously hashed the symlink target string. That made `InstallApplied.payload.hash` differ from the bytes later read by `edge-doctor` and `rollup-render-install-drift.py`.

For #439, the pressure ledger was reading runtime-emitted user-message preambles as operator pressure. Once that input is contaminated, the digest renderer faithfully compresses runtime boilerplate into actionable operator-pain text. Separately, when the current ledger empties, the LLM renderer can bleed items forward from `previous_digest`; the deterministic empty digest is the correct output for that case.

## Validation

- `bash tests/test_edge_apply_bookkeeping_drift.sh`
- `bash tests/test_operator_pressure_layers.sh`
- `bash tests/test_render_install_drift.sh`
- `python3 -m py_compile tools/_shared/operator_pressure.py tools/edge-apply`