### PR TITLE
Add citation-weighted corpus search

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -21,7 +21,7 @@
 #   2.  Content report indexing/confirmation
 #   3.  Verificação (API, frontmatter, files)
 #   3.4 LLM cost injection
-#   5.  State commit (threads + event + digest)
+#   5.  State commit (threads + event + curated corpus citations + digest)
 #   5b. State audit
 #   6.  Diffs + Git commit (audit trail)
 #
@@ -1035,13 +1035,13 @@ fi
 archive_scratchpad_if_present
 echo ""
 
-# ─── PHASE 5: State commit (threads + event + digest) ───
+# ─── PHASE 5: State commit (threads + event + curated corpus citations + digest) ───
 # Tudo acontece aqui. Zero LLM. Um script, uma leitura do frontmatter.
 echo "── Phase 5: State Commit ──"
 ledger_record "phase-5" "ok"
 emit_run_step_event "phase-5" "started" "state_commit" ""
 REPORT_FOR_COMMIT="${REPORT_FILENAME:-}"
-python3 - "$ENTRY_PATH" "$SLUG" "$REPORT_FOR_COMMIT" <<'PYEOF'
+python3 - "$ENTRY_PATH" "$SLUG" "$REPORT_FOR_COMMIT" "${REPORT_INPUT:-}" <<'PYEOF'
 import sys, json, yaml, re, os, traceback, subprocess
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -1050,6 +1050,7 @@ import uuid
 entry_path = sys.argv[1]
 slug = sys.argv[2]
 report_filename = sys.argv[3] if len(sys.argv) > 3 else ""
+report_input = sys.argv[4] if len(sys.argv) > 4 else ""
 
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -1186,6 +1187,32 @@ try:
 except Exception as e:
     log_failure("5", "event_log", e, traceback.format_exc())
     fail(f"Event log failed: {e}")
+
+# ── 3b. Curated corpus citations ──
+try:
+    search_dir = Path(os.environ.get("SEARCH_DIR", Path(os.environ.get("EDGE_REPO_DIR", "") or ".") / "search"))
+    if str(search_dir) not in sys.path:
+        sys.path.insert(0, str(search_dir))
+    from citations import record_citations, references_from_artifacts  # type: ignore
+
+    artifact_paths = [Path(entry_path)]
+    if report_input and Path(report_input).suffix.lower() in {".yaml", ".yml"}:
+        artifact_paths.append(Path(report_input))
+    refs = references_from_artifacts(artifact_paths)
+    published_entry = Path(os.environ.get("ENTRIES_DIR", "")) / f"{slug}.md"
+    source_path = published_entry if published_entry.exists() else Path(entry_path)
+    result = record_citations(str(source_path), refs)
+    inserted = int(result.get("inserted") or 0)
+    unknown = len(result.get("unknown") or [])
+    if inserted:
+        ok(f"Corpus citations recorded: {inserted}")
+    elif refs:
+        warn(f"Corpus citations found but not indexed: {unknown} unknown path(s)")
+    else:
+        ok("Corpus citations: none declared")
+except Exception as e:
+    log_failure("5", "corpus_citations", e, traceback.format_exc())
+    warn(f"Corpus citations failed: {e}")
 
 # ── 4. Digest (gera briefing.md) ──
 try:

