### PR TITLE
[codex] require artifact evidence before completed skill close

### DIFF
--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -80,6 +80,14 @@ If no explicit topic, question, or args are present:
 Ask the operator for a topic only when the runtime frame contains no reasonable
 candidate and any inferred report would be misleading. That should be rare.
 
+If the runtime frame yields one or more candidates, choose the strongest one and
+publish. A bare invocation must not finish with candidate options instead of an
+artifact. Do not end with prompts such as "What topic do you want", "What report
+should I generate", or "A few candidates" when any defensible topic can be
+selected from runtime evidence. The final chat response for a successful
+`/ed-report` run must name the published blog entry, HTML report, and
+meta-report paths.
+
 ### 2. Gather Evidence
 
 Use the right sources for the topic:

--- a/tests/test_edge_close.sh
+++ b/tests/test_edge_close.sh
@@ -82,6 +82,29 @@ DISPATCH_TOOL="$EDGE_DIR/tools/edge-dispatch"
 CLOSE_TOOL="$EDGE_DIR/tools/edge-close"
 STEP_TOOL="$EDGE_DIR/tools/edge-skill-step"
 
+append_artifact_published() {
+    local cycle_id="$1"
+    local skill="$2"
+    local slug="$3"
+    python3 - <<'PY' "$TMP_EDGE/state/events/log.jsonl" "$cycle_id" "$skill" "$slug"
+import json
+import sys
+from datetime import datetime, timezone
+
+path, cycle_id, skill, slug = sys.argv[1:5]
+event = {
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "type": "ArtifactPublished",
+    "actor": "continuity",
+    "cycle_id": cycle_id,
+    "artifact": f"blog/entries/{slug}.md",
+    "payload": {"source_skill": skill},
+}
+with open(path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(event) + "\n")
+PY
+}
+
 echo "=== edge-close Smoke Test ==="
 echo "Temp state: $TMP_EDGE"
 echo ""
@@ -145,13 +168,45 @@ fi
 
 EDGE_CYCLE_ID=cycle-close-mismatch "$DISPATCH_TOOL" close --status aborted >/dev/null
 
-echo "--- Test 2: completed close succeeds with skill end evidence and postflight ---"
+echo "--- Test 2: completed close is rejected without artifact publication evidence ---"
+"$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-no-artifact --force >/dev/null
+"$DISPATCH_TOOL" dispatch --skill discovery >/dev/null
+for step in direction explore application persistence; do
+    EDGE_CYCLE_ID=cycle-close-no-artifact "$STEP_TOOL" discovery "$step" >/dev/null
+done
+EDGE_CYCLE_ID=cycle-close-no-artifact "$STEP_TOOL" discovery end >/dev/null
+set +e
+"$CLOSE_TOOL" --status completed >/dev/null
+STATUS=$?
+set -e
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$STATUS"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+status = int(sys.argv[2])
+
+assert status == 1
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "failed"
+assert dispatch["state"]["close_reason"] == "missing_artifact_published"
+assert dispatch["state"]["postflight_status"] == "failed"
+PY
+then
+    pass "edge-close requires artifact publication for every completed skill"
+else
+    fail "edge-close requires artifact publication for every completed skill"
+fi
+
+echo "--- Test 3: completed close succeeds with skill end evidence, artifact publication, and postflight ---"
 "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-complete --force >/dev/null
 "$DISPATCH_TOOL" dispatch --skill discovery >/dev/null
 for step in direction explore application persistence; do
     EDGE_CYCLE_ID=cycle-close-complete "$STEP_TOOL" discovery "$step" >/dev/null
 done
 EDGE_CYCLE_ID=cycle-close-complete "$STEP_TOOL" discovery end >/dev/null
+append_artifact_published cycle-close-complete discovery complete
 "$CLOSE_TOOL" --status completed >/dev/null
 
 if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/logs/post-skill.log"
@@ -171,12 +226,12 @@ assert len(steps) >= 6
 assert "claims_open_delta" in delta
 PY
 then
-    pass "edge-close completes only after skill end evidence and enriched postflight"
+    pass "edge-close completes only after skill end evidence, artifact publication, and enriched postflight"
 else
-    fail "edge-close completes only after skill end evidence and enriched postflight"
+    fail "edge-close completes only after skill end evidence, artifact publication, and enriched postflight"
 fi
 
