### PR TITLE
[codex] Harden operator pressure digests

### DIFF
--- a/tests/test_operator_pressure_layers.sh
+++ b/tests/test_operator_pressure_layers.sh
@@ -151,6 +151,61 @@ else
     fail "unchanged ledger reuses the cached hot digest"
 fi
 
+echo "--- Test 2b: changed source hash refreshes redigest inside interval ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_BASE"
+import json
+import sys
+from pathlib import Path
+
+edge_dir, tmp_base = sys.argv[1:]
+sys.path.insert(0, f"{edge_dir}/tools")
+
+from _shared.operator_pressure import build_operator_pressure_layers
+
+tmp_base = Path(tmp_base)
+project = tmp_base / "redigest-project"
+state = tmp_base / "redigest-state"
+project.mkdir(parents=True, exist_ok=True)
+state.mkdir(parents=True, exist_ok=True)
+session = project / "session-redigest.jsonl"
+session.write_text(
+    '{"type":"user","timestamp":"2026-04-23T10:00:00Z","sessionId":"redigest","message":{"role":"user","content":"workflow automatico so com orientacao explicita do operador"}}\n',
+    encoding="utf-8",
+)
+
+kwargs = {
+    "project_dir": project,
+    "memory_path": state / "missing-memory.md",
+    "ledger_path": state / "operator-pressure" / "ledger.json",
+    "hot_digest_path": state / "operator-pressure" / "hot-digest.json",
+    "redigest_dir": state / "operator-pressure" / "redigests",
+    "allow_llm": False,
+}
+first = build_operator_pressure_layers(**kwargs)
+latest_path = state / "operator-pressure" / "redigests" / "latest.json"
+first_latest = json.loads(latest_path.read_text(encoding="utf-8"))
+
+with session.open("a", encoding="utf-8") as handle:
+    handle.write(
+        '{"type":"user","timestamp":"2026-04-23T10:01:00Z","sessionId":"redigest","message":{"role":"user","content":"corrija o install do edge e rode heartbeat depois"}}\n'
+    )
+
+second = build_operator_pressure_layers(**kwargs)
+second_latest = json.loads(latest_path.read_text(encoding="utf-8"))
+
+assert first["ledger"]["source_hash"] != second["ledger"]["source_hash"]
+assert first_latest["source_hash"] == first["ledger"]["source_hash"]
+assert second_latest["source_hash"] == second["ledger"]["source_hash"]
+assert second_latest["snapshot_hash"] != first_latest["snapshot_hash"]
+assert second_latest["item_total"] == second["ledger"]["item_total"]
+assert len(second_latest["segments"]) == second["ledger"]["item_total"]
+PY
+then
+    pass "changed source hash refreshes redigest inside interval"
+else
+    fail "changed source hash refreshes redigest inside interval"
+fi
+
 echo "--- Test 3: CQRS projection wraps the pressure layers ---"
 if python3 - <<'PY' "$EDGE_DIR" "$TMP_PROJECT" "$TMP_STATE"
 import json
@@ -287,6 +342,51 @@ rows = [
         "sessionId": "noise",
         "message": {
             "role": "user",
+            "content": "## System\n\nYou are a rigorous, intellectually honest critic. Your job is to find the flaws in the reasoning presented."
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:08:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "## System\n\nYou validate claim extraction quality for a continuity graph. Return strict JSON only.\n\n## User\n\n{\"title\":\"demo\"}"
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:09:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "## System\n\nYou are a co-author helping an autonomous AI agent improve a YAML report specification before publication."
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:10:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "<task-notification>\n<task-id>demo</task-id>\n<output-file>/tmp/demo.md</output-file>"
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:11:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
+            "content": "This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion."
+        },
+    },
+    {
+        "type": "user",
+        "timestamp": "2026-05-01T12:12:00Z",
+        "sessionId": "noise",
+        "message": {
+            "role": "user",
             "content": "corrija o install do edge e rode heartbeat depois"
         },
     },
@@ -376,6 +476,101 @@ then
     pass "empty ledger skips LLM renderer even with sticky previous digest"
 else
     fail "empty ledger skips LLM renderer even with sticky previous digest"
