### PR TITLE
[codex] Add deterministic primitive self-healing

### DIFF
--- a/config/preflight.yaml
+++ b/config/preflight.yaml
@@ -11,6 +11,8 @@ procedures:
     kind: claude.sessions.digest
   - id: claims
     kind: claims.refresh
+  - id: self-healing
+    kind: self_healing.primitives
   - id: primitives
     kind: primitives.status
   - id: capabilities

--- a/skills/autonomy/SKILL.md
+++ b/skills/autonomy/SKILL.md
@@ -33,7 +33,9 @@ A run is incomplete if it only observes missing capability and leaves no decisio
 
 Autonomy does not own project delivery, product code, broad refactors, or skill creation.
 
-It still reports every run. The difference is that the report is an operational accountability record, not a separate publication ritual. If autonomy acts, the report must make the action auditable: decision, evidence, changed surface, verification readback, residual risk, and next route.
+Autonomy is no longer a publication ritual. It records operational accountability through lifecycle events, status readbacks, and a concise terminal report. Do not create a blog entry, HTML report, meta-report, adversarial review, or general publication artifact for routine autonomy work.
+
+When invoked from heartbeat self-healing, autonomy is a secondary subroutine: investigate only the primitives listed in `request.self_healing.needs_llm`, attempt the smallest reversible repair or diagnosis, log what happened, then let the heartbeat continue to its normal action dispatch.
 
 ## Boundary
 
@@ -50,6 +52,7 @@ Use read models first:
 ```bash
 edge-cap status --json --skill autonomy
 edge-primitives status --json
+edge-self-healing --json
 ```
 
 These are the canonical sources for capability and primitive state. They combine configuration, materialized primitives, probe results, and recent usage.
@@ -58,6 +61,7 @@ Also inspect when relevant:
 
 - `state/source-affordance-digest.json`;
 - runtime capability and workflow status;
+- `request.self_healing` from preflight;
 - operational signals such as autonomy, friction, cost, reflection, and serendipity;
 - recent failed or repeated tool/search/signal paths;
 - local workflow and primitive usage evidence.
@@ -127,7 +131,7 @@ The readback is the proof. Do not infer success from the file edit alone.
 
 ### 1. Read The Substrate
 
-Start from capability and primitive read models. Identify degraded, broken, unprobed, unused, duplicated, or high-friction items.
+Start from capability and primitive read models. If `request.self_healing.needs_llm` is present, start with those primitives before sweeping the broader substrate. Identify degraded, broken, unprobed, unused, duplicated, or high-friction items.
 
 ### 2. Build The Attempt Queue
 
@@ -160,7 +164,7 @@ After each mutation, run the relevant probe or status readback. If one item fail
 
 ### 5. Close With Decision
 
-Return a concise operational report:
+Return a concise operational terminal report:
 
 ```markdown
 Autonomy Sweep: <scope>
@@ -176,6 +180,14 @@ Routed:
 Residual Risk: <what may still be wrong>
 Next: <remaining work or next sweep focus>
 ```
+
+Also log durable facts for actions that matter:
+
+```bash
+edge-event log --type maintenance --summary "<primitive/action/result>"
+```
+
+Do not run `consolidate-state` for autonomy unless the operator explicitly asked for a published artifact.
 
 ## Routing
 
@@ -193,4 +205,5 @@ Next: <remaining work or next sweep focus>
 - Do not skip because priority, demand, or evidence seems weak.
 - Only mark work not done after a concrete failed attempt or hard blocker.
 - Do not create skill proposals.
+- Do not create routine autonomy publication artifacts.
 - Verification readback is part of the action, not optional.

--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -36,6 +36,7 @@ Use the prepared request fields:
 
 - `request.dispatch_queue_summary`
 - `request.heartbeat_routing`
+- `request.self_healing`
 - `request.beat_launch_context`
 - `request.async_inbox`
 - `request.health_snapshot`
@@ -43,27 +44,28 @@ Use the prepared request fields:
 
 `beat_launch_context` is the short-lived launch frame for the beat. Use it to compare operator pressure, edge-state pressure, and exploration budget.
 
