### PR TITLE
[codex] Publish stdout artifacts through runtime bridge

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -168,6 +168,9 @@ fi
 if [ "${MOCK_CLAUDE_EXIT_CODE:-0}" = "0" ] && [[ "$PROMPT" == *"/autonomy"* ]]; then
   publish_mock_artifact autonomy
 fi
+if [ -n "${MOCK_CLAUDE_ARTIFACT_MARKDOWN:-}" ]; then
+  printf '%b\n' "$MOCK_CLAUDE_ARTIFACT_MARKDOWN"
+fi
 exit "${MOCK_CLAUDE_EXIT_CODE:-0}"
 SH
 chmod +x "$TMP_HOME/.local/bin/claude"
@@ -377,6 +380,86 @@ then
     pass "inline heartbeat work skips duplicate follow-on invocation"
 else
     fail "inline heartbeat work skips duplicate follow-on invocation"
+fi
+
+echo "--- Test 1c: artifact-producing skills publish stdout through the shared runtime bridge ---"
+PUBLISH_SKILLS=(discovery research report strategy planner)
+PUBLISH_OK=1
+for skill in "${PUBLISH_SKILLS[@]}"; do
+    export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id-publish-$skill.txt"
+    export MOCK_CLAUDE_ARGS_OUT="$TMP_BASE/args-publish-$skill.txt"
+    rm -f "$MOCK_CLAUDE_ENV_OUT" "$MOCK_CLAUDE_ARGS_OUT"
+    unset MOCK_CLAUDE_HEARTBEAT_FLOW || true
+    export MOCK_CLAUDE_ARTIFACT_MARKDOWN="# Runtime Artifact ${skill}
+
+This is a complete markdown artifact emitted by the backend for ${skill}.
+
+It should be published by the runtime bridge, not by the individual skill."
+    if ! "$RUNNER_TOOL" skill \
+        --skill "$skill" \
+        --dispatch-trigger operator \
+        --dispatch-policy operator \
+        --dispatch-routing-mode explicit \
+        --dispatch-preflight-profile standard \
+        --dispatch-postflight-profile standard \
+        --dispatch-force >/dev/null; then
+        PUBLISH_OK=0
+        break
+    fi
+    if ! python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$TMP_EDGE/blog/entries" "$TMP_EDGE/reports" "$skill"; then
+import json
+import sys
+from pathlib import Path
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+entries_dir = Path(sys.argv[3])
+reports_dir = Path(sys.argv[4])
+skill = sys.argv[5]
+cycle_id = dispatch["cycle_id"]
+
+assert dispatch["request"]["skill"] == skill
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "completed"
+assert dispatch["state"]["close_reason"] != "missing_artifact_published"
+
+published = [
+    event for event in events
+    if event.get("cycle_id") == cycle_id
+    and event.get("type") == "ArtifactPublished"
+    and (event.get("payload") or {}).get("source_skill") == skill
+    and (event.get("payload") or {}).get("auto_published") is True
+]
+assert published, f"no auto-published artifact for {skill}"
+artifact = published[-1]["artifact"]
+assert artifact.startswith("blog/entries/")
+entry_path = entries_dir / Path(artifact).name
+assert entry_path.exists()
+entry = entry_path.read_text(encoding="utf-8")
+assert "runtime-published" in entry
+assert f"source_skill: {skill}" in entry
+report_name = (published[-1].get("payload") or {})["report"]
+assert (reports_dir / report_name).exists()
+
+phase_events = [
+    event for event in events
+    if event.get("cycle_id") == cycle_id
+    and event.get("type") == "PhaseCompleted"
+    and (event.get("payload") or {}).get("pipeline") == "runtime-stdout-artifact"
+    and (event.get("payload") or {}).get("ok") is True
+]
+assert phase_events
+PY
+        PUBLISH_OK=0
+        break
+    fi
+done
+unset MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
+
+if [[ "$PUBLISH_OK" -eq 1 ]]; then
+    pass "artifact-producing skills publish stdout through the shared runtime bridge"
+else
+    fail "artifact-producing skills publish stdout through the shared runtime bridge"
 fi
 
 echo "--- Test 2: success without skill completion evidence closes as failed ---"
@@ -640,19 +723,22 @@ captured = {}
 
 class Result:
     returncode = 0
+    stdout = ""
+    stderr = ""
 
