### PR TITLE
[codex] Update Grok review model to 4.3

### DIFF
--- a/agent.yaml.example
+++ b/agent.yaml.example
@@ -224,7 +224,7 @@ repo_name: "edge-of-chaos"     # GitHub repo name
 # router_client.py falls back to these when routers: is missing.
 openai_model: "gpt-5.4"                    # edge-consult primary, review-gate
 openai_model_mini: "gpt-4.1-mini"          # seed generation, cheap tasks
-grok_model: "grok-4.20-multi-agent-beta-0309"  # edge-consult secondary
+grok_model: "grok-4.3"  # edge-consult secondary
 image_model: "gpt-image-1"                 # avatar generation
 
 # --- Routers (agnostic LLM handler — issue #222) ---
@@ -273,7 +273,7 @@ routers:
   review:
     base_url: https://api.x.ai/v1
     secret_ref: xai.env:XAI_API_KEY
-    model: grok-4.20-multi-agent-beta-0309
+    model: grok-4.3
   embedding:
     base_url: https://api.openai.com/v1
     secret_ref: openai.env:OPENAI_API_KEY

--- a/config/runtime-routers.yaml
+++ b/config/runtime-routers.yaml
@@ -13,7 +13,7 @@ routers:
   review:
     base_url: https://api.x.ai/v1
     secret_ref: xai.env:XAI_API_KEY
-    model: grok-4.20-multi-agent-beta-0309
+    model: grok-4.3
   embedding:
     base_url: https://api.openai.com/v1
     secret_ref: openai.env:OPENAI_API_KEY

--- a/tests/test_runtime_router_config.sh
+++ b/tests/test_runtime_router_config.sh
@@ -38,7 +38,7 @@ routers:
   review:
     base_url: https://api.x.ai/v1
     secret_ref: xai.env:XAI_API_KEY
-    model: grok-4.20-multi-agent-beta-0309
+    model: grok-4.3
 YAML
 
 export HOME="$TMP_HOME"
@@ -111,7 +111,7 @@ routers:
   review:
     base_url: https://api.x.ai/v1
     secret_ref: xai.env:XAI_API_KEY
-    model: grok-4.20-multi-agent-beta-0309
+    model: grok-4.3
 YAML
 cat >"$TMP_RUNTIME/secrets/openai.env" <<'ENV'
 OPENAI_API_KEY=test-openai-key
@@ -129,7 +129,7 @@ from _shared.router_client import find_router_for_model, load_router_config
 
 review = load_router_config("review")
 assert review["base_url"] == "https://api.x.ai/v1"
-assert review["model"] == "grok-4.20-multi-agent-beta-0309"
+assert review["model"] == "grok-4.3"
 name, chat = find_router_for_model("gpt-5.4")
 assert name == "chat"
 assert chat["secret_ref"] == "openai.env:OPENAI_API_KEY"

