### PR TITLE
[codex] supervise artifact skill completion

### DIFF
--- a/tests/test_edge_dispatch.sh
+++ b/tests/test_edge_dispatch.sh
@@ -290,6 +290,46 @@ else
     fail "close finalizes state and emits CycleClosed"
 fi
 
+echo "--- Test 4a: dispatch skips heavy preflight enrichment when preflight already ran ---"
+"$DISPATCH_TOOL" open --trigger operator --cycle-id cycle-preflight-ready --skill research >/dev/null
+python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json"
+import json
+import sys
+
+path = sys.argv[1]
+dispatch = json.load(open(path, encoding="utf-8"))
+dispatch["state"]["preflight_status"] = "completed"
+dispatch["state"]["preflight_checked_at"] = "2026-05-02T00:00:00+00:00"
+dispatch["request"]["schema_version"] = 1
+dispatch["request"]["preflight_evidence"] = [{"id": "sentinel", "kind": "sentinel.preflight"}]
+dispatch["request"]["health_snapshot"] = {"status": "cached", "score": 100}
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(dispatch, handle, indent=2)
+PY
+EDGE_CYCLE_ID=cycle-preflight-ready "$DISPATCH_TOOL" dispatch --skill research >/dev/null
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+cycle_events = [event for event in events if event.get("cycle_id") == "cycle-preflight-ready"]
+
+assert dispatch["state"]["skill_dispatched"] is True
+assert dispatch["state"]["phase"] == "skill_dispatched"
+assert dispatch["request"]["preflight_evidence"] == [{"id": "sentinel", "kind": "sentinel.preflight"}]
+assert not [event for event in cycle_events if event["type"] == "PreSkillContextLoaded"]
+assert [event for event in cycle_events if event["type"] == "SkillDispatched"]
+PY
+then
+    pass "dispatch skips heavy preflight enrichment when preflight already ran"
+else
+    fail "dispatch skips heavy preflight enrichment when preflight already ran"
+fi
+
+EDGE_CYCLE_ID=cycle-preflight-ready "$DISPATCH_TOOL" close --status aborted >/dev/null
+
 echo "--- Test 4b: force does not replace an active cycle owned by a live runner ---"
 EDGE_RUNNER_PID=$$ "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-active-owner >/dev/null
 set +e

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -135,6 +135,13 @@ printf '__END__\n' >> "${MOCK_CLAUDE_ARGS_OUT:?}"
 if [ -n "${MOCK_CLAUDE_SLEEP_SECONDS:-}" ]; then
   sleep "${MOCK_CLAUDE_SLEEP_SECONDS}"
 fi
+if [ "${MOCK_CLAUDE_FAIL_ONCE:-0}" = "1" ]; then
+  INVOCATIONS="$(grep -c '^__INVOCATION__$' "${MOCK_CLAUDE_ARGS_OUT:?}" 2>/dev/null || true)"
+  if [ "$INVOCATIONS" = "1" ]; then
+    printf '%s\n' "${MOCK_CLAUDE_FAIL_ONCE_OUTPUT:-Acknowledged — standing by.}"
+    exit "${MOCK_CLAUDE_FAIL_ONCE_EXIT_CODE:-1}"
+  fi
+fi
 if [ "${MOCK_CLAUDE_HEARTBEAT_FLOW:-0}" = "1" ]; then
   if [[ "$PROMPT" == *"/ed-heartbeat"* ]]; then
     "${EDGE_REPO_DIR:?}/tools/edge-dispatch" dispatch --skill discovery >/dev/null
@@ -536,6 +543,57 @@ then
     pass "plain terminal prose is captured as an artifact without dumping the body"
 else
     fail "plain terminal prose is captured as an artifact without dumping the body"
