### PR TITLE
[codex] capture stdout artifacts and bound health preflight

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -490,6 +490,54 @@ else
     fail "non-heartbeat skills publish stdout through the shared runtime bridge"
 fi
 
+echo "--- Test 1d: plain terminal prose is captured as an artifact without dumping the body ---"
+export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id-plain-stdout.txt"
+export MOCK_CLAUDE_ARGS_OUT="$TMP_BASE/args-plain-stdout.txt"
+rm -f "$MOCK_CLAUDE_ENV_OUT" "$MOCK_CLAUDE_ARGS_OUT" "$TMP_BASE/plain-stdout.out"
+export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'Plain Runtime Report\n\nThis report intentionally has no markdown heading. The runtime should still capture the terminal prose as a durable artifact instead of letting an artifact-producing skill close with text only in stdout. The body is long enough to satisfy the artifact bridge threshold.'
+"$RUNNER_TOOL" skill \
+    --skill /report \
+    --dispatch-trigger operator \
+    --dispatch-policy operator \
+    --dispatch-routing-mode explicit \
+    --dispatch-preflight-profile heartbeat_default \
+    --dispatch-postflight-profile standard \
+    --dispatch-force >"$TMP_BASE/plain-stdout.out"
+unset MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$TMP_EDGE/blog/entries" "$TMP_BASE/plain-stdout.out"
+import json
+import sys
+from pathlib import Path
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+entries_dir = Path(sys.argv[3])
+runner_stdout = Path(sys.argv[4]).read_text(encoding="utf-8")
+
+assert dispatch["request"]["skill"] == "report"
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "completed"
+published = [
+    event for event in events
+    if event.get("type") == "ArtifactPublished"
+    and event.get("cycle_id") == dispatch["cycle_id"]
+]
+assert published
+artifact = published[-1]["artifact"]
+entry = entries_dir / Path(artifact).name
+text = entry.read_text(encoding="utf-8")
+assert "# Plain Runtime Report" in text
+assert "artifact-producing skill close with text only in stdout" in text
+assert "edge-runner: published artifact blog/entries/" in runner_stdout
+assert "artifact-producing skill close with text only in stdout" not in runner_stdout
+PY
+then
+    pass "plain terminal prose is captured as an artifact without dumping the body"
+else
+    fail "plain terminal prose is captured as an artifact without dumping the body"
+fi
+
 echo "--- Test 2: dispatched skill success without artifact closes as failed ---"
 unset MOCK_CLAUDE_HEARTBEAT_FLOW || true
 cat >"$TMP_EDGE/state/dispatch-queue.json" <<'JSON'
@@ -806,6 +854,51 @@ then
     pass "large backend prompt is streamed through stdin"
 else
     fail "large backend prompt is streamed through stdin"
+fi
+
+echo "--- Test 10: health snapshot refresh timeout falls back to the last snapshot ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_BASE"
+import importlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+tmp_base = Path(sys.argv[2])
+runtime = tmp_base / "health-timeout-runtime"
+(runtime / "bin").mkdir(parents=True, exist_ok=True)
+(runtime / "health").mkdir(parents=True, exist_ok=True)
+(runtime / "bin" / "edge-check.sh").write_text("#!/usr/bin/env bash\nsleep 10\n", encoding="utf-8")
+(runtime / "bin" / "edge-check.sh").chmod(0o755)
+(runtime / "health" / "current.json").write_text(
+    json.dumps({"status": "degraded", "score": 67, "ts": "2026-05-02T00:00:00+00:00"}),
+    encoding="utf-8",
+)
+
+sys.path.insert(0, str(edge_dir / "tools"))
+module = importlib.import_module("_shared.dispatch_runtime")
+module.EDGE_REPO_DIR = runtime
+module.HEALTH_CURRENT_FILE = runtime / "health" / "current.json"
+os.environ["EDGE_PREFLIGHT_HEALTH_TIMEOUT_SEC"] = "1"
+started = time.monotonic()
+try:
+    snapshot = module._health_snapshot()
+finally:
+    os.environ.pop("EDGE_PREFLIGHT_HEALTH_TIMEOUT_SEC", None)
+elapsed = time.monotonic() - started
+
+assert elapsed < 4, elapsed
+assert snapshot["status"] == "degraded"
+assert snapshot["score"] == 67
+assert snapshot["refresh_status"] == "stale_timeout"
+assert "timeout" in snapshot["refresh_reason"]
+PY
+then
+    pass "health snapshot refresh timeout falls back to the last snapshot"
+else
+    fail "health snapshot refresh timeout falls back to the last snapshot"
 fi
 
 echo ""

