### PR TITLE
[codex] cache postflight claims refresh

### DIFF
--- a/tests/test_postflight_resilience.sh
+++ b/tests/test_postflight_resilience.sh
@@ -15,7 +15,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$TMP_EDGE/state" "$TMP_EDGE/logs" "$TMP_EDGE/search"
+mkdir -p "$TMP_EDGE/state/projections" "$TMP_EDGE/logs" "$TMP_EDGE/search"
 
 export EDGE_REPO_DIR="$EDGE_DIR"
 export EDGE_STATE_DIR="$TMP_EDGE"
@@ -189,6 +189,49 @@ then
     pass "async inbox response failures degrade to warning"
 else
     fail "async inbox response failures degrade to warning"
+fi
+
+echo "--- Test 4: claims refresh uses cached projections without continuity rebuild ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import importlib.machinery
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+loader = importlib.machinery.SourceFileLoader("edge_postflight", str(edge_dir / "tools" / "edge-postflight"))
+spec = importlib.util.spec_from_loader("edge_postflight", loader)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+assert not hasattr(module, "refresh_continuity_projections")
+module.CLAIMS_DIGEST_FILE.parent.mkdir(parents=True, exist_ok=True)
+module.CLAIMS_DIGEST_FILE.write_text(
+    json.dumps({"open_total": 3, "verified_total": 7, "unthreaded_count": 1}),
+    encoding="utf-8",
+)
+module.ORPHAN_CLAIMS_FILE.write_text(
+    json.dumps({"orphan_total": 2, "open_orphan_total": 1}),
+    encoding="utf-8",
+)
+
+result = module._execute_postflight_step(
+    {"id": "claims", "kind": "claims.refresh"},
+    {"cycle_id": "cycle-postflight-claims", "request": {}, "state": {}},
+)
+
+assert result["status"] == "ok", result
+assert result["satisfied"] is True, result
+assert result["payload"]["digest"]["open_total"] == 3
+assert result["payload"]["orphans"]["orphan_total"] == 2
+assert result["payload"]["cache"]["status"] == "cached"
+PY
+then
+    pass "claims refresh reads cached projection files"
+else
+    fail "claims refresh reads cached projection files"
 fi
 
 echo ""

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -18,9 +19,8 @@ from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import EDGE_REPO_DIR, LOGS_DIR  # noqa: E402
+from paths import CLAIMS_DIGEST_FILE, EDGE_REPO_DIR, LOGS_DIR, ORPHAN_CLAIMS_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
-from _shared.continuity import refresh_continuity_projections  # noqa: E402
 from _shared.capability_runtime import build_capability_status, invoke_capability, probe_capability  # noqa: E402
 from _shared.dispatch_runtime import read_dispatch_state, write_dispatch_state  # noqa: E402
 from _shared.health_runtime import observe_cycle_health_events  # noqa: E402
@@ -30,6 +30,7 @@ from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
 from _shared.workflow_runtime import build_workflow_status  # noqa: E402
 
 POST_SKILL_LOG = LOGS_DIR / "post-skill.log"
+DEFAULT_CLAIMS_PROJECTION_MAX_AGE_SECONDS = 6 * 60 * 60
 
 
 def now_iso() -> str:
@@ -48,6 +49,58 @@ def append_postskill_log(name: str, status: str, detail: str = "") -> None:
 def run_subprocess(cmd: list[str]) -> tuple[int, str, str]:
     result = subprocess.run(cmd, cwd=str(EDGE_REPO_DIR), capture_output=True, text=True)
     return result.returncode, (result.stdout or "").strip(), (result.stderr or "").strip()
