### PR TITLE
[codex] add narrative scaffolding to reports

### DIFF
--- a/skills/_shared/report-template.md
+++ b/skills/_shared/report-template.md
@@ -113,6 +113,7 @@ metrics:
 
 sections:
   - title: "1. [Skill section]"
+    lead: "Two to four sentences that frame the section's question, why it matters now, and how to read the evidence below."
     blocks: [...]
 
 # MANDATORY — auto-renders as the last section "References"
@@ -125,6 +126,26 @@ bibliography:
 ---
 
 ## Available Block Types
+
+Sections also support a top-level `lead` field. Use it for the short narrative
+bridge between the section title and the evidence blocks:
+
+```yaml
+sections:
+  - title: "2. What changed in the runtime"
+    lead: >
+      This section separates legitimate long-running work from actual stalls.
+      The table is evidence, not the argument: read it as a status map of
+      process liveness, event progress, and artifact completion.
+    blocks:
+      - type: table
+        headers: [...]
+        rows: [...]
+      - type: paragraph
+        text: >
+          The operational conclusion is that duration alone should not become
+          a failure signal when the owner process and event stream are alive.
+```
 
 | Type | Usage | Main fields |
 |------|-------|-------------|
@@ -166,6 +187,33 @@ The FIRST section of every report MUST include a block showing the chain of reas
 Include: previous reports, breaks, discoveries, proposals, research, executions, conversations with the user — any action that informed this work. Cite by name/number (e.g.: "Break #26 — tradecraft", "Research pipeline-minimo-viavel").
 
 If there is no relevant prior work, state explicitly: "First work on this topic."
+
+---
+
+## Golden Rule 1: Narrative Scaffolding (ALL skills)
+
+Do not make tables, charts, matrices, diagrams, metrics grids, or gap tables do
+the explanatory work alone. The reader needs a small interpretive bridge before
+dense evidence appears.
+
+Every non-reference section MUST satisfy one of these:
+
+- section has a `lead` with 2-4 concrete sentences;
+- or the first block is `paragraph` and explains the section's question,
+  relevance, and reading frame.
+
+If a section contains `table`, `comparison-table`, `risk-table`, `bar-chart`,
+`line-chart`, `comparison`, `metrics-grid`, `gap-table`, `raw-html` diagram, or
+similar dense evidence block, add reader guidance around it:
+
+- before: what question the evidence answers;
+- after: what the reader should conclude, decide, or keep uncertain.
+
+This is not permission to inflate the artifact. Preserve analytical depth,
+sources, gaps, and recommendations by shortening oversized tables, merging
+duplicate rows, and moving low-value detail into fewer, better explained blocks.
+Do not compensate for narrative leads by deleting evidence, citations,
+uncertainties, or executable next steps.
 
 ---
 

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -124,12 +124,21 @@ Adapt titles to the topic, but preserve the arc: context -> evidence -> analysis
 ## Report Quality
 
 - Sections should build on each other; order matters.
+- Each section should open with a short narrative lead or an initial paragraph
+  that explains the question, why it matters now, and how to read the evidence.
 - Tables beat prose when 3+ comparable items exist.
+- Tables, charts, diagrams, and matrices are evidence blocks, not substitutes
+  for explanation. Put a short interpretation after dense evidence so the
+  reader knows what changed, what decision it supports, or what remains
+  uncertain.
 - Comparisons beat paragraphs when alternatives have trade-offs.
 - Callouts should mark insights, risks, caveats, or decisions the reader should not miss.
 - Claims should be traceable to sources, files, or explicit reasoning.
 - Uncertainty should be visible, not hidden.
 - Recommendations should be concrete enough to execute or test.
+- Do not pay for narrative scaffolding by deleting sources, gaps, derivation,
+  or recommendations. If space is tight, compress oversized tables and remove
+  duplicate rows before weakening the analysis.
 
 ## Visuals
 

