### PR TITLE
Fix health scoring to respect suspended primitives

### DIFF
--- a/tools/_shared/capability_runtime.py
+++ b/tools/_shared/capability_runtime.py
@@ -433,7 +433,11 @@ def _primitive_capability_row(item: dict[str, Any], *, invocations: dict[str, An
     name = f"source.{item.get('name')}"
     probe_event = probes.get(name, {})
     invocation_event = invocations.get(name, {})
-    effective_status = _normalize_effective_status(item.get("effective_status"))
+    manifest_status = str(item.get("manifest_status") or item.get("status") or "").strip()
+    if manifest_status == "suspended":
+        effective_status = "suspended"
+    else:
+        effective_status = _normalize_effective_status(item.get("effective_status"))
     normalized_skill = _normalize_skill(skill)
     roles = _normalize_roles(item.get("roles")) or ["search"]
     if "source" not in roles:

--- a/tools/edge-primitives
+++ b/tools/edge-primitives
@@ -229,6 +229,8 @@ def _effective_status(
     if binary_exists and not meta_exists and manifest_exists:
         problems.append("binary_without_meta")
 
+    if manifest_status == "suspended":
+        return "suspended", problems
     if binary_exists and probe_ok is False:
         return "broken", problems + ["last_probe_failed"]
     if problems:


### PR DESCRIPTION
## Summary
- Suspended primitives (e.g. publer with expired API key) were counted as `broken` in health scoring, causing capabilities dimension to report `fail` permanently
- Now `edge-primitives` and `capability_runtime.py` return `effective_status=suspended` for manifest entries with `status: suspended`, excluding them from broken counts
- Immediate effect: capabilities 53→83, overall health 76→82

## Test plan
- [x] `python3 tools/edge-primitives status --json` shows publer as `suspended` (not `broken`) and `broken_total=0`
- [x] `python3 tools/rollup-health-v2.py` shows capabilities `ok(83)` instead of `fail(53)`
- [ ] Verify next heartbeat dispatch picks up the improved score

🤖 Generated with [Claude Code](https://claude.com/claude-code)