+Primitive self-healing has already run deterministically in preflight. If `request.self_healing.needs_llm` is non-empty, dispatch `autonomy` as the exceptional repair lane; autonomy must investigate/log the primitive failure without producing a publication artifact.
+
 ## Routing Order
 
 Choose the next skill in this order:
 
 1. `dispatch_queue_summary.head`: explicit queued work wins.
-2. `heartbeat_routing.priority_hints`: runtime/inbox hints beat fairness.
-3. `beat_launch_context.signal_from_operator_now`: reduce immediate operator pressure.
-4. `beat_launch_context.signal_from_edge_state_now`: address the strongest internal state signal.
-5. `heartbeat_routing.suggested_skill`: fall back to the round-robin candidate.
+2. `request.self_healing.needs_llm`: unknown primitive failure dispatches `autonomy`.
+3. `heartbeat_routing.priority_hints`: runtime/inbox hints beat fairness.
+4. `beat_launch_context.signal_from_operator_now`: reduce immediate operator pressure.
+5. `beat_launch_context.signal_from_edge_state_now`: address the strongest internal state signal.
+6. `heartbeat_routing.suggested_skill`: fall back to the action-skill rotation candidate.
 
 If routing data is missing or stale, dispatch `discovery`.
 
 ## Skill Heuristics
 
-- `reflection`: correction, confusion, contradictory state, diagnosis.
-- `autonomy`: operational change, substrate adjustment, concrete internal action.
+- `autonomy`: exceptional primitive repair from self-healing or concrete substrate action requested by operator/runtime.
 - `report`: clear synthesis for operator consumption.
 - `research`: unresolved question, evidence gap, investigation before action.
-- `map`: landscape, structure, taxonomy, comparison.
 - `discovery`: no dominant signal, open exploration.
-- `strategy`: sequencing, prioritization, medium-horizon direction.
+- `planner`: sequencing, implementation plan, next concrete project step.
 
 If multiple skills are plausible, choose the one that best reduces immediate operator pain, then the strongest edge-state signal, then the fairness candidate.
 

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -234,7 +234,7 @@ request = dispatch["request"]
 assert len(cycle_ids) == 1
 assert cycle_ids[0] == dispatch["cycle_id"]
 assert request["trigger"] == "heartbeat"
-assert request["skill"] == "autonomy"
+assert request["skill"] == "report"
 assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
 assert dispatch["state"]["preflight_status"] == "warning"
@@ -280,26 +280,23 @@ assert request["delta_prerequisite"]["required"] is True
 assert request["delta_prerequisite"]["digest_update_required"] is False
 assert request["delta_prerequisite"]["inputs"]["raw_chat"]["available"] is True
 assert request["delta_prerequisite"]["inputs"]["raw_chat"]["recent_items"]
-assert request["exploration_pack"]["skill"] == "autonomy"
+assert request["exploration_pack"]["skill"] == "report"
 assert request["exploration_pack"]["status"] in ("ready", "degraded")
 assert request["exploration_pack"]["path"].endswith("/pack.json")
-assert request["heartbeat_routing"]["suggested_skill"] == "autonomy"
-assert request["heartbeat_routing"]["selected_skill"] == "autonomy"
+assert request["heartbeat_routing"]["suggested_skill"] == "report"
+assert request["heartbeat_routing"]["selected_skill"] == "report"
 assert request["heartbeat_routing"]["dispatch_mode"] == "deterministic_heartbeat_router"
 assert request["heartbeat_routing"]["acknowledged"] is True
 assert request["heartbeat_routing"]["round_robin_skills"] == [
-    "autonomy",
-    "reflection",
     "report",
     "research",
-    "map",
     "discovery",
-    "strategy",
+    "planner",
 ]
 assert len(invocations) == 1
 assert invocations[0].splitlines()[0] == "ARGS: -p -"
 assert "/ed-heartbeat" not in invocations[0]
-assert "/autonomy" in invocations[0]
+assert "/report" in invocations[0]
 assert "Dispatch runtime context below" in invocations[0]
 assert "health_snapshot" in invocations[0]
 assert "pre_skill_context" in invocations[0]
