### PR TITLE
Fix #483 calibrate blog entry voice contract

### DIFF
--- a/docs/blog-entry-voice-calibration-483.md
+++ b/docs/blog-entry-voice-calibration-483.md
@@ -1,0 +1,39 @@
+# Blog Entry Voice Calibration (#483)
+
+Issue #483 reopens the #388 voice contract with a narrower question: the feed
+can obey the letter of "2-4 paragraphs" and still feel unnatural to a
+Roberto-class reader, meaning a smart casual reader outside the runtime.
+
+## Evidence Sample
+
+Post-#388 entries inspected from the live edge state:
+
+| Entry | Shape | Reader-facing problem |
+|---|---:|---|
+| `2026-05-02-report-dispatch-ack-trap-broke-cycle-7-fired-first-ack.md` | 3 paragraphs | The paragraph count is right, but the first paragraph leans on cycle IDs, timestamps, a commit hash, and internal gate vocabulary before saying why the finding matters. |
+| `entry-report-empty-digest-g3-audit.md` | 3 paragraphs | The entry is coherent for the operator but assumes G3b/P1/static-audit/LLM-renderer context. It reads like a status memo, not a doorway for an external reader. |
+| `2026-05-03-map-substrate-gap-confirmed-gdrive-primitive-operations-are-list-tree-read-head-no-u.md` | 16 paragraphs | This is a report/map body published into the feed: duplicate H1, scope block, mode banner, evidence list, and process chatter. |
+
+## Diagnosis
+
+#388 landed the generic contract in `state-protocol.md` and
+`report-template.md`, but it did not cover every publication path. In
+particular, `runtime-stdout-artifact` wrote the skill output verbatim into both
+the report and the feed entry. That path can bypass the entry-as-invitation
+contract even when the full report artifact is useful.
+
+The missing bar is not just length. The entry must first explain, in plain
+language, what changed and why the reader should care. Internal identifiers,
+scope blocks, and evidence dumps can appear in the report, but they should not
+be the feed body's opening experience.
+
+## Contract Adjustment
+
+- The reader model is explicit: Roberto-class means intelligent, curious, and
+  outside the runtime.
+- The first paragraph must stand without cycle IDs, commit hashes, queue/gap
+  shorthand, or protocol vocabulary as load-bearing context.
+- Raw report scaffolding is banned from the feed body: duplicate H1, mode/scope
+  banners, evidence lists, and "writing the map/report" process chatter.
+- Runtime stdout artifacts keep the full body in the HTML report and publish a
+  short feed invitation.

--- a/skills/_shared/report-template.md
+++ b/skills/_shared/report-template.md
@@ -22,9 +22,11 @@ with Lineage, Gaps, Glossary, Bibliography, ≥1 SVG all MANDATORY.
    `consolidate-state` pipeline.
 4. **Write the blog entry as a light strategic invitation, then include open
    gaps in frontmatter when something remains unresolved.** The entry body should be only a