--- a/tests/test_report_narrative_scaffolding.sh
+++ b/tests/test_report_narrative_scaffolding.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d /tmp/edge-report-narrative-XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEMPLATE="$EDGE_DIR/skills/_shared/report-template.md"
+REPORT_SKILL="$EDGE_DIR/skills/report/SKILL.md"
+REVIEW_GATE="$EDGE_DIR/tools/review-gate.py"
+
+echo "=== report narrative scaffolding contract ==="
+
+grep -q "Golden Rule 1: Narrative Scaffolding" "$TEMPLATE"
+grep -q "section has a \`lead\` with 2-4 concrete sentences" "$TEMPLATE"
+grep -q "Do not compensate for narrative leads by deleting evidence" "$TEMPLATE"
+grep -q "Each section should open with a short narrative lead" "$REPORT_SKILL"
+grep -q "Do not pay for narrative scaffolding by deleting sources" "$REPORT_SKILL"
+grep -q "Any non-reference section begins directly with a table" "$REVIEW_GATE"
+grep -q "Do not make these additions by weakening analysis" "$REVIEW_GATE"
+
+GOOD="$TMP_DIR/good.yaml"
+cat >"$GOOD" <<'YAML'
+title: "Runtime Dispatch Report"
+subtitle: "Narrative lead smoke test"
+date: "02/05/2026"
+executive_summary:
+  - "**Finding:** lead text frames the evidence before tables."
+metrics:
+  - value: "1"
+    label: "Narrative lead rendered"
+sections:
+  - title: "1. Linhagem"
+    lead: >
+      This section explains why the report exists before showing prior work.
+      The table is a compact evidence map rather than a substitute for the
+      argument.
+    blocks:
+      - type: table
+        headers: ["Previous Action", "What It Brought", "Connection to This Work"]
+        rows:
+          - ["Heartbeat validation", "Long-running cycles completed", "Report needs better reader guidance"]
+      - type: paragraph
+        text: >
+          The practical reading is that the artifact should make dense evidence
+          legible without removing the evidence itself.
+  - title: "O que Nao Sei"
+    lead: >
+      This section keeps uncertainty visible. It distinguishes missing evidence
+      from known defects so the report does not overclaim.
+    blocks:
+      - type: gap-table
+        gaps:
+          - id: "gap-1"
+            description: "Whether every skill-specific prompt will honor the new lead rule"
+            need: "Fleet validation over real reports"
+            status: "open"
+      - type: paragraph
+        text: "The unresolved question is behavioral adoption, not renderer support."
+  - title: "Contextualization and Glossary"
+    lead: >
+      This report is for operators reading autonomous runtime artifacts. It
+      defines the terms needed to inspect a report without knowing the pipeline.
+    blocks:
+      - type: glossary
+        context: "Runtime report vocabulary."
+        terms:
+          - term: "lead"
+            definition: "Short narrative bridge between a section title and dense evidence."
+bibliography:
+  - text: "Local report template"
+    source: "Repo"
+YAML
+
+python3 "$EDGE_DIR/tools/yaml_to_html.py" "$GOOD" --output "$TMP_DIR/good.html" >/dev/null
+grep -q 'class="section-lead"' "$TMP_DIR/good.html"
+grep -q "This section explains why the report exists" "$TMP_DIR/good.html"
+
+BAD="$TMP_DIR/bad.yaml"
+cat >"$BAD" <<'YAML'
+title: "Runtime Dispatch Report"
+subtitle: "Missing lead smoke test"
+date: "02/05/2026"
+executive_summary:
+  - "**Finding:** this should fail."
+metrics:
+  - value: "0"
+    label: "Narrative leads"
+sections:
+  - title: "1. Linhagem"
+    blocks:
+      - type: table
+        headers: ["Previous Action", "What It Brought", "Connection to This Work"]
+        rows:
+          - ["Heartbeat validation", "Completed", "Needs narrative"]
+bibliography:
+  - text: "Local report template"
+    source: "Repo"
+YAML
+
+if python3 "$EDGE_DIR/tools/yaml_to_html.py" "$BAD" --output "$TMP_DIR/bad.html" >"$TMP_DIR/bad.out" 2>"$TMP_DIR/bad.err"; then
+  echo "FAIL: table-first section without lead should be blocked" >&2
+  exit 1
+fi
+grep -q "sem lead narrativo" "$TMP_DIR/bad.err"
+
+echo "PASS: report sections require narrative scaffolding before dense evidence"

--- a/tools/assets/base.css
+++ b/tools/assets/base.css
@@ -109,6 +109,14 @@ body {
   margin-bottom: 20px;
 }
 
