### PR TITLE
[codex] use cached claims projections in preflight

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -901,6 +901,52 @@ else
     fail "health snapshot refresh timeout falls back to the last snapshot"
 fi
 
+echo "--- Test 11: preflight claims summary uses cached projections ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_BASE"
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+tmp_base = Path(sys.argv[2])
+runtime = tmp_base / "claims-cache-runtime"
+projection_dir = runtime / "state" / "projections"
+projection_dir.mkdir(parents=True, exist_ok=True)
+claims_path = projection_dir / "claims-digest.json"
+orphans_path = projection_dir / "orphan-claims.json"
+claims_path.write_text(json.dumps({"open_total": 2, "verified_total": 5, "attention_count": 1}), encoding="utf-8")
+orphans_path.write_text(json.dumps({"orphan_total": 3, "open_orphan_total": 1}), encoding="utf-8")
+
+sys.path.insert(0, str(edge_dir / "tools"))
+module = importlib.import_module("_shared.dispatch_runtime")
+module.CLAIMS_DIGEST_FILE = claims_path
+module.ORPHAN_CLAIMS_FILE = orphans_path
+if hasattr(module, "refresh_continuity_projections"):
+    def _explode():
+        raise AssertionError("preflight claims summary must not refresh continuity projections")
+    module.refresh_continuity_projections = _explode
+
+os.environ["EDGE_PREFLIGHT_CLAIMS_MAX_AGE_SEC"] = "86400"
+try:
+    claims, orphans = module._claims_summary()
+finally:
+    os.environ.pop("EDGE_PREFLIGHT_CLAIMS_MAX_AGE_SEC", None)
+
+assert claims["open_total"] == 2
+assert claims["verified_total"] == 5
+assert claims["projection_status"] == "cached"
+assert orphans["orphan_total"] == 3
+assert orphans["open_orphan_total"] == 1
+assert orphans["projection_status"] == "cached"
+PY
+then
+    pass "preflight claims summary uses cached projections"
+else
+    fail "preflight claims summary uses cached projections"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -39,7 +39,6 @@ from paths import (  # noqa: E402
     THREADS_DIR,
     WORKFLOW_HEALTH_FILE,
 )
-from .continuity import refresh_continuity_projections  # noqa: E402
 from .capability_runtime import build_capability_status, build_configured_integrations, build_source_bindings, invoke_capability, probe_capability  # noqa: E402
 from .operator_pressure import read_or_refresh_operator_pressure_projection  # noqa: E402
 from .protocol_runtime import emit_protocol_step_observed, ensure_compiled_protocol, protocol_context  # noqa: E402
