### PR TITLE
[codex] Fix policy memory heartbeat routing

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -234,7 +234,7 @@ request = dispatch["request"]
 assert len(cycle_ids) == 1
 assert cycle_ids[0] == dispatch["cycle_id"]
 assert request["trigger"] == "heartbeat"
-assert request["skill"] == "planner"
+assert request["skill"] == "report"
 assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
 assert dispatch["state"]["preflight_status"] == "warning"
@@ -279,13 +279,14 @@ assert request["delta_prerequisite"]["required"] is True
 assert request["delta_prerequisite"]["digest_update_required"] is False
 assert request["delta_prerequisite"]["inputs"]["raw_chat"]["available"] is True
 assert request["delta_prerequisite"]["inputs"]["raw_chat"]["recent_items"]
-assert request["exploration_pack"]["skill"] == "planner"
+assert request["exploration_pack"]["skill"] == "report"
 assert request["exploration_pack"]["status"] in ("ready", "degraded")
 assert request["exploration_pack"]["path"].endswith("/pack.json")
 assert request["heartbeat_routing"]["suggested_skill"] == "report"
-assert request["heartbeat_routing"]["selected_skill"] == "planner"
+assert request["heartbeat_routing"]["selected_skill"] == "report"
 assert request["heartbeat_routing"]["dispatch_mode"] == "deterministic_heartbeat_router"
