### PR TITLE
[codex] bound runtime evidence log scans

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -1005,6 +1005,79 @@ else
     fail "preflight claims summary uses cached projections"
 fi
 
+echo "--- Test 12: runner evidence gates scan bounded JSONL tails ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_BASE"
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+tmp_base = Path(sys.argv[2])
+state_dir = tmp_base / "runner-tail-runtime" / "state" / "events"
+state_dir.mkdir(parents=True, exist_ok=True)
+events_path = state_dir / "log.jsonl"
+steps_path = tmp_base / "runner-tail-runtime" / "logs" / "skill-steps.jsonl"
+steps_path.parent.mkdir(parents=True, exist_ok=True)
+
+cycle_id = "cycle-tail-proof"
+old_cycle = "cycle-old"
+threshold = "2026-05-02T00:00:00+00:00"
+large_payload = "x" * 2048
+with events_path.open("w", encoding="utf-8") as handle:
+    for index in range(5000):
+        handle.write(json.dumps({
+            "ts": "2026-05-01T00:00:00+00:00",
+            "type": "ArtifactPublished",
+            "cycle_id": old_cycle,
+            "artifact": f"blog/entries/old-{index}.md",
+            "payload": {"noise": large_payload},
+        }) + "\n")
+    handle.write(json.dumps({
+        "ts": "2026-05-02T00:01:00+00:00",
+        "type": "SkillRunCompleted",
+        "cycle_id": cycle_id,
+        "payload": {"skill": "strategy", "registry_skill": "strategy"},
+    }) + "\n")
+    handle.write(json.dumps({
+        "ts": "2026-05-02T00:02:00+00:00",
+        "type": "ArtifactPublished",
+        "cycle_id": cycle_id,
+        "artifact": "blog/entries/current.md",
+        "payload": {"artifact": "blog/entries/current.md"},
+    }) + "\n")
+
+loader = importlib.machinery.SourceFileLoader("edge_runner", str(edge_dir / "tools" / "edge-runner"))
+spec = importlib.util.spec_from_loader("edge_runner", loader)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+module.STATE_EVENTS_FILE = events_path
+module.SKILL_STEPS_FILE = steps_path
+module.read_dispatch_state = lambda: {
+    "cycle_id": cycle_id,
+    "request": {"skill": "strategy"},
+    "state": {"skill_dispatched": True, "dispatched_at": threshold},
+}
+os.environ["EDGE_JSONL_TAIL_BYTES"] = "8192"
+try:
+    assert module.skill_run_completed_for_cycle(cycle_id, "strategy") is True
+    assert module.artifact_published_for_cycle(cycle_id) is True
+finally:
+    os.environ.pop("EDGE_JSONL_TAIL_BYTES", None)
+
+assert events_path.stat().st_size > 8 * 1024 * 1024
+PY
+then
+    pass "runner evidence gates scan bounded JSONL tails"
+else
+    fail "runner evidence gates scan bounded JSONL tails"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/tools/_shared/jsonl_runtime.py
+++ b/tools/_shared/jsonl_runtime.py
@@ -1,0 +1,62 @@
+"""Bounded JSONL readers for runtime gates."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterator
+
+DEFAULT_JSONL_TAIL_BYTES = 16 * 1024 * 1024
+DEFAULT_JSONL_TAIL_ROWS = 5000
+
+
+def jsonl_tail_bytes() -> int:
+    raw = os.environ.get("EDGE_JSONL_TAIL_BYTES", str(DEFAULT_JSONL_TAIL_BYTES))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_JSONL_TAIL_BYTES
+    return max(4096, value)
+
+
+def iter_jsonl_reverse(
+    path: Path,
+    *,
+    max_bytes: int | None = None,
+    max_rows: int = DEFAULT_JSONL_TAIL_ROWS,
+) -> Iterator[dict[str, Any]]:
+    """Yield JSONL rows newest-first from a bounded tail window.
+
+    Runtime close gates only need evidence for the current cycle, which is
+    always near the end of append-only event logs. Reading the full log can be
+    pathological on long-lived agents.
+    """
+    if not path.exists():
+        return
+    limit_bytes = jsonl_tail_bytes() if max_bytes is None else max(4096, int(max_bytes))
+    try:
+        size = path.stat().st_size
+        start = max(0, size - limit_bytes)
+        with path.open("rb") as handle:
+            if start:
+                handle.seek(start)
+                handle.readline()
+            data = handle.read()
+    except OSError:
+        return
+
+    yielded = 0
+    for raw_line in reversed(data.splitlines()):
+        if yielded >= max_rows:
+            break
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line.decode("utf-8", errors="replace"))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            yielded += 1
+            yield row

--- a/tools/edge-close
+++ b/tools/edge-close
@@ -19,6 +19,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import CURRENT_DISPATCH_FILE, EDGE_REPO_DIR, LOGS_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.jsonl_runtime import iter_jsonl_reverse  # noqa: E402
 from _shared.skill_policy import skill_requires_artifact_publication  # noqa: E402
 from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
 
@@ -71,20 +72,6 @@ def append_postskill_log(name: str, status: str, detail: str = "") -> None:
         f.write(message + "\n")
 
 
-def iter_jsonl(path: Path) -> list[dict]:
-    if not path.exists():
-        return []
-    rows = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        try:
-            rows.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-    return rows
-
-
 def iso_ge(left: str | None, right: str | None) -> bool:
     if not left or not right:
         return False
@@ -110,7 +97,7 @@ def check_skill_completion(state: dict) -> tuple[bool, str, dict]:
     if not state_block.get("skill_dispatched") or not skill:
         return False, "missing_dispatch", {"skill": skill or "", "cycle_id": cycle_id}
 
-    for event in reversed(iter_jsonl(STATE_EVENTS_FILE)):
+    for event in iter_jsonl_reverse(STATE_EVENTS_FILE):
         if event.get("type") != "SkillRunCompleted":
             continue
         if event.get("cycle_id") != cycle_id:
@@ -135,7 +122,7 @@ def check_skill_completion(state: dict) -> tuple[bool, str, dict]:
 
     # Backwards-compatible fallback: allow the step log's end marker if the
     # shadow event is missing.
-    for row in reversed(iter_jsonl(SKILL_STEPS_FILE)):
+    for row in iter_jsonl_reverse(SKILL_STEPS_FILE):
         if row.get("event") != "end":
             continue
         row_skill = row.get("skill") or ""
@@ -164,7 +151,7 @@ def check_artifact_publication(state: dict) -> tuple[bool, str, dict]:
     if not skill_requires_artifact_publication(skill):
         return True, "artifact_not_required", {"skill": skill or "", "cycle_id": cycle_id}
 
-    for event in reversed(iter_jsonl(STATE_EVENTS_FILE)):
+    for event in iter_jsonl_reverse(STATE_EVENTS_FILE):
         if event.get("type") != "ArtifactPublished":
             continue
         if event.get("cycle_id") != cycle_id:

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -304,10 +304,10 @@ def refresh_claims_status() -> dict[str, Any]:
     if cache_age is not None:
         detail += f" age={cache_age}s"
 
-    status = "ok" if cache_status == "cached" else "warning"
-    append_postskill_log("claims_digest", "OK" if status == "ok" else "WARN", detail)
+    status = "warning" if cache_status in {"partial_cached", "stale_cached", "unknown"} else "ok"
+    append_postskill_log("claims_digest", "OK" if cache_status in {"cached", "missing"} else "WARN", detail)
     return {
-        "ok": cache_status not in {"missing", "partial_cached", "unknown"},
+        "ok": cache_status != "unknown",
         "status": status,
         "detail": detail,
         "payload": {

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -26,6 +26,7 @@ from paths import EDGE_INSTANCE, EDGE_REPO_DIR, ENTRIES_DIR, REPORTS_DIR, SKILL_
 sys.path.insert(0, str(SCRIPT_DIR))
 from _shared.artifact_runtime import publish_stdout_artifact  # noqa: E402
 from _shared.dispatch_runtime import HEARTBEAT_FAIRNESS_SKILLS, read_dispatch_state, render_skill_runtime_prompt, write_dispatch_state  # noqa: E402
+from _shared.jsonl_runtime import iter_jsonl_reverse  # noqa: E402
 from _shared.skill_policy import skill_accepts_stdout_artifact, skill_requires_artifact_publication  # noqa: E402
 from _shared.telemetry import emit_shadow_event  # noqa: E402
 from _shared.telemetry import log_run_step  # noqa: E402
@@ -446,20 +447,6 @@ def dispatch_state_matches(cycle_id: str) -> dict | None:
     return state
 
 
-def iter_jsonl(path: Path) -> list[dict]:
-    if not path.exists():
-        return []
-    rows = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        try:
-            rows.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-    return rows
-
-
 def iso_ge(left: str | None, right: str | None) -> bool:
     if not left or not right:
         return False
@@ -494,7 +481,7 @@ def skill_run_completed_for_cycle(cycle_id: str, skill: str | None) -> bool:
     threshold = state_block.get("dispatched_at") or state_block.get("opened_at")
 
     accepted = {requested_skill, f"/{requested_skill}"}
-    for event in reversed(iter_jsonl(STATE_EVENTS_FILE)):
+    for event in iter_jsonl_reverse(STATE_EVENTS_FILE):
         if event.get("type") != "SkillRunCompleted":
             continue
         if event.get("cycle_id") != cycle_id:
@@ -508,7 +495,7 @@ def skill_run_completed_for_cycle(cycle_id: str, skill: str | None) -> bool:
             continue
         return True
 
-    for row in reversed(iter_jsonl(SKILL_STEPS_FILE)):
+    for row in iter_jsonl_reverse(SKILL_STEPS_FILE):
         if row.get("event") != "end":
             continue
         if normalize_skill_name(row.get("skill")) not in accepted and normalize_skill_name(row.get("registry_skill")) not in accepted:
@@ -730,7 +717,7 @@ def artifact_published_for_cycle(cycle_id: str | None) -> bool:
     if state:
         state_block = state.get("state", {}) or {}
         threshold = state_block.get("dispatched_at") or state_block.get("opened_at")
-    for event in reversed(iter_jsonl(STATE_EVENTS_FILE)):
+    for event in iter_jsonl_reverse(STATE_EVENTS_FILE):
         if event.get("type") != "ArtifactPublished":
             continue
         if event.get("cycle_id") != cycle_id:


### PR DESCRIPTION
## Summary

- Add a bounded reverse JSONL reader for runtime evidence gates.
- Use it in `edge-runner` and `edge-close` when checking `SkillRunCompleted` and `ArtifactPublished` evidence, avoiding full reads of long-lived event logs.
- Treat missing postflight claims projection caches as informational while keeping stale, partial, or unknown cache states visible as warnings.
- Cover the runner evidence gate with a regression test using an event log larger than 8 MB and a small tail window.

## Root Cause

Bob's `/bob-strategy` validation reached the backend exit path, then `edge-runner` entered disk sleep while holding `state/events/log.jsonl`; the process had multi-GB virtual memory and was scanning a large event log just to find current-cycle completion/artifact evidence.

Grafana corroborated the same window: Bob fleet snapshots around 2026-05-02 15:09 UTC showed projection refreshes scanning about 38.8k events, dispatch rollup around 36.6s, pipeline rollup around 27.0s, render drift around 26.9s, and health-v2 timing out around 91.4s.

## Validation

- `python3 -m py_compile tools/edge-runner tools/edge-close tools/edge-postflight tools/_shared/jsonl_runtime.py`
- `bash tests/test_edge_runner.sh` (16/16)
- `bash tests/test_edge_close.sh` (9/9)
- `bash tests/test_postflight_resilience.sh` (4/4)
- `bash tests/test_postflight_pipeline_state.sh` (2/2)