--- a/search/citations.py
+++ b/search/citations.py
@@ -1,0 +1,270 @@
+"""Curated corpus citation helpers for edge-memory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
+from paths import EDGE_REPO_DIR, EDGE_STATE_DIR, ENTRIES_DIR, REPORTS_DIR  # noqa: E402
+
+from db import ensure_db  # noqa: E402
+
+CITATION_BOOST_FACTOR = 0.1
+REFERENCE_KEYS = (
+    "corpus_references",
+    "citations",
+    "references",
+    "bibliography",
+    "source_entries",
+    "related_entries",
+)
+DICT_PATH_KEYS = ("cited_path", "path", "entry", "report", "source_path", "source", "url")
+PATH_RE = re.compile(
+    r"(?P<path>(?:/?(?:[\w.-]+/)*[\w.-]+|[\w.-]+)\.(?:md|html))",
+    re.I,
+)
+
+
+def _read_yamlish(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return {}
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        try:
+            data = yaml.safe_load(raw) or {}
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+    if not raw.startswith("---"):
+        return {}
+    parts = raw.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    try:
+        data = yaml.safe_load(parts[1]) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _iter_reference_specs(value: Any, *, inherited_context: str = "curated_reference") -> Iterable[tuple[str, str]]:
+    if value is None:
+        return
+    if isinstance(value, dict):
+        context = str(value.get("context") or value.get("role") or inherited_context).strip() or inherited_context
+        for key in DICT_PATH_KEYS:
+            if key in value:
+                yield from _iter_reference_specs(value.get(key), inherited_context=context)
+        return
+    if isinstance(value, (list, tuple, set)):
+        for item in value:
+            yield from _iter_reference_specs(item, inherited_context=inherited_context)
+        return
+
+    text = str(value or "").strip()
+    if not text:
+        return
+    markdown_target = re.search(r"\[[^\]]+\]\(([^)]+)\)", text)
+    if markdown_target:
+        text = markdown_target.group(1).strip()
+    if re.match(r"^[a-z][a-z0-9+.-]*://", text, flags=re.I):
+        return
+    matches = list(PATH_RE.finditer(text))
+    if matches:
+        for match in matches:
+            yield match.group("path"), inherited_context
+    else:
+        yield text.strip("`'\" "), inherited_context
+
+
+def references_from_artifacts(paths: list[Path]) -> list[tuple[str, str]]:
+    """Extract curated corpus reference paths from entry/report metadata."""
+    refs: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for path in paths:
+        fm = _read_yamlish(path)
+        for key in REFERENCE_KEYS:
+            for raw_path, context in _iter_reference_specs(fm.get(key)):
+                item = (raw_path, context)
+                if item not in seen:
+                    seen.add(item)
+                    refs.append(item)
+    return refs
+
+
+def _candidate_paths(raw_path: str) -> list[Path]:
+    raw = str(raw_path or "").strip().strip("`'\"")
+    if not raw:
+        return []
+    path = Path(raw).expanduser()
+    candidates: list[Path] = []
+    if path.is_absolute():
+        candidates.append(path)
+    else:
+        candidates.extend(
+            [
+                EDGE_STATE_DIR / path,
+                EDGE_REPO_DIR / path,
+                ENTRIES_DIR / path.name if path.suffix == ".md" else EDGE_STATE_DIR / path,
+                REPORTS_DIR / path.name if path.suffix == ".html" else EDGE_STATE_DIR / path,
+            ]
+        )
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = str(candidate.resolve(strict=False))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(candidate)
+    return unique
+
+
+def _known_document_path(raw_path: str, conn) -> str | None:
+    candidates = [str(path.resolve(strict=False)) for path in _candidate_paths(raw_path)]
+    if not candidates:
+        return None
+    placeholders = ",".join("?" for _ in candidates)
+    row = conn.execute(
+        f"SELECT path FROM documents WHERE path IN ({placeholders}) LIMIT 1",
+        candidates,
+    ).fetchone()
+    if row:
+        return str(row["path"])
+    basename = Path(str(raw_path)).name
+    if basename:
+        row = conn.execute(
+            "SELECT path FROM documents WHERE path LIKE ? ORDER BY updated_at DESC LIMIT 1",
+            (f"%/{basename}",),
+        ).fetchone()
+        if row:
+            return str(row["path"])
+    return None
+
+
+def _normalize_source_path(source_path: str) -> str:
+    candidates = _candidate_paths(source_path)
+    if candidates:
+        return str(candidates[0].resolve(strict=False))
+    return str(source_path)
+
+
+def record_citations(
+    source_path: str,
+    references: Iterable[str | tuple[str, str]],
+    *,
+    default_context: str = "curated_reference",
+    conn=None,
+) -> dict[str, Any]:
+    """Record idempotent curated citations for one produced artifact."""
+    own_conn = conn is None
+    if own_conn:
+        conn = ensure_db()
+    inserted = 0
+    skipped = 0
+    unknown: list[str] = []
+    source = _normalize_source_path(source_path)
+    ts = datetime.now(timezone.utc).isoformat()
+    try:
+        for item in references:
+            if isinstance(item, tuple):
+                raw_path, context = item
+            else:
+                raw_path, context = str(item), default_context
+            cited = _known_document_path(str(raw_path), conn)
+            if not cited:
+                unknown.append(str(raw_path))
+                skipped += 1
+                continue
+            cur = conn.execute(
+                """
+                INSERT OR IGNORE INTO citations (source_path, cited_path, ts, context)
+                VALUES (?, ?, ?, ?)
+                """,
+                (source, cited, ts, str(context or default_context)),
+            )
+            if cur.rowcount:
+                inserted += 1
+            else:
+                skipped += 1
+        conn.commit()
+        return {"inserted": inserted, "skipped": skipped, "unknown": unknown}
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def citation_counts_for_paths(paths: Iterable[str], conn) -> dict[str, int]:
+    unique = [path for path in dict.fromkeys(str(item) for item in paths if str(item))]
+    if not unique:
+        return {}
+    placeholders = ",".join("?" for _ in unique)
+    rows = conn.execute(
+        f"""
+        SELECT cited_path, COUNT(*) AS citation_count
+        FROM citations
+        WHERE cited_path IN ({placeholders})
+        GROUP BY cited_path
+        """,
+        unique,
+    ).fetchall()
+    return {str(row["cited_path"]): int(row["citation_count"]) for row in rows}
+
+
+def apply_citation_boost(results: list[dict], conn, *, boost_factor: float = CITATION_BOOST_FACTOR) -> list[dict]:
+    """Annotate and rank results using curated citation counts."""
+    counts = citation_counts_for_paths((item.get("path") for item in results), conn)
+    boosted: list[dict] = []
+    for item in results:
+        path = str(item.get("path") or "")
+        citation_count = int(counts.get(path, 0))
+        base_score = float(item.get("score") or 0.0)
+        multiplier = 1 + (boost_factor * citation_count)
+        boosted_score = base_score * multiplier
+        enriched = dict(item)
+        enriched["base_score"] = round(base_score, 6)
+        enriched["citation_count"] = citation_count
+        enriched["citation_boost"] = round(multiplier, 6)
+        enriched["boosted_score"] = round(boosted_score, 6)
+        enriched["score"] = round(boosted_score, 6)
+        boosted.append(enriched)
+    boosted.sort(key=lambda item: (float(item.get("boosted_score") or 0.0), int(item.get("citation_count") or 0)), reverse=True)
+    return boosted
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Record curated corpus citations")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    record = sub.add_parser("record", help="Record citations from explicit paths")
+    record.add_argument("--source", required=True, help="Produced artifact path")
+    record.add_argument("--context", default="curated_reference")
+    record.add_argument("paths", nargs="+", help="Cited corpus paths")
+
+    artifacts = sub.add_parser("record-artifact", help="Extract citations from entry/report metadata")
+    artifacts.add_argument("--source", required=True, help="Produced artifact path")
+    artifacts.add_argument("artifacts", nargs="+", help="Entry/report files to scan")
+
+    args = parser.parse_args()
+    if args.command == "record":
+        result = record_citations(args.source, args.paths, default_context=args.context)
+    else:
+        refs = references_from_artifacts([Path(item) for item in args.artifacts])
+        result = record_citations(args.source, refs)
+        result["references_found"] = len(refs)
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/search/db.py
+++ b/search/db.py
@@ -163,6 +163,23 @@ def init_db(conn: sqlite3.Connection) -> None:
         CREATE INDEX IF NOT EXISTS idx_search_events_ts ON search_events(ts);
     """)
 
