### PR TITLE
[codex] Tighten skill artifact policy exceptions

### DIFF
--- a/tests/test_edge_close.sh
+++ b/tests/test_edge_close.sh
@@ -105,6 +105,36 @@ with open(path, "a", encoding="utf-8") as fh:
 PY
 }
 
+append_skill_completed() {
+    local cycle_id="$1"
+    local skill="$2"
+    python3 - <<'PY' "$TMP_EDGE/state/events/log.jsonl" "$cycle_id" "$skill"
+import json
+import sys
+from datetime import datetime, timezone
+
+path, cycle_id, skill = sys.argv[1:4]
+event = {
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "type": "SkillRunCompleted",
+    "actor": "edge-runner",
+    "cycle_id": cycle_id,
+    "payload": {
+        "skill": skill,
+        "registry_skill": skill,
+        "event": "end",
+        "expected": 1,
+        "done": 1,
+        "explicit_skips": 0,
+        "silent_skips": [],
+        "completion_pct": 100,
+    },
+}
+with open(path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(event) + "\n")
+PY
+}
+
 echo "=== edge-close Smoke Test ==="
 echo "Temp state: $TMP_EDGE"
 echo ""
@@ -199,11 +229,10 @@ else
     fail "edge-close requires artifact publication for publishing skills"
 fi
 
-echo "--- Test 2b: operational skills close without artifact publication evidence ---"
-"$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-operational --force >/dev/null
-"$DISPATCH_TOOL" dispatch --skill roberto-autonomy >/dev/null
-EDGE_CYCLE_ID=cycle-close-operational "$STEP_TOOL" /roberto-autonomy diagnosis >/dev/null
-EDGE_CYCLE_ID=cycle-close-operational "$STEP_TOOL" /roberto-autonomy end >/dev/null
+echo "--- Test 2b: heartbeat router closes without artifact publication evidence ---"
+"$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-heartbeat-router --force >/dev/null
+"$DISPATCH_TOOL" dispatch --skill roberto-heartbeat >/dev/null
+append_skill_completed cycle-close-heartbeat-router roberto-heartbeat
 "$CLOSE_TOOL" --status completed >/dev/null
 
 if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/logs/post-skill.log"
@@ -214,7 +243,7 @@ dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
 postflight = open(sys.argv[2], encoding="utf-8").read()
 steps = dispatch["state"].get("postflight_steps", [])
 
-assert dispatch["request"]["skill"] == "roberto-autonomy"
+assert dispatch["request"]["skill"] == "roberto-heartbeat"
 assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
 assert dispatch["state"]["close_reason"] != "missing_artifact_published"
@@ -223,9 +252,64 @@ assert "procedure: artifact_published | status: OK" not in postflight
 assert len(steps) >= 6
 PY
 then
-    pass "edge-close exempts prefixed operational skills from artifact publication"
+    pass "edge-close exempts heartbeat router from artifact publication"
 else
-    fail "edge-close exempts prefixed operational skills from artifact publication"
+    fail "edge-close exempts heartbeat router from artifact publication"
+fi
+
+echo "--- Test 2c: non-heartbeat skills require artifact publication regardless of prefix ---"
+"$DISPATCH_TOOL" open --trigger operator --cycle-id cycle-close-prefixed-no-artifact --force >/dev/null
+"$DISPATCH_TOOL" dispatch --skill roberto-autonomy >/dev/null
+EDGE_CYCLE_ID=cycle-close-prefixed-no-artifact "$STEP_TOOL" /roberto-autonomy diagnosis >/dev/null
+EDGE_CYCLE_ID=cycle-close-prefixed-no-artifact "$STEP_TOOL" /roberto-autonomy end >/dev/null
+set +e
+"$CLOSE_TOOL" --status completed >/dev/null
+STATUS=$?
+set -e
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$STATUS"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+status = int(sys.argv[2])
+
+assert status == 1
+assert dispatch["request"]["trigger"] == "operator"
+assert dispatch["request"]["skill"] == "roberto-autonomy"
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "failed"
+assert dispatch["state"]["close_reason"] == "missing_artifact_published"
+assert dispatch["state"]["postflight_status"] == "failed"
+PY
+then
+    pass "edge-close requires artifact publication for prefixed non-heartbeat skills"
+else
+    fail "edge-close requires artifact publication for prefixed non-heartbeat skills"
+fi
+
+echo "--- Test 2d: delta and loader support skills are artifact-exempt ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+sys.path.insert(0, str(edge_dir / "tools"))
+from _shared.skill_policy import skill_requires_artifact_publication
+
+assert not skill_requires_artifact_publication("delta")
+assert not skill_requires_artifact_publication("ed-delta", instance="ed")
+assert not skill_requires_artifact_publication("loader")
+assert not skill_requires_artifact_publication("ed-loader", instance="ed")
+assert not skill_requires_artifact_publication("heartbeat")
+assert skill_requires_artifact_publication("autonomy")
+assert skill_requires_artifact_publication("ed-autonomy", instance="ed")
+assert skill_requires_artifact_publication("reflection")
+PY
+then
+    pass "edge-close policy exempts delta and loader support skills only"
+else
+    fail "edge-close policy exempts delta and loader support skills only"
 fi
 
 echo "--- Test 3: completed close succeeds with skill end evidence, artifact publication, and postflight ---"

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -165,7 +165,7 @@ PY
     publish_mock_artifact discovery
   fi
 fi
