### PR TITLE
[codex] Parse dates for recent validation

### DIFF
--- a/blog/validate.py
+++ b/blog/validate.py
@@ -13,6 +13,7 @@ Usage:
 """
 
 import os
+import re
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -60,13 +61,30 @@ def normalize_report_ref(ref):
     return os.path.basename(ref.rstrip("/"))
 
 
+def extract_date(value):
+    """Return a YYYY-MM-DD date from the start of a metadata value or filename."""
+    match = re.match(r"^(\d{4}-\d{2}-\d{2})", str(value or ""))
+    if not match:
+        return None
+    try:
+        return datetime.strptime(match.group(1), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def is_recent_value(value, cutoff_date):
+    """Whether a dated value falls inside the recent validation window."""
+    parsed = extract_date(value)
+    return parsed is not None and parsed >= cutoff_date
+
+
 def validate(recent_only=False, fix=False):
     entries = load_entries()
     reports = {f.name for f in REPORTS_DIR.glob("*.html")}
 
-    cutoff = ""
+    cutoff_date = None
     if recent_only:
-        cutoff = (datetime.now() - timedelta(days=3)).strftime("%Y-%m-%d")
+        cutoff_date = (datetime.now() - timedelta(days=3)).date()
 
     # Track all issues
     orphan_reports = []
@@ -81,7 +99,7 @@ def validate(recent_only=False, fix=False):
             normalized = normalize_report_ref(ref)
             referenced.add(normalized)
 
-            if recent_only and entry["date"] < cutoff:
+            if recent_only and not is_recent_value(entry["date"], cutoff_date):
                 continue
 
             # Check wrong format (path instead of filename)
@@ -94,14 +112,14 @@ def validate(recent_only=False, fix=False):
 
     # Orphan reports
     for rname in sorted(reports):
-        if recent_only and not rname >= cutoff:
+        if recent_only and not is_recent_value(rname, cutoff_date):
             continue
         if rname not in referenced:
             orphan_reports.append(rname)
 
     # ALL blog entries MUST have a report field — no exceptions (Regra #0)
     for slug, entry in entries.items():
-        if recent_only and entry["date"] < cutoff:
+        if recent_only and not is_recent_value(entry["date"], cutoff_date):
             continue
         if not entry["report"]:
             candidates = [r for r in reports if slug in r or r.startswith(entry["date"])]

--- a/tests/test_blog_validate_recent_scope.sh
+++ b/tests/test_blog_validate_recent_scope.sh
@@ -48,6 +48,10 @@ cat > "$TMP/reports/${old_day}-old-wrong-format.html" <<'EOF'
 <html><body>old report</body></html>
 EOF
 
+cat > "$TMP/reports/spec-legacy-orphan.html" <<'EOF'
+<html><body>undated legacy orphan</body></html>
+EOF
+
 if ! EDGE_REPO_DIR="$ROOT" EDGE_STATE_DIR="$TMP" python3 "$ROOT/blog/validate.py" --recent > "$TMP/recent.out"; then
   cat "$TMP/recent.out"
   echo "expected --recent to ignore historical broken refs" >&2
@@ -63,3 +67,17 @@ fi
 grep -q "ALL CLEAR" "$TMP/recent.out"
 grep -q "BROKEN REFS" "$TMP/full.out"
 grep -q "WRONG FORMAT" "$TMP/full.out"
+grep -q "spec-legacy-orphan.html" "$TMP/full.out"
+
+cat > "$TMP/reports/${today}-orphan-report.html" <<'EOF'
+<html><body>recent orphan</body></html>
+EOF
+
+if EDGE_REPO_DIR="$ROOT" EDGE_STATE_DIR="$TMP" python3 "$ROOT/blog/validate.py" --recent > "$TMP/recent-orphan.out"; then
+  cat "$TMP/recent-orphan.out"
+  echo "expected --recent to report dated recent orphan reports" >&2
+  exit 1
+fi
+
+grep -q "ORPHAN REPORTS" "$TMP/recent-orphan.out"
+grep -q "${today}-orphan-report.html" "$TMP/recent-orphan.out"


### PR DESCRIPTION
Fixes #493.

## Summary
- Replaces raw string recency comparisons in `blog/validate.py` with explicit `YYYY-MM-DD` date parsing.
- Applies the parsed date window to entry checks and orphan report checks.
- Extends the recent validation regression test to ensure undated legacy reports are ignored by `--recent`, while dated recent orphan reports are still reported.

## Root Cause
Report names without date prefixes sort lexicographically after `2026-...`, so the previous `rname >= cutoff` check treated legacy undated reports as recent.

## Validation
- `python3 -m py_compile blog/validate.py`
- `bash -n tests/test_blog_validate_recent_scope.sh`
- `tests/test_blog_validate_recent_scope.sh`
- `tests/test_postflight_resilience.sh`