### PR TITLE
[codex] fix heartbeat review-gate degraded path

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -181,6 +181,7 @@ run_review_gate() {
     local artifact="$1"
     local skill_name="${2:-}"
     local review_cmd=()
+    local review_env=()
     if command -v review-gate &>/dev/null; then
         review_cmd=(review-gate "$artifact" --json)
     elif [[ -x "$TOOLS_DIR/review-gate.py" ]]; then
@@ -190,7 +191,67 @@ run_review_gate() {
     fi
     [[ -n "$skill_name" ]] && review_cmd+=(--skill "$skill_name")
     [[ -n "${ENTRY_PATH:-}" ]] && review_cmd+=(--entry "$ENTRY_PATH")
-    "${review_cmd[@]}"
+    if review_gate_degraded_allowed; then
+        review_env+=("EDGE_REVIEW_GATE_LLM_TIMEOUT_SEC=${EDGE_REVIEW_GATE_HEARTBEAT_TIMEOUT_SEC:-30}")
+    fi
+    env "${review_env[@]}" "${review_cmd[@]}"
+}
+
+review_gate_degraded_allowed() {
+    case "${EDGE_CONSOLIDATE_REVIEW_GATE_DEGRADED_OK:-}" in
+        0|false|FALSE|no|NO|off|OFF) return 1 ;;
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    esac
+    [[ "${EDGE_DISPATCH_TRIGGER:-}" == "heartbeat" ]]
+}
+
+build_degraded_review_gate_json() {
+    local artifact="$1"
+    local skill_name="${2:-}"
+    local review_exit="${3:-}"
+    python3 - "$artifact" "$skill_name" "$review_exit" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+artifact = sys.argv[1]
+skill = sys.argv[2]
+review_exit = sys.argv[3]
+payload = {
+    "final_review": {
+        "overall": 0,
+        "status": "degraded",
+        "critical_issues": [
+            "review-gate unavailable during heartbeat publication; artifact published with degraded review metadata"
+        ],
+        "suggestions": [
+            "Re-run review-gate when providers recover and update the artifact if the review finds blocking issues."
+        ],
+        "_meta": {
+            "phase": "review",
+            "model": "unavailable",
+            "cost_estimate": "$0",
+            "degraded": True,
+            "artifact": str(Path(artifact).name),
+            "skill": skill,
+            "exit_code": review_exit,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        },
+    },
+    "coauthor": {
+        "suggestions": [],
+        "_meta": {
+            "phase": "co-author",
+            "model": "unavailable",
+            "cost_estimate": "$0",
+            "degraded": True,
+        },
+    },
+    "rounds": [],
+}
+print(json.dumps(payload, ensure_ascii=False))
+PY
 }
 
 # Parse flags
@@ -778,12 +839,25 @@ except Exception:
         SKILL_NAME="${BASH_REMATCH[1]}"
     fi
 
+    REVIEW_GATE_STATUS="completed"
+    REVIEW_GATE_REASON=""
+    set +e
     REVIEW_JSON=$(run_review_gate "$REPORT_INPUT" "$SKILL_NAME" 2>/dev/null)
     REVIEW_EXIT=$?
+    set -e
     if [[ $REVIEW_EXIT -ne 0 ]]; then
