### PR TITLE
Fix primitive probe passing --help instead of probe (#495)

### DIFF
--- a/tools/edge-primitives
+++ b/tools/edge-primitives
@@ -370,7 +370,7 @@ def _probe_primitives(payload: dict, *, skip: bool = False) -> list[dict]:
             "search",
             "--command",
             binary_path,
-            "--help",
+            "probe",
         ]
         try:
             result = subprocess.run(cmd, cwd=str(EDGE_REPO_DIR), capture_output=True, text=True)


### PR DESCRIPTION
## Summary
- Fixed `tools/edge-primitives` line 373: changed `--help` to `probe` in the probe command construction
- All 14 primitives have a working `probe` subcommand but were receiving `--help`, which they don't recognize
- This was the root cause of capabilities health score at 6/100, dragging overall health to 66

## Evidence
- Before fix: `github: unknown operation '--help'`
- After fix: `github probe` → `ok auth=gh`, `exa probe` → `ok results=1`

## Test plan
- [x] Verified `github probe` and `exa probe` return success
- [x] Verified `edge-primitive-lifecycle probe github --operation search --command <path> probe` succeeds
- [ ] After merge: run `edge-primitives probe-all` and confirm broken_total drops from 14 to near 0

Fixes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)