### PR TITLE
[codex] normalize publication frontmatter before publish

### DIFF
--- a/tests/test_consolidate_report_frontmatter_sync.sh
+++ b/tests/test_consolidate_report_frontmatter_sync.sh
@@ -24,7 +24,7 @@ Body.
 EOF
 
 python3 "$TOOL" "$ENTRY" "entry-research-contract.html" >"$OUT"
-grep -q "updated:research-contract.html->entry-research-contract.html" "$OUT"
+grep -q "report=updated:research-contract.html->entry-research-contract.html" "$OUT"
 grep -q "^report: entry-research-contract.html$" "$ENTRY"
 
 python3 - "$ENTRY" <<'PY'
@@ -52,8 +52,34 @@ Body.
 EOF
 
 python3 "$TOOL" "$ENTRY" "entry-research-contract.html" >"$OUT"
-grep -q "updated:<missing>->entry-research-contract.html" "$OUT"
+grep -q "report=updated:<missing>->entry-research-contract.html" "$OUT"
 grep -q "^report: entry-research-contract.html$" "$ENTRY"
+
+cat >"$ENTRY" <<'EOF'
+---
+title: "Reflection R6 — Sinal Emergente de missing_artifact_published"
+date: 2026-05-02
+type: note
+tags: [reflection, runtime, health, failure-analysis]
+claims:
+  - id: claim-r6-missing-artifact
+    text: "missing_artifact_published apareceu em 4/5 falhas"
+    kind: open
+    threads: [infrastructure-security]
+  - id: claim-r6-work-stagnation
+    text: "0/4 open work items avancaram em 5 dias"
+    kind: verified
+    threads: [infrastructure-security, analise-processual]
+---
+
+Body.
+EOF
+
+python3 "$TOOL" "$ENTRY" "edge-reflection-R6-entry.html" >"$OUT"
+grep -q "threads=derived:2" "$OUT"
+grep -q "keywords=derived:" "$OUT"
+grep -q "^threads: \\[infrastructure-security, analise-processual\\]$" "$ENTRY"
+grep -q "^keywords: " "$ENTRY"
 
 grep -q 'sync-report-frontmatter.py" "$ENTRY_PATH" "$REPORT_FILENAME"' "$SCRIPT"
 grep -q 'VERIFY_ENTRY_PATH="$ENTRIES_DIR/$SLUG.md"' "$SCRIPT"

--- a/tools/sync-report-frontmatter.py
+++ b/tools/sync-report-frontmatter.py
@@ -1,13 +1,109 @@
 #!/usr/bin/env python3
-"""Synchronize a blog entry's frontmatter report field."""
+"""Normalize blog entry frontmatter before publication."""
 
 from __future__ import annotations
 
 import argparse
+import re
 import sys
+import unicodedata
 from pathlib import Path
 
 import yaml
+
+
+def _yaml_scalar(value: str) -> str:
+    text = str(value).strip()
+    if re.fullmatch(r"[A-Za-z0-9_.@/-]+", text):
+        return text
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _list_literal(values: list[str]) -> str:
+    return "[" + ", ".join(_yaml_scalar(value) for value in values) + "]"
+
+
+def _as_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return []
+
+
+def _claim_threads(frontmatter: dict) -> list[str]:
+    threads: list[str] = []
+    claims = frontmatter.get("claims", [])
+    if isinstance(claims, list):
+        for claim in claims:
+            if not isinstance(claim, dict):
+                continue
+            threads.extend(_as_list(claim.get("threads")))
+    seen: set[str] = set()
+    unique: list[str] = []
+    for thread in threads:
+        if thread not in seen:
+            seen.add(thread)
+            unique.append(thread)
+    return unique
+
+
+def _keyword_token(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"[^a-z0-9]+", "-", ascii_text.lower()).strip("-")
+
+
+def _derived_keywords(frontmatter: dict, threads: list[str], expected_report: str) -> list[str]:
+    stopwords = {
+        "and",
+        "com",
+        "das",
+        "dos",
+        "for",
+        "para",
+        "por",
+        "the",
+        "uma",
+    }
+    raw_values: list[str] = []
+    raw_values.extend(_as_list(frontmatter.get("tags")))
+    raw_values.extend(threads)
+    raw_values.append(str(frontmatter.get("title") or ""))
+    raw_values.append(Path(expected_report).stem)
+
+    keywords: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_values:
+        for part in re.split(r"[\s,/|:;()[\]{}]+", raw):
+            token = _keyword_token(part)
+            if len(token) < 3 or token in stopwords or token in seen:
+                continue
+            seen.add(token)
+            keywords.append(token)
+            if len(keywords) >= 12:
+                return keywords
+    return keywords or ["artifact"]
+
+
+def _replace_or_append(lines: list[str], key: str, rendered: str) -> tuple[list[str], bool]:
+    updated: list[str] = []
+    replaced = False
+    for line in lines:
+        if line.startswith(f"{key}:"):
+            if not replaced:
+                updated.append(rendered)
+                replaced = True
+            continue
+        updated.append(line)
+    if replaced:
+        return updated, True
+
+    while updated and not updated[-1].strip():
+        updated.pop()
+    updated.append(rendered)
+    return updated, False
 
 
 def sync_report(entry_path: Path, expected_report: str) -> str:
