### PR TITLE
Fix #489 primitive probe uses probe operation instead of --help

### DIFF
--- a/tools/_shared/capability_runtime.py
+++ b/tools/_shared/capability_runtime.py
@@ -743,7 +743,7 @@ def probe_capability(name: str, *, skill: str | None = None) -> subprocess.Compl
         command = list(capability.get("resolved_command") or [])
         if not command:
             raise RuntimeError(f"primitive capability unavailable: {name}")
-        probe_cmd = command + ["--help"]
+        probe_cmd = command + ["probe"]
     else:
         probe_cmd = list(capability.get("resolved_command") or capability.get("configured_command") or [])
         resolved_probe = list(_normalize_command(capability.get("resolved_probe")))

--- a/tools/edge-primitives
+++ b/tools/edge-primitives
@@ -370,7 +370,7 @@ def _probe_primitives(payload: dict, *, skip: bool = False) -> list[dict]:
             "search",
             "--command",
             binary_path,
-            "--help",
+            "probe",
         ]
         try:
             result = subprocess.run(cmd, cwd=str(EDGE_REPO_DIR), capture_output=True, text=True)

--- a/tools/edge-self-healing
+++ b/tools/edge-self-healing
@@ -115,7 +115,7 @@ def reprobe_primitive(row: dict[str, Any], *, cycle_id: str | None = None) -> di
         "search",
         "--command",
         binary_path,
-        "--help",
+        "probe",
     ]
     code, stdout, stderr = run(cmd, timeout=30)
     detail = (stderr or stdout or f"exit={code}").splitlines()[-1][:500]


### PR DESCRIPTION
## Summary
- Primitive probe mechanism was passing `--help` to binaries instead of using their `probe` operation
- All 14 primitives have a `probe` subcommand as their canonical health check
- This caused 14/14 false-positive "broken" in autonomy checkups, dragging capabilities score to 24

## Changes
- `tools/edge-self-healing:118` — `--help` → `probe`
- `tools/edge-primitives:373` — `--help` → `probe`
- `tools/_shared/capability_runtime.py:746` — `["--help"]` → `["probe"]`

## Verification
```
$ github probe → exit 0 (ok)
$ xai-grok probe → exit 0, 15 models (ok)
$ publer probe → exit 1, 401 (real auth issue, unrelated)
```

## Impact
- Capabilities health: 24 → ~90+ (13/14 primitives will pass)
- Overall health: 70 → 80+ projected
- Only publer remains genuinely broken (401 auth)

## Test plan
- [x] Verified `edge-primitive-lifecycle probe github --command .../github probe` → exit 0
- [x] Verified `edge-primitive-lifecycle probe xai-grok --command .../xai-grok probe` → exit 0
- [ ] Run full `edge-primitives status --json` after merge to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)