-def fake_run(cmd, *, env, cwd, input, text):
+def fake_run(cmd, *, env, cwd, input, text, capture_output):
     captured["cmd"] = cmd
     captured["input"] = input
     captured["text"] = text
     captured["cwd"] = cwd
+    captured["capture_output"] = capture_output
     return Result()
 
 module.resolve_claude_bin = lambda: "/mock/claude"
 module.subprocess.run = fake_run
 os.environ["EDGE_RUNNER_SKILL_TIMEOUT_SEC"] = "0"
 try:
-    status = module.invoke_backend(args, {"EDGE_REPO_DIR": edge_dir}, cycle_id=None)
+    status, output = module.invoke_backend(args, {"EDGE_REPO_DIR": edge_dir}, cycle_id=None)
 finally:
     os.environ.pop("EDGE_RUNNER_SKILL_TIMEOUT_SEC", None)
 
@@ -672,6 +758,8 @@ assert captured["cmd"] == [
 assert captured["input"] == large_prompt
 assert large_prompt not in captured["cmd"]
 assert captured["text"] is True
+assert captured["capture_output"] is True
+assert output == ""
 PY
 then
     pass "large backend prompt is streamed through stdin"

--- a/tools/_shared/artifact_runtime.py
+++ b/tools/_shared/artifact_runtime.py
@@ -1,0 +1,181 @@
+"""Runtime publication bridge for skill-produced markdown artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .skill_policy import canonical_skill_id, skill_accepts_stdout_artifact
+from .telemetry import emit_shadow_event
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _strip_ansi(value: str) -> str:
+    return ANSI_RE.sub("", value or "")
+
+
+def _slugify(value: str, *, fallback: str) -> str:
+    slug = SLUG_RE.sub("-", value.lower()).strip("-")
+    return (slug or fallback)[:80].strip("-") or fallback
+
+
+def _json_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _extract_markdown_artifact(output: str) -> tuple[str, str] | None:
+    cleaned = _strip_ansi(output).replace("\r\n", "\n").replace("\r", "\n").strip()
+    if not cleaned:
+        return None
+    lines = cleaned.splitlines()
+    start = None
+    title = ""
+    for idx, line in enumerate(lines):
+        if line.startswith("# "):
+            start = idx
+            title = line[2:].strip()
+            break
+    if start is None:
+        return None
+    body = "\n".join(lines[start:]).strip() + "\n"
+    if len(body) < 80:
+        return None
+    return title or "Untitled artifact", body
+
+
+def _unique_path(path: Path) -> Path:
+    if not path.exists():
+        return path
+    stem = path.stem
+    suffix = path.suffix
+    for idx in range(2, 1000):
+        candidate = path.with_name(f"{stem}-{idx}{suffix}")
+        if not candidate.exists():
+            return candidate
+    raise RuntimeError(f"could not choose unique artifact path for {path}")
+
+
+def _render_report_html(*, title: str, body: str, skill: str, cycle_id: str) -> str:
+    escaped_title = html.escape(title)
+    escaped_skill = html.escape(skill)
+    escaped_cycle = html.escape(cycle_id)
+    escaped_body = html.escape(body)
+    return (
+        "<!doctype html>\n"
+        "<html lang=\"en\">\n"
+        "<head>\n"
+        "  <meta charset=\"utf-8\">\n"
+        f"  <title>{escaped_title}</title>\n"
+        "  <style>body{font-family:system-ui,sans-serif;max-width:920px;margin:40px auto;"
+        "line-height:1.55;padding:0 20px}pre{white-space:pre-wrap;font:inherit}</style>\n"
+        "</head>\n"
+        "<body>\n"
+        f"  <p><strong>Skill:</strong> {escaped_skill} · <strong>Cycle:</strong> {escaped_cycle}</p>\n"
+        f"  <pre>{escaped_body}</pre>\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def publish_stdout_artifact(
+    *,
+    skill: object,
+    cycle_id: str | None,
+    output: str,
+    entries_dir: Path,
+    reports_dir: Path,
+    instance: object = "",
+) -> dict[str, Any]:
+    canonical_skill = canonical_skill_id(skill, instance=instance)
+    if not cycle_id:
+        return {"published": False, "reason": "missing_cycle_id", "skill": canonical_skill}
+    if not skill_accepts_stdout_artifact(canonical_skill):
+        return {"published": False, "reason": "skill_not_artifact_pipeline", "skill": canonical_skill}
+
+    extracted = _extract_markdown_artifact(output)
+    if not extracted:
+        return {"published": False, "reason": "missing_markdown_artifact", "skill": canonical_skill}
+    title, body = extracted
+
+    now = _now()
+    date = now.date().isoformat()
+    slug_title = _slugify(title, fallback=cycle_id)
+    entry_path = _unique_path(entries_dir / f"{date}-{canonical_skill}-{slug_title}.md")
+    report_name = f"{entry_path.stem}.html"
+    report_path = reports_dir / report_name
+    artifact = f"blog/entries/{entry_path.name}"
+    artifact_hash = "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+    entries_dir.mkdir(parents=True, exist_ok=True)
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        _render_report_html(title=title, body=body, skill=canonical_skill, cycle_id=cycle_id),
+        encoding="utf-8",
+    )
+    entry_path.write_text(
+        "---\n"
+        f"date: {date}\n"
+        f"title: {_json_string(title)}\n"
+        f"report: {report_name}\n"
+        "tags:\n"
+        f"  - {canonical_skill}\n"
+        "  - runtime-published\n"
+        "status: approved\n"
+        f"source_skill: {canonical_skill}\n"
+        f"cycle_id: {cycle_id}\n"
+        f"hash: {artifact_hash}\n"
+        "---\n\n"
+        f"{body}",
+        encoding="utf-8",
+    )
+
+    phase_payload = {
+        "pipeline": "runtime-stdout-artifact",
+        "phase": "pipeline",
+        "ok": True,
+        "source_skill": canonical_skill,
+        "artifact": artifact,
+        "report": report_name,
+        "auto_published": True,
+    }
+    emit_shadow_event(
+        "PhaseCompleted",
+        actor="edge-runner",
+        artifact=artifact,
+        cycle_id=cycle_id,
+        payload=phase_payload,
+    )
+    emit_shadow_event(
+        "ArtifactPublished",
+        actor="continuity",
+        artifact=artifact,
+        cycle_id=cycle_id,
+        payload={
+            "title": title,
+            "source_skill": canonical_skill,
+            "hash": artifact_hash,
+            "report": report_name,
+            "auto_published": True,
+            "pipeline": "runtime-stdout-artifact",
+        },
+    )
+    return {
+        "published": True,
+        "artifact": artifact,
+        "entry_path": str(entry_path),
+        "report_path": str(report_path),
+        "skill": canonical_skill,
+        "hash": artifact_hash,
+    }

--- a/tools/_shared/skill_policy.py
+++ b/tools/_shared/skill_policy.py
@@ -1,0 +1,66 @@
+"""Shared skill classification and lifecycle policy."""
+
+from __future__ import annotations
+
+KNOWN_SKILLS = {
+    "autonomy",
+    "delta",
+    "discovery",
+    "heartbeat",
+    "loader",
+    "map",
+    "planner",
+    "reflection",
+    "report",
+    "research",
+    "sources",
+    "strategy",
+}
+
+ARTIFACT_PIPELINE_SKILLS = {
+    "discovery",
+    "planner",
+    "report",
+    "research",
+    "strategy",
+}
+
+ARTIFACT_OPTIONAL_SKILLS = {
+    "autonomy",
+    "delta",
+    "heartbeat",
+    "loader",
+    "map",
+    "prompt",
+    "reflection",
+    "sources",
+}
+
+
+def normalize_skill_id(value: object) -> str:
+    return str(value or "").strip().lstrip("/").lower()
+
+
+def canonical_skill_id(value: object, *, instance: object = "") -> str:
+    normalized = normalize_skill_id(value)
+    if normalized in KNOWN_SKILLS or normalized == "prompt":
+        return normalized
+
+    prefix = normalize_skill_id(instance)
+    if prefix and normalized.startswith(f"{prefix}-"):
+        candidate = normalized[len(prefix) + 1 :]
+        if candidate in KNOWN_SKILLS or candidate == "prompt":
+            return candidate
+
+    for skill in KNOWN_SKILLS:
+        if normalized.endswith(f"-{skill}"):
+            return skill
+    return normalized
+
+
+def skill_requires_artifact_publication(skill: object, *, instance: object = "") -> bool:
+    return canonical_skill_id(skill, instance=instance) in ARTIFACT_PIPELINE_SKILLS
+
+
+def skill_accepts_stdout_artifact(skill: object, *, instance: object = "") -> bool:
+    return skill_requires_artifact_publication(skill, instance=instance)

--- a/tools/edge-close
+++ b/tools/edge-close
@@ -19,6 +19,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import CURRENT_DISPATCH_FILE, EDGE_REPO_DIR, LOGS_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.skill_policy import skill_requires_artifact_publication  # noqa: E402
 from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
 
 POST_SKILL_LOG = LOGS_DIR / "post-skill.log"
@@ -82,48 +83,6 @@ def iter_jsonl(path: Path) -> list[dict]:
         except json.JSONDecodeError:
             continue
     return rows
-
-
-def normalize_skill_id(value: object) -> str:
-    return str(value or "").strip().lstrip("/").lower()
-
-
-KNOWN_SKILLS = {
-    "autonomy",
-    "delta",
-    "discovery",
-    "heartbeat",
-    "loader",
-    "map",
-    "planner",
-    "reflection",
-    "report",
-    "research",
-    "sources",
-    "strategy",
-}
-
-ARTIFACT_OPTIONAL_SKILLS = {
-    "autonomy",
-    "heartbeat",
-    "prompt",
-    "reflection",
-}
-
-
-def canonical_skill_id(value: object) -> str:
-    normalized = normalize_skill_id(value)
-    if normalized in KNOWN_SKILLS or normalized == "prompt":
-        return normalized
-    for skill in KNOWN_SKILLS:
-        if normalized.endswith(f"-{skill}"):
-            return skill
-    return normalized
-
-
-def skill_requires_artifact_publication(skill: object) -> bool:
-    normalized = canonical_skill_id(skill)
-    return bool(normalized and normalized not in ARTIFACT_OPTIONAL_SKILLS)
 
 
 def iso_ge(left: str | None, right: str | None) -> bool:

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -22,9 +22,11 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import EDGE_INSTANCE, EDGE_REPO_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
+from paths import EDGE_INSTANCE, EDGE_REPO_DIR, ENTRIES_DIR, REPORTS_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.artifact_runtime import publish_stdout_artifact  # noqa: E402
 from _shared.dispatch_runtime import read_dispatch_state, render_skill_runtime_prompt, write_dispatch_state  # noqa: E402
+from _shared.skill_policy import skill_accepts_stdout_artifact  # noqa: E402
 from _shared.telemetry import emit_shadow_event  # noqa: E402
 from _shared.telemetry import log_run_step  # noqa: E402
 
@@ -514,27 +516,49 @@ def resolve_skill_timeout_seconds() -> int | None:
     return value
 
 
-def invoke_backend(args: argparse.Namespace, env: dict[str, str], *, cycle_id: str | None = None) -> int:
+def _print_backend_output(output: str) -> None:
+    if not output:
+        return
+    sys.stdout.write(output)
+    if not output.endswith("\n"):
+        sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def invoke_backend(args: argparse.Namespace, env: dict[str, str], *, cycle_id: str | None = None) -> tuple[int, str]:
     content = build_backend_content(args, cycle_id)
     cmd = build_backend_command(args)
 
     timeout_seconds = resolve_skill_timeout_seconds()
     if timeout_seconds is None:
-        result = subprocess.run(cmd, env=env, cwd=resolve_cwd(args.cwd), input=content, text=True)
-        return result.returncode
+        result = subprocess.run(
+            cmd,
+            env=env,
+            cwd=resolve_cwd(args.cwd),
+            input=content,
+            text=True,
+            capture_output=True,
+        )
+        output = (result.stdout or "") + (result.stderr or "")
+        _print_backend_output(output)
+        return result.returncode, output
 
     popen_kwargs: dict = {
         "env": env,
         "cwd": resolve_cwd(args.cwd),
         "stdin": subprocess.PIPE,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,
         "text": True,
     }
     if os.name == "posix":
         popen_kwargs["start_new_session"] = True
     proc = subprocess.Popen(cmd, **popen_kwargs)
     try:
-        proc.communicate(input=content, timeout=timeout_seconds)
-        return proc.returncode
+        output, _ = proc.communicate(input=content, timeout=timeout_seconds)
+        output = output or ""
+        _print_backend_output(output)
+        return proc.returncode, output
     except subprocess.TimeoutExpired:
         target = args.skill if args.cmd == "skill" else "prompt"
         emit_shadow_event(
@@ -620,6 +644,56 @@ def maybe_mark_skill_completion(skill: str, cycle_id: str | None, exit_code: int
     )
 
 
+def artifact_published_for_cycle(cycle_id: str | None) -> bool:
+    if not cycle_id:
+        return False
+    state = dispatch_state_matches(cycle_id)
+    threshold = None
+    if state:
+        state_block = state.get("state", {}) or {}
+        threshold = state_block.get("dispatched_at") or state_block.get("opened_at")
+    for event in reversed(iter_jsonl(STATE_EVENTS_FILE)):
+        if event.get("type") != "ArtifactPublished":
+            continue
+        if event.get("cycle_id") != cycle_id:
+            continue
+        if threshold and not iso_ge(event.get("ts"), threshold):
+            continue
+        artifact = str(event.get("artifact") or (event.get("payload", {}) or {}).get("artifact") or "")
+        if artifact.startswith("blog/entries/"):
+            return True
+    return False
+
+
+def maybe_publish_stdout_artifact(skill: str, cycle_id: str | None, exit_code: int, output: str) -> None:
+    if not cycle_id or exit_code != 0:
+        return
+    normalized = normalize_skill_name(skill)
+    if not skill_accepts_stdout_artifact(normalized, instance=EDGE_INSTANCE):
+        return
+    if artifact_published_for_cycle(cycle_id):
+        return
+    result = publish_stdout_artifact(
+        skill=normalized,
+        cycle_id=cycle_id,
+        output=output,
+        entries_dir=ENTRIES_DIR,
+        reports_dir=REPORTS_DIR,
+        instance=EDGE_INSTANCE,
+    )
+    status = "completed" if result.get("published") else "warning"
+    log_run_step(
+        "edge-runner",
+        "stdout_artifact_publish",
+        status,
+        run_id=cycle_id,
+        backend="runtime",
+        mode="artifact",
+        target=normalized,
+        close_reason=str(result.get("reason") or ""),
+    )
+
+
 def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--backend", default="claude", choices=["claude"])
     parser.add_argument("--cwd", help="Working directory for the backend invocation")
@@ -689,11 +763,12 @@ def main() -> int:
                 target=args.skill if args.cmd == "skill" else "prompt",
             )
 
-        exit_code = invoke_backend(args, env, cycle_id=cycle_id)
+        exit_code, backend_output = invoke_backend(args, env, cycle_id=cycle_id)
         if args.cmd == "prompt":
             maybe_mark_skill_completion("prompt", cycle_id, exit_code)
         elif args.cmd == "skill":
             maybe_mark_skill_completion(args.skill, cycle_id, exit_code)
+            maybe_publish_stdout_artifact(args.skill, cycle_id, exit_code, backend_output)
 
         follow_on_skill = dispatched_follow_on_skill(args, cycle_id)
         if follow_on_skill and exit_code == 0:
@@ -723,8 +798,9 @@ def main() -> int:
                     target=follow_on_skill,
                 )
                 follow_on_args = make_follow_on_skill_args(args, follow_on_skill)
-                follow_on_exit = invoke_backend(follow_on_args, env, cycle_id=cycle_id)
+                follow_on_exit, follow_on_output = invoke_backend(follow_on_args, env, cycle_id=cycle_id)
                 maybe_mark_skill_completion(follow_on_skill, cycle_id, follow_on_exit)
+                maybe_publish_stdout_artifact(follow_on_skill, cycle_id, follow_on_exit, follow_on_output)
                 final_status = "completed" if follow_on_exit == 0 else "failed"
                 log_run_step(
                     "edge-runner",


### PR DESCRIPTION
## Summary

Fixes #449.

This moves publication behavior out of individual skills and into the runtime set policy:

- Adds shared skill lifecycle policy for artifact-producing vs operational skills.
- Limits the close gate to the artifact-producing set: `discovery`, `research`, `report`, `strategy`, and `planner`.
- Adds a runtime stdout artifact bridge that publishes successful markdown artifacts from those skills as blog entries, creates matching report HTML, and emits `PhaseCompleted` + `ArtifactPublished` evidence before `edge-close` runs.
- Keeps operational/non-publishing skills such as `heartbeat`, `autonomy`, `reflection`, `map`, `sources`, `delta`, and `loader` out of the publication gate.

The behavior is now shared across the artifact-producing set instead of being implemented separately in `/discovery` or any single skill.

## Validation

- `python3 -m py_compile tools/edge-runner tools/edge-close tools/_shared/artifact_runtime.py tools/_shared/skill_policy.py`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_postflight_resilience.sh`
- `bash tests/test_pipeline_state_projection.sh`
- `git diff --check`