+    # Curated corpus citations. These are explicitly selected references that
+    # informed a produced artifact, not every document returned by search.
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS citations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_path TEXT NOT NULL,
+            cited_path TEXT NOT NULL,
+            ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+            context TEXT DEFAULT ''
+        );
+        CREATE INDEX IF NOT EXISTS idx_citations_cited ON citations(cited_path);
+        CREATE INDEX IF NOT EXISTS idx_citations_source ON citations(source_path);
+        CREATE INDEX IF NOT EXISTS idx_citations_ts ON citations(ts);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_citations_unique
+            ON citations(source_path, cited_path, context);
+    """)
+
     # Primitive call telemetry (#226 item 2). One row per call, rolled up
     # by tools/rollup-primitives.py into state/primitive-usage-rollup.json.
     conn.executescript("""

--- a/search/search.py
+++ b/search/search.py
@@ -16,6 +16,7 @@ from paths import EDGE_STATE_DIR, NOTES_DIR  # noqa: E402
 
 from db import EMBEDDING_DIM, ensure_db
 from embed import embed_text
+from citations import apply_citation_boost
 
 TYPE_GROUPS: dict[str, tuple[str, ...]] = {
     "topic": ("topic",),
@@ -231,8 +232,10 @@ def hybrid_search(
             if doc_id not in doc_info:
                 doc_info[doc_id] = doc
 
-        # Sort by RRF score
-        ranked = sorted(scores.items(), key=lambda x: -x[1])[:limit]
+        # Sort by RRF score, then apply curated citation boost inside that
+        # candidate pool so frequently used corpus artifacts can overtake
+        # nearby uncited matches without overriding query relevance entirely.
+        ranked = sorted(scores.items(), key=lambda x: -x[1])[: max(limit * 3, limit)]
 
         results = []
         for doc_id, score in ranked:
@@ -246,6 +249,7 @@ def hybrid_search(
                 "snippet": info.get("snippet"),
             })
 
+        results = apply_citation_boost(results, conn)[:limit]
         _enrich_with_notes(results)
         return results
     finally:
@@ -538,6 +542,11 @@ def format_results(
             if r.get("snippet"):
                 snippet = r["snippet"].replace("\n", " ")[:120]
                 lines.append(f"       {' ' * 8}  {' ' * 8} ...{snippet}...")
+            if int(r.get("citation_count") or 0) > 0:
+                lines.append(
+                    f"       {' ' * 8}  {' ' * 8} citations={int(r.get('citation_count') or 0)} "
+                    f"base={float(r.get('base_score') or 0.0):.4f}"
+                )
             lines.append("")
 
     return "\n".join(lines)

--- a/skills/_shared/state-protocol.md
+++ b/skills/_shared/state-protocol.md
@@ -144,6 +144,21 @@ Use direct web search only as a complement when the source capability does not c
 
 The output artifact should say which source routes were used and how they changed the analysis. If source lookup is unavailable or degraded, surface that limitation instead of silently proceeding as if external context was checked.
 
+When corpus results materially inform a published artifact, add curated corpus
+references to the entry/report metadata before `consolidate-state`:
+
+```yaml
+corpus_references:
+  - path: blog/entries/example-prior-work.md
+    context: primary_reference
+  - path: reports/example-supporting-report.html
+    context: background
+```
+
+List only entries/reports that changed content, decisions, or framing. Do not
+record every search result. `consolidate-state` records these references in the
+search DB as citations; `edge-search` uses the counts as a relevance boost.
+
 ---
 
 ## Full Flow (with status changes)

--- a/skills/sources/SKILL.md
+++ b/skills/sources/SKILL.md
@@ -140,6 +140,7 @@ Test variants such as:
 For each test, record what changed in the answer quality.
 
 Use `--feedback-json` when curating. It returns the run id, episode id, selected route, source summaries, ODI ids, and a feedback contract for `edge-affordance`.
+For corpus routing, it also includes `source_playbook.corpus` with citation-weighted query guidance, high-value entries, and decay notes from the observability rollup.
 
 ### 4. Grade Source/Signal Affordances
 
@@ -154,6 +155,10 @@ Score guidance:
 - `1`: failed, misleading, stale, or unavailable.
 
 Grade atomic sources/channels, not wrappers. Prefer `source.hn`, `source.exa`, `source.github`, `signal.friction`, `search.corpus` over `edge-sources`.
+
+When a corpus result directly informs an artifact, make sure the publishing
+skill records it under `corpus_references` so future search ranking can learn
+from actual use.
 
 ### 5. Curate The Pattern Set
 

--- a/tests/test_citation_weighted_search.sh
+++ b/tests/test_citation_weighted_search.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-citations-XXXXXX)"
+TMP_STATE="$TMP_BASE/state"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_STATE/blog/entries" "$TMP_STATE/reports" "$TMP_STATE/search" "$TMP_STATE/logs" "$TMP_STATE/threads" "$TMP_STATE/state"
+
+export EDGE_REPO_DIR="$EDGE_DIR"
+export EDGE_STATE_DIR="$TMP_STATE"
+
+cat >"$TMP_STATE/blog/entries/source.md" <<'MD'
+---
+title: Source artifact
+corpus_references:
+  - path: blog/entries/cited.md
+    context: primary_reference
+  - path: reports/support.html
+    context: background
+---
+body
+MD
+
+touch "$TMP_STATE/blog/entries/cited.md" "$TMP_STATE/blog/entries/uncited.md" "$TMP_STATE/reports/support.html"
+
+echo "=== citation-weighted search Test ==="
+echo ""
+
+echo "--- Test 1: curated references are recorded idempotently and boost hybrid ranking ---"
+if python3 - <<'PY'
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+search_dir = Path(os.environ["EDGE_REPO_DIR"]) / "search"
+sys.path.insert(0, str(search_dir))
+
+from db import ensure_db
+from citations import record_citations, references_from_artifacts
+import search as edge_search
+
+state = Path(os.environ["EDGE_STATE_DIR"])
+conn = ensure_db()
+now = datetime.now(timezone.utc).isoformat()
+
+def add_doc(path, title):
+    cur = conn.execute(
+        """
+        INSERT INTO documents (path, type, title, content, content_hash, created_at, updated_at)
+        VALUES (?, 'blog', ?, ?, ?, ?, ?)
+        """,
+        (str(path.resolve()), title, title, title, now, now),
+    )
+    return cur.lastrowid
+
+cited = add_doc(state / "blog" / "entries" / "cited.md", "Cited prior work")
+uncited = add_doc(state / "blog" / "entries" / "uncited.md", "Uncited adjacent work")
+support = add_doc(state / "reports" / "support.html", "Supporting report")
+conn.commit()
+
+refs = references_from_artifacts([state / "blog" / "entries" / "source.md"])
+result = record_citations(str(state / "blog" / "entries" / "source.md"), refs, conn=conn)
+assert result["inserted"] == 2, result
+result_again = record_citations(str(state / "blog" / "entries" / "source.md"), refs, conn=conn)
+assert result_again["inserted"] == 0, result_again
+
+for idx in range(9):
+    record_citations(
+        str(state / "blog" / "entries" / f"source-{idx}.md"),
+        [str(state / "blog" / "entries" / "cited.md")],
+        conn=conn,
+    )
+
+edge_search.embed_text = lambda _query: [0.0]
+edge_search.vec_search = lambda *_args, **_kwargs: []
+edge_search.fts_search = lambda *_args, **_kwargs: [
+    {"id": uncited, "path": str((state / "blog" / "entries" / "uncited.md").resolve()), "type": "blog", "title": "Uncited adjacent work", "score": 0.02, "snippet": None},
+    {"id": cited, "path": str((state / "blog" / "entries" / "cited.md").resolve()), "type": "blog", "title": "Cited prior work", "score": 0.01, "snippet": None},
+    {"id": support, "path": str((state / "reports" / "support.html").resolve()), "type": "report", "title": "Supporting report", "score": 0.005, "snippet": None},
+]
+
+hits = edge_search.hybrid_search("prior work", limit=3, conn=conn)
+assert hits[0]["id"] == cited, hits
+assert hits[0]["citation_count"] == 10, hits[0]
+assert hits[0]["base_score"] < hits[0]["score"], hits[0]
+assert hits[-1]["id"] == uncited, hits
+conn.close()
+PY
+then
+    pass "citation records are idempotent and boost cited documents"
+else
+    fail "citation records are idempotent and boost cited documents"
+fi
+
+echo "--- Test 2: observability rollup exposes citation stats ---"
+if EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" python3 "$EDGE_DIR/tools/rollup-observability.py" >/dev/null && \
+   python3 - <<'PY' "$TMP_STATE/state/observability-rollup.json"
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+citations = data["citations"]
+assert citations["available"] is True
+assert citations["total"] == 11, citations
+assert citations["top_cited"][0]["citations"] == 10, citations
+assert citations["recently_cited_7d"] >= 2, citations
+PY
+then
+    pass "observability rollup includes citation stats"
+else
+    fail "observability rollup includes citation stats"
+fi
+
+echo "--- Test 3: corpus curation preserves high-value cited docs ---"
+if EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" python3 "$EDGE_DIR/tools/curadoria_compute.py" --mode lite >/dev/null && \
+   python3 - <<'PY' "$TMP_STATE/state/curadoria-candidates.json"
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+top = data["high_value_cited"][0]
+assert top["citation_count"] == 10, data
+assert top["title"] == "Cited prior work", data
+PY
+then
+    pass "curadoria surfaces high-value cited docs"
+else
+    fail "curadoria surfaces high-value cited docs"
+fi
+
+echo ""
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [[ $FAIL -ne 0 ]]; then
+    exit 1
+fi

--- a/tools/curadoria_compute.py
+++ b/tools/curadoria_compute.py
@@ -68,7 +68,7 @@ class UnionFind:
 # --- Doc health metrics ---
 
 def get_doc_health(conn):
-    """Per-doc health metrics combining documents and search_events."""
+    """Per-doc health metrics combining documents, search events, and citations."""
     rows = conn.execute("""
         SELECT d.id, d.path, d.type, d.title, d.created_at,
                COALESCE(se.retrieved_count, 0) AS retrieved_count,
@@ -77,7 +77,10 @@ def get_doc_health(conn):
                COALESCE(se.query_diversity, 0) AS query_diversity,
                CAST(julianday('now') - julianday(d.created_at) AS INTEGER) AS age_days,
                COALESCE(se30.retrieved_30d, 0) AS retrieved_30d,
-               COALESCE(se30.top3_30d, 0) AS top3_30d
+               COALESCE(se30.top3_30d, 0) AS top3_30d,
+               COALESCE(c.citation_count, 0) AS citation_count,
+               COALESCE(c.cited_30d, 0) AS cited_30d,
+               c.last_cited
         FROM documents d
         LEFT JOIN (
             SELECT doc_id,
@@ -96,6 +99,14 @@ def get_doc_health(conn):
             WHERE ts >= datetime('now', '-30 days')
             GROUP BY doc_id
         ) se30 ON se30.doc_id = d.id
+        LEFT JOIN (
+            SELECT cited_path,
+                   COUNT(*) AS citation_count,
+                   SUM(CASE WHEN ts >= datetime('now', '-30 days') THEN 1 ELSE 0 END) AS cited_30d,
+                   MAX(ts) AS last_cited
+            FROM citations
+            GROUP BY cited_path
+        ) c ON c.cited_path = d.path
         ORDER BY retrieved_count DESC
     """).fetchall()
     return [dict(r) for r in rows]
@@ -105,9 +116,27 @@ def get_stale_candidates(docs):
     """Docs with age > 45 days and no recent retrieval or no top-3 in 30d."""
     stale = []
     for d in docs:
+        if int(d.get("cited_30d") or 0) > 0 or int(d.get("citation_count") or 0) >= 3:
+            continue
         if d["age_days"] > 45 and (d["retrieved_30d"] == 0 or d["top3_30d"] == 0):
             stale.append(d)
     return stale
+
+
+def get_high_value_cited(docs, limit=12):
+    cited = [d for d in docs if int(d.get("citation_count") or 0) > 0]
+    cited.sort(key=lambda item: (-int(item.get("citation_count") or 0), str(item.get("title") or "")))
+    return [
+        {
+            "doc_id": d["id"],
+            "path": d.get("path", ""),
+            "title": d.get("title", ""),
+            "type": d.get("type", ""),
+            "citation_count": int(d.get("citation_count") or 0),
+            "last_cited": d.get("last_cited"),
+        }
+        for d in cited[:limit]
+    ]
 
 
 # --- Self-probes ---
@@ -406,6 +435,7 @@ def main():
             "mode": "stats",
             "total_docs": len(docs),
             "docs": docs,
+            "high_value_cited": get_high_value_cited(docs),
         }
         OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
         OUTPUT_FILE.write_text(json.dumps(output, indent=2, ensure_ascii=False) + "\n")