@@ -99,6 +98,7 @@ DELTA_OPEN_WORK_LIMIT = int(os.environ.get("EDGE_DELTA_OPEN_WORK_LIMIT", "20") o
 DELTA_CHAT_ITEM_LIMIT = int(os.environ.get("EDGE_DELTA_CHAT_ITEM_LIMIT", "12") or "12")
 DELTA_EVENT_LIMIT = int(os.environ.get("EDGE_DELTA_EVENT_LIMIT", "8") or "8")
 DEFAULT_HEALTH_CHECK_TIMEOUT_SECONDS = 45
+DEFAULT_CLAIMS_PROJECTION_MAX_AGE_SECONDS = 6 * 60 * 60
 
 EXTERNAL_SEARCH_INTENTS = {
     "autonomy": "strategy",
@@ -588,10 +588,42 @@ def _health_snapshot() -> dict[str, Any]:
     }
 
 
+def _claims_projection_max_age_seconds() -> int | None:
+    raw = os.environ.get("EDGE_PREFLIGHT_CLAIMS_MAX_AGE_SEC", str(DEFAULT_CLAIMS_PROJECTION_MAX_AGE_SECONDS))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_CLAIMS_PROJECTION_MAX_AGE_SECONDS
+    if value <= 0:
+        return None
+    return value
+
+
+def _projection_cache_status(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"projection_status": "missing", "projection_age_seconds": None}
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+        age_seconds = max(0, int((datetime.now(timezone.utc) - mtime).total_seconds()))
+    except OSError:
+        return {"projection_status": "unknown", "projection_age_seconds": None}
+    max_age = _claims_projection_max_age_seconds()
+    if max_age is not None and age_seconds > max_age:
+        status = "stale_cached"
+    else:
+        status = "cached"
+    return {"projection_status": status, "projection_age_seconds": age_seconds}
+
+
 def _claims_summary() -> tuple[dict[str, Any], dict[str, Any]]:
-    projections = refresh_continuity_projections()
-    digest = projections.get("digest") or {}
-    orphans = projections.get("orphans") or {}
+    digest = _read_json(CLAIMS_DIGEST_FILE, {})
+    orphans = _read_json(ORPHAN_CLAIMS_FILE, {})
+    if not isinstance(digest, dict):
+        digest = {}
+    if not isinstance(orphans, dict):
+        orphans = {}
+    digest_cache = _projection_cache_status(CLAIMS_DIGEST_FILE)
+    orphan_cache = _projection_cache_status(ORPHAN_CLAIMS_FILE)
     return (
         {
             "open_total": digest.get("open_total", 0),
@@ -603,6 +635,7 @@ def _claims_summary() -> tuple[dict[str, Any], dict[str, Any]]:
             "hot_threads_by_open_claims": digest.get("hot_threads_by_open_claims", [])[:5],
             "oldest_open_claims": digest.get("oldest_open_claims", [])[:5],
             "source_path": str(CLAIMS_DIGEST_FILE),
+            **digest_cache,
         },
         {
             "orphan_total": orphans.get("orphan_total", 0),
@@ -611,6 +644,7 @@ def _claims_summary() -> tuple[dict[str, Any], dict[str, Any]]:
             "multi_artifact_orphan_total": orphans.get("multi_artifact_orphan_total", 0),
             "candidate_clusters": orphans.get("candidate_clusters", [])[:5],
             "source_path": str(ORPHAN_CLAIMS_FILE),
+            **orphan_cache,
         },
     )
 
@@ -1627,11 +1661,23 @@ def _execute_preflight_step(
         claims_summary, orphan_summary = _claims_summary()
         request["claims_summary"] = claims_summary
         request["orphan_claims_summary"] = orphan_summary
+        cache_statuses = {
+            str(claims_summary.get("projection_status") or ""),
+            str(orphan_summary.get("projection_status") or ""),
+        }
+        satisfied = "missing" not in cache_statuses
+        status = "warning" if (not satisfied or "stale_cached" in cache_statuses) else "ok"
         return _step_result(
             step,
-            status="ok",
-            satisfied=True,
+            status=status,
+            satisfied=satisfied,
             detail=f"open={claims_summary.get('open_total', 0)} orphans={orphan_summary.get('orphan_total', 0)}",
+            extra={
+                "claims_projection_status": claims_summary.get("projection_status"),
+                "claims_projection_age_seconds": claims_summary.get("projection_age_seconds"),
+                "orphan_projection_status": orphan_summary.get("projection_status"),
+                "orphan_projection_age_seconds": orphan_summary.get("projection_age_seconds"),
+            },
         )
 
     if kind == "primitives.status":


### PR DESCRIPTION
## Summary

- stop recomputing continuity/claims projections during dispatch preflight
- read the cached claims and orphan projections instead, with cache status/age included in preflight evidence
- keep missing or stale projections as warnings rather than letting preflight scan large event logs
- add runner coverage that fails if preflight claims summary tries to refresh continuity projections

## Root Cause

The Bob Marley validation run got stuck before dispatch after `claude.sessions.digest`. The next preflight step was `claims.refresh`, which still called `refresh_continuity_projections()`. On that host, `state/events/log.jsonl` is about 618MB, so preflight performed heavy projection work on the hot path and could wedge the dispatch lifecycle.

This keeps preflight bounded. Projection refresh remains a postflight/publication concern; preflight consumes the last known snapshot.

## Validation

- `git diff --check`
- `python3 -m py_compile tools/_shared/dispatch_runtime.py tools/edge-preflight tools/edge-runner`
- `bash tests/test_edge_runner.sh` (14/14)
- `bash tests/test_edge_dispatch.sh && bash tests/test_edge_close.sh`