-if [ "${MOCK_CLAUDE_EXIT_CODE:-0}" = "0" ] && [[ "$PROMPT" == *"/autonomy"* ]]; then
+if [ -z "${MOCK_CLAUDE_ARTIFACT_MARKDOWN:-}" ] && [ "${MOCK_CLAUDE_EXIT_CODE:-0}" = "0" ] && [[ "$PROMPT" == *"/autonomy"* ]]; then
   publish_mock_artifact autonomy
 fi
 if [ -n "${MOCK_CLAUDE_ARTIFACT_MARKDOWN:-}" ]; then
@@ -382,8 +382,8 @@ else
     fail "inline heartbeat work skips duplicate follow-on invocation"
 fi
 
-echo "--- Test 1c: artifact-producing skills publish stdout through the shared runtime bridge ---"
-PUBLISH_SKILLS=(discovery research report strategy planner)
+echo "--- Test 1c: non-heartbeat skills publish stdout through the shared runtime bridge ---"
+PUBLISH_SKILLS=(discovery research report strategy planner autonomy reflection sources map test-agent-autonomy)
 PUBLISH_OK=1
 for skill in "${PUBLISH_SKILLS[@]}"; do
     export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id-publish-$skill.txt"
@@ -418,7 +418,10 @@ reports_dir = Path(sys.argv[4])
 skill = sys.argv[5]
 cycle_id = dispatch["cycle_id"]
 
-assert dispatch["request"]["skill"] == skill
+expected_skill = skill
+expected_source_skill = "autonomy" if skill == "test-agent-autonomy" else skill
+
+assert dispatch["request"]["skill"] == expected_skill
 assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
 assert dispatch["state"]["close_reason"] != "missing_artifact_published"
@@ -427,7 +430,7 @@ published = [
     event for event in events
     if event.get("cycle_id") == cycle_id
     and event.get("type") == "ArtifactPublished"
-    and (event.get("payload") or {}).get("source_skill") == skill
+    and (event.get("payload") or {}).get("source_skill") == expected_source_skill
     and (event.get("payload") or {}).get("auto_published") is True
 ]
 assert published, f"no auto-published artifact for {skill}"
@@ -437,7 +440,7 @@ entry_path = entries_dir / Path(artifact).name
 assert entry_path.exists()
 entry = entry_path.read_text(encoding="utf-8")
 assert "runtime-published" in entry
-assert f"source_skill: {skill}" in entry
+assert f"source_skill: {expected_source_skill}" in entry
 report_name = (published[-1].get("payload") or {})["report"]
 assert (reports_dir / report_name).exists()
 
@@ -457,9 +460,9 @@ done
 unset MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
 
 if [[ "$PUBLISH_OK" -eq 1 ]]; then
-    pass "artifact-producing skills publish stdout through the shared runtime bridge"
+    pass "non-heartbeat skills publish stdout through the shared runtime bridge"
 else
-    fail "artifact-producing skills publish stdout through the shared runtime bridge"
+    fail "non-heartbeat skills publish stdout through the shared runtime bridge"
 fi
 
 echo "--- Test 2: success without skill completion evidence closes as failed ---"

--- a/tools/_shared/skill_policy.py
+++ b/tools/_shared/skill_policy.py
@@ -17,23 +17,11 @@ KNOWN_SKILLS = {
     "strategy",
 }
 
-ARTIFACT_PIPELINE_SKILLS = {
-    "discovery",
-    "planner",
-    "report",
-    "research",
-    "strategy",
-}
-
-ARTIFACT_OPTIONAL_SKILLS = {
-    "autonomy",
+ARTIFACT_EXEMPT_SKILLS = {
     "delta",
     "heartbeat",
     "loader",
-    "map",
     "prompt",
-    "reflection",
-    "sources",
 }
 
 
@@ -59,7 +47,8 @@ def canonical_skill_id(value: object, *, instance: object = "") -> str:
 
 
 def skill_requires_artifact_publication(skill: object, *, instance: object = "") -> bool:
-    return canonical_skill_id(skill, instance=instance) in ARTIFACT_PIPELINE_SKILLS
+    normalized = canonical_skill_id(skill, instance=instance)
+    return bool(normalized and normalized not in ARTIFACT_EXEMPT_SKILLS)
 
 
 def skill_accepts_stdout_artifact(skill: object, *, instance: object = "") -> bool:


### PR DESCRIPTION
## Summary

- Require artifact publication for every substantive skill, regardless of whether the cycle was operator- or heartbeat-triggered.
- Keep only router/support contexts artifact-exempt: `heartbeat`, `prompt`, `delta`, and `loader`.
- Extend close/runner tests so prefixed substantive skills require artifacts, support skills stay exempt, and stdout publishing covers substantive non-heartbeat skills.

## Validation

- `python3 -m py_compile tools/_shared/skill_policy.py tools/_shared/artifact_runtime.py tools/edge-runner tools/edge-close`
- `bash tests/test_edge_close.sh`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_edge_dispatch.sh`