@@ -431,9 +461,12 @@ def main():
                     "retrieved_count": d["retrieved_count"],
                     "retrieved_30d": d["retrieved_30d"],
                     "top3_30d": d["top3_30d"],
+                    "citation_count": d.get("citation_count", 0),
+                    "cited_30d": d.get("cited_30d", 0),
                 }
                 for d in stale
             ],
+            "high_value_cited": get_high_value_cited(docs),
         }
         OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
         OUTPUT_FILE.write_text(json.dumps(output, indent=2, ensure_ascii=False) + "\n")
@@ -465,6 +498,7 @@ def main():
         "merge_review": merge_review,
         "strengthen_targets": strengthen_targets,
         "suppressed_due_to_active_thread": suppressed,
+        "high_value_cited": get_high_value_cited(docs),
     }
 
     OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/edge-digest
+++ b/tools/edge-digest
@@ -299,6 +299,7 @@ def generate_briefing():
         ][:5]
         publish = observability.get("blog_publish_failures", {}).get("by_class", {})
         lifecycle = observability.get("lifecycle", {})
+        citations = observability.get("citations", {})
         failed_steps = []
         for run_kind, phases in lifecycle.items():
             for phase, statuses in phases.items():
@@ -322,6 +323,13 @@ def generate_briefing():
         if failed_steps:
             top_failed = ", ".join(f"{rk}/{ph}:{n}" for n, rk, ph in failed_steps[:4])
             lines.append(f"- Lifecycle failures: {top_failed}")