-echo "--- Test 3: autofixable validate_recent becomes warning, not failed close ---"
+echo "--- Test 4: autofixable validate_recent becomes warning, not failed close ---"
 TODAY="$(date +%Y-%m-%d)"
 cat >"$TMP_EDGE/blog/entries/2026-04-22-warning.md" <<EOF
 ---
@@ -197,6 +252,7 @@ for step in direction explore application persistence; do
     EDGE_CYCLE_ID=cycle-close-warning "$STEP_TOOL" discovery "$step" >/dev/null
 done
 EDGE_CYCLE_ID=cycle-close-warning "$STEP_TOOL" discovery end >/dev/null
+append_artifact_published cycle-close-warning discovery warning
 "$CLOSE_TOOL" --status completed >/dev/null
 
 if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/blog/entries/2026-04-22-warning.md"
@@ -218,7 +274,7 @@ else
     fail "autofixable validate_recent closes as completed with warning"
 fi
 
-echo "--- Test 4: mixed aware/naive completion timestamps still close successfully ---"
+echo "--- Test 5: mixed aware/naive completion timestamps still close successfully ---"
 "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-naive-mixed --force >/dev/null
 "$DISPATCH_TOOL" dispatch --skill discovery >/dev/null
 python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl"
@@ -243,6 +299,16 @@ event = {
 }
 with open(events_path, "a", encoding="utf-8") as fh:
     fh.write(json.dumps(event) + "\n")
+artifact = {
+    "ts": "2026-04-22T00:00:03",
+    "type": "ArtifactPublished",
+    "actor": "continuity",
+    "cycle_id": "cycle-close-naive-mixed",
+    "artifact": "blog/entries/naive-mixed.md",
+    "payload": {"source_skill": "discovery"},
+}
+with open(events_path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(artifact) + "\n")
 PY
 "$CLOSE_TOOL" --status completed >/dev/null
 

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -98,6 +98,34 @@ RUNNER_TOOL="$EDGE_DIR/tools/edge-runner"
 cat >"$TMP_HOME/.local/bin/claude" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+publish_mock_artifact() {
+  local skill="$1"
+  python3 - "$skill" <<'PY'
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+skill = sys.argv[1].strip().lstrip("/") or "skill"
+cycle_id = os.environ.get("EDGE_CYCLE_ID", "")
+state_dir = Path(os.environ["EDGE_STATE_DIR"])
+events = state_dir / "state" / "events" / "log.jsonl"
+events.parent.mkdir(parents=True, exist_ok=True)
+safe_skill = re.sub(r"[^a-z0-9-]+", "-", skill.lower()).strip("-") or "skill"
+event = {
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "type": "ArtifactPublished",
+    "actor": "continuity",
+    "cycle_id": cycle_id,
+    "artifact": f"blog/entries/mock-{safe_skill}-{cycle_id}.md",
+    "payload": {"source_skill": safe_skill},
+}
+with open(events, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(event) + "\n")
+PY
+}
 PROMPT="$(cat)"
 printf '%s\n' "$EDGE_CYCLE_ID" >> "${MOCK_CLAUDE_ENV_OUT:?}"
 printf '__INVOCATION__\n' >> "${MOCK_CLAUDE_ARGS_OUT:?}"