+fi
+
+echo "--- Test 1e: artifact supervisor retries acknowledgement-only backend failure ---"
+export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id-retry.txt"
+export MOCK_CLAUDE_ARGS_OUT="$TMP_BASE/args-retry.txt"
+rm -f "$MOCK_CLAUDE_ENV_OUT" "$MOCK_CLAUDE_ARGS_OUT" "$TMP_BASE/retry.out"
+export MOCK_CLAUDE_FAIL_ONCE=1
+export MOCK_CLAUDE_FAIL_ONCE_OUTPUT="Acknowledged — staying out of Frostpeck's way."
+export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'# Retry Published Report\n\nThe artifact supervisor retried a backend response that only acknowledged and did not publish. This second attempt produces a complete runtime-published report artifact.'
+"$RUNNER_TOOL" skill \
+    --skill /research \
+    --dispatch-trigger operator \
+    --dispatch-policy operator \
+    --dispatch-routing-mode explicit \
+    --dispatch-preflight-profile heartbeat_default \
+    --dispatch-postflight-profile standard \
+    --dispatch-force >"$TMP_BASE/retry.out"
+unset MOCK_CLAUDE_FAIL_ONCE MOCK_CLAUDE_FAIL_ONCE_OUTPUT MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$TMP_EDGE/blog/entries" "$TMP_BASE/retry.out" "$TMP_BASE/args-retry.txt"
+import json
+import sys
+from pathlib import Path
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+entries_dir = Path(sys.argv[3])
+runner_stdout = Path(sys.argv[4]).read_text(encoding="utf-8")
+args_log = Path(sys.argv[5]).read_text(encoding="utf-8")
+
+assert dispatch["request"]["skill"] == "research"
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "completed"
+assert args_log.count("__INVOCATION__") == 2
+assert "ARTIFACT SUPERVISOR RETRY" in args_log
+published = [
+    event for event in events
+    if event.get("type") == "ArtifactPublished"
+    and event.get("cycle_id") == dispatch["cycle_id"]
+]
+assert published
+artifact = published[-1]["artifact"]
+entry = entries_dir / Path(artifact).name
+assert "Retry Published Report" in entry.read_text(encoding="utf-8")
+assert "edge-runner: published artifact blog/entries/" in runner_stdout
+assert "Frostpeck" not in runner_stdout
+PY
+then
+    pass "artifact supervisor retries acknowledgement-only backend failure"
+else
+    fail "artifact supervisor retries acknowledgement-only backend failure"
 fi
 
 echo "--- Test 2: dispatched skill success without artifact closes as failed ---"

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -2065,12 +2065,22 @@ def render_skill_runtime_prompt(skill: str, state: dict[str, Any]) -> str:
             "- After dispatch, the substantive skill owns search, synthesis, publication, and postflight.\n"
             "- Inline artifact publication before dispatch is a protocol violation and is mechanically blocked.\n\n"
         )
