### PR TITLE
[codex] bound cycle health event scans

### DIFF
--- a/tests/test_health_v2.sh
+++ b/tests/test_health_v2.sh
@@ -199,6 +199,53 @@ else
   fail "rollup-health-v2 execution failed"
 fi
 
+echo "--- Test 2: cycle health observation scans bounded JSONL tails ---"
+if env HOME="$TMP_HOME" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" EDGE_JSONL_TAIL_BYTES=8192 python3 - "$EDGE_DIR" "$TMP_BASE" <<'PY'
+import importlib
+import json
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+tmp_base = Path(sys.argv[2])
+state_dir = tmp_base / "cycle-health-tail" / "state" / "events"
+state_dir.mkdir(parents=True, exist_ok=True)
+events_path = state_dir / "log.jsonl"
+
+cycle_id = "cycle-health-tail-proof"
+large_payload = "x" * 2048
+with events_path.open("w", encoding="utf-8") as handle:
+    for index in range(5000):
+        handle.write(json.dumps({
+            "ts": "2026-05-01T00:00:00+00:00",
+            "type": "PrimitiveInvocationObserved",
+            "cycle_id": "old-cycle",
+            "payload": {"source": "old", "noise": large_payload, "index": index},
+        }) + "\n")
+    handle.write(json.dumps({
+        "ts": "2026-05-02T00:01:00+00:00",
+        "type": "PrimitiveInvocationObserved",
+        "cycle_id": cycle_id,
+        "payload": {"source": "exa"},
+    }) + "\n")
+
+sys.path.insert(0, str(edge_dir / "tools"))
+module = importlib.import_module("_shared.health_runtime")
+
+def fail_full_read(path):
+    raise AssertionError("cycle health must not read the full JSONL file")
+
+module._read_jsonl = fail_full_read
+observations = module.observe_cycle_health_events({"cycle_id": cycle_id}, path=events_path)
+assert observations["primitive_bypass"] == 1
+assert events_path.stat().st_size > 8 * 1024 * 1024
+PY
+then
+  pass "cycle health observation scans bounded JSONL tails"
+else
+  fail "cycle health observation scans bounded JSONL tails"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/tools/_shared/health_runtime.py
+++ b/tools/_shared/health_runtime.py
@@ -26,6 +26,7 @@ from paths import (  # noqa: E402
     WORKFLOW_HEALTH_FILE,
 )
 from .capability_runtime import build_capability_status  # noqa: E402
+from .jsonl_runtime import iter_jsonl_reverse  # noqa: E402
 from .telemetry import emit_shadow_event  # noqa: E402
 from .workflow_runtime import build_workflow_status  # noqa: E402
 
@@ -819,7 +820,7 @@ def write_health_snapshot(path: Path = HEALTH_CURRENT_FILE) -> dict[str, Any]:
 
 
 def _events_for_cycle(cycle_id: str, path: Path = STATE_EVENTS_FILE) -> list[dict[str, Any]]:
-    return [row for row in _read_jsonl(path) if str(row.get("cycle_id") or "") == cycle_id]
+    return [row for row in iter_jsonl_reverse(path) if str(row.get("cycle_id") or "") == cycle_id]
 
 
 def observe_cycle_health_events(state: dict[str, Any], *, path: Path = STATE_EVENTS_FILE) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- Make postflight cycle-health observation read the bounded reverse JSONL tail instead of the full `state/events/log.jsonl`.
- Add a health-runtime regression test that fails if `observe_cycle_health_events` falls back to `_read_jsonl` for the current-cycle path.

## Root Cause

After PR #460 fixed runner/close evidence gates, Bob still exposed another full-log reader: postflight reached `cycle_health.observe` after publishing the artifact, then stayed CPU-bound in `edge-postflight` with about 659 MB RSS and more than 11 GB read from disk. The cycle-health observer only needs current-cycle events, so scanning the complete long-lived fleet log is unnecessary and pathological.

## Validation

- `python3 -m py_compile tools/_shared/health_runtime.py tools/_shared/jsonl_runtime.py tools/edge-postflight`
- `bash tests/test_health_v2.sh` (7/7)
- `bash tests/test_postflight_resilience.sh` (4/4)
- `bash tests/test_postflight_pipeline_state.sh` (2/2)