--- a/tools/_shared/artifact_runtime.py
+++ b/tools/_shared/artifact_runtime.py
@@ -55,6 +55,25 @@ def _extract_markdown_artifact(output: str) -> tuple[str, str] | None:
     return title or "Untitled artifact", body
 
 
+def _extract_plaintext_artifact(output: str) -> tuple[str, str] | None:
+    cleaned = _strip_ansi(output).replace("\r\n", "\n").replace("\r", "\n").strip()
+    if not cleaned:
+        return None
+    words = re.findall(r"\w+", cleaned)
+    if len(cleaned) < 120 or len(words) < 20:
+        return None
+
+    first_line = ""
+    for line in cleaned.splitlines():
+        candidate = line.strip().strip("#").strip()
+        if candidate:
+            first_line = candidate
+            break
+    title = first_line[:96].strip(" :-\t") or "Runtime captured artifact"
+    body = f"# {title}\n\n{cleaned}\n"
+    return title, body
+
+
 def _unique_path(path: Path) -> Path:
     if not path.exists():
         return path
@@ -104,7 +123,7 @@ def publish_stdout_artifact(
     if not skill_accepts_stdout_artifact(canonical_skill):
         return {"published": False, "reason": "skill_not_artifact_pipeline", "skill": canonical_skill}
 
-    extracted = _extract_markdown_artifact(output)
+    extracted = _extract_markdown_artifact(output) or _extract_plaintext_artifact(output)
     if not extracted:
         return {"published": False, "reason": "missing_markdown_artifact", "skill": canonical_skill}
     title, body = extracted

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import fcntl
@@ -97,6 +98,7 @@ DELTA_HISTORY_DIR = CONTINUITY_DELTAS_DIR / "runtime-history"
 DELTA_OPEN_WORK_LIMIT = int(os.environ.get("EDGE_DELTA_OPEN_WORK_LIMIT", "20") or "20")
 DELTA_CHAT_ITEM_LIMIT = int(os.environ.get("EDGE_DELTA_CHAT_ITEM_LIMIT", "12") or "12")
 DELTA_EVENT_LIMIT = int(os.environ.get("EDGE_DELTA_EVENT_LIMIT", "8") or "8")
+DEFAULT_HEALTH_CHECK_TIMEOUT_SECONDS = 45
 
 EXTERNAL_SEARCH_INTENTS = {
     "autonomy": "strategy",
@@ -158,14 +160,52 @@ def _append_preflight_log(name: str, status: str, detail: str = "") -> None:
         handle.write(line + "\n")
 
 
-def _run_subprocess(cmd: list[str], *, cwd: Path | None = None) -> tuple[int, str, str]:
-    result = subprocess.run(
+def _health_check_timeout_seconds() -> int | None:
+    raw = os.environ.get("EDGE_PREFLIGHT_HEALTH_TIMEOUT_SEC", str(DEFAULT_HEALTH_CHECK_TIMEOUT_SECONDS))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_HEALTH_CHECK_TIMEOUT_SECONDS
+    if value <= 0:
+        return None
+    return value
+
+
+def _run_subprocess(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: int | None = None,
+) -> tuple[int, str, str]:
+    proc = subprocess.Popen(
         cmd,
         cwd=str(cwd or EDGE_REPO_DIR),
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
+        start_new_session=timeout is not None,
     )
-    return result.returncode, result.stdout.strip(), result.stderr.strip()
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+        return proc.returncode, (stdout or "").strip(), (stderr or "").strip()
+    except subprocess.TimeoutExpired:
+        if timeout is not None:
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError, OSError):
+                proc.terminate()
+        try:
+            stdout, stderr = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            if timeout is not None:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError, OSError):
+                    proc.kill()
+            stdout, stderr = proc.communicate()
+        detail = f"timeout after {timeout}s" if timeout is not None else "timeout"
+        stderr = "\n".join(part for part in [(stderr or "").strip(), detail] if part)
+        return 124, (stdout or "").strip(), stderr
 
 
 def _normalize_skill_name(skill: str | None) -> str:
@@ -492,8 +532,38 @@ def _resolve_runtime_policy(skill: str | None, args: dict[str, Any]) -> dict[str
 
 def _health_snapshot() -> dict[str, Any]:
     check_script = EDGE_REPO_DIR / "bin" / "edge-check.sh"
+    refresh_status = "missing"
+    refresh_reason = ""
     if check_script.exists():
-        _run_subprocess([str(check_script)], cwd=EDGE_REPO_DIR)
+        status, _stdout, stderr = _run_subprocess(
+            [str(check_script)],
+            cwd=EDGE_REPO_DIR,
+            timeout=_health_check_timeout_seconds(),
+        )
+        if status == 0:
+            refresh_status = "refreshed"
+        elif status == 124:
+            refresh_status = "stale_timeout"
+            refresh_reason = stderr or "health check timed out"
+            emit_shadow_event(
+                "HealthSnapshotRefreshTimedOut",
+                actor="edge-preflight",
+                payload={
+                    "script": str(check_script),
+                    "timeout_seconds": _health_check_timeout_seconds(),
+                    "fallback": str(HEALTH_CURRENT_FILE),
+                },
+            )
+            log_event(
+                "health_snapshot",
+                actor="edge-preflight",
+                action="refresh_timeout",
+                script=str(check_script),
+                timeout_seconds=_health_check_timeout_seconds() or 0,
+            )
+        else:
+            refresh_status = "stale_error"
+            refresh_reason = stderr or f"edge-check exited {status}"
     payload = _read_json(HEALTH_CURRENT_FILE, {})
     if not isinstance(payload, dict):
         payload = {}
@@ -504,6 +574,8 @@ def _health_snapshot() -> dict[str, Any]:
         "score": int(payload.get("score", 100) or 100),
         "hard_fail": bool(payload.get("hard_fail", False)),
         "updated_at": payload.get("ts") or payload.get("updated_at") or "",
+        "refresh_status": refresh_status,
+        "refresh_reason": refresh_reason,
         "remediation_count": len(remediation) if isinstance(remediation, list) else 0,
         "dimensions": {
             name: {

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -594,7 +594,13 @@ def _print_backend_output(output: str) -> None:
     sys.stdout.flush()
 
 
-def invoke_backend(args: argparse.Namespace, env: dict[str, str], *, cycle_id: str | None = None) -> tuple[int, str]:
+def invoke_backend(
+    args: argparse.Namespace,
+    env: dict[str, str],
+    *,
+    cycle_id: str | None = None,
+    echo_output: bool = True,
+) -> tuple[int, str]:
     content = build_backend_content(args, cycle_id)
     cmd = build_backend_command(args)
 
@@ -609,7 +615,8 @@ def invoke_backend(args: argparse.Namespace, env: dict[str, str], *, cycle_id: s
             capture_output=True,
         )
         output = (result.stdout or "") + (result.stderr or "")
-        _print_backend_output(output)
+        if echo_output:
+            _print_backend_output(output)
         return result.returncode, output
 
     popen_kwargs: dict = {
@@ -626,7 +633,8 @@ def invoke_backend(args: argparse.Namespace, env: dict[str, str], *, cycle_id: s
     try:
         output, _ = proc.communicate(input=content, timeout=timeout_seconds)
         output = output or ""
-        _print_backend_output(output)
+        if echo_output:
+            _print_backend_output(output)
         return proc.returncode, output
     except subprocess.TimeoutExpired:
         target = args.skill if args.cmd == "skill" else "prompt"
@@ -734,14 +742,14 @@ def artifact_published_for_cycle(cycle_id: str | None) -> bool:
     return False
 
 
-def maybe_publish_stdout_artifact(skill: str, cycle_id: str | None, exit_code: int, output: str) -> None:
+def maybe_publish_stdout_artifact(skill: str, cycle_id: str | None, exit_code: int, output: str) -> dict:
     if not cycle_id or exit_code != 0:
-        return
+        return {"published": False, "reason": "not_publishable_exit", "skill": normalize_skill_name(skill)}
     normalized = normalize_skill_name(skill)
     if not skill_accepts_stdout_artifact(normalized, instance=EDGE_INSTANCE):
-        return
+        return {"published": False, "reason": "skill_not_artifact_pipeline", "skill": normalized}
     if artifact_published_for_cycle(cycle_id):
-        return
+        return {"published": True, "reason": "already_published", "skill": normalized}
     result = publish_stdout_artifact(
         skill=normalized,
         cycle_id=cycle_id,
@@ -761,6 +769,25 @@ def maybe_publish_stdout_artifact(skill: str, cycle_id: str | None, exit_code: i
         target=normalized,
         close_reason=str(result.get("reason") or ""),
     )
+    return result
+
+
+def should_echo_backend_output(skill: str | None) -> bool:
+    normalized = normalize_skill_name(skill)
+    return not skill_accepts_stdout_artifact(normalized, instance=EDGE_INSTANCE)
+
+
+def print_artifact_publish_result(result: dict, output: str) -> None:
+    if result.get("published"):
+        artifact = result.get("artifact")
+        report_path = result.get("report_path")
+        if artifact:
+            message = f"edge-runner: published artifact {artifact}"
+            if report_path:
+                message += f" ({report_path})"
+            print(message)
+        return
+    _print_backend_output(output)
 
 
 def add_common_arguments(parser: argparse.ArgumentParser) -> None:
@@ -836,6 +863,7 @@ def main() -> int:
                 follow_on_target=routed_heartbeat_skill,
             )
         else:
+            echo_output = args.cmd != "skill" or should_echo_backend_output(args.skill)
             if cycle_id:
                 log_run_step(
                     "edge-runner",
@@ -847,12 +875,14 @@ def main() -> int:
                     target=args.skill if args.cmd == "skill" else "prompt",
                 )
 
-            exit_code, backend_output = invoke_backend(args, env, cycle_id=cycle_id)
+            exit_code, backend_output = invoke_backend(args, env, cycle_id=cycle_id, echo_output=echo_output)
         if args.cmd == "prompt":
             maybe_mark_skill_completion("prompt", cycle_id, exit_code)
         elif args.cmd == "skill" and not routed_heartbeat_skill:
             maybe_mark_skill_completion(args.skill, cycle_id, exit_code)
-            maybe_publish_stdout_artifact(args.skill, cycle_id, exit_code, backend_output)
+            publish_result = maybe_publish_stdout_artifact(args.skill, cycle_id, exit_code, backend_output)
+            if not should_echo_backend_output(args.skill):
+                print_artifact_publish_result(publish_result, backend_output)
 
         follow_on_skill = dispatched_follow_on_skill(args, cycle_id)
         if follow_on_skill and exit_code == 0:
@@ -882,9 +912,17 @@ def main() -> int:
                     target=follow_on_skill,
                 )
                 follow_on_args = make_follow_on_skill_args(args, follow_on_skill)
-                follow_on_exit, follow_on_output = invoke_backend(follow_on_args, env, cycle_id=cycle_id)
+                follow_on_echo_output = should_echo_backend_output(follow_on_skill)
+                follow_on_exit, follow_on_output = invoke_backend(
+                    follow_on_args,
+                    env,
+                    cycle_id=cycle_id,
+                    echo_output=follow_on_echo_output,
+                )
                 maybe_mark_skill_completion(follow_on_skill, cycle_id, follow_on_exit)
-                maybe_publish_stdout_artifact(follow_on_skill, cycle_id, follow_on_exit, follow_on_output)
+                follow_on_publish_result = maybe_publish_stdout_artifact(follow_on_skill, cycle_id, follow_on_exit, follow_on_output)
+                if not follow_on_echo_output:
+                    print_artifact_publish_result(follow_on_publish_result, follow_on_output)
                 final_status = "completed" if follow_on_exit == 0 else "failed"
                 log_run_step(
                     "edge-runner",


### PR DESCRIPTION
## Summary

- capture long plain stdout from artifact-producing skills as a runtime-published blog artifact, even when the model does not emit a Markdown heading
- suppress artifact skill body output in `edge-runner`; print a concise publication line instead, and only dump stdout when publication fails
- bound preflight `edge-check.sh` refreshes with `EDGE_PREFLIGHT_HEALTH_TIMEOUT_SEC` and fall back to the last health snapshot on timeout
- add runner coverage for plain terminal prose artifact capture and stale health snapshot fallback

## Context

Refs #453 and #455. The recent report incidents had the same operational shape: the model produced report-like content, but the runtime path still allowed that content to live outside the canonical artifact publication path. This makes artifact production a mechanical runtime contract instead of relying on skill discipline alone.

## Validation

- `git diff --check`
- `python3 -m py_compile tools/edge-runner tools/_shared/artifact_runtime.py tools/_shared/dispatch_runtime.py tools/edge-close tools/edge-dispatch`
- `bash tests/test_edge_runner.sh` (13/13)
- `bash tests/test_report_publication_completion.sh && bash tests/test_report_skill_contract.sh && bash tests/test_research_publication_completion.sh && bash tests/test_report_review_ownership.sh && bash tests/test_edge_dispatch.sh && bash tests/test_edge_close.sh`