+    artifact_contract = ""
+    if normalized_skill and normalized_skill not in {"heartbeat", "delta", "loader", "prompt"} and not normalized_skill.endswith("heartbeat"):
+        artifact_contract = (
+            "ARTIFACT SKILL CONTRACT:\n"
+            "- This invocation must end with a durable artifact or a concrete failure report artifact. Acknowledgement-only text, standby text, topic-choice lists, or deference to another session is not completion.\n"
+            "- If no explicit topic was supplied, infer one bounded target from `exploration_pack`, `beat_launch_context`, `operator_pressure`, health, claims, queue, or recent failures.\n"
+            "- If another persona/session appears active, treat that as context only; the runtime already prevented unsafe concurrent dispatch ownership before invoking you.\n"
+            "- If the full publication pipeline cannot run, emit a complete Markdown artifact in stdout with a top-level `#` heading so the runtime can publish it.\n\n"
+        )
     return (
         f"{skill}\n\n"
         "Dispatch runtime context below is authoritative for cross-cutting checks already handled by CLI "
         "(health, inbox, corpus, claims, primitives, workflows, queue, onboarding, protocol execution).\n"
         "Do not re-derive those manually unless a field is missing or obviously stale.\n\n"
         f"{heartbeat_contract}"
+        f"{artifact_contract}"
         "The `operator_pressure_digest` captures recent operator signal only. The `beat_launch_context` is the ephemeral composition of that operator signal with current edge-state signals and the exploration budget for this beat. Treat those two together as the launch frame for what matters now.\n\n"
         "DELTA PREREQUISITE:\n"
         "For substantive non-heartbeat skills, `request.delta_prerequisite.required` is true. Before the main skill performs substantive work, execute the internal `ed-delta` pass over `request.delta_prerequisite`: reconcile previous_delta_digest, raw chat, structured preflight state, events, and relevant work surfaces; produce a `delta_frame`; and carry `delta_frame.work_continuity.inject_to_next_skill` into the main skill. The delta pass runs in this same backend invocation, so its explored text and frame remain available to the dispatched skill. If no real delta is found, state that explicitly and continue with an empty delta frame.\n\n"

--- a/tools/edge-dispatch
+++ b/tools/edge-dispatch
@@ -75,6 +75,10 @@ def canonical_trigger(value: str) -> str:
     return value
 
 
+def comparable_skill(value: object) -> str:
+    return str(value or "").strip().lstrip("/")
+
+
 def parse_args_items(items: list[str] | None, args_json: str | None) -> dict[str, object]:
     merged: dict[str, object] = {}
     if args_json:
@@ -447,6 +451,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print(json.dumps({"ok": False, "error": "dispatch requires a skill"}, indent=2), file=sys.stderr)
         return 1
 
+    previous_skill = request.get("skill")
     if state_block.get("skill_dispatched"):
         existing_skill = request.get("skill")
         existing_args = request.get("args", {})
@@ -473,6 +478,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     request["skill"] = requested_skill
     request["args"] = requested_args
     request["primary_thread_id"] = primary_thread_id
+    preflight_already_enriched = bool(
+        state_block.get("preflight_checked_at")
+        and request.get("preflight_evidence")
+        and comparable_skill(previous_skill) == comparable_skill(requested_skill)
+    )
     acknowledge_heartbeat_routing(
         state,
         dispatched_skill=requested_skill,
@@ -484,12 +494,13 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     state_block["dispatched_at"] = timestamp
     state_block["updated_at"] = timestamp
     inbox = attach_snapshot_to_dispatch(state, skill=requested_skill)
-    enrich_dispatch_state(
-        state,
-        skill=requested_skill,
-        stage="dispatch",
-        profile=request.get("preflight_profile"),
-    )
+    if not preflight_already_enriched:
+        enrich_dispatch_state(
+            state,
+            skill=requested_skill,
+            stage="dispatch",
+            profile=request.get("preflight_profile"),
+        )
     state_block["phase"] = "skill_dispatched"
     state_block["skill_status"] = "running"
     state_block["dispatched_at"] = timestamp

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -600,8 +600,9 @@ def invoke_backend(
     *,
     cycle_id: str | None = None,
     echo_output: bool = True,
+    content_override: str | None = None,
 ) -> tuple[int, str]:
-    content = build_backend_content(args, cycle_id)
+    content = content_override if content_override is not None else build_backend_content(args, cycle_id)
     cmd = build_backend_command(args)
 
     timeout_seconds = resolve_skill_timeout_seconds()
@@ -772,6 +773,47 @@ def maybe_publish_stdout_artifact(skill: str, cycle_id: str | None, exit_code: i
     return result
 
 
+def build_artifact_supervisor_retry_prompt(
+    args: argparse.Namespace,
+    cycle_id: str | None,
+    *,
+    previous_output: str,
+    reason: str,
+) -> str:
+    state = read_dispatch_state() if cycle_id else {}
+    base = render_skill_runtime_prompt(args.skill, state) if cycle_id else str(args.skill or "")
+    clipped_output = (previous_output or "").strip()
+    if len(clipped_output) > 2000:
+        clipped_output = clipped_output[:2000] + "\n...[truncated]"
+    return (
+        f"{base}\n\n"
+        "ARTIFACT SUPERVISOR RETRY:\n"
+        f"- The previous backend attempt ended without a durable artifact. Reason: {reason}.\n"
+        "- This is a substantive artifact-producing skill invocation, not an acknowledgement channel.\n"
+        "- Do not answer with only deference, standby text, topic choices, or a refusal to act because another persona/session appears active.\n"
+        "- If no explicit topic was supplied, infer one bounded target from the runtime frame: exploration_pack, beat_launch_context, operator_pressure, health, claims, queue, or recent failures.\n"
+        "- Produce a durable artifact now. If the full publication pipeline is unavailable, emit a complete Markdown artifact in stdout with a top-level `#` heading so the runtime can publish it.\n"
+        "- If a real blocker remains, the artifact must be a failure report with the concrete command, missing access, or invariant that blocked completion.\n\n"
+        "Previous backend output:\n"
+        "```text\n"
+        f"{clipped_output}\n"
+        "```\n"
+    )
+
+
+def should_retry_artifact_skill(skill: str | None, cycle_id: str | None, exit_code: int, publish_result: dict) -> bool:
+    if not cycle_id:
+        return False
+    normalized = normalize_skill_name(skill)
+    if not skill_accepts_stdout_artifact(normalized, instance=EDGE_INSTANCE):
+        return False
+    if artifact_published_for_cycle(cycle_id):
+        return False
+    if exit_code != 0:
+        return True
+    return str(publish_result.get("reason") or "") == "missing_markdown_artifact"
+
+
 def should_echo_backend_output(skill: str | None) -> bool:
     normalized = normalize_skill_name(skill)
     return not skill_accepts_stdout_artifact(normalized, instance=EDGE_INSTANCE)
@@ -879,8 +921,45 @@ def main() -> int:
         if args.cmd == "prompt":
             maybe_mark_skill_completion("prompt", cycle_id, exit_code)
         elif args.cmd == "skill" and not routed_heartbeat_skill:
-            maybe_mark_skill_completion(args.skill, cycle_id, exit_code)
             publish_result = maybe_publish_stdout_artifact(args.skill, cycle_id, exit_code, backend_output)
+            if should_retry_artifact_skill(args.skill, cycle_id, exit_code, publish_result):
+                retry_reason = str(publish_result.get("reason") or close_reason or f"backend_exit_{exit_code}")
+                log_run_step(
+                    "edge-runner",
+                    "artifact_supervisor_retry",
+                    "started",
+                    run_id=cycle_id,
+                    backend=args.backend,
+                    mode=args.cmd,
+                    target=args.skill,
+                    close_reason=retry_reason,
+                )
+                retry_prompt = build_artifact_supervisor_retry_prompt(
+                    args,
+                    cycle_id,
+                    previous_output=backend_output,
+                    reason=retry_reason,
+                )
+                exit_code, backend_output = invoke_backend(
+                    args,
+                    env,
+                    cycle_id=cycle_id,
+                    echo_output=echo_output,
+                    content_override=retry_prompt,
+                )
+                publish_result = maybe_publish_stdout_artifact(args.skill, cycle_id, exit_code, backend_output)
+                log_run_step(
+                    "edge-runner",
+                    "artifact_supervisor_retry",
+                    "completed" if exit_code == 0 and publish_result.get("published") else "failed",
+                    run_id=cycle_id,
+                    backend=args.backend,
+                    mode=args.cmd,
+                    target=args.skill,
+                    exit_code=exit_code,
+                    close_reason=str(publish_result.get("reason") or ""),
+                )
+            maybe_mark_skill_completion(args.skill, cycle_id, exit_code)
             if not should_echo_backend_output(args.skill):
                 print_artifact_publish_result(publish_result, backend_output)
 
@@ -921,6 +1000,45 @@ def main() -> int:
                 )
                 maybe_mark_skill_completion(follow_on_skill, cycle_id, follow_on_exit)
                 follow_on_publish_result = maybe_publish_stdout_artifact(follow_on_skill, cycle_id, follow_on_exit, follow_on_output)
+                if should_retry_artifact_skill(follow_on_skill, cycle_id, follow_on_exit, follow_on_publish_result):
+                    retry_reason = str(follow_on_publish_result.get("reason") or f"backend_exit_{follow_on_exit}")
+                    log_run_step(
+                        "edge-runner",
+                        "artifact_supervisor_retry",
+                        "started",
+                        run_id=cycle_id,
+                        backend=args.backend,
+                        mode="skill",
+                        target=follow_on_skill,
+                        close_reason=retry_reason,
+                    )
+                    retry_args = make_follow_on_skill_args(args, follow_on_skill)
+                    retry_prompt = build_artifact_supervisor_retry_prompt(
+                        retry_args,
+                        cycle_id,
+                        previous_output=follow_on_output,
+                        reason=retry_reason,
+                    )
+                    follow_on_exit, follow_on_output = invoke_backend(
+                        retry_args,
+                        env,
+                        cycle_id=cycle_id,
+                        echo_output=follow_on_echo_output,
+                        content_override=retry_prompt,
+                    )
+                    maybe_mark_skill_completion(follow_on_skill, cycle_id, follow_on_exit)
+                    follow_on_publish_result = maybe_publish_stdout_artifact(follow_on_skill, cycle_id, follow_on_exit, follow_on_output)
+                    log_run_step(
+                        "edge-runner",
+                        "artifact_supervisor_retry",
+                        "completed" if follow_on_exit == 0 and follow_on_publish_result.get("published") else "failed",
+                        run_id=cycle_id,
+                        backend=args.backend,
+                        mode="skill",
+                        target=follow_on_skill,
+                        exit_code=follow_on_exit,
+                        close_reason=str(follow_on_publish_result.get("reason") or ""),
+                    )
                 if not follow_on_echo_output:
                     print_artifact_publish_result(follow_on_publish_result, follow_on_output)
                 final_status = "completed" if follow_on_exit == 0 else "failed"


### PR DESCRIPTION
## Summary

- add a runtime artifact supervisor retry in `edge-runner` for artifact-producing skills that exit without a durable artifact
- add an explicit artifact skill contract to the runtime prompt: ack-only, standby/deference, topic-choice lists, or persona conflicts are not completion
- retry once with a recovery prompt that forces either a durable artifact or a concrete failure report artifact
- avoid running heavy dispatch enrichment inside the global dispatch lock when preflight for the same skill already ran
- add coverage for acknowledgement-only backend failure recovery and dispatch lock-safe preflight reuse

## Root Cause

Fleet validation after #456/#457 surfaced two remaining lifecycle gaps:

1. `gauss-research` returned only an acknowledgement/deference message and exited non-zero, so the run still closed without an artifact.
2. `bobmarley` reached preflight completion, then `edge-dispatch dispatch` repeated enrichment while holding the dispatch lock, which blocked abort/close from acquiring the same lock.

This is the first mechanical supervisor layer: it does not try to build a full process tree yet, but it supervises the artifact contract and keeps dispatch lifecycle mutation bounded.

## Validation

- `git diff --check`
- `python3 -m py_compile tools/edge-runner tools/_shared/dispatch_runtime.py tools/edge-dispatch tools/edge-preflight`
- `bash tests/test_edge_runner.sh` (15/15)
- `bash tests/test_edge_dispatch.sh && bash tests/test_edge_close.sh`