@@ -315,7 +312,7 @@ assert "exploration_pack" in invocations[0]
 assert "Adversarial Feynman" in open(request["exploration_pack"]["markdown_path"], encoding="utf-8").read()
 assert "configured_integrations" in invocations[0]
 assert "heartbeat_routing" in invocations[0]
-assert "autonomy_primitives_checkup" in request
+assert "autonomy_primitives_checkup" not in request
 assert request["primitives_status"]["summary"]["health_status"] == "ok"
 assert "workflow_status" in request
 assert "claims_summary" in request

--- a/tests/test_edge_self_healing.sh
+++ b/tests/test_edge_self_healing.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-self-healing-XXXXXX)"
+TMP_STATE="$TMP_BASE/state"
+TMP_LIBEXEC="$TMP_STATE/libexec/self-healing-test"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE/state/events" "$TMP_LIBEXEC"
+
+export EDGE_REPO_DIR="$EDGE_DIR"
+export EDGE_STATE_DIR="$TMP_STATE"
+export EDGE_CODENAME="self-healing-test"
+
+cat >"$TMP_STATE/state/sources-manifest.yaml" <<YAML
+version: 1
+sources:
+  - name: exa
+    description: Web search
+    status: active
+    meta_path: "$TMP_LIBEXEC/exa.meta.yaml"
+    binary_path: "$TMP_LIBEXEC/exa"
+    operations: [search]
+YAML
+
+cat >"$TMP_LIBEXEC/exa.meta.yaml" <<'YAML'
+name: exa
+description: Web search
+status: active
+operations:
+  - name: search
+    status: active
+YAML
+
+cat >"$TMP_LIBEXEC/exa" <<'SH'
+#!/usr/bin/env bash
+printf '{"ok": true, "results": []}\n'
+SH
+chmod +x "$TMP_LIBEXEC/exa"
+
+cat >"$TMP_STATE/state/events/log.jsonl" <<JSONL
+{"ts":"2026-05-02T20:00:00+00:00","type":"PrimitiveProbeCompleted","actor":"test","payload":{"source":"exa","ok":false,"exit_code":1},"prev_hash":"sha256:root"}
+JSONL
+
+TOOL="$EDGE_DIR/tools/edge-self-healing"
+STATUS_TOOL="$EDGE_DIR/tools/edge-primitives"
+
+echo "=== edge-self-healing Smoke Test ==="
+echo "Temp state: $TMP_STATE"
+echo ""
+
+echo "--- Test 1: broken primitive is reprobed and recovered ---"
+if python3 - <<'PY' "$TOOL" "$STATUS_TOOL"
+import json
+import subprocess
+import sys
+
+tool, status_tool = sys.argv[1:]
+before = json.loads(subprocess.run([status_tool, "status", "--json"], capture_output=True, text=True, check=True).stdout)
+rows = {row["name"]: row for row in before["sources"]}
+assert rows["exa"]["effective_status"] == "broken"
+
+payload = json.loads(subprocess.run([tool, "--json"], capture_output=True, text=True, check=True).stdout)
+assert payload["ok"] is True
+assert payload["summary"]["broken_total"] == 1
+assert payload["summary"]["recovered_total"] == 1
+assert payload["summary"]["needs_llm_total"] == 0
+assert payload["actions"][0]["action"] == "reprobe_success"
+
+after = json.loads(subprocess.run([status_tool, "status", "--json"], capture_output=True, text=True, check=True).stdout)
+rows = {row["name"]: row for row in after["sources"]}
+assert rows["exa"]["effective_status"] == "probed"
+PY
+then
+    pass "broken primitive is reprobed and recovered"
+else
+    fail "broken primitive is reprobed and recovered"
+fi
+
+echo "--- Test 2: self-healing emits telemetry facts ---"
+if python3 - <<'PY' "$TMP_STATE/state/events/log.jsonl" "$TMP_STATE/logs/events.jsonl"
+import json
+import sys
+from pathlib import Path
+
+shadow = [json.loads(line) for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines() if line.strip()]
+typed = [json.loads(line) for line in Path(sys.argv[2]).read_text(encoding="utf-8").splitlines() if line.strip()]
+assert any(row.get("type") == "PrimitiveSelfHealingCompleted" for row in shadow)
+assert any(row.get("type") == "self_healing" and row.get("action") == "reprobe_success" for row in typed)
+PY
+then
+    pass "self-healing emits telemetry facts"
+else
+    fail "self-healing emits telemetry facts"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/tests/test_heartbeat_routing.sh
+++ b/tests/test_heartbeat_routing.sh
@@ -28,7 +28,7 @@ echo "=== heartbeat routing Smoke Test ==="
 echo "Temp state: $TMP_STATE"
 echo ""
 