-        fail "review-gate unavailable or failed (exit $REVIEW_EXIT)"
-        emit_run_step_event "phase-0.5" "failed" "review_gate" "review-gate unavailable or failed"
-        exit 3
+        if review_gate_degraded_allowed; then
+            REVIEW_JSON=$(build_degraded_review_gate_json "$REPORT_INPUT" "$SKILL_NAME" "$REVIEW_EXIT")
+            FEEDBACK_FILE="${REPORT_ARTIFACT_STEM}.feedback.json"
+            printf '%s\n' "$REVIEW_JSON" > "$FEEDBACK_FILE"
+            REVIEW_GATE_STATUS="degraded"
+            REVIEW_GATE_REASON="review-gate unavailable during heartbeat publication"
+            warn "review-gate degraded (exit $REVIEW_EXIT); continuing with degraded review metadata"
+        else
+            fail "review-gate unavailable or failed (exit $REVIEW_EXIT)"
+            emit_run_step_event "phase-0.5" "failed" "review_gate" "review-gate unavailable or failed"
+            exit 3
+        fi
     fi
 
     REVIEW_SCORE=$(echo "$REVIEW_JSON" | python3 -c "
@@ -848,12 +922,12 @@ if suggestions:
     fi
 
     if [[ "$REVIEW_ONLY" == "true" ]]; then
-        emit_run_step_event "phase-0.5" "completed" "review_gate" ""
+        emit_run_step_event "phase-0.5" "$REVIEW_GATE_STATUS" "review_gate" "$REVIEW_GATE_REASON"
         echo ""
         echo "Review-only mode. Nothing published."
         exit 0
     fi
-    emit_run_step_event "phase-0.5" "completed" "review_gate" ""
+    emit_run_step_event "phase-0.5" "$REVIEW_GATE_STATUS" "review_gate" "$REVIEW_GATE_REASON"
     echo ""
 fi
 

--- a/tests/test_consolidate_adversarial_phase.sh
+++ b/tests/test_consolidate_adversarial_phase.sh
@@ -260,6 +260,71 @@ else
     fail "review-only HTML publish with generated review succeeds"
 fi
 
+echo "--- Test 4: heartbeat review-gate degradation records metadata and continues ---"
+TMP_DEGRADED_ENTRY="$TMP_STATE/blog/entries/degraded-entry.md"
+TMP_DEGRADED_REPORT="$TMP_STATE/reports/spec-report-degraded-gate.yaml"
+cat >"$TMP_DEGRADED_ENTRY" <<'EOF'
+---
+title: "Degraded gate entry"
+date: "2026-04-23"
+tags: [test]
+open_gaps: []
+threads: [test-thread]
+---
+
+Test body for degraded review-gate.
+EOF
+cat >"$TMP_DEGRADED_REPORT" <<'EOF'
+title: "Degraded gate report"
+subtitle: "Heartbeat degraded review-gate smoke"
+date: "23/04/2026"
+sections:
+  - title: "1. Test"
+    content: "This report exists to test degraded review-gate metadata."
+EOF
+cat >"${TMP_DEGRADED_REPORT%.yaml}.review.json" <<'EOF'
+{"resolved": true, "response": "already resolved"}
+EOF
+touch "${TMP_DEGRADED_REPORT%.yaml}.resolved"
+cat >"$TMP_BIN/review-gate" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${EDGE_REVIEW_GATE_LLM_TIMEOUT_SEC:-}" > "$EDGE_REVIEW_GATE_TIMEOUT_CAPTURE"
+echo "simulated review-gate provider failure" >&2
+exit 2
+EOF
+chmod +x "$TMP_BIN/review-gate"
+if EDGE_REVIEW_GATE_TIMEOUT_CAPTURE="$TMP_BASE/review-timeout-env" \
+   EDGE_CONSOLIDATE_REVIEW_GATE_DEGRADED_OK=1 \
+   EDGE_REVIEW_GATE_HEARTBEAT_TIMEOUT_SEC=11 \
+   "$CONSOLIDATE" "$TMP_DEGRADED_ENTRY" "$TMP_DEGRADED_REPORT" --review-only >"$TEST_LOG" 2>&1; then
+    if python3 - <<'PY' "$TMP_DEGRADED_REPORT" "$EVENTS_MIRROR_FILE" "$TMP_BASE/review-timeout-env"
+import json, pathlib, sys
+report = pathlib.Path(sys.argv[1])
+events_path = pathlib.Path(sys.argv[2])
+timeout_capture = pathlib.Path(sys.argv[3])
+feedback = pathlib.Path(str(report).replace(".yaml", ".feedback.json"))
+assert feedback.exists(), "degraded feedback json missing"
+data = json.loads(feedback.read_text(encoding="utf-8"))
+final = data["final_review"]
+assert final["status"] == "degraded", final
+assert final["_meta"]["degraded"] is True
+assert timeout_capture.read_text(encoding="utf-8").strip() == "11"
+events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+steps = [e for e in events if e.get("type") == "run_step"]
+phase05 = [(e["phase"], e["status"], e.get("operation")) for e in steps if e["phase"] == "phase-0.5"]
+assert ("phase-0.5", "degraded", "review_gate") in phase05
+PY
+    then
+        pass "heartbeat degraded review-gate continues with explicit metadata"
+    else
+        cat "$TEST_LOG"
+        fail "heartbeat degraded review-gate continues with explicit metadata"
+    fi
+else
+    cat "$TEST_LOG"
+    fail "heartbeat degraded review-gate exits successfully"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -892,6 +892,11 @@ def main() -> int:
     env["EDGE_RUNNER_MODE"] = args.cmd
     env["EDGE_RUNNER_PID"] = str(os.getpid())
     env["EDGE_RUNNER_STARTED_AT"] = now_iso()
+    env["EDGE_DISPATCH_TRIGGER"] = args.dispatch_trigger or ""
+    env["EDGE_DISPATCH_POLICY"] = args.dispatch_policy or ""
+    env["EDGE_DISPATCH_ROUTING_MODE"] = args.dispatch_routing_mode or ""
+    if args.dispatch_trigger == "heartbeat":
+        env.setdefault("EDGE_CONSOLIDATE_REVIEW_GATE_DEGRADED_OK", "1")
 
     cycle_id = None
     exit_code = 0


### PR DESCRIPTION
Fixes #502.

## Summary
- propagate heartbeat dispatch context from `edge-runner` into backend skills
- allow `consolidate-state` to continue heartbeat publication with explicit degraded review metadata when `review-gate` providers fail
- shorten review-gate LLM timeout for that degraded heartbeat path and preserve normal blocking behavior outside heartbeat
- add coverage for degraded review-gate metadata and phase events

## Validation
- `./tests/test_consolidate_adversarial_phase.sh`
- `./tests/test_review_gate_timeout_contract.sh`
- `./tests/test_edge_runner.sh`
- `git diff --check`