-assert request["heartbeat_routing"]["acknowledged"] is False
+assert request["heartbeat_routing"]["acknowledged"] is True
+assert request["heartbeat_routing"]["next_suggested_skill"] == "research"
 assert request["heartbeat_routing"]["round_robin_skills"] == [
     "report",
     "research",
@@ -295,7 +296,7 @@ assert request["heartbeat_routing"]["round_robin_skills"] == [
 assert len(invocations) == 1
 assert invocations[0].splitlines()[0] == "ARGS: -p -"
 assert "/ed-heartbeat" not in invocations[0]
-assert "/planner" in invocations[0]
+assert "/report" in invocations[0]
 assert "Dispatch runtime context below" in invocations[0]
 assert "health_snapshot" in invocations[0]
 assert "pre_skill_context" in invocations[0]
@@ -385,7 +386,7 @@ assert "/report" in invocations[0]
 assert dispatch["request"]["skill"] == "report"
 assert dispatch["request"]["heartbeat_routing"]["selected_skill"] == "report"
 assert dispatch["request"]["heartbeat_routing"]["dispatch_mode"] == "deterministic_heartbeat_router"
-assert dispatch["request"]["heartbeat_routing"]["acknowledged"] is True
+assert dispatch["request"]["heartbeat_routing"]["acknowledged"] is False
 assert dispatch["state"]["active"] is False
 assert dispatch["state"]["close_status"] == "completed"
 assert dispatch["state"]["postflight_status"] in {"completed", "warning"}

--- a/tests/test_heartbeat_routing.sh
+++ b/tests/test_heartbeat_routing.sh
@@ -171,6 +171,66 @@ else
     fail "self-healing unknown primitive failures hint autonomy"
 fi
 
+echo "--- Test 5: policy-only memory does not force planner routing ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_STATE/state/heartbeat-rotation.json"
+import sys
+from pathlib import Path
+
+edge_dir, rotation_path = sys.argv[1:]
+Path(rotation_path).unlink(missing_ok=True)
+sys.path.insert(0, f"{edge_dir}/tools")
+from _shared.dispatch_runtime import _recommend_action_skill, build_beat_launch_context
+
+policy_request = {
+    "operator_pressure_digest": {
+        "signal_from_operator_now": [
+            {
+                "kind": "memory_update",
+                "target": "policy",
+                "source_kinds": ["memory"],
+                "text": "Genotype workflow: issue -> clone -> PR -> merge -> close -> deploy",
+            }
+        ],
+        "memory_updates": [
+            {
+                "kind": "memory_update",
+                "target": "policy",
+                "source_kinds": ["memory"],
+                "text": "Genotype workflow: issue -> clone -> PR -> merge -> close -> deploy",
+            }
+        ],
+    },
+    "open_gaps_summary": {"open_total": 0},
+}
+beat_launch = build_beat_launch_context(policy_request)
+skill, reason = _recommend_action_skill(policy_request, beat_launch)
+assert skill == "report"
+assert "no dominant" in reason
+
+actionable_request = {
+    "operator_pressure_digest": {
+        "signal_from_operator_now": [
+            {
+                "kind": "task_intent",
+                "target": "repo",
+                "source_kinds": ["session"],
+                "text": "Corrija a issue 499, abra PR e deploy.",
+            }
+        ],
+    },
+    "open_gaps_summary": {"open_total": 0},
+}
+beat_launch = build_beat_launch_context(actionable_request)
+skill, reason = _recommend_action_skill(actionable_request, beat_launch)
+assert skill == "planner"
+assert "execution sequencing" in reason
+PY
+then
+    pass "policy-only memory does not force planner routing"
+else
+    fail "policy-only memory does not force planner routing"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -898,6 +898,34 @@ def _first_text(values: Any) -> str:
     return ""
 
 
+def _operator_pressure_text(item: Any) -> str:
+    if isinstance(item, dict):
+        return str(item.get("text") or item.get("summary") or item.get("title") or "").strip()
+    return str(item or "").strip()
+
+
+def _policy_only_operator_signal(item: Any) -> bool:
+    if not isinstance(item, dict):
+        return False
+    kind = str(item.get("kind") or "").strip().lower()
+    target = str(item.get("target") or "").strip().lower()
+    source_kinds = [str(value or "").strip().lower() for value in item.get("source_kinds") or []]
+    if kind == "memory_update" and target in {"", "policy", "guardrail"}:
+        return True
+    if target in {"policy", "guardrail"} and "memory" in source_kinds:
+        return True
+    return False
+
+
+def _actionable_operator_text(request: dict[str, Any], beat_launch: dict[str, Any]) -> str:
+    digest = request.get("operator_pressure_digest") or {}
+    raw_items = digest.get("signal_from_operator_now")
+    if isinstance(raw_items, list):
+        texts = [_operator_pressure_text(item) for item in raw_items if not _policy_only_operator_signal(item)]
+        return " ".join(text for text in texts if text).lower()
+    return " ".join(beat_launch.get("signal_from_operator_now") or []).lower()
+
+
 def _recommend_action_skill(request: dict[str, Any], beat_launch: dict[str, Any]) -> tuple[str, str]:
     rotation = _read_heartbeat_rotation_state()
     cursor = int(rotation.get("cursor") or 0) % len(HEARTBEAT_FAIRNESS_SKILLS)
@@ -906,7 +934,7 @@ def _recommend_action_skill(request: dict[str, Any], beat_launch: dict[str, Any]
     if self_healing.get("needs_llm"):
         return "autonomy", "primitive self-healing needs an LLM repair lane"
 
-    operator_text = " ".join(beat_launch.get("signal_from_operator_now") or []).lower()
+    operator_text = _actionable_operator_text(request, beat_launch)
     open_gaps = int((request.get("open_gaps_summary") or {}).get("open_total", 0) or 0)
     if any(token in operator_text for token in ("implementar", "implement", "pr ", "issue", "fix", "corrija", "deploy")):
         return "planner", "operator pressure is asking for concrete execution sequencing"


### PR DESCRIPTION
## Summary

Fixes #499.

The heartbeat router now ignores policy-only memory updates when deciding whether operator pressure should force `planner`/`report`. Durable policy guidance still remains in pre-skill context, but it no longer overrides round-robin heartbeat fairness just because the policy text contains words like `issue`, `PR`, or `deploy`.

This preserves planner routing for actionable/current operator requests, covered by the new heartbeat routing test.

## Validation

- `bash ./tests/test_heartbeat_routing.sh`
- `./tests/test_edge_runner.sh`