-echo "--- Test 1: heartbeat routing exposes explicit fairness lane without procedural curation skill ---"
+echo "--- Test 1: heartbeat routing exposes explicit action-skill fairness lane ---"
 if python3 - <<'PY' "$EDGE_DIR"
 import sys
 
@@ -49,13 +49,13 @@ state = {
 routing = prepare_heartbeat_routing(state, skill="heartbeat")
 assert routing is not None
 assert tuple(routing["round_robin_skills"]) == HEARTBEAT_FAIRNESS_SKILLS
-assert routing["suggested_skill"] == "autonomy"
+assert routing["suggested_skill"] == "report"
 assert routing["priority_hints"] == []
 PY
 then
-    pass "heartbeat routing exposes explicit fairness lane without procedural curation skill"
+    pass "heartbeat routing exposes explicit action-skill fairness lane"
 else
-    fail "heartbeat routing exposes explicit fairness lane without procedural curation skill"
+    fail "heartbeat routing exposes explicit action-skill fairness lane"
 fi
 
 echo "--- Test 2: fairness cursor only advances when the suggested skill is actually dispatched ---"
@@ -84,12 +84,12 @@ assert ack is not None
 assert ack["acknowledged"] is False
 assert not Path(rotation_path).exists()
 
-ack = acknowledge_heartbeat_routing(state, dispatched_skill="autonomy", dispatch_mode="normal")
+ack = acknowledge_heartbeat_routing(state, dispatched_skill="report", dispatch_mode="normal")
 assert ack is not None
 assert ack["acknowledged"] is True
 saved = json.loads(Path(rotation_path).read_text(encoding="utf-8"))
 assert saved["cursor"] == 1
-assert saved["last_acknowledged_skill"] == "autonomy"
+assert saved["last_acknowledged_skill"] == "report"
 
 next_state = {
     "cycle_id": "cycle-routing-3",
@@ -103,7 +103,7 @@ next_state = {
 }
 next_routing = prepare_heartbeat_routing(next_state, skill="heartbeat")
 assert next_routing is not None
-assert next_routing["suggested_skill"] == "reflection"
+assert next_routing["suggested_skill"] == "research"
 PY
 then
     pass "fairness cursor only advances when the suggested skill is actually dispatched"
@@ -140,6 +140,35 @@ then
     pass "priority hints override fairness when queue or inbox is hot"
 else
     fail "priority hints override fairness when queue or inbox is hot"
+fi
+
+echo "--- Test 4: self-healing unknown primitive failures hint autonomy ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import sys
+
+edge_dir = sys.argv[1]
+sys.path.insert(0, f"{edge_dir}/tools")
+from _shared.dispatch_runtime import prepare_heartbeat_routing
+
+state = {
+    "cycle_id": "cycle-routing-5",
+    "request": {
+        "trigger": "heartbeat",
+        "skill": "heartbeat",
+        "async_inbox": {"priority": "normal", "direct_messages": [], "steering_intents": []},
+        "dispatch_queue_summary": {"pending_total": 0, "head": None},
+        "self_healing": {"needs_llm": [{"primitive": "exa"}]},
+    },
+    "state": {},
+}
+routing = prepare_heartbeat_routing(state, skill="heartbeat")
+assert routing is not None
+assert any(item["reason"] == "self_healing_needs_llm" and item["skill"] == "autonomy" for item in routing["priority_hints"])
+PY
+then
+    pass "self-healing unknown primitive failures hint autonomy"
+else
+    fail "self-healing unknown primitive failures hint autonomy"
 fi
 
 echo ""

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -53,13 +53,10 @@ RECENT_DUPLICATE_HOURS = 36
 CORPUS_REQUIRED_TYPES = ["workflow", "memory"]
 CORPUS_OPTIONAL_TYPES = ["topic"]
 HEARTBEAT_FAIRNESS_SKILLS = (
-    "autonomy",
-    "reflection",
     "report",
     "research",
-    "map",
     "discovery",
-    "strategy",
+    "planner",
 )
 
 _QUERY_KEYS = (
@@ -375,6 +372,17 @@ def _priority_hints_for_heartbeat(state: dict[str, Any]) -> list[dict[str, Any]]
                 "reason": "async_inbox_priority",
                 "skill": "reflection",
                 "priority": priority or "high",
+            }
+        )
+
+    self_healing = request.get("self_healing") or {}
+    needs_llm = self_healing.get("needs_llm") or []
+    if needs_llm:
+        hints.append(
+            {
+                "reason": "self_healing_needs_llm",
+                "skill": "autonomy",
+                "primitive_count": len(needs_llm),
             }
         )
 
@@ -1224,6 +1232,34 @@ def _primitives_status() -> dict[str, Any]:
     }
 
 
