### PR TITLE
[codex] Filter install prompts from operator pressure

### DIFF
--- a/tests/test_operator_pressure_layers.sh
+++ b/tests/test_operator_pressure_layers.sh
@@ -246,6 +246,42 @@ rows = [
         "sessionId": "noise",
         "message": {
             "role": "user",
+            "content": "## System\n\nYou compress operator pressure into compact structured JSON for runtime use.\n\n## User\n\nYou are rendering an operator-pressure digest for runtime preflight."
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:04:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "You are converting an operator's free-form description of a research or work routine into a structured workflow entry. The operator's prose is verbatim text."
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:05:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "You are bootstrapping an autonomous AI agent. Generate seed content for its operational memory.\n\nAgent: roberto"
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:06:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "You are implementing a source primitive for an autonomous agent.\n\nSource: test"
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:07:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
             "content": "corrija o install do edge e rode heartbeat depois"
         },
     },

--- a/tools/_shared/operator_pressure.py
+++ b/tools/_shared/operator_pressure.py
@@ -186,7 +186,11 @@ _RUNTIME_PRESSURE_NOISE_RE = (
         re.I,
     ),
     re.compile(r"^\s*Base directory for this skill:\s+\S*\.claude/skills/", re.I),
+    re.compile(r"^\s*## System\s*\n\s*You compress operator pressure into compact structured JSON\b", re.I),
     re.compile(r"^\s*## System\s*\n\s*You are a quality reviewer for report artifacts\b", re.I),
+    re.compile(r"^\s*You are converting an operator's free-form description of a research or work routine\b", re.I),
+    re.compile(r"^\s*You are bootstrapping an autonomous AI agent\. Generate seed content\b", re.I),
+    re.compile(r"^\s*You are implementing a source primitive for an autonomous agent\b", re.I),
 )
 
 


### PR DESCRIPTION
## Summary

Fixes #441.

The first roberto fresh-install heartbeat exposed a remaining pressure-ledger pollution path: install-time Claude prompts from seed generation, routine conversion, and the operator-pressure renderer itself were still recorded as `type=user` Claude session messages and admitted as operator pressure.

This PR extends the runtime-pressure noise filter to exclude those known machine prompt templates before atom creation.

## Validation

- `bash tests/test_operator_pressure_layers.sh`
- `python3 -m py_compile tools/_shared/operator_pressure.py`

## Notes

This intentionally preserves legitimate operator instructions. The regression fixture includes the known machine prompts plus one real operator instruction and asserts that exactly one pressure atom remains.