### PR TITLE
[codex] Fix primitive probe operation

### DIFF
--- a/tests/test_edge_cap_invoke.sh
+++ b/tests/test_edge_cap_invoke.sh
@@ -70,7 +70,18 @@ cat >"$TMP_STATE/state/primitives-status.json" <<'JSON'
 JSON
 cat >"$TMP_STATE/libexec/captest/arxiv" <<'EOF'
 #!/usr/bin/env bash
-printf '{"query":"%s","source":"arxiv"}\n' "${2:-}"
+case "${1:-}" in
+  probe)
+    printf '{"ok":true,"source":"arxiv","probe":true}\n'
+    ;;
+  --query)
+    printf '{"query":"%s","source":"arxiv"}\n' "${2:-}"
+    ;;
+  *)
+    printf 'unknown operation: %s\n' "${1:-}" >&2
+    exit 1
+    ;;
+esac
 EOF
 chmod +x "$TMP_STATE/libexec/captest/arxiv"
 cat >"$TMP_STATE/libexec/captest/arxiv.meta.yaml" <<'YAML'
@@ -111,6 +122,13 @@ else
   fail "probe runs static capability probe"
 fi
 
+if env PATH="$TMP_BIN:/bin" EDGE_REPO_DIR="$TMP_REPO" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="captest" \
+  /usr/bin/python3 "$EDGE_DIR/tools/edge-cap" probe source.arxiv >/dev/null; then
+  pass "probe runs primitive capability probe"
+else
+  fail "probe runs primitive capability probe"
+fi
+
 SYNC_OUT=$(env PATH="$TMP_BIN:/bin" EDGE_REPO_DIR="$TMP_REPO" EDGE_STATE_DIR="$TMP_STATE" EDGE_CODENAME="captest" \
   /usr/bin/python3 "$EDGE_DIR/tools/edge-cap" invoke repo.sync -- status --json)
 if grep -q '"exact_code":true' <<<"$SYNC_OUT"; then
@@ -128,6 +146,7 @@ assert ("CapabilityInvocationObserved", "search.corpus") in types
 assert ("CapabilityInvocationObserved", "source.arxiv") in types
 assert ("CapabilityInvocationObserved", "repo.sync") in types
 assert ("CapabilityProbeCompleted", "repo.status") in types
+assert ("CapabilityProbeCompleted", "source.arxiv") in types
 PY
 then
   pass "capability telemetry is emitted"

--- a/tests/test_primitives_status.sh
+++ b/tests/test_primitives_status.sh
@@ -196,7 +196,41 @@ else
     fail "status reports degraded when active binary disappears"
 fi
 
-echo "--- Test 6: checkup probes capabilities and reports candidate actions without aborting ---"
+echo "--- Test 6: checkup probes materialized primitives with probe operation ---"
+cat >"$LIBEXEC_DIR/arxiv" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "probe" ]]; then
+  printf '{"ok": true, "probe": true}\n'
+  exit 0
+fi
+printf 'expected probe operation, got %s\n' "${1:-}" >&2
+exit 1
+SH
+chmod +x "$LIBEXEC_DIR/arxiv"
+EDGE_CYCLE_ID="primitive-status:test-rematerialize" "$LIFECYCLE_TOOL" materialize arxiv --ensure-executable >/dev/null
+
+if OUTPUT=$("$STATUS_TOOL" status --json --checkup --skill autonomy --skip-capability-probes); then
+    if python3 - <<'PY' "$OUTPUT"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+checkup = payload["checkup"]
+probes = {item["name"]: item for item in checkup["primitive_probes"]}
+assert probes["arxiv"]["status"] == "ok"
+assert probes["arxiv"]["command"][-1] == "probe"
+assert checkup["failed_probe_total"] == 0
+PY
+    then
+        pass "checkup probes materialized primitives with probe operation"
+    else
+        fail "checkup probes materialized primitives with probe operation"
+    fi
+else
+    fail "checkup probes materialized primitives with probe operation"
+fi
+
+echo "--- Test 7: checkup probes capabilities and reports candidate actions without aborting ---"
 if OUTPUT=$("$STATUS_TOOL" status --json --checkup --skill autonomy --skip-primitive-probes); then
     if python3 - <<'PY' "$OUTPUT"
 import json

--- a/tools/_shared/capability_runtime.py
+++ b/tools/_shared/capability_runtime.py
@@ -743,7 +743,7 @@ def probe_capability(name: str, *, skill: str | None = None) -> subprocess.Compl
         command = list(capability.get("resolved_command") or [])
         if not command:
             raise RuntimeError(f"primitive capability unavailable: {name}")
-        probe_cmd = command + ["--help"]
+        probe_cmd = command + ["probe"]
     else:
         probe_cmd = list(capability.get("resolved_command") or capability.get("configured_command") or [])
         resolved_probe = list(_normalize_command(capability.get("resolved_probe")))

--- a/tools/edge-primitives
+++ b/tools/edge-primitives
@@ -367,10 +367,10 @@ def _probe_primitives(payload: dict, *, skip: bool = False) -> list[dict]:
             "probe",
             name,
             "--operation",
-            "search",
+            "probe",
             "--command",
             binary_path,
-            "--help",
+            "probe",
         ]
         try:
             result = subprocess.run(cmd, cwd=str(EDGE_REPO_DIR), capture_output=True, text=True)


### PR DESCRIPTION
## Summary

Fixes #497.

Primitive-backed health checks now call the canonical `probe` operation instead of sending `--help` to materialized primitive wrappers. This prevents false `last_probe_failed` lifecycle events when wrappers correctly implement `probe` but do not implement `--help`.

## Validation

- `./tests/test_primitives_status.sh`
- `./tests/test_edge_cap_invoke.sh`
- `./tests/test_edge_cap_status.sh`