### PR TITLE
[codex] Add artifact lifecycle supervision

### DIFF
--- a/tests/test_edge_close.sh
+++ b/tests/test_edge_close.sh
@@ -105,6 +105,34 @@ with open(path, "a", encoding="utf-8") as fh:
 PY
 }
 
+append_phase_failed() {
+    local cycle_id="$1"
+    local slug="$2"
+    local reason="$3"
+    python3 - <<'PY' "$TMP_EDGE/state/events/log.jsonl" "$cycle_id" "$slug" "$reason"
+import json
+import sys
+from datetime import datetime, timezone
+
+path, cycle_id, slug, reason = sys.argv[1:5]
+event = {
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "type": "PhaseCompleted",
+    "actor": "consolidate-state",
+    "cycle_id": cycle_id,
+    "artifact": f"blog/entries/{slug}.md",
+    "payload": {
+        "pipeline": "consolidate-state",
+        "phase": "review",
+        "ok": False,
+        "reason": reason,
+    },
+}
+with open(path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(event) + "\n")
+PY
+}
+
 append_skill_completed() {
     local cycle_id="$1"
     local skill="$2"
@@ -210,18 +238,31 @@ set +e
 STATUS=$?
 set -e
 
-if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$STATUS"
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$STATUS"
 import json
 import sys
 
 dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
-status = int(sys.argv[2])
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+status = int(sys.argv[3])
 
 assert status == 1
 assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "failed"
 assert dispatch["state"]["close_reason"] == "missing_artifact_published"
 assert dispatch["state"]["postflight_status"] == "failed"
+assert dispatch["state"]["artifact_supervision_status"] == "blocked"
+assert dispatch["state"]["artifact_supervision_reason"] == "missing_artifact_published"
+assert dispatch["state"]["artifact_supervision_required"] is True
+blocked = [
+    event for event in events
+    if event.get("cycle_id") == "cycle-close-no-artifact"
+    and event.get("type") == "ArtifactSupervisionBlocked"
+]
+assert blocked
+payload = blocked[-1]["payload"]
+assert payload["required"] is True
+assert payload["reason"] == "missing_artifact_published"
 PY
 then
     pass "edge-close requires artifact publication for publishing skills"
@@ -235,12 +276,13 @@ echo "--- Test 2b: heartbeat router closes without artifact publication evidence
 append_skill_completed cycle-close-heartbeat-router roberto-heartbeat
 "$CLOSE_TOOL" --status completed >/dev/null
 
-if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/logs/post-skill.log"
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/logs/post-skill.log" "$TMP_EDGE/state/events/log.jsonl"
 import json
 import sys
 
 dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
 postflight = open(sys.argv[2], encoding="utf-8").read()
+events = [json.loads(line) for line in open(sys.argv[3], encoding="utf-8") if line.strip()]
 steps = dispatch["state"].get("postflight_steps", [])
 
 assert dispatch["request"]["skill"] == "roberto-heartbeat"
@@ -248,7 +290,14 @@ assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
 assert dispatch["state"]["close_reason"] != "missing_artifact_published"
 assert dispatch["state"]["postflight_status"] in {"completed", "warning"}
-assert "procedure: artifact_published | status: OK" not in postflight
+assert "procedure: artifact_supervision | status: OK" not in postflight
+assert dispatch["state"]["artifact_supervision_status"] == "not_required"
+assert dispatch["state"]["artifact_supervision_required"] is False
+assert any(
+    event.get("cycle_id") == "cycle-close-heartbeat-router"
+    and event.get("type") == "ArtifactSupervisionSkipped"
+    for event in events
+)
 assert len(steps) >= 6
 PY
 then
@@ -281,6 +330,8 @@ assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "failed"
 assert dispatch["state"]["close_reason"] == "missing_artifact_published"
 assert dispatch["state"]["postflight_status"] == "failed"
+assert dispatch["state"]["artifact_supervision_status"] == "blocked"
+assert dispatch["state"]["artifact_supervision_required"] is True
 PY
 then
     pass "edge-close requires artifact publication for prefixed non-heartbeat skills"
@@ -312,6 +363,48 @@ else
     fail "edge-close policy exempts delta and loader support skills only"
 fi
 
+echo "--- Test 2e: failed publication pipeline is reported by artifact supervision ---"
+"$DISPATCH_TOOL" open --trigger operator --cycle-id cycle-close-pipeline-blocked --force >/dev/null
+"$DISPATCH_TOOL" dispatch --skill research >/dev/null
+append_skill_completed cycle-close-pipeline-blocked research
+append_phase_failed cycle-close-pipeline-blocked blocked-report review_gate_failed
+set +e
+"$CLOSE_TOOL" --status completed >/dev/null
+STATUS=$?
+set -e
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$STATUS"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+status = int(sys.argv[3])
+
+assert status == 1
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "failed"
+assert dispatch["state"]["close_reason"] == "pipeline_blocked_before_publish"
+assert dispatch["state"]["artifact_supervision_status"] == "blocked"
+assert dispatch["state"]["artifact_supervision_reason"] == "pipeline_blocked_before_publish"
+evidence = dispatch["state"]["artifact_supervision_evidence"]
+assert evidence["artifact"] == "blog/entries/blocked-report.md"
+assert evidence["reason"] == "review_gate_failed"
+blocked = [
+    event for event in events
+    if event.get("cycle_id") == "cycle-close-pipeline-blocked"
+    and event.get("type") == "ArtifactSupervisionBlocked"
+]
+assert blocked
+payload = blocked[-1]["payload"]
+assert payload["pipeline_evidence"]["reason"] == "review_gate_failed"
+PY
+then
+    pass "edge-close reports failed pipeline evidence through artifact supervision"
+else
+    fail "edge-close reports failed pipeline evidence through artifact supervision"
+fi
+
 echo "--- Test 3: completed close succeeds with skill end evidence, artifact publication, and postflight ---"
 "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-complete --force >/dev/null
 "$DISPATCH_TOOL" dispatch --skill discovery >/dev/null
@@ -322,18 +415,28 @@ EDGE_CYCLE_ID=cycle-close-complete "$STEP_TOOL" discovery end >/dev/null
 append_artifact_published cycle-close-complete discovery complete
 "$CLOSE_TOOL" --status completed >/dev/null
 
-if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/logs/post-skill.log"
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/logs/post-skill.log" "$TMP_EDGE/state/events/log.jsonl"
 import json
 import sys
 
 dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
 postflight = open(sys.argv[2], encoding="utf-8").read()
+events = [json.loads(line) for line in open(sys.argv[3], encoding="utf-8") if line.strip()]
 steps = dispatch["state"].get("postflight_steps", [])
 delta = dispatch["state"].get("postflight_delta", {})
 
 assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
 assert dispatch["state"]["postflight_status"] in {"completed", "warning"}
+assert dispatch["state"]["artifact_supervision_status"] == "published"
+assert dispatch["state"]["artifact_supervision_reason"] == "artifact_published"
+assert dispatch["state"]["artifact_supervision_artifact"] == "blog/entries/complete.md"
+assert any(
+    event.get("cycle_id") == "cycle-close-complete"
+    and event.get("type") == "ArtifactSupervisionCompleted"
+    and event.get("artifact") == "blog/entries/complete.md"
+    for event in events
+)
 assert postflight.strip()
 assert len(steps) >= 6
 assert "claims_open_delta" in delta

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -582,6 +582,19 @@ assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
 assert args_log.count("__INVOCATION__") == 2
 assert "ARTIFACT SUPERVISOR RETRY" in args_log
+retry_started = [
+    event for event in events
+    if event.get("type") == "ArtifactSupervisionRetryStarted"
+    and event.get("cycle_id") == dispatch["cycle_id"]
+]
+retry_completed = [
+    event for event in events
+    if event.get("type") == "ArtifactSupervisionRetryCompleted"
+    and event.get("cycle_id") == dispatch["cycle_id"]
+]
+assert retry_started
+assert retry_completed
+assert retry_completed[-1]["payload"]["published"] is True
 published = [
     event for event in events
     if event.get("type") == "ArtifactPublished"
@@ -726,7 +739,7 @@ events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if li
 
 assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
-assert dispatch["state"]["close_reason"] in ("", None)
+assert dispatch["state"]["close_reason"] in ("", None, "postflight_step_warning")
 assert not any(event["type"] == "HeartbeatDispatchTimedOut" for event in events[-20:])
 PY
 then
@@ -796,7 +809,7 @@ events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if li
 
 assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
-assert dispatch["state"]["close_reason"] in ("", None)
+assert dispatch["state"]["close_reason"] in ("", None, "postflight_step_warning")
 assert not any(event["type"] == "HeartbeatDispatchTimedOut" for event in events[-20:])
 PY
 then

--- a/tools/_shared/artifact_supervisor.py
+++ b/tools/_shared/artifact_supervisor.py
@@ -1,0 +1,187 @@
+"""Artifact lifecycle supervision for dispatch cycles."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .jsonl_runtime import iter_jsonl_reverse
+from .skill_policy import canonical_skill_id, skill_requires_artifact_publication
+from .telemetry import emit_shadow_event
+
+
+TRUE_VALUES = {"1", "true", "yes", "ok", "success", "succeeded", "completed", "pass", "passed"}
+FALSE_VALUES = {"0", "false", "no", "fail", "failed", "error", "blocked", "aborted"}
+
+
+def iso_ge(left: str | None, right: str | None) -> bool:
+    if not left or not right:
+        return False
+    try:
+        left_dt = datetime.fromisoformat(left)
+        right_dt = datetime.fromisoformat(right)
+    except ValueError:
+        return False
+    if left_dt.tzinfo is None:
+        left_dt = left_dt.replace(tzinfo=timezone.utc)
+    if right_dt.tzinfo is None:
+        right_dt = right_dt.replace(tzinfo=timezone.utc)
+    return left_dt >= right_dt
+
+
+def _payload(event: dict[str, Any] | None) -> dict[str, Any]:
+    payload = (event or {}).get("payload") or {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _artifact(event: dict[str, Any], payload: dict[str, Any]) -> str:
+    return str(event.get("artifact") or payload.get("artifact") or payload.get("path") or "").strip()
+
+
+def _phase_ok(payload: dict[str, Any]) -> bool | None:
+    value = payload.get("ok")
+    if isinstance(value, bool):
+        return value
+    if value is not None:
+        text = str(value).strip().lower()
+        if text in TRUE_VALUES:
+            return True
+        if text in FALSE_VALUES:
+            return False
+
+    status = str(payload.get("status") or "").strip().lower()
+    if status in TRUE_VALUES:
+        return True
+    if status in FALSE_VALUES:
+        return False
+    return None
+
+
+def _event_after_threshold(event: dict[str, Any], threshold: str | None) -> bool:
+    if not threshold:
+        return True
+    return iso_ge(str(event.get("ts") or ""), threshold)
+
+
+def _pipeline_failure_evidence(event: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    reason = str(payload.get("reason") or payload.get("error") or payload.get("status") or "").strip()
+    etype = str(event.get("type") or "")
+    if not reason:
+        reason = "artifact_write_rejected" if etype == "ArtifactWriteRejected" else "pipeline_phase_failed"
+    return {
+        "event_type": etype,
+        "ts": event.get("ts") or "",
+        "artifact": _artifact(event, payload),
+        "pipeline": str(payload.get("pipeline") or ""),
+        "phase": str(payload.get("phase") or ""),
+        "reason": reason,
+    }
+
+
+def _base_result(state: dict[str, Any], *, instance: object) -> dict[str, Any]:
+    request = state.get("request", {}) or {}
+    state_block = state.get("state", {}) or {}
+    skill = request.get("skill") or ""
+    canonical_skill = canonical_skill_id(skill, instance=instance)
+    return {
+        "ok": False,
+        "status": "unknown",
+        "reason": "unknown",
+        "required": skill_requires_artifact_publication(skill, instance=instance),
+        "skill": skill,
+        "canonical_skill": canonical_skill,
+        "cycle_id": state.get("cycle_id") or "",
+        "threshold": state_block.get("dispatched_at") or state_block.get("opened_at") or "",
+    }
+
+
+def supervise_artifact_publication(
+    state: dict[str, Any],
+    *,
+    events_path: Path,
+    instance: object = "",
+) -> dict[str, Any]:
+    """Return the artifact lifecycle status for the dispatch state's cycle.
+
+    The invariant is intentionally mechanical: a substantive skill may close as
+    completed only when a cycle-local `ArtifactPublished` fact exists. Failed
+    pipeline facts enrich the diagnosis, but a durable failure report artifact
+    still satisfies the publication requirement.
+    """
+    result = _base_result(state, instance=instance)
+    if not result["required"]:
+        result.update({"ok": True, "status": "not_required", "reason": "artifact_not_required"})
+        return result
+
+    cycle_id = str(result.get("cycle_id") or "")
+    if not cycle_id:
+        result.update({"status": "blocked", "reason": "missing_cycle_id"})
+        return result
+
+    threshold = str(result.get("threshold") or "") or None
+    pipeline_failure: dict[str, Any] | None = None
+    for event in iter_jsonl_reverse(events_path):
+        if event.get("cycle_id") != cycle_id:
+            continue
+        if not _event_after_threshold(event, threshold):
+            continue
+
+        etype = str(event.get("type") or "")
+        payload = _payload(event)
+        artifact = _artifact(event, payload)
+
+        if etype == "ArtifactPublished" and artifact.startswith("blog/entries/"):
+            result.update(
+                {
+                    "ok": True,
+                    "status": "published",
+                    "reason": "artifact_published",
+                    "artifact": artifact,
+                    "artifact_published_at": event.get("ts") or "",
+                    "source_skill": payload.get("source_skill") or payload.get("skill") or "",
+                }
+            )
+            return result
+
+        if etype == "ArtifactWriteRejected" and pipeline_failure is None:
+            pipeline_failure = _pipeline_failure_evidence(event, payload)
+        elif etype == "PhaseCompleted" and _phase_ok(payload) is False and pipeline_failure is None:
+            pipeline_failure = _pipeline_failure_evidence(event, payload)
+
+    if pipeline_failure:
+        result.update(
+            {
+                "status": "blocked",
+                "reason": "pipeline_blocked_before_publish",
+                "pipeline_evidence": pipeline_failure,
+            }
+        )
+        return result
+
+    result.update({"status": "blocked", "reason": "missing_artifact_published"})
+    return result
+
+
+def event_type_for_result(result: dict[str, Any]) -> str:
+    if result.get("ok") and result.get("status") == "not_required":
+        return "ArtifactSupervisionSkipped"
+    if result.get("ok"):
+        return "ArtifactSupervisionCompleted"
+    return "ArtifactSupervisionBlocked"
+
+
+def emit_artifact_supervision_result(result: dict[str, Any], *, actor: str) -> None:
+    payload = {}
+    for key, value in result.items():
+        if key in {"ok", "artifact"} or value is None or value == "":
+            continue
+        payload[key] = value
+    payload["ok"] = bool(result.get("ok"))
+    emit_shadow_event(
+        event_type_for_result(result),
+        actor=actor,
+        artifact=str(result.get("artifact") or "") or None,
+        cycle_id=str(result.get("cycle_id") or "") or None,
+        payload=payload,
+    )

--- a/tools/edge-close
+++ b/tools/edge-close
@@ -12,15 +12,19 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import CURRENT_DISPATCH_FILE, EDGE_REPO_DIR, LOGS_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
+from paths import CURRENT_DISPATCH_FILE, EDGE_INSTANCE, EDGE_REPO_DIR, LOGS_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.artifact_supervisor import (  # noqa: E402
+    emit_artifact_supervision_result,
+    iso_ge,
+    supervise_artifact_publication,
+)
 from _shared.jsonl_runtime import iter_jsonl_reverse  # noqa: E402
-from _shared.skill_policy import skill_requires_artifact_publication  # noqa: E402
 from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
 
 POST_SKILL_LOG = LOGS_DIR / "post-skill.log"
@@ -70,21 +74,6 @@ def append_postskill_log(name: str, status: str, detail: str = "") -> None:
         message += f" | detail: {detail}"
     with open(POST_SKILL_LOG, "a", encoding="utf-8") as f:
         f.write(message + "\n")
-
-
-def iso_ge(left: str | None, right: str | None) -> bool:
-    if not left or not right:
-        return False
-    try:
-        left_dt = datetime.fromisoformat(left)
-        right_dt = datetime.fromisoformat(right)
-    except ValueError:
-        return False
-    if left_dt.tzinfo is None:
-        left_dt = left_dt.replace(tzinfo=timezone.utc)
-    if right_dt.tzinfo is None:
-        right_dt = right_dt.replace(tzinfo=timezone.utc)
-    return left_dt >= right_dt
 
 
 def check_skill_completion(state: dict) -> tuple[bool, str, dict]:
@@ -141,33 +130,20 @@ def check_skill_completion(state: dict) -> tuple[bool, str, dict]:
     return False, "missing_skill_run_completed", {"skill": skill, "cycle_id": cycle_id}
 
 
-def check_artifact_publication(state: dict) -> tuple[bool, str, dict]:
-    cycle_id = state.get("cycle_id")
-    request = state.get("request", {}) or {}
-    state_block = state.get("state", {}) or {}
-    skill = request.get("skill")
-    threshold = state_block.get("dispatched_at") or state_block.get("opened_at")
-
-    if not skill_requires_artifact_publication(skill):
-        return True, "artifact_not_required", {"skill": skill or "", "cycle_id": cycle_id}
-
-    for event in iter_jsonl_reverse(STATE_EVENTS_FILE):
-        if event.get("type") != "ArtifactPublished":
-            continue
-        if event.get("cycle_id") != cycle_id:
-            continue
-        if threshold and not iso_ge(event.get("ts"), threshold):
-            continue
-        artifact = str(event.get("artifact") or (event.get("payload", {}) or {}).get("artifact") or "")
-        if not artifact or not artifact.startswith("blog/entries/"):
-            continue
-        return True, "artifact_published", {
-            "skill": skill,
-            "artifact": artifact,
-            "ts": event.get("ts"),
-        }
-
-    return False, "missing_artifact_published", {"skill": skill, "cycle_id": cycle_id}
+def record_artifact_supervision(state: dict, result: dict) -> None:
+    state_block = state.setdefault("state", {})
+    checked_at = now_iso()
+    state_block["artifact_supervision_status"] = result.get("status")
+    state_block["artifact_supervision_reason"] = result.get("reason")
+    state_block["artifact_supervision_required"] = bool(result.get("required"))
+    state_block["artifact_supervision_checked_at"] = checked_at
+    state_block["updated_at"] = checked_at
+    if result.get("artifact"):
+        state_block["artifact_supervision_artifact"] = result.get("artifact")
+    if result.get("pipeline_evidence"):
+        state_block["artifact_supervision_evidence"] = result.get("pipeline_evidence")
+    write_state(state)
+    emit_artifact_supervision_result(result, actor="edge-close")
 
 
 def fail_close_with_postflight_reason(state: dict, *, profile: str, reason: str, step: dict) -> None:
@@ -257,20 +233,25 @@ def main() -> int:
             exit_code = 1
         else:
             append_postskill_log("skill_run_completed", "OK", skill_reason)
-            artifact_ok, artifact_reason, artifact_detail = check_artifact_publication(state)
-            if not artifact_ok:
+            artifact_result = supervise_artifact_publication(
+                state,
+                events_path=STATE_EVENTS_FILE,
+                instance=EDGE_INSTANCE,
+            )
+            record_artifact_supervision(state, artifact_result)
+            if not artifact_result.get("ok"):
                 fail_close_with_postflight_reason(
                     state,
                     profile=profile,
-                    reason=artifact_reason,
-                    step={"step": "artifact_published", "status": "failed", **artifact_detail},
+                    reason=str(artifact_result.get("reason") or "artifact_supervision_failed"),
+                    step={"step": "artifact_supervision", "status": "failed", **artifact_result},
                 )
                 effective_status = "failed"
-                effective_reason = effective_reason or artifact_reason
+                effective_reason = effective_reason or str(artifact_result.get("reason") or "artifact_supervision_failed")
                 exit_code = 1
             else:
-                if skill_requires_artifact_publication(request.get("skill")):
-                    append_postskill_log("artifact_published", "OK", artifact_reason)
+                if artifact_result.get("required"):
+                    append_postskill_log("artifact_supervision", "OK", str(artifact_result.get("reason") or ""))
                 post_ok, post_status, post_reason, post_steps = run_postflight(profile)
                 if post_ok and post_status == "warning":
                     effective_reason = effective_reason or post_reason

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -806,6 +806,34 @@ def should_echo_backend_output(skill: str | None) -> bool:
     return not skill_accepts_stdout_artifact(normalized, instance=EDGE_INSTANCE)
 
 
+def emit_artifact_retry_event(
+    event_type: str,
+    *,
+    skill: str | None,
+    cycle_id: str | None,
+    reason: str,
+    publish_result: dict | None = None,
+    exit_code: int | None = None,
+) -> None:
+    if not cycle_id:
+        return
+    result = publish_result or {}
+    emit_shadow_event(
+        event_type,
+        actor="edge-runner",
+        artifact=str(result.get("artifact") or "") or None,
+        cycle_id=cycle_id,
+        payload={
+            "skill": normalize_skill_name(skill),
+            "reason": reason,
+            "published": bool(result.get("published")),
+            "artifact": result.get("artifact") or "",
+            "publish_reason": result.get("reason") or "",
+            "exit_code": exit_code,
+        },
+    )
+
+
 def print_artifact_publish_result(result: dict, output: str) -> None:
     if result.get("published"):
         artifact = result.get("artifact")
@@ -911,6 +939,14 @@ def main() -> int:
             publish_result = maybe_publish_stdout_artifact(args.skill, cycle_id, exit_code, backend_output)
             if should_retry_artifact_skill(args.skill, cycle_id, exit_code, publish_result):
                 retry_reason = str(publish_result.get("reason") or close_reason or f"backend_exit_{exit_code}")
+                emit_artifact_retry_event(
+                    "ArtifactSupervisionRetryStarted",
+                    skill=args.skill,
+                    cycle_id=cycle_id,
+                    reason=retry_reason,
+                    publish_result=publish_result,
+                    exit_code=exit_code,
+                )
                 log_run_step(
                     "edge-runner",
                     "artifact_supervisor_retry",
@@ -935,6 +971,14 @@ def main() -> int:
                     content_override=retry_prompt,
                 )
                 publish_result = maybe_publish_stdout_artifact(args.skill, cycle_id, exit_code, backend_output)
+                emit_artifact_retry_event(
+                    "ArtifactSupervisionRetryCompleted",
+                    skill=args.skill,
+                    cycle_id=cycle_id,
+                    reason=retry_reason,
+                    publish_result=publish_result,
+                    exit_code=exit_code,
+                )
                 log_run_step(
                     "edge-runner",
                     "artifact_supervisor_retry",
@@ -989,6 +1033,14 @@ def main() -> int:
                 follow_on_publish_result = maybe_publish_stdout_artifact(follow_on_skill, cycle_id, follow_on_exit, follow_on_output)
                 if should_retry_artifact_skill(follow_on_skill, cycle_id, follow_on_exit, follow_on_publish_result):
                     retry_reason = str(follow_on_publish_result.get("reason") or f"backend_exit_{follow_on_exit}")
+                    emit_artifact_retry_event(
+                        "ArtifactSupervisionRetryStarted",
+                        skill=follow_on_skill,
+                        cycle_id=cycle_id,
+                        reason=retry_reason,
+                        publish_result=follow_on_publish_result,
+                        exit_code=follow_on_exit,
+                    )
                     log_run_step(
                         "edge-runner",
                         "artifact_supervisor_retry",
@@ -1015,6 +1067,14 @@ def main() -> int:
                     )
                     maybe_mark_skill_completion(follow_on_skill, cycle_id, follow_on_exit)
                     follow_on_publish_result = maybe_publish_stdout_artifact(follow_on_skill, cycle_id, follow_on_exit, follow_on_output)
+                    emit_artifact_retry_event(
+                        "ArtifactSupervisionRetryCompleted",
+                        skill=follow_on_skill,
+                        cycle_id=cycle_id,
+                        reason=retry_reason,
+                        publish_result=follow_on_publish_result,
+                        exit_code=follow_on_exit,
+                    )
                     log_run_step(
                         "edge-runner",
                         "artifact_supervisor_retry",


### PR DESCRIPTION
## Summary

- Add a shared artifact supervisor that classifies dispatch cycles as published, skipped, or blocked using cycle-local events.
- Gate `edge-close` through that supervisor, persist artifact supervision diagnostics in current dispatch state, and emit `ArtifactSupervisionCompleted` / `ArtifactSupervisionSkipped` / `ArtifactSupervisionBlocked` facts for Grafana.
- Emit retry telemetry from `edge-runner` when the runtime artifact supervisor retries a backend response that did not produce a durable artifact.

## Validation

- `python3 -m py_compile tools/_shared/artifact_supervisor.py tools/edge-close tools/edge-runner`
- `bash tests/test_edge_close.sh`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_postflight_pipeline_state.sh`

Note: local `config/preflight.yaml` and `config/postflight.yaml` changes are intentionally left unstaged and are not part of this PR.