+        if citations.get("available"):
+            top_cited = citations.get("top_cited") or []
+            top_label = Path(str(top_cited[0].get("path"))).name if top_cited else "none"
+            lines.append(
+                f"- Corpus citations: {citations.get('total', 0)} total, "
+                f"{citations.get('recently_cited_7d', 0)} docs cited in 7d, top={top_label}"
+            )
         lines.append("")
 
     return "\n".join(lines)

--- a/tools/edge-sources
+++ b/tools/edge-sources
@@ -28,7 +28,7 @@ except ImportError:  # pragma: no cover
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 sys.path.insert(0, str(SCRIPT_DIR.parent / "tools"))
-from paths import EDGE_REPO_DIR, TOOLS_DIR, SECRETS_DIR, SOURCES_MANIFEST_FILE
+from paths import EDGE_REPO_DIR, TOOLS_DIR, SECRETS_DIR, SOURCES_MANIFEST_FILE, STATE_DIR
 from _shared.telemetry import make_odi_id, log_odi_observed, log_primitive_call, log_run_step, log_source_query
 from _shared.search_runtime import (
     clear_builtin_web_search_allowance,
@@ -336,6 +336,9 @@ def search_corpus(topic):
         score_val = int(float(entry.get("score") or 0) * 1000)
         title = str(entry.get("title") or entry.get("id") or "")[:200]
         snippet = str(entry.get("snippet") or "")[:240]
+        citation_count = int(entry.get("citation_count") or 0)
+        if citation_count > 0:
+            snippet = f"citations={citation_count}. {snippet}".strip()
         doc_type = str(entry.get("type") or "")
         path = str(entry.get("path") or "")
         items.append({
@@ -344,8 +347,33 @@ def search_corpus(topic):
             "source": "Corpus",
             "detail": snippet,
             "score": score_val,
+            "citation_count": citation_count,
         })
     return items
+
+
+def corpus_playbook():
+    """Return corpus source guidance learned from citation-weighted search."""
+    playbook = {
+        "query_tips": "Hybrid (FTS + semantic). PT-BR and EN. Citation-boosted when curated references exist.",
+        "high_value_entries": [],
+        "decay_note": "",
+    }
+    path = STATE_DIR / "observability-rollup.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return playbook
+    citations = data.get("citations") or {}
+    for item in (citations.get("top_cited") or [])[:8]:
+        cited_path = str(item.get("path") or "")
+        count = int(item.get("citations") or 0)
+        if cited_path:
+            playbook["high_value_entries"].append(f"{Path(cited_path).name} ({count} citations)")
+    never = int(citations.get("never_cited_30d") or 0)
+    if never:
+        playbook["decay_note"] = f"{never} recent blog/report docs have no curated citations; search deprioritizes them naturally."
+    return playbook
 
 
 # --- Dispatcher ---
@@ -705,6 +733,9 @@ def format_feedback_json(
         },
         "summary": summary,
         "results_by_source": results_by_source,
+        "source_playbook": {
+            "corpus": corpus_playbook(),
+        },
         "feedback_contract": {
             "grade_command": "edge-affordance evaluate <source_id> --affordance <affordance> --score <1-5> --context <intent/context> --query <query> --reason <reason> --odi <odi_id> --episode-id <episode_id>",
             "grade_atomic_sources": True,

--- a/tools/rollup-observability.py
+++ b/tools/rollup-observability.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import re
+import sqlite3
 import statistics
 import sys
 from collections import defaultdict
@@ -26,7 +27,7 @@ import yaml
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import ENTRIES_DIR, EVENTS_FILE, LOGS_DIR, STATE_DIR, THREADS_DIR  # noqa: E402
+from paths import ENTRIES_DIR, EVENTS_FILE, LOGS_DIR, SEARCH_DB_FILE, STATE_DIR, THREADS_DIR  # noqa: E402
 
 OUT_PATH = STATE_DIR / "observability-rollup.json"
 WINDOW_DAYS = 30
@@ -114,6 +115,79 @@ def _rollup_backlog(today: str) -> dict:
         "resurface_due": due,
         "open_gaps": open_gaps,
     }
+
+
+def _rollup_citations(now: datetime) -> dict:
+    empty = {
+        "available": False,
+        "total": 0,
+        "top_cited": [],
+        "never_cited_30d": 0,
+        "recently_cited_7d": 0,
+    }
+    if not SEARCH_DB_FILE.exists():
+        return empty
+    try:
+        conn = sqlite3.connect(f"file:{SEARCH_DB_FILE}?mode=ro", uri=True, timeout=2)
+        conn.row_factory = sqlite3.Row
+    except Exception:
+        return empty
+    try:
+        has_table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='citations'"
+        ).fetchone()
+        if not has_table:
+            return empty
+        total = int(conn.execute("SELECT COUNT(*) FROM citations").fetchone()[0])
+        top_cited = [
+            {
+                "path": row["cited_path"],
+                "citations": int(row["citations"]),
+                "last_cited": row["last_cited"],
+            }
+            for row in conn.execute(
+                """
+                SELECT cited_path, COUNT(*) AS citations, MAX(ts) AS last_cited
+                FROM citations
+                GROUP BY cited_path
+                ORDER BY citations DESC, last_cited DESC
+                LIMIT 10
+                """
+            ).fetchall()
+        ]
+        cutoff_30 = (now - timedelta(days=30)).isoformat()
+        cutoff_7 = (now - timedelta(days=7)).isoformat()
+        never_cited_30d = int(
+            conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM documents d
+                WHERE d.type IN ('blog', 'report')
+                  AND d.updated_at >= ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM citations c WHERE c.cited_path = d.path
+                  )
+                """,
+                (cutoff_30,),
+            ).fetchone()[0]
+        )
+        recently_cited_7d = int(
+            conn.execute(
+                "SELECT COUNT(DISTINCT cited_path) FROM citations WHERE ts >= ?",
+                (cutoff_7,),
+            ).fetchone()[0]
+        )
+        return {
+            "available": True,
+            "total": total,
+            "top_cited": top_cited,
+            "never_cited_30d": never_cited_30d,
+            "recently_cited_7d": recently_cited_7d,
+        }
+    except Exception:
+        return empty
+    finally:
+        conn.close()
 
 
 def main() -> int:
@@ -267,6 +341,7 @@ def main() -> int:
         "search": {
             "query_stats": search_queries,
         },
+        "citations": _rollup_citations(now),
         "database": {
             "by_table": dict(sorted(db_payload.items(), key=lambda item: -(item[1]["reads"] + item[1]["writes"]))),
             "by_op": dict(sorted(db_by_op.items(), key=lambda item: -item[1])),


### PR DESCRIPTION
## Summary
- add curated `citations` table and idempotent citation recording helpers
- record corpus references from published entry/report metadata during `consolidate-state`
- boost hybrid `edge-search` ranking using citation counts and expose citation stats in observability/briefing/source playbook
- feed citation counts into corpus curation so high-value cited docs are preserved

Fixes #476

## Tests
- bash tests/test_citation_weighted_search.sh
- python3 -m py_compile search/db.py search/search.py search/ingest.py search/citations.py tools/curadoria_compute.py tools/rollup-observability.py tools/edge-sources tools/edge-digest
- bash tests/test_edge_search_coverage.sh
- bash tests/test_edge_sources_corpus.sh
- bash tests/test_source_affordance_digest.sh
- bash -n blog/consolidate-state.sh tests/test_citation_weighted_search.sh tests/test_edge_sources_corpus.sh tests/test_edge_search_coverage.sh
- git diff --check