@@ -127,13 +155,18 @@ state_block["postflight_checked_at"] = now
 state_block["updated_at"] = now
 path.write_text(json.dumps(state, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 PY
+      publish_mock_artifact discovery
     fi
   elif [[ "$PROMPT" == *"/discovery"* ]]; then
     for step in direction explore application persistence; do
       "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery "$step" >/dev/null
     done
     "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery end >/dev/null
+    publish_mock_artifact discovery
   fi
+fi
+if [ "${MOCK_CLAUDE_EXIT_CODE:-0}" = "0" ] && [[ "$PROMPT" == *"/autonomy"* ]]; then
+  publish_mock_artifact autonomy
 fi
 exit "${MOCK_CLAUDE_EXIT_CODE:-0}"
 SH

--- a/tests/test_report_skill_contract.sh
+++ b/tests/test_report_skill_contract.sh
@@ -27,6 +27,11 @@ required = [
     "State the inferred target and why it was selected.",
     "Produce the report artifact.",
     "Ask the operator for a topic only when the runtime frame contains no reasonable",
+    "If the runtime frame yields one or more candidates, choose the strongest one",
+    "must not finish with candidate options instead of an",
+    "What topic do you want",
+    "A few candidates",
+    "must name the published blog entry, HTML report, and",
 ]
 for needle in required:
     assert needle in text, needle

--- a/tests/test_skill_inbox.sh
+++ b/tests/test_skill_inbox.sh
@@ -26,6 +26,32 @@ CLOSE_TOOL="$EDGE_DIR/tools/edge-close"
 STEP_TOOL="$EDGE_DIR/tools/edge-skill-step"
 INBOX_TOOL="$EDGE_DIR/tools/edge-skill-inbox"
 
+append_artifact_published() {
+    local cycle_id="$1"
+    local skill="$2"
+    local slug="$3"
+    python3 - <<'PY' "$TMP_EDGE/state/events/log.jsonl" "$cycle_id" "$skill" "$slug"
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+path = Path(sys.argv[1])
+cycle_id, skill, slug = sys.argv[2:5]
+path.parent.mkdir(parents=True, exist_ok=True)
+event = {
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "type": "ArtifactPublished",
+    "actor": "continuity",
+    "cycle_id": cycle_id,
+    "artifact": f"blog/entries/{slug}.md",
+    "payload": {"source_skill": skill},
+}
+with open(path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(event) + "\n")
+PY
+}
+
 echo "=== edge-skill-inbox Smoke Test ==="
 echo "Temp state: $TMP_EDGE"
 echo ""
@@ -184,6 +210,7 @@ state_path.write_text(json.dumps(state, indent=2, ensure_ascii=False) + "\n", en
 print(json.dumps(result, ensure_ascii=False))
 PY
 )
+append_artifact_published cycle-skill-inbox research inbox
 "$CLOSE_TOOL" --status completed >/dev/null
 
 if python3 - <<'PY' "$EDGE_DIR" "$SEED_OUTPUT" "$LATE_OUTPUT" "$TMP_EDGE/state/current-dispatch.json" "$ACK_OUTPUT"

--- a/tools/edge-close
+++ b/tools/edge-close
@@ -2,8 +2,8 @@
 """edge-close — gated cycle finalization for dispatch runs.
 
 Closes the active dispatch cycle, but only allows `completed` when there is
-mechanical evidence that the skill actually finished and the postflight profile
-ran.
+mechanical evidence that the skill finished, published an artifact, and the
+postflight profile ran.
 """
 
 from __future__ import annotations
@@ -84,6 +84,15 @@ def iter_jsonl(path: Path) -> list[dict]:
     return rows
 
 
+def normalize_skill_id(value: object) -> str:
+    return str(value or "").strip().lstrip("/").lower()
+
+
+def skill_requires_artifact_publication(skill: object) -> bool:
+    normalized = normalize_skill_id(skill)
+    return bool(normalized and normalized != "prompt")
+
+
 def iso_ge(left: str | None, right: str | None) -> bool:
     if not left or not right:
         return False
@@ -152,6 +161,61 @@ def check_skill_completion(state: dict) -> tuple[bool, str, dict]:
 
     return False, "missing_skill_run_completed", {"skill": skill, "cycle_id": cycle_id}
 
+
+def check_artifact_publication(state: dict) -> tuple[bool, str, dict]:
+    cycle_id = state.get("cycle_id")
+    request = state.get("request", {}) or {}
+    state_block = state.get("state", {}) or {}
+    skill = request.get("skill")
+    threshold = state_block.get("dispatched_at") or state_block.get("opened_at")
+
+    if not skill_requires_artifact_publication(skill):
+        return True, "artifact_not_required", {"skill": skill or "", "cycle_id": cycle_id}
+
+    for event in reversed(iter_jsonl(STATE_EVENTS_FILE)):
+        if event.get("type") != "ArtifactPublished":
+            continue
+        if event.get("cycle_id") != cycle_id:
+            continue
+        if threshold and not iso_ge(event.get("ts"), threshold):
+            continue
+        artifact = str(event.get("artifact") or (event.get("payload", {}) or {}).get("artifact") or "")
+        if not artifact or not artifact.startswith("blog/entries/"):
+            continue
+        return True, "artifact_published", {
+            "skill": skill,
+            "artifact": artifact,
+            "ts": event.get("ts"),
+        }
+
+    return False, "missing_artifact_published", {"skill": skill, "cycle_id": cycle_id}
+
+
+def fail_close_with_postflight_reason(state: dict, *, profile: str, reason: str, step: dict) -> None:
+    append_postskill_log(step.get("step", "postflight_gate"), "FAIL", reason)
+    state_block = state.setdefault("state", {})
+    state_block["postflight_status"] = "failed"
+    state_block["postflight_checked_at"] = now_iso()
+    state_block["updated_at"] = state_block["postflight_checked_at"]
+    state_block["postflight_reason"] = reason
+    state_block["postflight_steps"] = [step]
+    write_state(state)
+    emit_shadow_event(
+        "PostflightFailed",
+        actor="edge-close",
+        cycle_id=state.get("cycle_id"),
+        payload={"profile": profile, "reason": reason, "steps": state_block["postflight_steps"]},
+    )
+    log_event(
+        "dispatch_postflight",
+        actor="edge-close",
+        cycle_id=state.get("cycle_id"),
+        profile=profile,
+        status="failed",
+        reason=reason,
+    )
+
+
 def close_dispatch(status: str, reason: str | None) -> tuple[int, dict]:
     import subprocess
 
@@ -203,40 +267,38 @@ def main() -> int:
     if requested_status == "completed":
         skill_ok, skill_reason, skill_detail = check_skill_completion(state)
         if not skill_ok:
-            append_postskill_log("skill_run_completed", "FAIL", skill_reason)
-            state_block = state.setdefault("state", {})
-            state_block["postflight_status"] = "failed"
-            state_block["postflight_checked_at"] = now_iso()
-            state_block["updated_at"] = state_block["postflight_checked_at"]
-            state_block["postflight_reason"] = skill_reason
-            state_block["postflight_steps"] = [{"step": "skill_run_completed", "status": "failed", **skill_detail}]
-            write_state(state)
-            emit_shadow_event(
-                "PostflightFailed",
-                actor="edge-close",
-                cycle_id=state.get("cycle_id"),
-                payload={"profile": profile, "reason": skill_reason, "steps": state_block["postflight_steps"]},
-            )
-            log_event(
-                "dispatch_postflight",
-                actor="edge-close",
-                cycle_id=state.get("cycle_id"),
+            fail_close_with_postflight_reason(
+                state,
                 profile=profile,
-                status="failed",
                 reason=skill_reason,
+                step={"step": "skill_run_completed", "status": "failed", **skill_detail},
             )
             effective_status = "failed"
             effective_reason = effective_reason or skill_reason
             exit_code = 1
         else:
             append_postskill_log("skill_run_completed", "OK", skill_reason)
-            post_ok, post_status, post_reason, post_steps = run_postflight(profile)
-            if post_ok and post_status == "warning":
-                effective_reason = effective_reason or post_reason
-            if not post_ok:
+            artifact_ok, artifact_reason, artifact_detail = check_artifact_publication(state)
+            if not artifact_ok:
+                fail_close_with_postflight_reason(
+                    state,
+                    profile=profile,
+                    reason=artifact_reason,
+                    step={"step": "artifact_published", "status": "failed", **artifact_detail},
+                )
                 effective_status = "failed"
-                effective_reason = effective_reason or post_reason
+                effective_reason = effective_reason or artifact_reason
                 exit_code = 1
+            else:
+                if skill_requires_artifact_publication(request.get("skill")):
+                    append_postskill_log("artifact_published", "OK", artifact_reason)
+                post_ok, post_status, post_reason, post_steps = run_postflight(profile)
+                if post_ok and post_status == "warning":
+                    effective_reason = effective_reason or post_reason
+                if not post_ok:
+                    effective_status = "failed"
+                    effective_reason = effective_reason or post_reason
+                    exit_code = 1
     else:
         state_block = state.setdefault("state", {})
         state_block["postflight_status"] = "skipped"


### PR DESCRIPTION
## Summary

- Make `edge-close` require an `ArtifactPublished` event before any dispatched skill can close as `completed`.
- Keep the rule generic across skills rather than special-casing report or research.
- Tighten bare `/ed-report` instructions so candidate lists cannot replace publishing.
- Update close, runner, and inbox tests to model artifact publication evidence explicitly.

## Validation

- `python3 -m py_compile tools/edge-close`
- `bash tests/test_report_skill_contract.sh`
- `bash tests/test_report_publication_completion.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_skill_inbox.sh`