### PR TITLE
Fix health scoring for suspended primitives

### DIFF
--- a/tools/edge-primitives
+++ b/tools/edge-primitives
@@ -219,6 +219,10 @@ def _effective_status(
     binary_exists: bool,
     probe_ok: bool | None,
 ) -> tuple[str, list[str]]:
+    # Suspended primitives are explicitly parked — do not count as broken.
+    if manifest_status == "suspended":
+        return "suspended", []
+
     problems: list[str] = []
     if manifest_exists and manifest_status in {"contract-only", "active", "probed"} and not meta_exists:
         problems.append("manifest_requires_meta")


### PR DESCRIPTION
## Summary
- Suspended primitives (`manifest_status=suspended`) now short-circuit to `effective_status=suspended` in `_effective_status()`, preventing them from being counted as `broken` in health scoring.
- Fixes the case where publer (API key expired, HTTP 401) was poisoning capabilities health every cycle despite being intentionally parked.

## Context
- `source.publer` key is expired/revoked → operator needs to regenerate at publer.io
- Manifest already updated to `suspended` via `edge-primitive-lifecycle materialize --status suspended`
- Without this fix, the health system keeps reporting `needs_llm` and `broken_total=1` even for intentionally suspended primitives

## Test plan
- [x] `edge-primitives status --json` now shows `health_status: ok`, `broken_total: 0`, `suspended: 1`
- [ ] Verify next heartbeat cycle no longer routes to autonomy for publer self-healing

🤖 Generated with [Claude Code](https://claude.com/claude-code)