-   few concise paragraphs: frame why this matters now, explain what the
-   operator gains by opening the report, and leave implementation depth to the
-   report. Do not duplicate the YAML/report structure in the blog body.
+   few concise paragraphs for a Roberto-class external reader: frame why this
+   matters now in plain language, explain what the operator gains by opening the
+   report, and leave implementation depth to the report. Do not duplicate the
+   YAML/report structure, raw scope blocks, evidence lists, or internal process
+   chatter in the blog body.
    ```yaml
    open_gaps:
      - "Thing I still don't know — knowledge gap"

--- a/skills/_shared/state-protocol.md
+++ b/skills/_shared/state-protocol.md
@@ -260,9 +260,15 @@ light strategic read that helps the operator remember why this work matters,
 what decision or leverage the report enables, and whether to open the attached
 report.
 
+Reader model: a Roberto-class reader is intelligent and curious but outside the
+runtime. Do not assume they know the current cycle, queue, internal gap IDs,
+skill names, commit hashes, or protocol vocabulary. Use those details only after
+the plain-language reason to care is already clear.
+
 Required voice:
 - Keep the body to a few concise paragraphs; default to 2-4 paragraphs.
-- Lead with what changed, what was learned, or what door this opens.
+- Lead with what changed, what was learned, or what door this opens in a
+  sentence a reader outside the system can follow.
 - Explain the operator gain: the decision, risk reduction, context, or next
   move the report makes easier.
 - Use plain language and an exploratory tone; avoid implementation dumps,
@@ -270,6 +276,9 @@ Required voice:
 - Put technical depth in the report, notes, procedures, and metadata.
 - End by pointing toward the reader-visible report or next question when useful,
   without turning the entry into a summary of every report section.
+- Never publish raw report scaffolding in the feed body: no duplicate H1, scope
+  blocks, mode banners, evidence lists, or "writing the map/report" process
+  chatter.
 
 If a publication needs heavy detail, the entry should summarize the shape of the
 finding and let the content report carry the technical load.

--- a/tests/test_blog_entry_voice_contract.sh
+++ b/tests/test_blog_entry_voice_contract.sh
@@ -10,10 +10,58 @@ echo "=== blog entry voice contract test ==="
 grep -q "Blog Entry Voice Contract" "$PROTOCOL"
 grep -q "The blog entry body is the invitation, not the report" "$PROTOCOL"
 grep -q "operator gain" "$PROTOCOL"
+grep -q "Roberto-class reader" "$PROTOCOL"
 grep -q "default to 2-4 paragraphs" "$PROTOCOL"
 grep -q "Put technical depth in the report" "$PROTOCOL"
+grep -q "Never publish raw report scaffolding" "$PROTOCOL"
 grep -q "Write the blog entry as a light strategic invitation" "$TEMPLATE"
-grep -q "operator gains by opening the report" "$TEMPLATE"
-grep -q "duplicate the YAML/report structure" "$TEMPLATE"
+grep -q "Roberto-class external reader" "$TEMPLATE"
+grep -q "operator gains" "$TEMPLATE"
+grep -q "YAML/report structure" "$TEMPLATE"
+grep -q "raw scope blocks" "$TEMPLATE"
+
+python3 - <<'PY' "$EDGE_DIR"
+import re
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+sys.path.insert(0, str(edge_dir / "tools"))
+from _shared import artifact_runtime as module
+
+body = """# Substrate gap confirmed: gdrive primitive operations are list/tree/read/head
+
+Substrate gap confirmed: gdrive primitive operations are list/tree/read/head. The Drive upload memory update presupposes a capability that the bound primitive does not expose.
+
+---
+
+**Map Mode:** coverage
+**Scope:** four operator memory_updates from MEMORY.md on 2026-05-02.
+
+## Evidence
+
+- operation: list
+- operation: tree
+- operation: read
+- operation: head
+
+## Gap
+
+There is no upload operation.
+
+## Next
+
+Open a genotype issue and add the missing primitive operation.
+"""
+
+entry = module._build_entry_body("Substrate gap confirmed: gdrive primitive operations are list/tree/read/head", body)
+paragraphs = [item for item in re.split(r"\n\s*\n", entry.strip()) if item.strip()]
+assert len(paragraphs) <= 4, entry
+assert not entry.lstrip().startswith("# "), entry
+assert "**Scope:**" not in entry
+assert "- operation:" not in entry
+assert "Writing the map" not in entry
+assert "Abra o relatório" in entry
+PY
 
 echo "ALL TESTS PASSED"

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -541,7 +541,8 @@ assert published
 artifact = published[-1]["artifact"]
 entry = entries_dir / Path(artifact).name
 text = entry.read_text(encoding="utf-8")
-assert "# Plain Runtime Report" in text
+assert "Plain Runtime Report" in text
+assert "\n# Plain Runtime Report" not in text
 assert "artifact-producing skill close with text only in stdout" in text
 assert "edge-runner: published artifact blog/entries/" in runner_stdout
 assert "artifact-producing skill close with text only in stdout" not in runner_stdout

--- a/tools/_shared/artifact_runtime.py
+++ b/tools/_shared/artifact_runtime.py
@@ -16,6 +16,18 @@ from .telemetry import emit_shadow_event
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
 SLUG_RE = re.compile(r"[^a-z0-9]+")
+HEADING_RE = re.compile(r"^#{1,6}\s+")
+LIST_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
+BANNER_RE = re.compile(r"^\*\*(?:map mode|scope|mode|status|frame|evidence|gap|next)\b", re.I)
+BOLD_LABEL_RE = re.compile(r"^\*\*[^*]{1,80}:\*\*")
+PROCESS_CHATTER_RE = re.compile(
+    r"\b(?:Now I have what I need\.?|Writing (?:the )?(?:map|report)\.?|End of (?:map|report)\.?)",
+    re.I,
+)
+TECH_TOKEN_RE = re.compile(
+    r"\b(?:cycle-\d+|GAP-\d+|G\d+[a-z]?|P\d+|sha256:[a-f0-9]+|[a-f0-9]{7,40})\b|`[^`]+`",
+    re.I,
+)
 
 
 def _now() -> datetime:
@@ -108,6 +120,93 @@ def _render_report_html(*, title: str, body: str, skill: str, cycle_id: str) -> 
     )
 
 
+def _norm_title(value: str) -> str:
+    return re.sub(r"\s+", " ", value or "").strip().strip("#").strip().lower()
+
+
+def _without_leading_title(body: str, title: str) -> str:
+    lines = body.replace("\r\n", "\n").replace("\r", "\n").strip().splitlines()
+    if not lines:
+        return ""
+    first = lines[0].strip()
+    if first.startswith("# ") and _norm_title(first[2:]) == _norm_title(title):
+        lines = lines[1:]
+        while lines and not lines[0].strip():
+            lines = lines[1:]
+    return "\n".join(lines).strip()
+
+
+def _paragraph_blocks(markdown: str) -> list[str]:
+    return [block.strip() for block in re.split(r"\n\s*\n", markdown.strip()) if block.strip()]
+
+
+def _is_reader_paragraph(block: str) -> bool:
+    lines = [line.strip() for line in block.splitlines() if line.strip()]
+    if not lines:
+        return False
+    first = lines[0]
+    if first == "---" or first.startswith("```") or first.startswith("|"):
+        return False
+    if HEADING_RE.match(first) or LIST_RE.match(first) or BANNER_RE.match(first) or BOLD_LABEL_RE.match(first):
+        return False
+    if len(lines) > 4:
+        return False
+    text = " ".join(lines)
+    if len(text) > 760:
+        return False
+    if text.count("|") >= 4 or text.count("`") >= 8:
+        return False
+    return True
+
+
+def _technical_density(text: str) -> float:
+    words = re.findall(r"\w+", text)
+    if not words:
+        return 0.0
+    return len(TECH_TOKEN_RE.findall(text)) / max(len(words), 1)
+
+
+def _trim_sentence(text: str, *, limit: int = 420) -> str:
+    value = PROCESS_CHATTER_RE.sub("", text or "")
+    value = re.sub(r"\s+", " ", value).strip()
+    if len(value) <= limit:
+        return value
+    clipped = value[:limit].rstrip()
+    end = max(clipped.rfind("."), clipped.rfind("!"), clipped.rfind("?"))
+    if end >= 120:
+        return clipped[: end + 1]
+    return clipped.rstrip(" ,;:") + "."
+
+
+def _reader_title(title: str) -> str:
+    value = re.sub(r"^(report|research|strategy|discovery|autonomy|map)\s*:\s*", "", title or "", flags=re.I)
+    return _trim_sentence(value.strip() or "este artefato", limit=180)
+
+
+def _build_entry_body(title: str, body: str) -> str:
+    """Return the public feed invitation; keep the full artifact in the report."""
+    content = _without_leading_title(body, title)
+    blocks = _paragraph_blocks(content)
+    reader_blocks = [block for block in blocks if _is_reader_paragraph(block)]
+    dense = len(blocks) > 4 or any(not _is_reader_paragraph(block) for block in blocks)
+    dense = dense or _technical_density(" ".join(reader_blocks[:2])) > 0.035
+
+    if not dense and 1 <= len(reader_blocks) <= 4:
+        return "\n\n".join(reader_blocks).strip() + "\n"
+
+    selected = [_trim_sentence(block) for block in reader_blocks[:2]]
+    if not selected:
+        selected = [
+            f"Este ciclo registrou {_reader_title(title)}.",
+            "A entrada curta fica aqui como porta de entrada; o relatório preserva a evidência e os detalhes técnicos.",
+        ]
+    elif len(selected) == 1:
+        selected.append("O relatório preserva a evidência completa, as decisões e os detalhes técnicos.")
+    selected = selected[:3]
+    selected.append("Abra o relatório para ver a evidência, os detalhes técnicos e os próximos passos.")
+    return "\n\n".join(selected).strip() + "\n"
+
+
 def publish_stdout_artifact(
     *,
     skill: object,
@@ -127,6 +226,7 @@ def publish_stdout_artifact(
     if not extracted:
         return {"published": False, "reason": "missing_markdown_artifact", "skill": canonical_skill}
     title, body = extracted
+    entry_body = _build_entry_body(title, body)
 
     now = _now()
     date = now.date().isoformat()
@@ -156,7 +256,7 @@ def publish_stdout_artifact(
         f"cycle_id: {cycle_id}\n"
         f"hash: {artifact_hash}\n"
         "---\n\n"
-        f"{body}",
+        f"{entry_body}",
         encoding="utf-8",
     )
 

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -323,8 +323,8 @@ DIMENSIONS = {
         "Title matches actual scope. Numbers consistent throughout. "
         "Linhagem references real prior work, not generic placeholders. "
         "Blog entry (if provided) is consistent with report content and acts as a light strategic invitation: "
-        "it contextualizes why the work matters, states what the operator gains by opening the report, and leaves "
-        "technical depth to the report instead of duplicating it."
+        "it contextualizes why the work matters for a Roberto-class reader outside the runtime, states what the "
+        "operator gains by opening the report, and leaves technical depth to the report instead of duplicating it."
     ),
     "didactic_clarity": (
         "Every concept, acronym, and technical term is explained on first use. "
@@ -445,6 +445,7 @@ Flag as critical_issues if ANY of these:
 - Any non-reference section begins directly with a table, chart, metrics grid, diagram, comparison matrix, or gap table without a narrative `lead` or opening paragraph that explains how to read it
 - A dense evidence block such as a table, chart, matrix, or diagram is left without nearby interpretation of what the reader should conclude, decide, or keep uncertain
 - Associated blog entry duplicates the report structure or does not explain the operator gain from opening the report (if blog entry provided)
+- Associated blog entry begins with raw report scaffolding, scope/mode banners, internal cycle/gap/commit vocabulary, or process chatter before explaining why a non-runtime reader should care (if blog entry provided)
 - "O que Nao Sei" is clearly boilerplate (vague generic text, not specific to this report's topic)
 - Sections reference data/events not present elsewhere in the spec (internal contradiction)
 - Blog entry says one thing, report says another (if blog entry provided)


### PR DESCRIPTION
## Summary
- add an empirical #483 calibration note with 3 post-#388 live entries and the observed reader-facing failures
- tighten the Blog Entry Voice Contract around a Roberto-class external reader and raw report scaffolding
- make `runtime-stdout-artifact` publish a short feed invitation while preserving the full skill output in the HTML report
- extend voice-contract and edge-runner tests for the runtime publication path

## Validation
- `python3 -m py_compile tools/_shared/artifact_runtime.py tools/review-gate.py`
- `bash -n tests/test_blog_entry_voice_contract.sh tests/test_edge_runner.sh`
- `bash tests/test_blog_entry_voice_contract.sh`
- `bash tests/test_edge_runner.sh`
- `git diff --check`

Closes #483.