@@ -21,33 +117,48 @@ def sync_report(entry_path: Path, expected_report: str) -> str:
     except Exception as exc:  # pragma: no cover - exact yaml message varies
         raise ValueError(f"invalid frontmatter YAML in {entry_path}: {exc}") from exc
 
+    lines = parts[1].splitlines()
+    changes: list[str] = []
+
     current = str(parsed.get("report") or "").strip()
     if current == expected_report:
+        changes.append(f"report=matched:{expected_report}")
+        updated_lines = lines
+    else:
+        updated_lines, _ = _replace_or_append(lines, "report", f"report: {expected_report}")
+        previous = current or "<missing>"
+        changes.append(f"report=updated:{previous}->{expected_report}")
+
+    threads = _as_list(parsed.get("threads"))
+    if not threads:
+        threads = _claim_threads(parsed)
+        if threads:
+            updated_lines, _ = _replace_or_append(
+                updated_lines,
+                "threads",
+                f"threads: {_list_literal(threads)}",
+            )
+            changes.append(f"threads=derived:{len(threads)}")
+
+    keywords = _as_list(parsed.get("keywords"))
+    if not keywords:
+        keywords = _derived_keywords(parsed, threads, expected_report)
+        updated_lines, _ = _replace_or_append(
+            updated_lines,
+            "keywords",
+            f"keywords: {_list_literal(keywords)}",
+        )
+        changes.append(f"keywords=derived:{len(keywords)}")
+
+    if changes == [f"report=matched:{expected_report}"]:
         return f"matched:{expected_report}"
-
-    lines = parts[1].splitlines()
-    updated_lines: list[str] = []
-    replaced = False
-    for line in lines:
-        if line.startswith("report:"):
-            if not replaced:
-                updated_lines.append(f"report: {expected_report}")
-                replaced = True
-            continue
-        updated_lines.append(line)
-
-    if not replaced:
-        while updated_lines and not updated_lines[-1].strip():
-            updated_lines.pop()
-        updated_lines.append(f"report: {expected_report}")
 
     new_frontmatter = "\n".join(updated_lines).strip("\n")
     entry_path.write_text(
         f"{parts[0]}---\n{new_frontmatter}\n---{parts[2]}",
         encoding="utf-8",
     )
-    previous = current or "<missing>"
-    return f"updated:{previous}->{expected_report}"
+    return " ".join(changes)
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Normalize blog entry frontmatter immediately before publication so generated artifacts can be published even when the skill omitted publication-only top-level fields.

## Root cause

`consolidate-state` synchronized the `report` field, but `blog-publish.sh` also requires top-level `threads` and `keywords`. Some valid generated entries only had claim-level `threads`, so publish repair loops could keep failing with a generic blog-publish error even though the artifact draft existed.

## Changes

- Derive top-level `threads` from `claims[].threads` when missing.
- Derive stable ASCII `keywords` from tags, threads, title, and report stem when missing.
- Preserve the existing line-oriented YAML update behavior instead of rewriting the whole frontmatter.
- Extend consolidate frontmatter sync coverage for the missing `threads`/`keywords` case.

## Validation

- `python3 -m py_compile tools/sync-report-frontmatter.py`
- `bash tests/test_consolidate_report_frontmatter_sync.sh`
- `bash tests/test_consolidate_frontmatter_errors.sh`
- `bash tests/test_blog_publish_branding.sh`
- `bash tests/test_consolidate_phase6_paths.sh`