### PR TITLE
[codex] Exempt operational skills from artifact close gate

### DIFF
--- a/tests/test_edge_close.sh
+++ b/tests/test_edge_close.sh
@@ -194,9 +194,38 @@ assert dispatch["state"]["close_reason"] == "missing_artifact_published"
 assert dispatch["state"]["postflight_status"] == "failed"
 PY
 then
-    pass "edge-close requires artifact publication for every completed skill"
+    pass "edge-close requires artifact publication for publishing skills"
 else
-    fail "edge-close requires artifact publication for every completed skill"
+    fail "edge-close requires artifact publication for publishing skills"
+fi
+
+echo "--- Test 2b: operational skills close without artifact publication evidence ---"
+"$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-operational --force >/dev/null
+"$DISPATCH_TOOL" dispatch --skill roberto-autonomy >/dev/null
+EDGE_CYCLE_ID=cycle-close-operational "$STEP_TOOL" /roberto-autonomy diagnosis >/dev/null
+EDGE_CYCLE_ID=cycle-close-operational "$STEP_TOOL" /roberto-autonomy end >/dev/null
+"$CLOSE_TOOL" --status completed >/dev/null
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/logs/post-skill.log"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+postflight = open(sys.argv[2], encoding="utf-8").read()
+steps = dispatch["state"].get("postflight_steps", [])
+
+assert dispatch["request"]["skill"] == "roberto-autonomy"
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "completed"
+assert dispatch["state"]["close_reason"] != "missing_artifact_published"
+assert dispatch["state"]["postflight_status"] in {"completed", "warning"}
+assert "procedure: artifact_published | status: OK" not in postflight
+assert len(steps) >= 6
+PY
+then
+    pass "edge-close exempts prefixed operational skills from artifact publication"
+else
+    fail "edge-close exempts prefixed operational skills from artifact publication"
 fi
 
 echo "--- Test 3: completed close succeeds with skill end evidence, artifact publication, and postflight ---"

--- a/tools/edge-close
+++ b/tools/edge-close
@@ -2,8 +2,8 @@
 """edge-close — gated cycle finalization for dispatch runs.
 
 Closes the active dispatch cycle, but only allows `completed` when there is
-mechanical evidence that the skill finished, published an artifact, and the
-postflight profile ran.
+mechanical evidence that the skill finished, published an artifact when
+required, and the postflight profile ran.
 """
 
 from __future__ import annotations
@@ -88,9 +88,42 @@ def normalize_skill_id(value: object) -> str:
     return str(value or "").strip().lstrip("/").lower()
 
 
+KNOWN_SKILLS = {
+    "autonomy",
+    "delta",
+    "discovery",
+    "heartbeat",
+    "loader",
+    "map",
+    "planner",
+    "reflection",
+    "report",
+    "research",
+    "sources",
+    "strategy",
+}
+
+ARTIFACT_OPTIONAL_SKILLS = {
+    "autonomy",
+    "heartbeat",
+    "prompt",
+    "reflection",
+}
+
+
+def canonical_skill_id(value: object) -> str:
+    normalized = normalize_skill_id(value)
+    if normalized in KNOWN_SKILLS or normalized == "prompt":
+        return normalized
+    for skill in KNOWN_SKILLS:
+        if normalized.endswith(f"-{skill}"):
+            return skill
+    return normalized
+
+
 def skill_requires_artifact_publication(skill: object) -> bool:
-    normalized = normalize_skill_id(skill)
-    return bool(normalized and normalized != "prompt")
+    normalized = canonical_skill_id(skill)
+    return bool(normalized and normalized not in ARTIFACT_OPTIONAL_SKILLS)
 
 
 def iso_ge(left: str | None, right: str | None) -> bool:


### PR DESCRIPTION
## Summary

Fixes #447.

`edge-close` was requiring an `ArtifactPublished` event for every completed skill. That is correct for publishing skills such as discovery, but too strict for operational skills like heartbeat, autonomy, and reflection. On Roberto's fresh install, `/roberto-autonomy` completed its substrate sweep and then failed postflight with `missing_artifact_published` even though autonomy explicitly reports operational accountability rather than publishing a blog artifact.

This change canonicalizes prefixed runtime skills such as `roberto-autonomy` back to their registry skill before deciding whether artifact publication is required. Operational skills now still require skill completion and postflight, but no longer require an artifact publication event.

## Validation

- `python3 -m py_compile tools/edge-close`
- `bash tests/test_edge_close.sh`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_postflight_resilience.sh`