+fi
+
+echo "--- Test 5b: LLM renderer omits unsupported temperature override ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import json
+import sys
+from types import SimpleNamespace
+
+edge_dir = sys.argv[1]
+sys.path.insert(0, f"{edge_dir}/tools")
+
+from _shared import operator_pressure as mod
+
+class FakeCompletions:
+    def create(self, **kwargs):
+        assert "temperature" not in kwargs, kwargs
+        payload = {
+            "summary": "operator pressure rendered",
+            "signal_from_operator_now": [
+                {
+                    "item_id": "pressure:demo",
+                    "text": "corrija o install do edge",
+                    "target": "workflow",
+                    "kind": "directive",
+                    "repeat_count": 1,
+                    "status": "active",
+                    "entities": ["workflow"],
+                    "source_kinds": ["session"],
+                    "last_seen_at": "2026-04-23T10:00:00+00:00",
+                }
+            ],
+            "operator_pains_resolvable_now": [],
+            "operator_toil_optimizable_now": [],
+            "mistakes_to_avoid_now": [],
+            "implicit_needs_hypotheses": [],
+            "memory_updates": [],
+            "pre_skill_context": [],
+            "workflow_candidates": [],
+            "capability_candidates": [],
+            "substrate_gap_requests": [],
+            "active_entities": ["workflow"],
+        }
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(message=SimpleNamespace(content=json.dumps(payload)))
+            ]
+        )
+
+class FakeChat:
+    def __init__(self):
+        self.completions = FakeCompletions()
+
+class FakeClient:
+    def __init__(self):
+        self.chat = FakeChat()
+
+def fake_client(*_args, **_kwargs):
+    return FakeClient(), "gpt-5.4"
+
+mod.LLM_DISABLED = False
+mod.make_client = fake_client
+
+ledger = {
+    "source_hash": "sha256:demo",
+    "item_total": 1,
+    "session_total": 1,
+    "items": [
+        {
+            "id": "pressure:demo",
+            "content": "corrija o install do edge",
+            "target": "workflow",
+            "kind": "directive",
+            "status": "active",
+            "repeat_count": 1,
+            "last_seen_at": "2026-04-23T10:00:00+00:00",
+            "entities": [{"name": "workflow", "type": "workflow"}],
+            "source_kinds": ["session"],
+            "explicit_operator_direction": True,
+            "scope": "global",
+            "substrate_gap_signal": False,
+            "substrate_gap_reasons": [],
+        }
+    ],
+}
+
+digest = mod._render_hot_digest_with_llm(ledger, previous_digest=None, delta_items=[])
+assert digest["render_mode"] == "gpt-5"
+assert digest["model"] == "gpt-5.4"
+assert digest["summary"] == "operator pressure rendered"
+assert digest["signal_from_operator_now"]
+PY
+then
+    pass "LLM renderer omits unsupported temperature override"
+else
+    fail "LLM renderer omits unsupported temperature override"
 fi
 
 echo "--- Test 6: memory.md updates enter pressure digest as state signals ---"

--- a/tools/_shared/operator_pressure.py
+++ b/tools/_shared/operator_pressure.py
@@ -209,9 +209,14 @@ _RUNTIME_PRESSURE_NOISE_RE = (
     re.compile(r"^\s*Base directory for this skill:\s+\S*\.claude/skills/", re.I),
     re.compile(r"^\s*## System\s*\n\s*You compress operator pressure into compact structured JSON\b", re.I),
     re.compile(r"^\s*## System\s*\n\s*You are a quality reviewer for report artifacts\b", re.I),
+    re.compile(r"^\s*## System\s*\n\s*You are a rigorous, intellectually honest critic\b", re.I),
+    re.compile(r"^\s*## System\s*\n\s*You validate claim extraction quality for a continuity graph\b", re.I),
+    re.compile(r"^\s*## System\s*\n\s*You are a co-author helping an autonomous AI agent\b", re.I),
     re.compile(r"^\s*You are converting an operator's free-form description of a research or work routine\b", re.I),
     re.compile(r"^\s*You are bootstrapping an autonomous AI agent\. Generate seed content\b", re.I),
     re.compile(r"^\s*You are implementing a source primitive for an autonomous agent\b", re.I),
+    re.compile(r"^\s*<task-notification>", re.I),
+    re.compile(r"^\s*This session is being continued from a previous conversation that ran out of context\.", re.I),
 )
 
 
@@ -1002,7 +1007,6 @@ def _render_hot_digest_with_llm(
         client, model = make_client("chat", model=LLM_MODEL, timeout=90)
         response = client.chat.completions.create(
             model=model,
-            temperature=0.2,
             messages=[
                 {"role": "system", "content": "You compress operator pressure into compact structured JSON for runtime use."},
                 {"role": "user", "content": prompt},
@@ -1202,7 +1206,12 @@ def _maybe_write_redigest(ledger: dict[str, Any], hot_digest: dict[str, Any], *,
     latest = _read_json(latest_path)
     if latest:
         previous_ts = _parse_ts(str(latest.get("generated_at") or ""))
-        if previous_ts and (_now() - previous_ts) < timedelta(hours=REDIGEST_INTERVAL_HOURS):
+        source_changed = str(latest.get("source_hash") or "") != str(ledger.get("source_hash") or "")
+        if (
+            not source_changed
+            and previous_ts
+            and (_now() - previous_ts) < timedelta(hours=REDIGEST_INTERVAL_HOURS)
+        ):
             return latest
     snapshot = _build_redigest(ledger, hot_digest, previous_latest=latest)
     stamp = _now().strftime("%Y%m%dT%H%M%SZ")


### PR DESCRIPTION
## Summary

Harden the operator-pressure digest path after fleet audit showed real operator signal mixed with runtime prompt noise.

## Changes

- Filter additional runtime-injected user messages from the pressure ledger, including critic prompts, claim-validation prompts, report co-author prompts, task notifications, and resumed-session summaries.
- Remove the unsupported `temperature=0.2` override from the LLM digest renderer so current GPT-5 models do not fall back to deterministic rendering.
- Refresh the cold operator-pressure redigest when `source_hash` changes, even inside the periodic redigest interval.
- Add regression tests for redigest refresh, runtime prompt filtering, and temperature-free LLM rendering.

## Root Cause

The pressure ledger was treating some backend/runtime prompt envelopes as user session messages. Separately, the hot digest renderer sent a temperature override unsupported by the current model family, and the redigest interval could keep a stale zero-segment snapshot after the source changed.

## Validation

- `python3 -m py_compile tools/_shared/operator_pressure.py`
- `bash tests/test_operator_pressure_layers.sh`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_edge_curation.sh`
- `git diff --check`