--- a/tools/_shared/router_client.py
+++ b/tools/_shared/router_client.py
@@ -59,7 +59,7 @@ _LEGACY_DEFAULTS: dict[str, dict[str, Any]] = {
         "base_url": "https://api.x.ai/v1",
         "secret_ref": "xai.env:XAI_API_KEY",
         "model_key": "grok_model",
-        "model_default": "grok-4.20-multi-agent-beta-0309",
+        "model_default": "grok-4.3",
     },
     "embedding": {
         "base_url": "https://api.openai.com/v1",

--- a/tools/_shared/telemetry.py
+++ b/tools/_shared/telemetry.py
@@ -43,7 +43,7 @@ _PRICE_PER_M: dict[str, tuple[float, float]] = {
     "gpt-4o-mini":             (0.15, 0.60),
     "text-embedding-3-small":  (0.02, 0.00),
     "text-embedding-3-large":  (0.13, 0.00),
-    "grok-4.20-multi-agent-beta-0309": (5.00, 15.00),
+    "grok-4.3": (5.00, 15.00),
 }
 
 

--- a/tools/edge-consult.py
+++ b/tools/edge-consult.py
@@ -173,7 +173,7 @@ def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> str
         "gpt-4.1-nano": (0.10, 0.40),
         "gpt-5.4": (2.50, 15.00),
         "gpt-5.4-pro": (30.00, 180.00),
-        "grok-4.20-multi-agent-beta-0309": (2.00, 6.00),
+        "grok-4.3": (2.00, 6.00),
         "grok-4-0709": (3.00, 15.00),
         "grok-4": (3.00, 15.00),
         "grok-3": (3.00, 15.00),
@@ -248,7 +248,7 @@ def log_consultation(mode: str, question: str, context_files: list,
 # Dual-model consultation (always both GPT + Grok)
 # ---------------------------------------------------------------------------
 
-DUAL_MODELS = ["gpt-5.4", "grok-4.20-multi-agent-beta-0309"]
+DUAL_MODELS = ["gpt-5.4", "grok-4.3"]
 
 
 def _build_user_msg(question: str, context_files: list = None,
@@ -277,7 +277,7 @@ def _build_user_msg(question: str, context_files: list = None,
 
 
 # Models that require Responses API instead of Chat Completions
-RESPONSES_API_MODELS = {"grok-4.20-multi-agent-beta-0309", "gpt-5.4-pro"}
+RESPONSES_API_MODELS = {"grok-4.3", "gpt-5.4-pro"}
 
 
 CLAUDE_FALLBACK_MODEL = "claude-cli"
@@ -370,7 +370,7 @@ def _call_model(model: str, system: str, user_msg: str,
 
 def consult(question: str, mode: str = "adversarial", context_files: list = None,
             stdin_content: str = None, gate_spec: str = None) -> str:
-    """Send consultation to BOTH GPT-5.4 and Grok-4.20 and return combined response.
+    """Send consultation to both configured review models and return combined response.
 
     If gate_spec is provided, saves review as {spec}.review.json for
     consolidate-state to enforce resolution before publishing.

--- a/tools/edge-render
+++ b/tools/edge-render
@@ -39,7 +39,7 @@ _ROUTER_FALLBACK_DEFAULTS = {
         "base_url": "https://api.x.ai/v1",
         "secret_ref": "xai.env:XAI_API_KEY",
         "model_key": "grok_model",
-        "model_default": "grok-4.20-multi-agent-beta-0309",
+        "model_default": "grok-4.3",
     },
     "embedding": {
         "base_url": "https://api.openai.com/v1",

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -43,7 +43,7 @@ from paths import (ENTRIES_DIR, MEMORY_DIR, REPORTS_DIR, NOTES_DIR, SKILLS_DIR, 
 from _shared.router_client import make_client  # noqa: E402
 _AGENT_NAME = load_branding().get("agent_name", "agent")
 _SKILL_PREFIX = load_branding().get("skill_prefix", "agent")
-GROK_MODEL = "grok-4.20-multi-agent-beta-0309"
+GROK_MODEL = "grok-4.3"
 
 # Router purpose used by default. The actual model comes from
 # config/runtime-routers.yaml routers.<purpose>.model — respecting per-agent configuration (Azure, OpenAI,
@@ -933,7 +933,7 @@ def _estimate_cost(model: str, usage) -> str:
         "gpt-4.1-nano": (0.10, 0.40),
         "gpt-5.4": (2.50, 15.00),
         "gpt-5.4-pro": (30.00, 180.00),
-        "grok-4.20-multi-agent-beta-0309": (2.00, 6.00),
+        "grok-4.3": (2.00, 6.00),
         "grok-4-0709": (3.00, 15.00),
         "grok-3": (3.00, 15.00),
     }


### PR DESCRIPTION
## Summary
- Switch the canonical xAI review router and agent defaults from `grok-4.20-multi-agent-beta-0309` to `grok-4.3`.
- Update edge-consult/review-gate Grok defaults, Responses API routing, telemetry cost table, and runtime router tests.

## Availability check
- xAI's public docs list Grok 4.3 and show API examples using `model="grok-4.3"`.
- Authenticated `/v1/models` probing could not complete because the current xAI team account returned HTTP 429 for exhausted credits/spend limit, so this PR relies on the official docs for availability.

## Validation
- `bash tests/test_runtime_router_config.sh`
- `python3 -m py_compile tools/edge-consult.py tools/review-gate.py tools/_shared/router_client.py tools/_shared/telemetry.py`
- `git diff --check`