+def _primitive_self_healing() -> dict[str, Any]:
+    code, stdout, stderr = _run_subprocess(
+        [sys.executable, str(EDGE_REPO_DIR / "tools" / "edge-self-healing"), "--json"],
+        timeout=45,
+    )
+    if code != 0 or not stdout:
+        return {
+            "ok": False,
+            "status": "failed",
+            "summary": {"broken_total": 0, "recovered_total": 0, "known_skip_total": 0, "needs_llm_total": 0},
+            "needs_llm": [],
+            "actions": [],
+            "error": stderr or stdout or f"edge-self-healing exited {code}",
+        }
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "status": "failed",
+            "summary": {"broken_total": 0, "recovered_total": 0, "known_skip_total": 0, "needs_llm_total": 0},
+            "needs_llm": [],
+            "actions": [],
+            "error": f"invalid self-healing json: {exc}",
+        }
+    return payload if isinstance(payload, dict) else {"ok": False, "status": "failed", "summary": {}, "needs_llm": [], "actions": []}
+
+
 def _workflow_status() -> dict[str, Any]:
     status = build_workflow_status()
     return {
@@ -1723,6 +1759,30 @@ def _execute_preflight_step(
             },
         )
 
+    if kind == "self_healing.primitives":
+        self_healing = _primitive_self_healing()
+        request["self_healing"] = self_healing
+        summary = self_healing.get("summary") or {}
+        needs_llm = int(summary.get("needs_llm_total", 0) or 0)
+        failed = not bool(self_healing.get("ok", False))
+        return _step_result(
+            step,
+            status="failed" if failed else "warning" if needs_llm else "ok",
+            satisfied=not failed,
+            detail=(
+                f"broken={summary.get('broken_total', 0)} "
+                f"recovered={summary.get('recovered_total', 0)} "
+                f"needs_llm={needs_llm}"
+            ),
+            extra={
+                "broken_total": int(summary.get("broken_total", 0) or 0),
+                "recovered_total": int(summary.get("recovered_total", 0) or 0),
+                "known_skip_total": int(summary.get("known_skip_total", 0) or 0),
+                "needs_llm_total": needs_llm,
+                "error": str(self_healing.get("error") or ""),
+            },
+        )
+
     if kind == "primitives.status":
         primitives = _primitives_status()
         request["primitives_status"] = primitives