+.section-lead {
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--gray-700);
+  margin: -4px 0 18px;
+  max-width: 860px;
+}
+
 .subsection-title {
   font-size: 18px;
   font-weight: 600;

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -274,6 +274,7 @@ DIMENSIONS = {
         "There is a narrative arc: setup (why this matters) → tension (the problem/question) "
         "→ exploration (what was tried/discovered) → resolution (what changed). "
         "Sections flow into each other with cause-effect or temporal logic. "
+        "Each section has a narrative lead or opening paragraph before dense evidence blocks. "
         "The reader should want to keep reading — not just scanning headers. "
         "The title and executive_summary hook the reader. "
         "Analogies and concrete scenarios make abstract ideas tangible. "
@@ -294,6 +295,7 @@ DIMENSIONS = {
     "writing_quality": (
         "Text in paragraph blocks is fluido (flowing prose), not telegráfico "
         "(bullet-point-only). Transitions between ideas. "
+        "Tables and charts are introduced and then interpreted; they do not appear as raw evidence dumps. "
         "Reflective tone, not didactic or robotic. "
         "Blockquotes sound like crystallized thoughts. "
         "Titles are evocative, not descriptive."
@@ -441,6 +443,8 @@ Flag as critical_issues if ANY of these:
 - Zero SVG-capable visualizations in entire spec (no bar-chart, line-chart, or raw-html inline SVG)
 - A report compares 3+ items/steps/metrics/risks/alternatives but has no chart, flow, matrix, timeline, or diagram representing that comparison visually
 - A report has multiple quantitative/trade-off comparisons but only one visual encoding and no clear reason for keeping the rest textual
+- Any non-reference section begins directly with a table, chart, metrics grid, diagram, comparison matrix, or gap table without a narrative `lead` or opening paragraph that explains how to read it
+- A dense evidence block such as a table, chart, matrix, or diagram is left without nearby interpretation of what the reader should conclude, decide, or keep uncertain
 - Associated blog entry duplicates the report structure or does not explain the operator gain from opening the report (if blog entry provided)
 - "O que Nao Sei" is clearly boilerplate (vague generic text, not specific to this report's topic)
 - Sections reference data/events not present elsewhere in the spec (internal contradiction)
@@ -489,6 +493,9 @@ Language: Portuguese (PT-BR). Output: ONLY the complete, corrected YAML. No mark
 - If an SVG/chart is missing and the reviewer flagged it, add a simple but real visualization; use `bar-chart` or `line-chart` for routine numerical data, and raw-html SVG for custom diagrams
 - If the report compares 3+ things, add a visual encoding of the comparison: bar-chart, line-chart, timeline, funnel, matrix, causal map, risk heatmap, before/after, or flow diagram
 - If the report has several analytical comparisons or operational trade-offs, add multiple visual encodings rather than one decorative chart
+- If a section starts with a table/chart/diagram/metrics grid, add a 2-4 sentence `lead` or opening paragraph that frames the question, relevance, and reading frame
+- After dense evidence blocks, add a concise paragraph or callout interpreting what the reader should conclude, decide, or keep uncertain
+- Do not make these additions by weakening analysis: preserve sources, gaps, derivation, recommendations, and concrete examples; compress oversized tables instead
 - If "O que Nao Sei" is flagged as boilerplate, rewrite with genuine, specific gaps
 - Keep all existing metadata intact (title, date, etc.)
 
@@ -498,6 +505,7 @@ Language: Portuguese (PT-BR). Output: ONLY the complete, corrected YAML. No mark
 - At least 1 SVG visualization (`bar-chart`, `line-chart`, or inline raw-html SVG); comparisons with 3+ values need a chart/diagram, not only a table
 - Reports with multiple comparisons/trends/trade-offs should use 2+ visual encodings when useful
 - Tables paired with charts when 3+ values compared
+- Each non-reference section needs a narrative lead or opening paragraph before dense evidence, and dense evidence needs interpretation after it
 """
 
 

--- a/tools/yaml_to_html.py
+++ b/tools/yaml_to_html.py
@@ -1106,6 +1106,21 @@ _validation_error_count = 0
 _RENDER_LOG = Path(os.environ.get("YAML_RENDER_LOG", str(LOGS_DIR / "yaml-render.jsonl")))
 _current_source: str | None = None  # set by caller (main or external)
 
+STRUCTURAL_LEAD_BLOCKS = {
+    "ascii-diagram",
+    "bar-chart",
+    "comparison",
+    "comparison-table",
+    "concept-grid",
+    "gap-table",
+    "line-chart",
+    "metrics-grid",
+    "next-steps-grid",
+    "raw-html",
+    "risk-table",
+    "table",
+}
+
 
 def _log_render_event(block_type: str, event: str, detail: str, fields: list[str] | None = None):
     """Append a structured event to the persistent render log."""
@@ -1252,6 +1267,45 @@ def render_block(block: dict) -> str:
     return error_html + result if error_html else result
 
 
+def _canonical_block_type(block: dict) -> str:
+    block_type = str(block.get("type", "paragraph") or "paragraph")
+    return _BLOCK_TYPE_ALIASES.get(block_type, block_type)
+
+
+def _section_narrative_errors(section: dict, blocks: list) -> list[str]:
+    title = str(section.get("title") or "(sem titulo)")
+    lead = str(section.get("lead") or "").strip()
+    if not blocks:
+        return []
+    if len(blocks) == 1 and _canonical_block_type(blocks[0]) == "bibliography":
+        return []
+
+    first_type = _canonical_block_type(blocks[0])
+    if first_type in STRUCTURAL_LEAD_BLOCKS and not lead:
+        return [
+            f"Secao '{title}' comeca com bloco estrutural '{first_type}' sem lead narrativo. "
+            "Adicione section.lead ou um primeiro bloco paragraph explicando como ler a evidencia."
+        ]
+    return []
+
+
+def _render_section_errors(errors: list[str]) -> str:
+    global _validation_error_count
+    if not errors:
+        return ""
+    _validation_error_count += len(errors)
+    for error in errors:
+        print(f"ERRO secao: {error}", file=sys.stderr)
+        _log_render_event("section", "missing_narrative_lead", error)
+    return (
+        '<div style="border:2px solid #DC2626;background:#FEF2F2;padding:8px;'
+        'border-radius:6px;margin:8px 0;font-size:13px;color:#991B1B;">'
+        'ERRO secao: '
+        + "<br>".join(html.escape(error) for error in errors)
+        + '</div>'
+    )
+
+
 def _normalize_section_blocks(section: dict) -> list:
     """Extract blocks from a section, handling alternate YAML formats.
 
@@ -1323,7 +1377,10 @@ def render_section(section: dict) -> str:
     parts = ['<div class="section">']
     if section.get("title"):
         parts.append(f'<h2 class="section-title">{render_text(section["title"])}</h2>')
+    if section.get("lead"):
+        parts.append(f'<p class="section-lead">{render_text(section["lead"])}</p>')
     blocks = _normalize_section_blocks(section)
+    parts.append(_render_section_errors(_section_narrative_errors(section, blocks)))
     if not blocks and section.get("title"):
         print(f"AVISO: secao '{section['title']}' sem conteudo (sem blocks, sem type/content). "
               f"Verifique o YAML.", file=sys.stderr)


### PR DESCRIPTION
## Summary

Adds narrative scaffolding to report artifacts so sections do not jump directly from headings into dense tables or charts.

## Changes

- Adds section-level `lead` rendering in `yaml_to_html.py` and styles it with `.section-lead`.
- Blocks report rendering when a non-reference section begins with a dense evidence block without a narrative lead/opening paragraph.
- Updates the shared report template and `/ed-report` skill contract to require short leads and post-evidence interpretation without weakening sources, gaps, derivation, or recommendations.
- Updates `review-gate` and the refiner prompt so table/chart-only sections become blocking quality issues.
- Adds `tests/test_report_narrative_scaffolding.sh` for renderer, contract, and deterministic validation coverage.

## Validation

- `python3 -m py_compile tools/yaml_to_html.py tools/generate_report.py tools/review-gate.py`
- `bash tests/test_report_narrative_scaffolding.sh`
- `bash tests/test_report_publication_completion.sh`
- `bash tests/test_blog_entry_voice_contract.sh`
- `bash tests/test_report_review_ownership.sh`
- `bash tests/test_review_gate_timeout_contract.sh`
- `bash tests/test_consolidate_report_frontmatter_sync.sh`
- `bash tests/test_consolidate_frontmatter_errors.sh`
- `bash tests/test_blog_publish_branding.sh`
- `bash tests/test_consolidate_phase6_paths.sh`
- `bash tests/test_consolidate_adversarial_phase.sh`
- `bash tests/test_postflight_pipeline_state.sh`
- `bash tests/test_edge_runner.sh`