### PR TITLE
[codex] Route memory pressure into pre-skill context

### DIFF
--- a/tests/test_edge_curation.sh
+++ b/tests/test_edge_curation.sh
@@ -166,7 +166,7 @@ JSON
 
 cat >"$TMP_STATE/state/operator-pressure/hot-digest.json" <<'JSON'
 {
-  "schema_version": 3,
+  "schema_version": 5,
   "generated_at": "2026-04-24T00:00:00+00:00",
   "summary": "operator feedback asks for hot-state curation",
   "signal_from_operator_now": [
@@ -187,9 +187,46 @@ cat >"$TMP_STATE/state/operator-pressure/hot-digest.json" <<'JSON'
   "implicit_needs_hypotheses": [],
   "workflow_candidates": [],
   "capability_candidates": [],
+  "memory_updates": [
+    {
+      "item_id": "pressure-memory-workflow",
+      "text": "workflow para reports deve introduzir contexto antes de tabelas densas",
+      "target": "workflow",
+      "kind": "memory_update",
+      "repeat_count": 1,
+      "status": "active",
+      "entities": ["memory", "report"],
+      "source_kinds": ["memory"],
+      "last_seen_at": ""
+    },
+    {
+      "item_id": "pressure-memory-preskill",
+      "text": "sempre introduza tabelas densas antes de renderizar seco",
+      "target": "policy",
+      "kind": "memory_update",
+      "repeat_count": 1,
+      "status": "active",
+      "entities": ["memory", "report"],
+      "source_kinds": ["memory"],
+      "last_seen_at": ""
+    }
+  ],
+  "pre_skill_context": [
+    {
+      "item_id": "pressure-memory-preskill",
+      "text": "sempre introduza tabelas densas antes de renderizar seco",
+      "target": "policy",
+      "kind": "memory_update",
+      "repeat_count": 1,
+      "status": "active",
+      "entities": ["memory", "report"],
+      "source_kinds": ["memory"],
+      "last_seen_at": ""
+    }
+  ],
   "substrate_gap_requests": [],
   "active_entities": ["topic"],
-  "item_ids": ["pressure-hot-state"]
+  "item_ids": ["pressure-hot-state", "pressure-memory-workflow", "pressure-memory-preskill"]
 }
 JSON
 
@@ -212,6 +249,7 @@ echo ""
 echo "--- Test 1: sync builds procedure-curation and digest ---"
 if python3 - <<'PY' "$TMP_REPO/tools/edge-curation" "$TMP_STATE/state/procedure-curation.json" "$TMP_STATE/state/curation-digest.json"
 import json
+import runpy
 import subprocess
 import sys
 from pathlib import Path
@@ -221,35 +259,70 @@ result = subprocess.run([tool, "sync", "--json"], capture_output=True, text=True
 payload = json.loads(result.stdout)
 proc = json.loads(Path(proc_path).read_text(encoding="utf-8"))
 digest = json.loads(Path(digest_path).read_text(encoding="utf-8"))
+repo_root = Path(tool).parents[1]
+module = runpy.run_path(tool)
+assert module["_is_memory_workflow_item"]({
+    "sections": ["memory_updates"],
+    "source_kinds": ["memory"],
+    "target": "workflow",
+    "text": "workflow para reports deve introduzir contexto",
+}) is True
+assert module["_is_memory_workflow_item"]({
+    "sections": ["memory_updates"],
+    "source_kinds": ["memory"],
+    "target": "capability",
+    "text": "Google Drive e a pasta edge sao o lugar padrao de upload",
+}) is False
+assert module["_is_operator_pre_skill_context_item"]({
+    "sections": ["memory_updates", "pre_skill_context"],
+    "source_kinds": ["memory"],
+    "target": "policy",
+    "text": "sempre introduza tabelas densas antes de renderizar seco",
+}) is True
+assert module["_is_memory_workflow_item"]({
+    "sections": ["memory_updates", "pre_skill_context"],
+    "source_kinds": ["memory"],
+    "target": "policy",
+    "text": "sempre introduza tabelas densas antes de renderizar seco",
+}) is False
 
 assert payload["procedures"]["candidate_total"] == 1
 assert proc["crystallization_candidates"][0]["claim_count"] == 3
 assert digest["corpus"]["stale_candidates"] == 2
-assert digest["topics"]["total"] == 4
+assert digest["topics"]["total"] == 5
 assert digest["hot_state"]["threads"]["referenced_total"] == 2
 assert digest["hot_state"]["threads"]["created_total"] == 1
 assert digest["hot_state"]["topics"]["created_total"] == 2
-assert digest["operator_pressure"]["items_total"] == 1
-assert digest["operator_pressure"]["groups_total"] == 1
-assert digest["operator_pressure"]["threads_created"] == 1
-assert digest["operator_pressure"]["topics_created"] == 1
+assert digest["operator_pressure"]["items_total"] == 3
+assert digest["operator_pressure"]["groups_total"] == 2
+assert digest["operator_pressure"]["threads_created"] == 2
+assert digest["operator_pressure"]["topics_created"] == 2
+assert digest["operator_pressure"]["workflows_created"] == 1
+assert digest["operator_pressure"]["pre_skill_context_total"] == 1
 state_root = Path(digest_path).parents[1]
 assert (state_root / "threads" / "search-substrate.md").exists()
 assert (state_root / "threads" / "threads-topics-hot-state.md").exists()
 assert (state_root / "topics" / "search-substrate.md").exists()
 assert (state_root / "topics" / "runtime-observability.md").exists()
 assert (state_root / "topics" / "threads-topics-hot-state.md").exists()
+workflows = list((repo_root / "blog" / "entries").glob("*memory-workflow-para-reports*.md"))
+assert workflows
+workflow_text = workflows[0].read_text(encoding="utf-8")
+assert "tags: [workflow, memory-derived, operator-pressure]" in workflow_text
+assert "workflow-draft" not in workflow_text
 assert "funnel_tracked_total" in digest["workflow_health"]
 assert "topics" in Path(f"{Path(digest_path).parent}/topics-index.args").read_text(encoding="utf-8")
 
 second = subprocess.run([tool, "sync", "--json"], capture_output=True, text=True, check=True)
 second_payload = json.loads(second.stdout)
 second_digest = json.loads(Path(digest_path).read_text(encoding="utf-8"))
-assert second_payload["topics"]["total"] == 4
+assert second_payload["topics"]["total"] == 5
 assert second_digest["hot_state"]["threads"]["created_total"] == 0
 assert second_digest["hot_state"]["topics"]["created_total"] == 0
 assert second_digest["operator_pressure"]["threads_created"] == 0
 assert second_digest["operator_pressure"]["topics_created"] == 0
+assert second_digest["operator_pressure"]["workflows_created"] == 0
+assert second_digest["operator_pressure"]["pre_skill_context_total"] == 1
 PY
 then
     pass "sync builds procedure-curation and digest"

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -250,11 +250,13 @@ assert corpus_step["missing_required_types"] == ["workflow", "memory"]
 assert request["operator_pressure_summary"]["item_total"] >= 3
 assert request["operator_pressure_summary"]["signal_from_operator_now"] >= 1
 assert request["operator_pressure_summary"]["operator_toil_optimizable_now"] >= 1
+assert request["operator_pressure_summary"]["pre_skill_context"] >= 1
 assert request["operator_pressure_summary"]["workflow_candidates"] >= 1
 assert request["operator_pressure_summary"]["capability_candidates"] >= 1
 assert request["operator_pressure_summary"]["substrate_gap_requests"] >= 1
 assert request["operator_pressure_digest"]["signal_from_operator_now"]
 assert request["operator_pressure_digest"]["operator_toil_optimizable_now"]
+assert request["operator_pressure_digest"]["pre_skill_context"]
 assert request["operator_pressure_digest"]["substrate_gap_requests"]
 assert "mistakes_to_avoid_now" in request["operator_pressure_digest"]
 assert request["operator_pressure_digest"]["active_entities"]
@@ -263,7 +265,9 @@ assert request["operator_pressure"]["projection"]["path"].endswith("/state/proje
 assert request["delta_prerequisite"]["inputs"]["raw_chat"]["source_paths"]["projection"].endswith("/state/projections/operator-pressure.json")
 assert request["beat_launch_context"]["signal_from_operator_now"]
 assert request["beat_launch_context"]["signal_from_edge_state_now"]
+assert request["beat_launch_context"]["pre_skill_context"]
 assert request["beat_launch_context"]["substrate_gap_requests"]
+assert any("Operator pressure pre-skill rule" in note for note in request["pre_skill_context"]["context_notes"])
 assert request["beat_launch_context"]["decision_blend"] == {
     "operator_min_weight": 0.20,
     "edge_state_min_weight": 0.20,

--- a/tests/test_operator_pressure_layers.sh
+++ b/tests/test_operator_pressure_layers.sh
@@ -60,6 +60,7 @@ redigest_dir = state_dir / "operator-pressure" / "redigests"
 
 payload = build_operator_pressure_layers(
     project_dir=Path(project_dir),
+    memory_path=state_dir / "missing-memory.md",
     ledger_path=ledger_path,
     hot_digest_path=hot_path,
     redigest_dir=redigest_dir,
@@ -127,12 +128,14 @@ redigest_dir = state_dir / "operator-pressure" / "redigests"
 
 first = build_operator_pressure_layers(
     project_dir=Path(project_dir),
+    memory_path=state_dir / "missing-memory.md",
     ledger_path=ledger_path,
     hot_digest_path=hot_path,
     redigest_dir=redigest_dir,
 )
 second = build_operator_pressure_layers(
     project_dir=Path(project_dir),
+    memory_path=state_dir / "missing-memory.md",
     ledger_path=ledger_path,
     hot_digest_path=hot_path,
     redigest_dir=redigest_dir,
@@ -168,6 +171,7 @@ projection_path = state_dir / "projections" / "operator-pressure.json"
 
 preview = build_operator_pressure_projection(
     project_dir=Path(project_dir),
+    memory_path=state_dir / "missing-memory.md",
     projection_path=projection_path,
     write_layers=False,
     allow_llm=False,
@@ -178,6 +182,7 @@ assert not projection_path.exists()
 
 payload = write_operator_pressure_projection(
     project_dir=Path(project_dir),
+    memory_path=state_dir / "missing-memory.md",
     projection_path=projection_path,
     allow_llm=False,
 )
@@ -290,6 +295,7 @@ session.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="
 
 payload = build_operator_pressure_layers(
     project_dir=project,
+    memory_path=state / "missing-memory.md",
     ledger_path=state / "operator-pressure" / "ledger.json",
     hot_digest_path=state / "operator-pressure" / "hot-digest.json",
     redigest_dir=state / "operator-pressure" / "redigests",
@@ -355,6 +361,8 @@ for key in (
     "operator_toil_optimizable_now",
     "mistakes_to_avoid_now",
     "implicit_needs_hypotheses",
+    "memory_updates",
+    "pre_skill_context",
     "workflow_candidates",
     "capability_candidates",
     "substrate_gap_requests",
@@ -368,6 +376,77 @@ then
     pass "empty ledger skips LLM renderer even with sticky previous digest"
 else
     fail "empty ledger skips LLM renderer even with sticky previous digest"
+fi
+
+echo "--- Test 6: memory.md updates enter pressure digest as state signals ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_BASE"
+import json
+import sys
+from pathlib import Path
+
+edge_dir, tmp_base = sys.argv[1:]
+sys.path.insert(0, f"{edge_dir}/tools")
+
+from _shared.operator_pressure import build_operator_pressure_layers, build_operator_pressure_projection
+
+tmp_base = Path(tmp_base)
+project = tmp_base / "memory-project"
+state = tmp_base / "memory-state"
+memory = tmp_base / "memory" / "MEMORY.md"
+project.mkdir(parents=True, exist_ok=True)
+state.mkdir(parents=True, exist_ok=True)
+memory.parent.mkdir(parents=True, exist_ok=True)
+(project / "session-empty.jsonl").write_text("", encoding="utf-8")
+memory.write_text(
+    "- [Report narrative workflow](report-narrative.md) - report sections must introduce dense tables before rendering them\n"
+    "- [Pre-skill memory context](pre-skill-memory.md) - memory updates should appear in pre-skill context before execution\n",
+    encoding="utf-8",
+)
+
+payload = build_operator_pressure_layers(
+    project_dir=project,
+    memory_path=memory,
+    ledger_path=state / "operator-pressure" / "ledger.json",
+    hot_digest_path=state / "operator-pressure" / "hot-digest.json",
+    redigest_dir=state / "operator-pressure" / "redigests",
+    allow_llm=False,
+)
+ledger = payload["ledger"]
+hot = payload["hot_digest"]
+summary = payload["summary"]
+atoms_path = state / "operator-pressure" / "pressure-ledger.jsonl"
+atom_entries = [json.loads(line) for line in atoms_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+assert ledger["memory"]["available"] is True
+assert ledger["memory"]["item_total"] == 2
+assert ledger["source_counts"]["memory"] == 2
+assert summary["memory_updates"] >= 1
+assert summary["pre_skill_context"] >= 1
+assert summary["memory_item_total"] == 2
+assert hot["memory_updates"]
+assert hot["pre_skill_context"]
+assert any("memory" in item.get("source_kinds", []) for item in hot["memory_updates"])
+assert any("pre-skill" in item.get("text", "").lower() for item in hot["pre_skill_context"])
+assert any("memory" in item.get("source_kinds", []) for item in ledger["items"])
+assert any((entry.get("source_kinds") or []) == ["memory"] for entry in atom_entries)
+assert any((prov.get("source_kind") == "memory") for item in ledger["items"] for prov in item["provenance"])
+
+projection = build_operator_pressure_projection(
+    project_dir=project,
+    memory_path=memory,
+    projection_path=state / "projections" / "operator-pressure.json",
+    write_layers=False,
+    allow_llm=False,
+)
+assert projection["memory"]["available"] is True
+assert projection["source_paths"]["memory"] == str(memory)
+assert projection["hot_digest"]["memory_updates"]
+assert projection["hot_digest"]["pre_skill_context"]
+PY
+then
+    pass "memory.md updates become pressure digest state signals"
+else
+    fail "memory.md updates become pressure digest state signals"
 fi
 
 echo ""

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -668,6 +668,7 @@ def _operator_pressure_digest() -> dict[str, Any]:
                 "text": str(item.get("content") or "")[:360],
                 "last_seen_at": item.get("last_seen_at"),
                 "repeat_count": int(item.get("repeat_count") or 0),
+                "source_kinds": list(item.get("source_kinds") or []),
                 "provenance": list(item.get("provenance") or [])[:3],
             }
         )
@@ -687,16 +688,19 @@ def _operator_pressure_digest() -> dict[str, Any]:
         },
         "raw_chat": {
             "available": bool(raw_items),
+            "input_total": int(ledger.get("input_total") or summary.get("input_total") or 0),
             "message_total": int(ledger.get("message_total") or summary.get("message_total") or 0),
             "session_total": int(ledger.get("session_total") or summary.get("session_total") or 0),
             "item_total": int(ledger.get("item_total") or summary.get("item_total") or 0),
             "window_days": ledger.get("window_days"),
             "project_dir": ledger.get("project_dir") or summary.get("project_dir"),
+            "memory": ledger.get("memory") or projection.get("memory") or {},
             "source_paths": {
                 "ledger": source_paths.get("ledger") or summary.get("ledger_path"),
                 "atoms": source_paths.get("atoms") or summary.get("atoms_path") or str(OPERATOR_PRESSURE_ATOMS_FILE),
                 "hot_digest": source_paths.get("hot_digest") or summary.get("hot_digest_path") or str(OPERATOR_PRESSURE_HOT_DIGEST_FILE),
                 "redigest": source_paths.get("redigest") or summary.get("redigest_path") or str(OPERATOR_PRESSURE_REDIGEST_DIR / "latest.json"),
+                "memory": source_paths.get("memory") or summary.get("memory_path"),
                 "projection": source_paths.get("projection") or str(OPERATOR_PRESSURE_PROJECTION_FILE),
             },
             "recent_items": raw_items,
@@ -735,6 +739,32 @@ def _item_texts(items: Any, *, limit: int = BEAT_LAUNCH_SECTION_LIMIT) -> list[s
             if text:
                 texts.append(text)
     return _unique_compact_strings(texts, limit=limit)
+
+
+def _operator_pressure_pre_skill_context(request: dict[str, Any], digest: dict[str, Any]) -> list[str]:
+    texts = _item_texts(digest.get("pre_skill_context"))
+    if not texts:
+        return []
+    context = request.setdefault("pre_skill_context", {})
+    notes = list(context.get("context_notes") or [])
+    existing = {re.sub(r"\s+", " ", str(note or "").strip()).casefold() for note in notes}
+    added: list[str] = []
+    for text in texts:
+        note = f"Operator pressure pre-skill rule: {text}"
+        key = re.sub(r"\s+", " ", note.strip()).casefold()
+        if key in existing:
+            continue
+        existing.add(key)
+        notes.append(note)
+        added.append(text)
+    if added:
+        context["context_notes"] = notes
+        context["operator_pressure_pre_skill_context"] = added
+        sources = list(context.get("dynamic_context_sources") or [])
+        if "operator_pressure.pre_skill_context" not in sources:
+            sources.append("operator_pressure.pre_skill_context")
+        context["dynamic_context_sources"] = sources
+    return added
 
 
 def _edge_state_signals(request: dict[str, Any]) -> list[str]:
@@ -790,6 +820,8 @@ def _expected_state_change(request: dict[str, Any], operator_signal: list[str], 
     changes: list[str] = []
     if operator_signal:
         changes.append("Reduce at least one active operator pressure item with a concrete state change in this beat.")
+    if (request.get("operator_pressure_digest") or {}).get("memory_updates"):
+        changes.append("Translate at least one memory.md update into the right state surface: active workflow, thread/topic, or pre-skill operating context.")
     if (request.get("operator_pressure_digest") or {}).get("substrate_gap_requests"):
         changes.append("Make at least one missing native-support gap more explicit, narrower, or better materialized than it was before this beat.")
     if int((request.get("async_inbox") or {}).get("unprocessed_total", 0) or 0) > 0:
@@ -827,6 +859,8 @@ def build_beat_launch_context(request: dict[str, Any]) -> dict[str, Any]:
         "signal_from_edge_state_now": edge_signal,
         "operator_pains_resolvable_now": _item_texts(digest.get("operator_pains_resolvable_now")),
         "operator_toil_optimizable_now": _item_texts(digest.get("operator_toil_optimizable_now")),
+        "memory_updates": _item_texts(digest.get("memory_updates")),
+        "pre_skill_context": _item_texts(digest.get("pre_skill_context")),
         "substrate_gap_requests": _item_texts(digest.get("substrate_gap_requests")),
         "mistakes_to_avoid_now": _item_texts(digest.get("mistakes_to_avoid_now")),
         "implicit_needs_hypotheses": _item_texts(digest.get("implicit_needs_hypotheses")),
@@ -1015,6 +1049,7 @@ def _delta_raw_chat_context(request: dict[str, Any]) -> dict[str, Any]:
             "atoms": summary.get("atoms_path") or str(OPERATOR_PRESSURE_ATOMS_FILE),
             "hot_digest": summary.get("hot_digest_path") or str(OPERATOR_PRESSURE_HOT_DIGEST_FILE),
             "redigest": summary.get("redigest_path") or str(OPERATOR_PRESSURE_REDIGEST_DIR / "latest.json"),
+            "memory": summary.get("memory_path"),
             "projection": str(OPERATOR_PRESSURE_PROJECTION_FILE),
         }
     recent_items = raw.get("recent_items")
@@ -1022,11 +1057,13 @@ def _delta_raw_chat_context(request: dict[str, Any]) -> dict[str, Any]:
         recent_items = []
     return {
         "available": bool(raw.get("available") or recent_items or summary.get("item_total")),
+        "input_total": int(raw.get("input_total") or summary.get("input_total") or 0),
         "message_total": int(raw.get("message_total") or summary.get("message_total") or 0),
         "session_total": int(raw.get("session_total") or summary.get("session_total") or 0),
         "item_total": int(raw.get("item_total") or summary.get("item_total") or 0),
         "window_days": raw.get("window_days"),
         "project_dir": raw.get("project_dir") or summary.get("project_dir"),
+        "memory": raw.get("memory") or {"path": summary.get("memory_path"), "item_total": summary.get("memory_item_total", 0)},
         "source_paths": source_paths,
         "recent_items": recent_items[:DELTA_CHAT_ITEM_LIMIT],
         "contract": "raw chat is the source of what the operator actually said; structured state is the source of what the system already persisted",
@@ -1632,6 +1669,7 @@ def _execute_preflight_step(
         request["operator_pressure"] = pressure
         request["operator_pressure_digest"] = digest
         request["operator_pressure_summary"] = summary
+        pre_skill_notes = _operator_pressure_pre_skill_context(request, digest)
         return _step_result(
             step,
             status="ok",
@@ -1640,6 +1678,8 @@ def _execute_preflight_step(
                 f"items={summary.get('item_total', 0)} "
                 f"operator_signal={summary.get('signal_from_operator_now', 0)} "
                 f"toil={summary.get('operator_toil_optimizable_now', 0)} "
+                f"memory_updates={summary.get('memory_updates', 0)} "
+                f"pre_skill_context={summary.get('pre_skill_context', 0)} "
                 f"workflow_candidates={summary.get('workflow_candidates', 0)} "
                 f"capability_candidates={summary.get('capability_candidates', 0)} "
                 f"substrate_gap_requests={summary.get('substrate_gap_requests', 0)} "
@@ -1649,6 +1689,9 @@ def _execute_preflight_step(
                 "item_total": int(summary.get("item_total", 0) or 0),
                 "signal_from_operator_now": int(summary.get("signal_from_operator_now", 0) or 0),
                 "operator_toil_optimizable_now": int(summary.get("operator_toil_optimizable_now", 0) or 0),
+                "memory_updates": int(summary.get("memory_updates", 0) or 0),
+                "pre_skill_context": int(summary.get("pre_skill_context", 0) or 0),
+                "pre_skill_context_notes_added": len(pre_skill_notes),
                 "workflow_candidates": int(summary.get("workflow_candidates", 0) or 0),
                 "capability_candidates": int(summary.get("capability_candidates", 0) or 0),
                 "substrate_gap_requests": int(summary.get("substrate_gap_requests", 0) or 0),
@@ -1952,6 +1995,8 @@ def enrich_dispatch_state(
         "operator_pressure_items": (request.get("operator_pressure_summary") or {}).get("item_total", 0),
         "operator_pressure_signal_from_operator_now": (request.get("operator_pressure_summary") or {}).get("signal_from_operator_now", 0),
         "operator_pressure_operator_toil_optimizable_now": (request.get("operator_pressure_summary") or {}).get("operator_toil_optimizable_now", 0),
+        "operator_pressure_memory_updates": (request.get("operator_pressure_summary") or {}).get("memory_updates", 0),
+        "operator_pressure_pre_skill_context": (request.get("operator_pressure_summary") or {}).get("pre_skill_context", 0),
         "operator_pressure_workflow_candidates": (request.get("operator_pressure_summary") or {}).get("workflow_candidates", 0),
         "operator_pressure_substrate_gap_requests": (request.get("operator_pressure_summary") or {}).get("substrate_gap_requests", 0),
         "beat_launch_operator_signals": len((request.get("beat_launch_context") or {}).get("signal_from_operator_now") or []),

--- a/tools/_shared/operator_pressure.py
+++ b/tools/_shared/operator_pressure.py
@@ -25,6 +25,7 @@ from typing import Any
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent.parent / "config"))
 from paths import (  # noqa: E402
+    EDGE_REPO_DIR,
     OPERATOR_PRESSURE_ATOMS_FILE,
     OPERATOR_PRESSURE_HOT_DIGEST_FILE,
     OPERATOR_PRESSURE_LEDGER_FILE,
@@ -36,15 +37,17 @@ from paths import (  # noqa: E402
 from .router_client import make_client  # noqa: E402
 from .telemetry import emit_shadow_event, log_event  # noqa: E402
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 5
 LEDGER_WINDOW_DAYS = int(os.environ.get("EDGE_OPERATOR_PRESSURE_WINDOW_DAYS", "7") or "7")
 MAX_SESSIONS = int(os.environ.get("EDGE_OPERATOR_PRESSURE_MAX_SESSIONS", "8") or "8")
 MAX_MESSAGES = int(os.environ.get("EDGE_OPERATOR_PRESSURE_MAX_MESSAGES", "48") or "48")
+MAX_MEMORY_ITEMS = int(os.environ.get("EDGE_OPERATOR_PRESSURE_MAX_MEMORY_ITEMS", "24") or "24")
 SECTION_LIMIT = int(os.environ.get("EDGE_OPERATOR_PRESSURE_SECTION_LIMIT", "4") or "4")
 REDIGEST_INTERVAL_HOURS = int(os.environ.get("EDGE_OPERATOR_PRESSURE_REDIGEST_INTERVAL_HOURS", "24") or "24")
 PROJECTION_MAX_AGE_MINUTES = int(os.environ.get("EDGE_OPERATOR_PRESSURE_PROJECTION_MAX_AGE_MINUTES", "30") or "30")
 LLM_DISABLED = os.environ.get("EDGE_OPERATOR_PRESSURE_DISABLE_LLM", "").strip() in {"1", "true", "yes"}
 LLM_MODEL = os.environ.get("EDGE_OPERATOR_PRESSURE_MODEL", "gpt-5.4").strip() or "gpt-5.4"
+MEMORY_PRESSURE_FILE = Path(os.environ.get("EDGE_OPERATOR_PRESSURE_MEMORY_FILE") or (EDGE_REPO_DIR / "memory" / "MEMORY.md"))
 
 _WHITESPACE_RE = re.compile(r"\s+")
 _PUNCT_RE = re.compile(r"[^a-z0-9]+")
@@ -69,6 +72,19 @@ _GLOBAL_SCOPE_RE = re.compile(
     re.I,
 )
 _STRONG_IMPERATIVE_RE = re.compile(r"\b(tem que|quero que|sempre|nunca|fa[cç]a|adicione|tire|remova|coloque|implemente|corrija|ajuste)\b", re.I)
+_PRE_SKILL_CONTEXT_RE = re.compile(
+    r"\b("
+    r"pre[- ]?skill|contexto pre[- ]?skill|context_notes|operating context|"
+    r"sempre|nunca|todo beat|todos os beats|toda skill|todas as skills|"
+    r"always|never|before every skill|before each skill|"
+    r"must|must not|deve|devem|nao deve|n[aã]o deve|tem que|por default|by default"
+    r")\b",
+    re.I,
+)
+_PROCEDURAL_WORKFLOW_RE = re.compile(
+    r"\b(workflow|procedur\w*|procedimento|pipeline|passos?|steps?|rotina|runbook|playbook|checklist|sequ[eê]ncia|rito)\b",
+    re.I,
+)
 _SUBSTRATE_GAP_RULES: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(
@@ -104,6 +120,7 @@ _TARGET_RULES: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\b(workflow|routines?|preflight|postflight|protocolo)\b", re.I), "workflow"),
     (re.compile(r"\b(procedure|procedural|procedimento)\b", re.I), "procedure"),
     (re.compile(r"\b(capability|primitive|primitiva|repo\.sync|exa|grafana|github|meta|whatsapp)\b", re.I), "capability"),
+    (re.compile(r"\b(memory|mem[oó]ria|rules-core|personality|metodo)\b", re.I), "memory"),
     (re.compile(r"\b(policy|politica|policy|regra|guardrail)\b", re.I), "policy"),
     (re.compile(r"\b(skill|heartbeat|autonomy|reflection|report|research|strategy|map|discovery)\b", re.I), "skill"),
     (re.compile(r"\b(thread|topic|topics|claim|claims)\b", re.I), "thread"),
@@ -161,6 +178,8 @@ _HOT_DIGEST_KEYS = {
     "operator_toil_optimizable_now",
     "mistakes_to_avoid_now",
     "implicit_needs_hypotheses",
+    "memory_updates",
+    "pre_skill_context",
     "workflow_candidates",
     "capability_candidates",
     "substrate_gap_requests",
@@ -174,6 +193,8 @@ _DIGEST_SECTION_KEYS = (
     "operator_toil_optimizable_now",
     "mistakes_to_avoid_now",
     "implicit_needs_hypotheses",
+    "memory_updates",
+    "pre_skill_context",
     "workflow_candidates",
     "capability_candidates",
     "substrate_gap_requests",
@@ -338,6 +359,52 @@ def _iter_recent_user_messages(
     return rows[-max_messages:]
 
 
+def _clean_memory_entry_text(text: str) -> str:
+    value = str(text or "").strip()
+    value = re.sub(r"^[-*]\s+", "", value).strip()
+    value = re.sub(r"^#+\s*", "", value).strip()
+    value = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 (\2)", value)
+    value = _WHITESPACE_RE.sub(" ", value).strip()
+    return value
+
+
+def _iter_memory_messages(memory_path: Path | None = None, *, max_items: int = MAX_MEMORY_ITEMS) -> list[dict[str, Any]]:
+    path = memory_path or MEMORY_PRESSURE_FILE
+    if not path.exists() or not path.is_file():
+        return []
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except Exception:
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for idx, line in enumerate(raw.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped in {"---", "..."}:
+            continue
+        if not (stripped.startswith(("-", "*", "#"))):
+            continue
+        text = _clean_memory_entry_text(stripped)
+        if len(text) < 12:
+            continue
+        fingerprint = _fingerprint_text(f"{path.name}:{idx}:{text}")
+        rows.append(
+            {
+                "session_id": f"memory:{path.name}",
+                "message_idx": idx,
+                "timestamp": "",
+                "text": text[:600],
+                "source_file": str(path),
+                "cwd": str(path.parent),
+                "source_kind": "memory",
+                "source_id": str(path),
+                "line_number": idx,
+                "memory_fingerprint": fingerprint,
+            }
+        )
+    return rows[-max_items:]
+
+
 def _normalize_text(text: str) -> str:
     value = _WHITESPACE_RE.sub(" ", text.strip().lower())
     return value
@@ -446,6 +513,8 @@ def _imperative_strength(text: str, kind: str, *, explicit_operator_direction: b
 def _salience_for_item(item: dict[str, Any]) -> float:
     score = 0.15
     score += min(int(item.get("repeat_count") or 0) * 0.12, 0.36)
+    if "memory" in set(item.get("source_kinds") or []):
+        score += 0.18
     if item.get("explicit_operator_direction"):
         score += 0.20
     if str(item.get("kind") or "") in {"correction", "contradiction", "failure"}:
@@ -477,6 +546,7 @@ def _atom_hash(item: dict[str, Any]) -> str:
         "scope": item.get("scope"),
         "substrate_gap_signal": item.get("substrate_gap_signal"),
         "substrate_gap_reasons": item.get("substrate_gap_reasons"),
+        "source_kinds": item.get("source_kinds"),
         "supersedes": item.get("supersedes"),
         "promoted_to": item.get("promoted_to"),
     }
@@ -495,14 +565,15 @@ def _items_from_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]
         text = str(message.get("text") or "").strip()
         if not text:
             continue
-        kind = _classify_kind(text)
+        source_kind = str(message.get("source_kind") or "session").strip() or "session"
+        kind = "memory_update" if source_kind == "memory" else _classify_kind(text)
         target = _infer_target(text)
         fingerprint = _fingerprint_text(text)
         item_id = f"pressure:{fingerprint}"
         item = grouped.get(item_id)
         if item is None:
             substrate_gap_reasons = _substrate_gap_reasons(text)
-            explicit_direction = _explicit_operator_direction(kind, text)
+            explicit_direction = source_kind == "memory" or _explicit_operator_direction(kind, text)
             item = {
                 "id": item_id,
                 "kind": kind,
@@ -518,10 +589,11 @@ def _items_from_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]
                 "salience": 0.0,
                 "explicit_operator_direction": explicit_direction,
                 "emotion": _infer_emotion(text, kind),
-                "imperative_strength": "low",
+                "imperative_strength": "high" if source_kind == "memory" else "low",
                 "scope": _infer_scope(text),
                 "substrate_gap_signal": bool(substrate_gap_reasons),
                 "substrate_gap_reasons": substrate_gap_reasons,
+                "source_kinds": [source_kind],
                 "provenance": [],
                 "supersedes": [],
                 "promoted_to": [],
@@ -531,17 +603,24 @@ def _items_from_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]
         item["last_seen_at"] = message["timestamp"]
         item["kind"] = kind if item["repeat_count"] == 1 else item["kind"]
         item["target"] = target if item["repeat_count"] == 1 else item["target"]
+        source_kinds = set(item.get("source_kinds") or [])
+        source_kinds.add(source_kind)
+        item["source_kinds"] = sorted(source_kinds)
+        if source_kind == "memory":
+            item["explicit_operator_direction"] = True
         provenance = item.setdefault("provenance", [])
-        provenance.append(
-            {
-                "source_kind": "session",
-                "source_id": message["session_id"],
-                "message_range": [int(message["message_idx"]), int(message["message_idx"])],
-                "timestamp": message["timestamp"],
-                "source_file": message["source_file"],
-                "cwd": message.get("cwd") or "",
-            }
-        )
+        provenance_entry = {
+            "source_kind": source_kind,
+            "source_id": str(message.get("source_id") or message["session_id"]),
+            "message_range": [int(message["message_idx"]), int(message["message_idx"])],
+            "timestamp": message["timestamp"],
+            "source_file": message["source_file"],
+            "cwd": message.get("cwd") or "",
+        }
+        if source_kind == "memory":
+            provenance_entry["line_number"] = int(message.get("line_number") or message["message_idx"])
+            provenance_entry["memory_fingerprint"] = str(message.get("memory_fingerprint") or "")
+        provenance.append(provenance_entry)
         item["provenance"] = provenance[-5:]
         merged_entities = {entity["name"]: entity for entity in item.get("entities") or [] if isinstance(entity, dict)}
         for entity in _extract_entity_objects(text):
@@ -551,12 +630,15 @@ def _items_from_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]
         merged_gap_reasons.update(_substrate_gap_reasons(text))
         item["substrate_gap_reasons"] = sorted(merged_gap_reasons)
         item["substrate_gap_signal"] = bool(item["substrate_gap_reasons"])
-        item["imperative_strength"] = _imperative_strength(
-            text,
-            kind,
-            explicit_operator_direction=bool(item.get("explicit_operator_direction")),
-            repeat_count=int(item.get("repeat_count") or 0),
-        )
+        if "memory" in item.get("source_kinds", []):
+            item["imperative_strength"] = "high"
+        else:
+            item["imperative_strength"] = _imperative_strength(
+                text,
+                kind,
+                explicit_operator_direction=bool(item.get("explicit_operator_direction")),
+                repeat_count=int(item.get("repeat_count") or 0),
+            )
     for item in grouped.values():
         item["salience"] = _salience_for_item(item)
         item["atom_hash"] = _atom_hash(item)
@@ -597,6 +679,7 @@ def _ledger_from_messages(messages: list[dict[str, Any]], *, project_dir: Path) 
             "scope": item["scope"],
             "substrate_gap_signal": item["substrate_gap_signal"],
             "substrate_gap_reasons": item["substrate_gap_reasons"],
+            "source_kinds": list(item.get("source_kinds") or []),
             "provenance": item["provenance"],
             "supersedes": item["supersedes"],
             "promoted_to": item["promoted_to"],
@@ -604,14 +687,34 @@ def _ledger_from_messages(messages: list[dict[str, Any]], *, project_dir: Path) 
         for item in items
     ]
     source_hash = _hash_payload(item_payload)
+    source_counts = Counter(str(row.get("source_kind") or "session") for row in messages)
+    memory_rows = [row for row in messages if str(row.get("source_kind") or "") == "memory"]
+    memory_path = str(memory_rows[0].get("source_file") or "") if memory_rows else str(MEMORY_PRESSURE_FILE)
     return {
         "schema_version": SCHEMA_VERSION,
         "store_kind": "operator_pressure_atom_store",
         "generated_at": _now_iso(),
         "project_dir": str(project_dir),
         "window_days": LEDGER_WINDOW_DAYS,
-        "message_total": len(messages),
-        "session_total": len({row["session_id"] for row in messages}),
+        "input_total": len(messages),
+        "message_total": int(source_counts.get("session", 0)),
+        "session_total": len({row["session_id"] for row in messages if str(row.get("source_kind") or "session") == "session"}),
+        "source_counts": dict(sorted(source_counts.items())),
+        "memory": {
+            "available": bool(memory_rows),
+            "path": memory_path,
+            "item_total": len(memory_rows),
+            "source_hash": _hash_payload(
+                [
+                    {
+                        "line_number": row.get("line_number"),
+                        "text": row.get("text"),
+                        "memory_fingerprint": row.get("memory_fingerprint"),
+                    }
+                    for row in memory_rows
+                ]
+            ) if memory_rows else "",
+        },
         "item_total": len(item_payload),
         "atom_total": len(item_payload),
         "source_hash": source_hash,
@@ -640,6 +743,8 @@ def _compact_item(item: dict[str, Any]) -> dict[str, Any]:
         "repeat_count": int(item.get("repeat_count") or 0),
         "status": item.get("status"),
         "entities": _entity_names(item.get("entities") or []),
+        "source_kinds": list(item.get("source_kinds") or []),
+        "scope": item.get("scope"),
         "last_seen_at": item.get("last_seen_at"),
     }
 
@@ -650,6 +755,31 @@ def _hot_digest_matches_schema(payload: dict[str, Any] | None) -> bool:
     if int(payload.get("schema_version") or 0) != SCHEMA_VERSION:
         return False
     return all(key in payload for key in _HOT_DIGEST_KEYS)
+
+
+def _is_pre_skill_context_item(item: dict[str, Any]) -> bool:
+    text = str(item.get("content") or item.get("text") or "")
+    target = str(item.get("target") or "").strip().lower()
+    scope = str(item.get("scope") or "").strip().lower()
+    entities = " ".join(_entity_names(item.get("entities") or []))
+    haystack = " ".join([text, target, scope, entities])
+    if not _PRE_SKILL_CONTEXT_RE.search(haystack):
+        return False
+    if target in {"workflow", "procedure"} or _PROCEDURAL_WORKFLOW_RE.search(text):
+        return bool(re.search(r"\bpre[- ]?skill|contexto pre[- ]?skill|context_notes|operating context\b", haystack, re.I))
+    return True
+
+
+def _is_workflow_candidate_item(item: dict[str, Any]) -> bool:
+    if _is_pre_skill_context_item(item):
+        return False
+    text = str(item.get("content") or item.get("text") or "")
+    target = str(item.get("target") or "").strip().lower()
+    if target in {"workflow", "procedure"}:
+        return True
+    if target == "policy" and _PROCEDURAL_WORKFLOW_RE.search(text):
+        return True
+    return False
 
 
 def _deterministic_hot_digest(ledger: dict[str, Any], previous_digest: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -676,8 +806,16 @@ def _deterministic_hot_digest(ledger: dict[str, Any], previous_digest: dict[str,
         for item in ranked
         if str(item.get("kind") or "") in {"tentative", "question"}
     ]
+    memory_updates = [
+        item for item in ranked if "memory" in set(item.get("source_kinds") or [])
+    ]
+    pre_skill_context = [
+        item for item in ranked if _is_pre_skill_context_item(item)
+    ]
     workflow_candidates = [
-        item for item in directives if str(item.get("target") or "") in {"workflow", "procedure", "policy"}
+        item
+        for item in directives
+        if _is_workflow_candidate_item(item)
     ]
     capability_candidates = [
         item for item in directives if str(item.get("target") or "") == "capability"
@@ -692,6 +830,10 @@ def _deterministic_hot_digest(ledger: dict[str, Any], previous_digest: dict[str,
         summary_parts.append(f"{len(toil)} recurring operator toil patterns")
     if mistakes:
         summary_parts.append(f"{len(mistakes)} recent mistakes to avoid")
+    if memory_updates:
+        summary_parts.append(f"{len(memory_updates)} memory-derived state signals")
+    if pre_skill_context:
+        summary_parts.append(f"{len(pre_skill_context)} pre-skill operating rules")
     if substrate_gap_requests:
         summary_parts.append(f"{len(substrate_gap_requests)} substrate gaps still requested by the operator")
     if not summary_parts:
@@ -709,6 +851,8 @@ def _deterministic_hot_digest(ledger: dict[str, Any], previous_digest: dict[str,
         "operator_toil_optimizable_now": [_compact_item(item) for item in toil[:SECTION_LIMIT]],
         "mistakes_to_avoid_now": [_compact_item(item) for item in mistakes[:SECTION_LIMIT]],
         "implicit_needs_hypotheses": [_compact_item(item) for item in hypotheses[:SECTION_LIMIT]],
+        "memory_updates": [_compact_item(item) for item in memory_updates[:SECTION_LIMIT]],
+        "pre_skill_context": [_compact_item(item) for item in pre_skill_context[:SECTION_LIMIT]],
         "workflow_candidates": [_compact_item(item) for item in workflow_candidates[:SECTION_LIMIT]],
         "capability_candidates": [_compact_item(item) for item in capability_candidates[:SECTION_LIMIT]],
         "substrate_gap_requests": [_compact_item(item) for item in substrate_gap_requests[:SECTION_LIMIT]],
@@ -742,11 +886,13 @@ def _llm_prompt(
         "Required JSON schema:\n"
         "{\n"
         '  "summary": "short paragraph",\n'
-        '  "signal_from_operator_now": [{"item_id":"...","text":"...","target":"...","kind":"...","repeat_count":1,"status":"active","entities":["..."],"last_seen_at":"..."}],\n'
+        '  "signal_from_operator_now": [{"item_id":"...","text":"...","target":"...","kind":"...","repeat_count":1,"status":"active","entities":["..."],"source_kinds":["session"],"last_seen_at":"..."}],\n'
         '  "operator_pains_resolvable_now": [same shape],\n'
         '  "operator_toil_optimizable_now": [same shape],\n'
         '  "mistakes_to_avoid_now": [same shape],\n'
         '  "implicit_needs_hypotheses": [same shape],\n'
+        '  "memory_updates": [same shape],\n'
+        '  "pre_skill_context": [same shape],\n'
         '  "workflow_candidates": [same shape],\n'
         '  "capability_candidates": [same shape],\n'
         '  "substrate_gap_requests": [same shape],\n'
@@ -755,6 +901,8 @@ def _llm_prompt(
         "Rules:\n"
         "- Keep lists bounded to the most important items already provided.\n"
         "- Do not invent workflow candidates unless they come from explicit operator direction.\n"
+        "- Treat memory_updates as durable operator-authored state changes from memory/MEMORY.md, not as casual chat.\n"
+        "- Put always-followed guidance in pre_skill_context; put repeatable procedural sequences in workflow_candidates.\n"
         "- Keep `text` concise but faithful.\n"
         "- Preserve item_id/target/kind/repeat_count/status/entities/last_seen_at from the inputs.\n"
         "- If a section has nothing useful, return an empty list.\n\n"
@@ -803,6 +951,8 @@ def _coerce_digest_shape(candidate: dict[str, Any], fallback: dict[str, Any]) ->
                         "repeat_count": int(item.get("repeat_count") or 0),
                         "status": str(item.get("status") or "active"),
                         "entities": [str(entity) for entity in (item.get("entities") or []) if str(entity).strip()],
+                        "source_kinds": [str(kind) for kind in (item.get("source_kinds") or []) if str(kind).strip()],
+                        "scope": str(item.get("scope") or ""),
                         "last_seen_at": str(item.get("last_seen_at") or ""),
                     }
                 )
@@ -838,6 +988,8 @@ def _render_hot_digest_with_llm(
         "operator_toil_optimizable_now": fallback.get("operator_toil_optimizable_now", []),
         "mistakes_to_avoid_now": fallback.get("mistakes_to_avoid_now", []),
         "implicit_needs_hypotheses": fallback.get("implicit_needs_hypotheses", []),
+        "memory_updates": fallback.get("memory_updates", []),
+        "pre_skill_context": fallback.get("pre_skill_context", []),
         "workflow_candidates": fallback.get("workflow_candidates", []),
         "capability_candidates": fallback.get("capability_candidates", []),
         "substrate_gap_requests": fallback.get("substrate_gap_requests", []),
@@ -949,6 +1101,7 @@ def _append_atom_store(ledger: dict[str, Any], *, atoms_path: Path) -> dict[str,
                 "scope": item.get("scope"),
                 "substrate_gap_signal": bool(item.get("substrate_gap_signal")),
                 "substrate_gap_reasons": list(item.get("substrate_gap_reasons") or []),
+                "source_kinds": list(item.get("source_kinds") or []),
                 "provenance": item.get("provenance") or [],
                 "supersedes": item.get("supersedes") or [],
                 "promoted_to": item.get("promoted_to") or [],
@@ -974,6 +1127,8 @@ def _build_redigest(ledger: dict[str, Any], hot_digest: dict[str, Any], previous
         "operator_toil_optimizable_now",
         "mistakes_to_avoid_now",
         "implicit_needs_hypotheses",
+        "memory_updates",
+        "pre_skill_context",
         "workflow_candidates",
         "capability_candidates",
         "substrate_gap_requests",
@@ -1006,6 +1161,7 @@ def _build_redigest(ledger: dict[str, Any], hot_digest: dict[str, Any], previous
                 "emotion": str(item.get("emotion") or ""),
                 "imperative_strength": str(item.get("imperative_strength") or ""),
                 "scope": str(item.get("scope") or ""),
+                "source_kinds": list(item.get("source_kinds") or []),
                 "entities": _entity_names(item.get("entities") or []),
                 "entity_refs": list(item.get("entities") or []),
                 "valid_from": str(item.get("valid_from") or item.get("created_at") or ""),
@@ -1094,8 +1250,14 @@ def _projection_summary(
         "schema_version": SCHEMA_VERSION,
         "generated_at": _now_iso(),
         "project_dir": str(project_dir),
+        "input_total": ledger.get("input_total", ledger.get("message_total", 0)),
         "message_total": ledger.get("message_total", 0),
         "session_total": ledger.get("session_total", 0),
+        "source_counts": ledger.get("source_counts") or {},
+        "memory_update_items": len(hot_digest.get("memory_updates") or []),
+        "pre_skill_context_items": len(hot_digest.get("pre_skill_context") or []),
+        "memory_item_total": int(((ledger.get("memory") or {}).get("item_total") or 0)),
+        "memory_path": str(((ledger.get("memory") or {}).get("path") or MEMORY_PRESSURE_FILE)),
         "item_total": ledger.get("item_total", 0),
         "active_entities": hot_digest.get("active_entities", []),
         "signal_from_operator_now": len(hot_digest.get("signal_from_operator_now") or []),
@@ -1103,6 +1265,8 @@ def _projection_summary(
         "operator_toil_optimizable_now": len(hot_digest.get("operator_toil_optimizable_now") or []),
         "mistakes_to_avoid_now": len(hot_digest.get("mistakes_to_avoid_now") or []),
         "implicit_needs_hypotheses": len(hot_digest.get("implicit_needs_hypotheses") or []),
+        "memory_updates": len(hot_digest.get("memory_updates") or []),
+        "pre_skill_context": len(hot_digest.get("pre_skill_context") or []),
         "workflow_candidates": len(hot_digest.get("workflow_candidates") or []),
         "capability_candidates": len(hot_digest.get("capability_candidates") or []),
         "substrate_gap_requests": len(hot_digest.get("substrate_gap_requests") or []),
@@ -1120,6 +1284,7 @@ def _projection_summary(
 def build_operator_pressure_layers(
     *,
     project_dir: Path | None = None,
+    memory_path: Path | None = None,
     ledger_path: Path | None = None,
     hot_digest_path: Path | None = None,
     redigest_dir: Path | None = None,
@@ -1135,7 +1300,9 @@ def build_operator_pressure_layers(
     redigest_dir = redigest_dir or OPERATOR_PRESSURE_REDIGEST_DIR
     atoms_path = atoms_path or ((explicit_ledger_path.parent / "pressure-ledger.jsonl") if explicit_ledger_path else OPERATOR_PRESSURE_ATOMS_FILE)
 
-    messages = _iter_recent_user_messages(project_dir=project_dir)
+    session_messages = _iter_recent_user_messages(project_dir=project_dir)
+    memory_messages = _iter_memory_messages(memory_path)
+    messages = session_messages + memory_messages
     ledger = _ledger_from_messages(messages, project_dir=project_dir)
     previous_digest = _read_json(hot_digest_path)
     if _hot_digest_matches_schema(previous_digest) and previous_digest.get("source_hash") == ledger.get("source_hash"):
@@ -1199,6 +1366,8 @@ def build_operator_pressure_layers(
             render_mode=summary["render_mode"],
             signal_from_operator_now=summary["signal_from_operator_now"],
             operator_toil_optimizable_now=summary["operator_toil_optimizable_now"],
+            memory_updates=summary["memory_updates"],
+            pre_skill_context=summary["pre_skill_context"],
             workflow_candidates=summary["workflow_candidates"],
             capability_candidates=summary["capability_candidates"],
             substrate_gap_requests=summary["substrate_gap_requests"],
@@ -1240,17 +1409,20 @@ def operator_pressure_projection_is_stale(
 def _raw_chat_from_ledger(ledger: dict[str, Any], summary: dict[str, Any]) -> dict[str, Any]:
     return {
         "available": bool(ledger.get("items") or ledger.get("atoms")),
+        "input_total": int(ledger.get("input_total") or summary.get("input_total") or 0),
         "message_total": int(ledger.get("message_total") or summary.get("message_total") or 0),
         "session_total": int(ledger.get("session_total") or summary.get("session_total") or 0),
         "item_total": int(ledger.get("item_total") or summary.get("item_total") or 0),
         "window_days": ledger.get("window_days"),
         "project_dir": ledger.get("project_dir") or summary.get("project_dir"),
+        "memory": ledger.get("memory") or {},
     }
 
 
 def build_operator_pressure_projection(
     *,
     project_dir: Path | None = None,
+    memory_path: Path | None = None,
     projection_path: Path | None = None,
     write_layers: bool = True,
     emit_events: bool = False,
@@ -1259,6 +1431,7 @@ def build_operator_pressure_projection(
     projection_path = projection_path or OPERATOR_PRESSURE_PROJECTION_FILE
     layers = build_operator_pressure_layers(
         project_dir=project_dir,
+        memory_path=memory_path,
         write=write_layers,
         emit_events=False,
         allow_llm=allow_llm,
@@ -1277,17 +1450,20 @@ def build_operator_pressure_projection(
             "project_dir": summary.get("project_dir"),
             "source_hash": summary.get("source_hash"),
             "window_days": ledger.get("window_days"),
+            "source_counts": ledger.get("source_counts") or {},
         },
         "summary": summary,
         "ledger": ledger,
         "hot_digest": hot_digest,
         "redigest": redigest,
         "raw_chat": _raw_chat_from_ledger(ledger, summary),
+        "memory": ledger.get("memory") or {},
         "source_paths": {
             "ledger": summary.get("ledger_path"),
             "atoms": summary.get("atoms_path"),
             "hot_digest": summary.get("hot_digest_path"),
             "redigest": summary.get("redigest_path"),
+            "memory": (ledger.get("memory") or {}).get("path"),
             "projection": str(projection_path),
         },
     }
@@ -1309,6 +1485,7 @@ def build_operator_pressure_projection(
 def write_operator_pressure_projection(
     *,
     project_dir: Path | None = None,
+    memory_path: Path | None = None,
     projection_path: Path | None = None,
     allow_llm: bool = True,
 ) -> dict[str, Any]:
@@ -1316,6 +1493,7 @@ def write_operator_pressure_projection(
     try:
         payload = build_operator_pressure_projection(
             project_dir=project_dir,
+            memory_path=memory_path,
             projection_path=projection_path,
             write_layers=True,
             emit_events=False,
@@ -1342,6 +1520,8 @@ def write_operator_pressure_projection(
             item_total=summary.get("item_total", 0),
             session_total=summary.get("session_total", 0),
             render_mode=summary.get("render_mode"),
+            memory_updates=summary.get("memory_updates", 0),
+            pre_skill_context=summary.get("pre_skill_context", 0),
             source_hash=summary.get("source_hash"),
         )
         return payload
@@ -1365,6 +1545,7 @@ def write_operator_pressure_projection(
             "hot_digest": _deterministic_hot_digest({"items": [], "source_hash": ""}),
             "redigest": {},
             "raw_chat": {"available": False, "message_total": 0, "session_total": 0, "item_total": 0},
+            "memory": {"available": False, "item_total": 0, "path": str(memory_path or MEMORY_PRESSURE_FILE)},
             "source_paths": {"projection": str(projection_path)},
         }
         _write_json(projection_path, failed)

--- a/tools/edge-curation
+++ b/tools/edge-curation
@@ -264,6 +264,8 @@ _OPERATOR_PRESSURE_SECTIONS = (
     "operator_pains_resolvable_now",
     "mistakes_to_avoid_now",
     "implicit_needs_hypotheses",
+    "memory_updates",
+    "pre_skill_context",
 )
 
 _OPERATOR_SECTION_WEIGHT = {
@@ -274,6 +276,8 @@ _OPERATOR_SECTION_WEIGHT = {
     "operator_toil_optimizable_now": 7,
     "operator_pains_resolvable_now": 6,
     "mistakes_to_avoid_now": 5,
+    "memory_updates": 9,
+    "pre_skill_context": 9,
     "implicit_needs_hypotheses": 3,
 }
 
@@ -382,6 +386,20 @@ _OPERATOR_CONCEPT_RULES: list[tuple[re.Pattern[str], str, str]] = [
     ),
 ]
 
+_PRE_SKILL_CONTEXT_RE = re.compile(
+    r"\b("
+    r"pre[- ]?skill|contexto pre[- ]?skill|context_notes|operating context|"
+    r"sempre|nunca|todo beat|todos os beats|toda skill|todas as skills|"
+    r"always|never|before every skill|before each skill|"
+    r"must|must not|deve|devem|nao deve|nao devem|tem que|por default|by default"
+    r")\b",
+    re.I,
+)
+_PROCEDURAL_WORKFLOW_RE = re.compile(
+    r"\b(workflow|procedur\w*|procedimento|pipeline|passos?|steps?|rotina|runbook|playbook|checklist|sequencia|rito)\b",
+    re.I,
+)
+
 
 def _compact_operator_text(text: str, limit: int = 220) -> str:
     compact = re.sub(r"\s+", " ", str(text or "").strip())
@@ -422,6 +440,8 @@ def _coerce_operator_pressure_item(raw: Any, section: str, index: int) -> dict[s
             "repeat_count": int(raw.get("repeat_count") or 0),
             "status": str(raw.get("status") or "active").strip(),
             "entities": _coerce_list(raw.get("entities")),
+            "source_kinds": _coerce_list(raw.get("source_kinds")),
+            "scope": str(raw.get("scope") or "").strip(),
             "last_seen_at": str(raw.get("last_seen_at") or "").strip(),
         }
     text = _compact_operator_text(str(raw or ""))
@@ -436,6 +456,8 @@ def _coerce_operator_pressure_item(raw: Any, section: str, index: int) -> dict[s
         "repeat_count": 0,
         "status": "active",
         "entities": [],
+        "source_kinds": [],
+        "scope": "",
         "last_seen_at": "",
         "synthetic_id": f"{section}:{index}",
     }
@@ -463,6 +485,8 @@ def _operator_pressure_items(operator_digest: dict[str, Any]) -> list[dict[str, 
                     "repeat_count": 0,
                     "status": item.get("status") or "active",
                     "entities": [],
+                    "source_kinds": [],
+                    "scope": item.get("scope") or "",
                     "last_seen_at": item.get("last_seen_at") or "",
                     "score": 0,
                 },
@@ -479,9 +503,16 @@ def _operator_pressure_items(operator_digest: dict[str, Any]) -> list[dict[str, 
                 if entity not in entities:
                     entities.append(entity)
             existing["entities"] = entities[:8]
+            source_kinds = list(existing.get("source_kinds") or [])
+            for source_kind in _coerce_list(item.get("source_kinds")):
+                if source_kind not in source_kinds:
+                    source_kinds.append(source_kind)
+            existing["source_kinds"] = source_kinds[:6]
             for key_name in ("target", "kind", "status"):
                 if item.get(key_name) and not existing.get(key_name):
                     existing[key_name] = item.get(key_name)
+            if item.get("scope") and not existing.get("scope"):
+                existing["scope"] = item.get("scope")
     return sorted(
         merged.values(),
         key=lambda item: (-int(item.get("score") or 0), str(item.get("last_seen_at") or ""), str(item.get("text") or "")),
@@ -520,10 +551,29 @@ def _operator_concept_for_item(item: dict[str, Any]) -> tuple[str, str]:
     return slug, _slug_title(slug)
 
 
+def _is_operator_pre_skill_context_item(item: dict[str, Any]) -> bool:
+    sections = set(_coerce_list(item.get("sections")))
+    if "pre_skill_context" in sections:
+        return True
+    text = str(item.get("text") or "")
+    target = str(item.get("target") or "").strip().lower()
+    scope = str(item.get("scope") or "").strip().lower()
+    entities = " ".join(_coerce_list(item.get("entities")))
+    haystack = " ".join([text, target, scope, entities])
+    normalized_text = _normalize_ascii(text)
+    if not _PRE_SKILL_CONTEXT_RE.search(haystack):
+        return False
+    if target in {"workflow", "procedure"} or _PROCEDURAL_WORKFLOW_RE.search(normalized_text):
+        return bool(re.search(r"\bpre[- ]?skill|contexto pre[- ]?skill|context_notes|operating context\b", haystack, re.I))
+    return True
+
+
 def _operator_pressure_groups(operator_digest: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
     items = _operator_pressure_items(operator_digest)
     groups: dict[str, dict[str, Any]] = {}
     for item in items:
+        if _is_operator_pre_skill_context_item(item):
+            continue
         slug, title = _operator_concept_for_item(item)
         group = groups.setdefault(
             slug,
@@ -534,6 +584,7 @@ def _operator_pressure_groups(operator_digest: dict[str, Any]) -> tuple[list[dic
                 "sections": Counter(),
                 "item_ids": set(),
                 "entities": set(),
+                "source_kinds": set(),
                 "evidence": [],
             },
         )
@@ -544,6 +595,8 @@ def _operator_pressure_groups(operator_digest: dict[str, Any]) -> tuple[list[dic
             group["item_ids"].add(str(item.get("item_id")))
         for entity in _coerce_list(item.get("entities")):
             group["entities"].add(entity)
+        for source_kind in _coerce_list(item.get("source_kinds")):
+            group.setdefault("source_kinds", set()).add(source_kind)
         evidence_key = str(item.get("item_id") or item.get("text") or "").casefold()
         if evidence_key and evidence_key not in {str(existing.get("key") or "") for existing in group["evidence"]}:
             group["evidence"].append(
@@ -554,6 +607,7 @@ def _operator_pressure_groups(operator_digest: dict[str, Any]) -> tuple[list[dic
                     "target": item.get("target") or "",
                     "kind": item.get("kind") or "",
                     "repeat_count": int(item.get("repeat_count") or 0),
+                    "source_kinds": _coerce_list(item.get("source_kinds")),
                     "last_seen_at": item.get("last_seen_at") or "",
                 }
             )
@@ -569,6 +623,7 @@ def _operator_pressure_groups(operator_digest: dict[str, Any]) -> tuple[list[dic
                 "sections": dict(sorted(sections.items())),
                 "item_ids": sorted(group["item_ids"]),
                 "entities": sorted(group["entities"]),
+                "source_kinds": sorted(group.get("source_kinds", set())),
                 "evidence": [
                     {key: value for key, value in evidence.items() if key != "key"}
                     for evidence in group["evidence"][:6]
@@ -589,6 +644,9 @@ def _operator_evidence_lines(group: dict[str, Any]) -> list[str]:
             suffix_parts.append(f"target={evidence.get('target')}")
         if evidence.get("kind"):
             suffix_parts.append(f"kind={evidence.get('kind')}")
+        source_kinds = _coerce_list(evidence.get("source_kinds"))
+        if source_kinds:
+            suffix_parts.append(f"source={'+'.join(source_kinds[:2])}")
         suffix = f" ({', '.join(suffix_parts)})" if suffix_parts else ""
         lines.append(f"- [{sections}] {text}{suffix}")
     return lines or ["- No operator evidence details available yet."]
@@ -660,6 +718,144 @@ def _write_operator_topic_stub(group: dict[str, Any]) -> Path:
     return path
 
 
+def _is_memory_workflow_item(item: dict[str, Any]) -> bool:
+    sections = set(_coerce_list(item.get("sections")))
+    source_kinds = set(_coerce_list(item.get("source_kinds")))
+    text = str(item.get("text") or "")
+    target = str(item.get("target") or "").strip().lower()
+    if "memory_updates" not in sections and "memory" not in source_kinds:
+        return False
+    if _is_operator_pre_skill_context_item(item):
+        return False
+    if target in {"workflow", "procedure"}:
+        return True
+    if target == "policy" and _PROCEDURAL_WORKFLOW_RE.search(_normalize_ascii(text)):
+        return True
+    return bool(re.search(r"\b(workflow|procedure|procedimento|steps?|passos?|rito|rotina)\b", _normalize_ascii(text), re.I))
+
+
+def _workflow_keywords(text: str) -> list[str]:
+    keywords = _operator_keywords(text)[:8]
+    return keywords or ["memory", "workflow"]
+
+
+def _write_memory_workflow(item: dict[str, Any]) -> Path | None:
+    text = _compact_operator_text(str(item.get("text") or ""), limit=360)
+    if not text:
+        return None
+    today = datetime.now(timezone.utc).date().isoformat()
+    slug = _slugify(f"memory {text}")[:80].rstrip("-")
+    filename = f"{today}-{slug}.md"
+    existing = list(ENTRIES_DIR.glob(f"*-{slug}.md"))
+    if existing:
+        return None
+    title_slug = _slugify(text)[:54].rstrip("-") or "memory-workflow"
+    title = f"workflow: {_slug_title(title_slug)}"
+    keywords = _workflow_keywords(text)
+    thread_ids = []
+    target = str(item.get("target") or "").strip()
+    if target in {"workflow", "procedure", "policy"}:
+        thread_ids.append(_slugify(text)[:50].rstrip("-") or "memory-workflow")
+    lines = [
+        "---",
+        f"title: {json.dumps(title, ensure_ascii=False)}",
+        f"date: {today}",
+        "tags: [workflow, memory-derived, operator-pressure]",
+        "trigger: memory/MEMORY.md update",
+        "claims:",
+        f"  - {json.dumps('Memory update introduced an operator-authored workflow: ' + text[:180], ensure_ascii=False)}",
+        f"threads: [{', '.join(thread_ids)}]" if thread_ids else "threads: []",
+        f"keywords: [{', '.join(keywords)}]",
+        "workflows_used: []",
+        "workflows_broken: []",
+        f"source_memory_item: {json.dumps(str(item.get('item_id') or ''), ensure_ascii=False)}",
+        "---",
+        "",
+        "## Memory Signal",
+        "",
+        text,
+        "",
+        "## Workflow",
+        "",
+        "### Trigger",
+        "",
+        "Use this workflow when the same operating situation appears in pre-skill context or operator pressure.",
+        "",
+        "### Steps",
+        "",
+        "- Read the memory signal as durable operator guidance, not casual chat.",
+        "- Apply the rule directly in the matching skill run.",
+        "- Cite this workflow in `workflows_used` once it is followed successfully; cite it in `workflows_broken` if it proves too vague or wrong.",
+        "",
+        "### Success Checks",
+        "",
+        "- A future skill can recall this workflow before acting.",
+        "- The next matching run either reinforces it or marks it broken.",
+        "",
+    ]
+    ENTRIES_DIR.mkdir(parents=True, exist_ok=True)
+    path = ENTRIES_DIR / filename
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _curate_memory_workflows(operator_digest: dict[str, Any]) -> dict[str, Any]:
+    items = _operator_pressure_items(operator_digest)
+    created: list[dict[str, Any]] = []
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in items:
+        if not _is_memory_workflow_item(item):
+            continue
+        key = str(item.get("item_id") or _slugify(item.get("text", "")))
+        if key in seen:
+            continue
+        seen.add(key)
+        candidate = {
+            "item_id": str(item.get("item_id") or ""),
+            "text": item.get("text"),
+            "target": item.get("target") or "",
+            "sections": item.get("sections") or [],
+            "judgement": "workflow",
+        }
+        candidates.append(candidate)
+        path = _write_memory_workflow(item)
+        if path:
+            created.append({"item_id": candidate["item_id"], "path": str(path)})
+    return {
+        "candidate_total": len(candidates),
+        "created_total": len(created),
+        "created": created,
+        "candidates": candidates[:12],
+    }
+
+
+def _curate_pre_skill_context(operator_digest: dict[str, Any]) -> dict[str, Any]:
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in _operator_pressure_items(operator_digest):
+        if not _is_operator_pre_skill_context_item(item):
+            continue
+        key = str(item.get("item_id") or _slugify(item.get("text", "")))
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates.append(
+            {
+                "item_id": str(item.get("item_id") or ""),
+                "text": item.get("text"),
+                "target": item.get("target") or "",
+                "sections": item.get("sections") or [],
+                "source_kinds": _coerce_list(item.get("source_kinds")),
+                "judgement": "pre_skill_context",
+            }
+        )
+    return {
+        "candidate_total": len(candidates),
+        "candidates": candidates[:12],
+    }
+
+
 def _curate_operator_pressure(operator_digest: dict[str, Any]) -> dict[str, Any]:
     thread_files = _read_thread_files()
     topic_files = _read_topic_files()
@@ -669,6 +865,8 @@ def _curate_operator_pressure(operator_digest: dict[str, Any]) -> dict[str, Any]
         for thread_id in _coerce_list(topic.get("threads"))
     }
     groups, item_total = _operator_pressure_groups(operator_digest)
+    memory_workflows = _curate_memory_workflows(operator_digest)
+    pre_skill_context = _curate_pre_skill_context(operator_digest)
 
     created_threads: list[dict[str, Any]] = []
     created_topics: list[dict[str, Any]] = []
@@ -715,9 +913,13 @@ def _curate_operator_pressure(operator_digest: dict[str, Any]) -> dict[str, Any]
         "groups_total": len(groups),
         "threads_created": len(created_threads),
         "topics_created": len(created_topics),
+        "workflows_created": int(memory_workflows.get("created_total") or 0),
+        "pre_skill_context_total": int(pre_skill_context.get("candidate_total") or 0),
         "missing_topic_candidates_total": len(missing_topic_candidates),
         "created_threads": created_threads,
         "created_topics": created_topics,
+        "memory_workflows": memory_workflows,
+        "pre_skill_context": pre_skill_context,
         "missing_topic_candidates": missing_topic_candidates[:12],
         "groups": [
             {
@@ -727,6 +929,7 @@ def _curate_operator_pressure(operator_digest: dict[str, Any]) -> dict[str, Any]
                 "sections": group.get("sections"),
                 "item_ids": group.get("item_ids"),
                 "entities": group.get("entities"),
+                "source_kinds": group.get("source_kinds"),
                 "evidence": group.get("evidence"),
             }
             for group in groups[:12]
@@ -1093,6 +1296,8 @@ def build_curation_digest(window_days: int) -> dict[str, Any]:
             "operator_pressure_items": operator_pressure["items_total"],
             "operator_pressure_topics_created": operator_pressure["topics_created"],
             "operator_pressure_threads_created": operator_pressure["threads_created"],
+            "operator_pressure_workflows_created": operator_pressure["workflows_created"],
+            "operator_pressure_pre_skill_context": operator_pressure["pre_skill_context_total"],
             "stale_candidates": digest["corpus"]["stale_candidates"],
         },
     )
@@ -1108,6 +1313,8 @@ def build_curation_digest(window_days: int) -> dict[str, Any]:
         operator_pressure_items=operator_pressure["items_total"],
         operator_pressure_topics_created=operator_pressure["topics_created"],
         operator_pressure_threads_created=operator_pressure["threads_created"],
+        operator_pressure_workflows_created=operator_pressure["workflows_created"],
+        operator_pressure_pre_skill_context=operator_pressure["pre_skill_context_total"],
         stale_candidates=digest["corpus"]["stale_candidates"],
     )
     return digest

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -260,7 +260,9 @@ def refresh_curation_digest() -> dict[str, Any]:
         f"topics_created={hot_topics.get('created_total', 0)} "
         f"operator_items={operator_pressure.get('items_total', 0)} "
         f"operator_threads_created={operator_pressure.get('threads_created', 0)} "
-        f"operator_topics_created={operator_pressure.get('topics_created', 0)}"
+        f"operator_topics_created={operator_pressure.get('topics_created', 0)} "
+        f"operator_workflows_created={operator_pressure.get('workflows_created', 0)} "
+        f"operator_pre_skill_context={operator_pressure.get('pre_skill_context_total', 0)}"
     )
     append_postskill_log("curation_digest", "WARN" if status == "warning" else "OK", detail)
     return {
@@ -769,6 +771,8 @@ def run_standard(state: dict[str, Any], profile: str) -> tuple[bool, str, str, l
             "operator_pressure_items": int((curation_payload.get("operator_pressure") or {}).get("items_total", 0) or 0),
             "operator_threads_created": int((curation_payload.get("operator_pressure") or {}).get("threads_created", 0) or 0),
             "operator_topics_created": int((curation_payload.get("operator_pressure") or {}).get("topics_created", 0) or 0),
+            "operator_workflows_created": int((curation_payload.get("operator_pressure") or {}).get("workflows_created", 0) or 0),
+            "operator_pre_skill_context": int((curation_payload.get("operator_pressure") or {}).get("pre_skill_context_total", 0) or 0),
             "operator_missing_topic_candidates": int((curation_payload.get("operator_pressure") or {}).get("missing_topic_candidates_total", 0) or 0),
         } if curation_payload else {},
         "async_inbox": {


### PR DESCRIPTION
## Summary

- Add `memory/MEMORY.md` as an operator-pressure source with schema v5 sections for `memory_updates` and `pre_skill_context`.
- Route always-followed operator guidance into pre-skill context notes at runtime, while procedural memory guidance can materialize as active workflows.
- Keep pre-skill guidance out of generated thread/topic clutter and expose counts in curation/postflight telemetry.

## Validation

- `python3 -m py_compile tools/_shared/operator_pressure.py tools/_shared/dispatch_runtime.py tools/edge-curation tools/edge-postflight`
- `bash tests/test_operator_pressure_layers.sh`
- `bash tests/test_edge_curation.sh`
- `bash tests/test_postflight_pipeline_state.sh`
- `bash tests/test_edge_runner.sh`