@@ -1999,6 +2059,8 @@ def enrich_dispatch_state(
         "operator_pressure_pre_skill_context": (request.get("operator_pressure_summary") or {}).get("pre_skill_context", 0),
         "operator_pressure_workflow_candidates": (request.get("operator_pressure_summary") or {}).get("workflow_candidates", 0),
         "operator_pressure_substrate_gap_requests": (request.get("operator_pressure_summary") or {}).get("substrate_gap_requests", 0),
+        "self_healing_needs_llm": ((request.get("self_healing") or {}).get("summary") or {}).get("needs_llm_total", 0),
+        "self_healing_recovered": ((request.get("self_healing") or {}).get("summary") or {}).get("recovered_total", 0),
         "beat_launch_operator_signals": len((request.get("beat_launch_context") or {}).get("signal_from_operator_now") or []),
         "beat_launch_edge_state_signals": len((request.get("beat_launch_context") or {}).get("signal_from_edge_state_now") or []),
         "delta_prerequisite_required": bool((request.get("delta_prerequisite") or {}).get("required")),
@@ -2091,6 +2153,7 @@ def render_skill_runtime_prompt(skill: str, state: dict[str, Any]) -> str:
         "exploration_pack": request.get("exploration_pack", {}),
         "claims_summary": request.get("claims_summary", {}),
         "orphan_claims_summary": request.get("orphan_claims_summary", {}),
+        "self_healing": request.get("self_healing", {}),
         "primitives_status": request.get("primitives_status", {}),
         "capabilities_status": request.get("capabilities_status", {}),
         "workflow_status": request.get("workflow_status", {}),

--- a/tools/_shared/protocol_runtime.py
+++ b/tools/_shared/protocol_runtime.py
@@ -33,6 +33,7 @@ _ALLOWED_KINDS: dict[str, set[str]] = {
         "inbox.snapshot",
         "claude.sessions.digest",
         "claims.refresh",
+        "self_healing.primitives",
         "primitives.status",
         "capabilities.status",
         "source.bindings",

--- a/tools/edge-render
+++ b/tools/edge-render
@@ -124,6 +124,7 @@ def _render_preflight_protocol(cfg: dict) -> str:
             {"id": "async-inbox", "kind": "inbox.snapshot"},
             {"id": "claude-sessions-digest", "kind": "claude.sessions.digest"},
             {"id": "claims-refresh", "kind": "claims.refresh"},
+            {"id": "self-healing", "kind": "self_healing.primitives"},
             {"id": "primitives-status", "kind": "primitives.status"},
             {"id": "capabilities-status", "kind": "capabilities.status"},
             {"id": "source-bindings", "kind": "source.bindings"},

--- a/tools/edge-self-healing
+++ b/tools/edge-self-healing
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""edge-self-healing — deterministic primitive recovery for heartbeat preflight."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import EDGE_REPO_DIR  # noqa: E402
+sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
+
+KNOWN_REMEDIATIONS: tuple[tuple[str, str, str], ...] = (
+    ("auth_expired", r"\b(401|403|unauthori[sz]ed|forbidden|invalid api key|expired token)\b", "skip_auth"),
+    ("timeout", r"\b(timeout|timed out|deadline exceeded)\b", "skip_timeout"),
+    ("service_down", r"\b(connection refused|could not connect|connection reset|temporarily unavailable|503|502|504)\b", "skip_service_down"),
+    ("missing_dependency", r"\b(command not found|no such file|module not found|importerror|modulenotfounderror)\b", "skip_missing_dependency"),
+)
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def run(cmd: list[str], *, timeout: int = 30) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(EDGE_REPO_DIR),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return proc.returncode, (proc.stdout or "").strip(), (proc.stderr or "").strip()
+    except subprocess.TimeoutExpired as exc:
+        return 124, (exc.stdout or "").strip() if isinstance(exc.stdout, str) else "", f"timeout after {timeout}s"
+    except Exception as exc:
+        return 1, "", str(exc)
+
+
+def load_primitive_status() -> dict[str, Any]:
+    code, stdout, stderr = run([sys.executable, str(SCRIPT_DIR / "edge-primitives"), "status", "--json"])
+    if code != 0 or not stdout:
+        return {
+            "ok": False,
+            "error": stderr or stdout or f"edge-primitives status exited {code}",
+            "summary": {},
+            "sources": [],
+        }
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        return {"ok": False, "error": f"invalid primitives status json: {exc}", "summary": {}, "sources": []}
+    payload["ok"] = True
+    return payload
+
+
+def classify_failure(text: str) -> tuple[str, str]:
+    lowered = str(text or "").lower()
+    for classification, pattern, action in KNOWN_REMEDIATIONS:
+        if re.search(pattern, lowered, flags=re.I):
+            return classification, action
+    return "unknown", "needs_llm"
+
+
+def log_self_healing(action: dict[str, Any], *, cycle_id: str | None = None) -> None:
+    payload = dict(action)
+    emit_shadow_event(
+        "PrimitiveSelfHealingObserved",
+        actor="edge-self-healing",
+        cycle_id=cycle_id,
+        payload=payload,
+    )
+    log_event(
+        "self_healing",
+        actor="edge-self-healing",
+        cycle_id=cycle_id,
+        primitive=payload.get("primitive") or "",
+        action=payload.get("action") or "",
+        classification=payload.get("classification") or "",
+        exit_code=payload.get("exit_code"),
+        detail=str(payload.get("detail") or "")[:500],
+    )
+
+
+def reprobe_primitive(row: dict[str, Any], *, cycle_id: str | None = None) -> dict[str, Any]:
+    name = str(row.get("name") or "").strip()
+    binary_path = str(row.get("binary_path") or "").strip()
+    if not name:
+        return {"primitive": "", "action": "skipped", "classification": "invalid_name", "detail": "missing primitive name"}
+    if not binary_path or not row.get("binary_exists"):
+        action = {
+            "primitive": name,
+            "action": "needs_llm",
+            "classification": "missing_binary",
+            "detail": "broken primitive has no materialized binary",
+        }
+        log_self_healing(action, cycle_id=cycle_id)
+        return action
+
+    cmd = [
+        sys.executable,
+        str(SCRIPT_DIR / "edge-primitive-lifecycle"),
+        "probe",
+        name,
+        "--operation",
+        "search",
+        "--command",
+        binary_path,
+        "--help",
+    ]
+    code, stdout, stderr = run(cmd, timeout=30)
+    detail = (stderr or stdout or f"exit={code}").splitlines()[-1][:500]
+    if code == 0:
+        action = {
+            "primitive": name,
+            "action": "reprobe_success",
+            "classification": "recovered",
+            "exit_code": code,
+            "detail": detail,
+        }
+    else:
+        classification, next_action = classify_failure(f"{stdout}\n{stderr}")
+        action = {
+            "primitive": name,
+            "action": next_action,
+            "classification": classification,
+            "exit_code": code,
+            "detail": detail,
+        }
+    log_self_healing(action, cycle_id=cycle_id)
+    return action
+
+
+def build_result(*, skip_reprobe: bool = False, cycle_id: str | None = None) -> dict[str, Any]:
+    status = load_primitive_status()
+    if not status.get("ok"):
+        payload = {
+            "ok": False,
+            "status": "failed",
+            "generated_at": now_iso(),
+            "error": status.get("error") or "unknown primitives status error",
+            "actions": [],
+            "summary": {
+                "broken_total": 0,
+                "recovered_total": 0,
+                "known_skip_total": 0,
+                "needs_llm_total": 0,
+            },
+        }
+        log_self_healing({"primitive": "", "action": "status_failed", "classification": "status_error", "detail": payload["error"]}, cycle_id=cycle_id)
+        return payload
+
+    broken = [
+        row
+        for row in status.get("sources") or []
+        if isinstance(row, dict) and str(row.get("effective_status") or "") == "broken"
+    ]
+    actions: list[dict[str, Any]] = []
+    if not skip_reprobe:
+        for row in broken:
+            actions.append(reprobe_primitive(row, cycle_id=cycle_id))
+
+    recovered = [item for item in actions if item.get("action") == "reprobe_success"]
+    needs_llm = [item for item in actions if item.get("action") == "needs_llm"]
+    known_skip = [
+        item
+        for item in actions
+        if str(item.get("action") or "").startswith("skip_")
+    ]
+    payload = {
+        "ok": True,
+        "status": "warning" if needs_llm else "ok",
+        "generated_at": now_iso(),
+        "broken_before_total": len(broken),
+        "actions": actions,
+        "needs_llm": needs_llm,
+        "summary": {
+            "broken_total": len(broken),
+            "recovered_total": len(recovered),
+            "known_skip_total": len(known_skip),
+            "needs_llm_total": len(needs_llm),
+        },
+    }
+    emit_shadow_event(
+        "PrimitiveSelfHealingCompleted",
+        actor="edge-self-healing",
+        cycle_id=cycle_id,
+        payload=payload["summary"],
+    )
+    return payload
+
+
+def print_human(payload: dict[str, Any]) -> None:
+    summary = payload.get("summary") or {}
+    print(
+        "self-healing:"
+        f" broken={summary.get('broken_total', 0)}"
+        f" recovered={summary.get('recovered_total', 0)}"
+        f" known_skip={summary.get('known_skip_total', 0)}"
+        f" needs_llm={summary.get('needs_llm_total', 0)}"
+        f" status={payload.get('status')}"
+    )
+    for item in payload.get("actions") or []:
+        print(
+            f"{item.get('primitive')}: {item.get('action')}"
+            f" classification={item.get('classification')}"
+            f" detail={item.get('detail') or ''}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Deterministic primitive self-healing")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    parser.add_argument("--skip-reprobe", action="store_true", help="Only inspect broken primitives")
+    parser.add_argument("--cycle-id", default="", help="Cycle id for telemetry")
+    args = parser.parse_args()
+
+    payload = build_result(skip_reprobe=args.skip_reprobe, cycle_id=args.cycle_id or None)
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False))
+    else:
+        print_human(payload)
+    return 0 if payload.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/heartbeat-preflight.sh
+++ b/tools/heartbeat-preflight.sh
@@ -111,6 +111,30 @@ Output ONLY the script content, no explanation." > "${stub_path}.new" 2>/dev/nul
   fi
 fi
 
