### PR TITLE
[codex] let operator dispatch preempt heartbeat cycles

### DIFF
--- a/tests/test_edge_dispatch.sh
+++ b/tests/test_edge_dispatch.sh
@@ -316,7 +316,61 @@ else
     fail "force refuses to overwrite a live active cycle"
 fi
 
-EDGE_CYCLE_ID=cycle-active-owner "$DISPATCH_TOOL" close --status aborted >/dev/null
+echo "--- Test 4b2: operator dispatch preempts a live heartbeat cycle without force ---"
+EDGE_RUNNER_PID=$$ "$DISPATCH_TOOL" open --trigger operator --cycle-id cycle-operator-preempt --skill report >/dev/null
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+closed = [
+    event for event in events
+    if event["type"] == "CycleClosed" and event.get("cycle_id") == "cycle-active-owner"
+][-1]
+
+assert dispatch["cycle_id"] == "cycle-operator-preempt"
+assert dispatch["request"]["trigger"] == "operator"
+assert dispatch["state"]["active"] is True
+assert closed["payload"]["close_status"] == "aborted"
+assert closed["payload"]["reason"] == "superseded_by_operator_dispatch"
+PY
+then
+    pass "operator dispatch preempts live heartbeat without force"
+else
+    fail "operator dispatch preempts live heartbeat without force"
+fi
+
+EDGE_CYCLE_ID=cycle-operator-preempt "$DISPATCH_TOOL" close --status aborted >/dev/null
+
+echo "--- Test 4b3: operator dispatch does not preempt a live operator cycle ---"
+EDGE_RUNNER_PID=$$ "$DISPATCH_TOOL" open --trigger operator --cycle-id cycle-operator-owner >/dev/null
+set +e
+OPERATOR_REPLACE_OUTPUT=$(EDGE_RUNNER_PID=$$ "$DISPATCH_TOOL" open --trigger operator --cycle-id cycle-operator-replacement --skill research 2>&1)
+OPERATOR_REPLACE_STATUS=$?
+set -e
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$OPERATOR_REPLACE_STATUS" "$OPERATOR_REPLACE_OUTPUT"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+status = int(sys.argv[2])
+output = sys.argv[3]
+
+assert status == 1
+assert dispatch["cycle_id"] == "cycle-operator-owner"
+assert dispatch["state"]["active"] is True
+assert "active dispatch cycle already exists" in output or "running process" in output
+PY
+then
+    pass "operator dispatch cannot overwrite another live operator cycle"
+else
+    fail "operator dispatch cannot overwrite another live operator cycle"
+fi
+
+EDGE_CYCLE_ID=cycle-operator-owner "$DISPATCH_TOOL" close --status aborted >/dev/null
 
 echo "--- Test 4c: force can replace a stale active cycle whose owner pid is gone ---"
 STALE_PID=99999999

--- a/tools/edge-dispatch
+++ b/tools/edge-dispatch
@@ -178,6 +178,53 @@ def active_cycle_error(existing: dict, *, reason: str) -> dict:
     }
 
 
+def operator_can_preempt_active_cycle(existing: dict, *, trigger: str) -> bool:
+    if trigger != "operator":
+        return False
+    request = existing.get("request", {}) or {}
+    existing_trigger = canonical_trigger(str(request.get("trigger") or ""))
+    existing_policy = str(request.get("policy") or "").strip()
+    return existing_trigger == "heartbeat" or existing_policy == "autonomous"
+
+
+def mark_cycle_preempted(existing: dict, *, reason: str) -> None:
+    request = existing.setdefault("request", {})
+    state_block = existing.setdefault("state", {})
+    timestamp = now_iso()
+    state_block["active"] = False
+    state_block["phase"] = "closed"
+    state_block["close_status"] = "aborted"
+    state_block["close_reason"] = reason
+    state_block["closed_at"] = timestamp
+    state_block["updated_at"] = timestamp
+    if state_block.get("skill_status") == "running":
+        state_block["skill_status"] = "aborted"
+    write_json(CURRENT_DISPATCH_FILE, existing)
+    mirror_heartbeat_guard(existing)
+    emit_shadow_event(
+        "CycleClosed",
+        actor="edge-dispatch",
+        cycle_id=existing.get("cycle_id"),
+        payload={
+            "trigger": request.get("trigger"),
+            "skill": request.get("skill"),
+            "thread_id": request.get("primary_thread_id"),
+            "primary_thread_id": request.get("primary_thread_id"),
+            "close_status": "aborted",
+            "reason": reason,
+        },
+    )
+    log_event(
+        "dispatch_cycle",
+        action="closed",
+        cycle_id=existing.get("cycle_id"),
+        trigger=request.get("trigger"),
+        skill=request.get("skill") or "",
+        close_status="aborted",
+        reason=reason,
+    )
+
+
 def mirror_heartbeat_guard(state: dict) -> None:
     request = state.get("request", {}) or {}
     if request.get("trigger") != "heartbeat":
@@ -272,10 +319,14 @@ def touch_thread(thread_id: str, *, reason: str, cycle_id: str | None) -> None:
 
 
 def cmd_open(args: argparse.Namespace) -> int:
+    requested_trigger = args.trigger
+    trigger = canonical_trigger(requested_trigger)
     existing = read_state(require_exists=False)
     if existing and state_active(existing):
         alive = owner_alive(existing)
-        if args.force and alive is False:
+        if operator_can_preempt_active_cycle(existing, trigger=trigger):
+            mark_cycle_preempted(existing, reason="superseded_by_operator_dispatch")
+        elif args.force and alive is False:
             pass
         else:
             reason = "active dispatch cycle already exists"
@@ -287,8 +338,6 @@ def cmd_open(args: argparse.Namespace) -> int:
             return 1
 
     cycle_id = args.cycle_id or make_cycle_id()
-    requested_trigger = args.trigger
-    trigger = canonical_trigger(requested_trigger)
     policy = args.policy or ("autonomous" if trigger == "heartbeat" else "operator")
     routing_mode = args.routing_mode or ("auto" if trigger == "heartbeat" else "explicit")
     preflight_profile = args.preflight_profile or ("heartbeat_default" if trigger == "heartbeat" else "operator_default")
@@ -618,7 +667,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_open.add_argument("--cycle-id", help="Override generated cycle id")
     p_open.add_argument("--arg", action="append", help="Request arg (key=value). Repeatable.")
     p_open.add_argument("--args-json", help="JSON object with request args")
-    p_open.add_argument("--force", action="store_true", help="Replace only stale active cycles whose owner process is gone")
+    p_open.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace stale active cycles whose owner process is gone",
+    )
 
     p_dispatch = sub.add_parser("dispatch", help="Mark the current cycle as skill-dispatched")
     p_dispatch.add_argument("--skill", help="Dispatched skill name")


### PR DESCRIPTION
## Summary

- Allow ordinary operator-triggered dispatch opens to preempt an active autonomous/heartbeat cycle without requiring `--force`.
- Preserve protection against overwriting another live operator cycle.
- Record the preempted heartbeat/autonomous cycle as aborted with `superseded_by_operator_dispatch` before opening the operator cycle.

## Validation

- `python3 -m py_compile tools/edge-dispatch`
- `bash tests/test_edge_dispatch.sh`
- `bash tests/test_edge_runner.sh`