+
+
+def _read_json_file(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return default
+
+
+def _claims_projection_max_age_seconds() -> int | None:
+    raw = (
+        os.environ.get("EDGE_POSTFLIGHT_CLAIMS_MAX_AGE_SEC")
+        or os.environ.get("EDGE_PREFLIGHT_CLAIMS_MAX_AGE_SEC")
+        or str(DEFAULT_CLAIMS_PROJECTION_MAX_AGE_SECONDS)
+    )
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_CLAIMS_PROJECTION_MAX_AGE_SECONDS
+    if value <= 0:
+        return None
+    return value
+
+
+def _projection_cache_status(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"projection_status": "missing", "projection_age_seconds": None}
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+        age_seconds = max(0, int((datetime.now(timezone.utc) - mtime).total_seconds()))
+    except OSError:
+        return {"projection_status": "unknown", "projection_age_seconds": None}
+
+    max_age = _claims_projection_max_age_seconds()
+    status = "stale_cached" if max_age is not None and age_seconds > max_age else "cached"
+    return {"projection_status": status, "projection_age_seconds": age_seconds}
+
+
+def _combined_claims_cache_status(digest_cache: dict[str, Any], orphan_cache: dict[str, Any]) -> str:
+    statuses = {
+        str(digest_cache.get("projection_status") or "unknown"),
+        str(orphan_cache.get("projection_status") or "unknown"),
+    }
+    if statuses == {"cached"}:
+        return "cached"
+    if "missing" in statuses:
+        return "missing" if statuses == {"missing"} else "partial_cached"
+    if "stale_cached" in statuses:
+        return "stale_cached"
+    return "unknown"
 
 
 def before_snapshot(state: dict[str, Any]) -> dict[str, Any]:
@@ -232,11 +285,48 @@ def refresh_capabilities_status(skill: str | None = None) -> dict[str, Any]:
 
 
 def refresh_claims_status() -> dict[str, Any]:
-    projections = refresh_continuity_projections()
-    digest = projections.get("digest") or {}
-    detail = f"open={digest.get('open_total', 0)} orphans={digest.get('unthreaded_count', 0)}"
-    append_postskill_log("claims_digest", "OK", detail)
-    return {"ok": True, "detail": detail, "payload": projections}
+    digest = _read_json_file(CLAIMS_DIGEST_FILE, {})
+    orphans = _read_json_file(ORPHAN_CLAIMS_FILE, {})
+    if not isinstance(digest, dict):
+        digest = {}
+    if not isinstance(orphans, dict):
+        orphans = {}
+
+    digest_cache = _projection_cache_status(CLAIMS_DIGEST_FILE)
+    orphan_cache = _projection_cache_status(ORPHAN_CLAIMS_FILE)
+    cache_status = _combined_claims_cache_status(digest_cache, orphan_cache)
+    cache_age = digest_cache.get("projection_age_seconds")
+    detail = (
+        f"open={digest.get('open_total', 0)} "
+        f"orphans={orphans.get('orphan_total', digest.get('unthreaded_count', 0))} "
+        f"cache={cache_status}"
+    )
+    if cache_age is not None:
+        detail += f" age={cache_age}s"
+
+    status = "ok" if cache_status == "cached" else "warning"
+    append_postskill_log("claims_digest", "OK" if status == "ok" else "WARN", detail)
+    return {
+        "ok": cache_status not in {"missing", "partial_cached", "unknown"},
+        "status": status,
+        "detail": detail,
+        "payload": {
+            "digest": digest,
+            "orphans": orphans,
+            "cache": {
+                "status": cache_status,
+                "claims_digest": {
+                    "source_path": str(CLAIMS_DIGEST_FILE),
+                    **digest_cache,
+                },
+                "orphan_claims": {
+                    "source_path": str(ORPHAN_CLAIMS_FILE),
+                    **orphan_cache,
+                },
+                "max_age_seconds": _claims_projection_max_age_seconds(),
+            },
+        },
+    }
 
 
 def refresh_pipeline_state(cycle_id: str | None = None) -> dict[str, Any]:
@@ -346,7 +436,14 @@ def _execute_postflight_step(step: dict[str, Any], state: dict[str, Any]) -> dic
 
     if kind == "claims.refresh":
         refreshed = refresh_claims_status()
-        return _protocol_step(step, status="ok", satisfied=bool(refreshed.get("ok", False)), detail=str(refreshed.get("detail") or ""), extra={"payload": refreshed.get("payload") or {}})
+        refreshed_status = str(refreshed.get("status") or ("ok" if refreshed.get("ok") else "warning"))
+        return _protocol_step(
+            step,
+            status=refreshed_status,
+            satisfied=bool(refreshed.get("ok", False)),
+            detail=str(refreshed.get("detail") or ""),
+            extra={"payload": refreshed.get("payload") or {}},
+        )
 
     if kind == "pipeline_state.refresh":
         refreshed = refresh_pipeline_state(cycle_id=state.get("cycle_id"))


### PR DESCRIPTION
## Summary

- Make postflight `claims.refresh` read cached claims/orphan projections instead of rebuilding continuity projections from the full event log.
- Add cache status/age metadata to the postflight payload and degrade stale or missing projections to warnings.
- Cover the behavior with a resilience test that ensures the continuity rebuild path is not imported by postflight.

## Root Cause

Bob's event log is large enough that `edge-close` could hang in postflight because `claims.refresh` called `refresh_continuity_projections()` directly. Preflight had already moved to cached projections; postflight still used the expensive rebuild.

## Validation

- `python3 -m py_compile tools/edge-postflight tools/edge-close`
- `bash tests/test_postflight_resilience.sh`
- `bash tests/test_postflight_pipeline_state.sh`
- `bash tests/test_edge_close.sh`