+# 0c. Primitive self-healing — deterministic reprobe before LLM dispatch
+SELF_HEALING_BIN="$TOOLS_DIR/edge-self-healing"
+if [ -x "$SELF_HEALING_BIN" ]; then
+  self_healing_json=$("$SELF_HEALING_BIN" --json 2>/dev/null || true)
+  self_healing_signal=$(python3 -c "
+import json, sys
+try:
+    payload = json.loads(sys.stdin.read() or '{}')
+    summary = payload.get('summary') or {}
+    recovered = int(summary.get('recovered_total') or 0)
+    needs = payload.get('needs_llm') or []
+    if needs:
+        names = ','.join(str(item.get('primitive') or '') for item in needs if item.get('primitive'))
+        print(f'SELF_HEALING:NEEDS_LLM {len(needs)} primitives ({names})')
+    elif recovered:
+        print(f'SELF_HEALING:RECOVERED {recovered} primitives')
+except Exception:
+    pass
+" <<< "$self_healing_json" 2>/dev/null)
+  if [ -n "$self_healing_signal" ]; then
+    SIGNALS+=("$self_healing_signal")
+  fi
+fi
+
 # 1. Pending chat?
 chat_pending=$(curl -s --max-time 3 $CURL_AUTH "http://localhost:${BLOG_PORT}/api/chat?unprocessed=true" 2>/dev/null | \
   python3 -c "


### PR DESCRIPTION
## Summary

- Add `edge-self-healing`, a deterministic primitive recovery pass that reprobes broken primitives, classifies known failures, and emits self-healing telemetry.
- Run primitive self-healing in preflight and the legacy heartbeat preflight wrapper before refreshing primitive status.
- Route unknown primitive failures to `autonomy` as an exceptional repair lane while keeping regular heartbeat fairness on action skills.
- Update heartbeat/autonomy contracts and regression coverage for the new routing behavior.

Closes #468.

## Validation

- `python3 -m py_compile tools/edge-self-healing tools/_shared/dispatch_runtime.py tools/edge-render`
- `bash tests/test_edge_self_healing.sh`
- `bash tests/test_heartbeat_routing.sh`
- `bash tests/test_primitives_status.sh`
- `bash tests/test_protocol_runtime.sh`
- `bash tests/test_edge_dispatch.sh`
- `bash tests/test_edge_runner.sh`