### PR TITLE
[codex] Scope recent blog validation

### DIFF
--- a/blog/validate.py
+++ b/blog/validate.py
@@ -81,6 +81,9 @@ def validate(recent_only=False, fix=False):
             normalized = normalize_report_ref(ref)
             referenced.add(normalized)
 
+            if recent_only and entry["date"] < cutoff:
+                continue
+
             # Check wrong format (path instead of filename)
             if ref != normalized:
                 wrong_format_refs.append((slug, ref, normalized))

--- a/tests/test_blog_validate_recent_scope.sh
+++ b/tests/test_blog_validate_recent_scope.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/blog/entries" "$TMP/reports"
+
+today="$(date +%F)"
+old_day="$(date -d '10 days ago' +%F)"
+
+cat > "$TMP/blog/entries/${today}-valid-entry.md" <<EOF
+---
+title: Recent valid entry
+date: ${today}
+report: ${today}-valid-entry.html
+---
+
+Recent valid body.
+EOF
+
+cat > "$TMP/reports/${today}-valid-entry.html" <<'EOF'
+<html><body>recent report</body></html>
+EOF
+
+cat > "$TMP/blog/entries/${old_day}-old-broken-ref.md" <<EOF
+---
+title: Old broken ref
+date: ${old_day}
+report: missing-old-report.html
+---
+
+Old broken body.
+EOF
+
+cat > "$TMP/blog/entries/${old_day}-old-wrong-format.md" <<EOF
+---
+title: Old wrong format
+date: ${old_day}
+report: reports/${old_day}-old-wrong-format.html
+---
+
+Old wrong-format body.
+EOF
+
+cat > "$TMP/reports/${old_day}-old-wrong-format.html" <<'EOF'
+<html><body>old report</body></html>
+EOF
+
+if ! EDGE_REPO_DIR="$ROOT" EDGE_STATE_DIR="$TMP" python3 "$ROOT/blog/validate.py" --recent > "$TMP/recent.out"; then
+  cat "$TMP/recent.out"
+  echo "expected --recent to ignore historical broken refs" >&2
+  exit 1
+fi
+
+if EDGE_REPO_DIR="$ROOT" EDGE_STATE_DIR="$TMP" python3 "$ROOT/blog/validate.py" > "$TMP/full.out"; then
+  cat "$TMP/full.out"
+  echo "expected full validation to report historical broken refs" >&2
+  exit 1
+fi
+
+grep -q "ALL CLEAR" "$TMP/recent.out"
+grep -q "BROKEN REFS" "$TMP/full.out"
+grep -q "WRONG FORMAT" "$TMP/full.out"


### PR DESCRIPTION
Fixes #491.

## Summary
- Applies the `--recent` cutoff to per-entry wrong-format and broken-report-reference checks in `blog/validate.py`.
- Adds a regression test proving historical broken refs still fail full validation but are ignored by `--recent`.

## Root Cause
`--recent` filtered orphan reports and missing report fields, but not entry-level `WRONG FORMAT` or `BROKEN REFS`, so fleet postflight failed on old content debt unrelated to the current heartbeat.

## Validation
- `python3 -m py_compile blog/validate.py`
- `bash -n tests/test_blog_validate_recent_scope.sh`
- `tests/test_blog_validate_recent_scope.sh`
- `tests/test_postflight_resilience.sh`