### PR TITLE
[codex] extend heartbeat watchdog on publish progress

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -132,6 +132,34 @@ printf '__INVOCATION__\n' >> "${MOCK_CLAUDE_ARGS_OUT:?}"
 printf 'ARGS: %s\n' "$*" >> "${MOCK_CLAUDE_ARGS_OUT:?}"
 printf 'STDIN:\n%s\n' "$PROMPT" >> "${MOCK_CLAUDE_ARGS_OUT:?}"
 printf '__END__\n' >> "${MOCK_CLAUDE_ARGS_OUT:?}"
+if [ "${MOCK_CLAUDE_PHASE_PROGRESS_ON_START:-0}" = "1" ]; then
+  python3 - <<'PY'
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+state_dir = Path(os.environ["EDGE_STATE_DIR"])
+events = state_dir / "state" / "events" / "log.jsonl"
+events.parent.mkdir(parents=True, exist_ok=True)
+event = {
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "type": "PhaseCompleted",
+    "actor": "consolidate-state",
+    "cycle_id": os.environ.get("EDGE_CYCLE_ID", ""),
+    "artifact": "blog/entries/mock-progress.md",
+    "payload": {
+        "pipeline": "consolidate-state",
+        "phase": "1",
+        "operation": "blog_publish",
+        "status": "completed",
+        "ok": True,
+    },
+}
+with open(events, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(event) + "\n")
+PY
+fi
 if [ -n "${MOCK_CLAUDE_SLEEP_SECONDS:-}" ]; then
   sleep "${MOCK_CLAUDE_SLEEP_SECONDS}"
 fi
@@ -854,6 +882,50 @@ then
     pass "watchdog kills hung backend and closes cycle as skill_subprocess_timeout"
 else
     fail "watchdog kills hung backend and closes cycle as skill_subprocess_timeout"
+fi
+
+echo "--- Test 8b: watchdog extends once when consolidate-state is still progressing ---"
+unset MOCK_CLAUDE_HEARTBEAT_FLOW || true
+unset MOCK_CLAUDE_EXIT_CODE || true
+export MOCK_CLAUDE_SLEEP_SECONDS=2
+export MOCK_CLAUDE_PHASE_PROGRESS_ON_START=1
+export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'# Progress Grace Report\n\nThis artifact proves the backend was allowed to finish after the initial timeout because consolidate-state had recent phase progress.'
+export EDGE_RUNNER_SKILL_TIMEOUT_SEC=1
+export EDGE_RUNNER_TIMEOUT_PROGRESS_GRACE_SEC=4
+export EDGE_RUNNER_TIMEOUT_PROGRESS_MAX_EXTENSIONS=1
+"$RUNNER_TOOL" skill \
+    --skill /report \
+    --dispatch-trigger heartbeat \
+    --dispatch-policy autonomous \
+    --dispatch-routing-mode explicit \
+    --dispatch-preflight-profile heartbeat_default \
+    --dispatch-postflight-profile standard \
+    --dispatch-force >/dev/null
+unset MOCK_CLAUDE_SLEEP_SECONDS || true
+unset MOCK_CLAUDE_PHASE_PROGRESS_ON_START || true
+unset MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
+unset EDGE_RUNNER_SKILL_TIMEOUT_SEC || true
+unset EDGE_RUNNER_TIMEOUT_PROGRESS_GRACE_SEC || true
+unset EDGE_RUNNER_TIMEOUT_PROGRESS_MAX_EXTENSIONS || true
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+cycle_id = dispatch["cycle_id"]
+cycle_events = [e for e in events if e.get("cycle_id") == cycle_id]
+
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "completed"
+assert any(e["type"] == "SkillSubprocessTimeoutExtended" for e in cycle_events)
+assert not any(e["type"] == "SkillSubprocessTimeout" for e in cycle_events)
+PY
+then
+    pass "watchdog grants bounded grace for active consolidate-state progress"
+else
+    fail "watchdog grants bounded grace for active consolidate-state progress"
 fi
 
 echo "--- Test 9: backend prompt is delivered through stdin, not argv ---"

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -574,6 +574,67 @@ def resolve_skill_timeout_seconds() -> int | None:
     return value
 
 
+def resolve_timeout_progress_grace_seconds() -> int:
+    raw = os.environ.get("EDGE_RUNNER_TIMEOUT_PROGRESS_GRACE_SEC", "300")
+    try:
+        value = int(raw)
+    except ValueError:
+        return 300
+    return max(value, 0)
+
+
+def resolve_timeout_progress_max_extensions() -> int:
+    raw = os.environ.get("EDGE_RUNNER_TIMEOUT_PROGRESS_MAX_EXTENSIONS", "2")
+    try:
+        value = int(raw)
+    except ValueError:
+        return 2
+    return max(value, 0)
+
+
+def _parse_iso_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def recent_consolidate_progress(cycle_id: str | None, *, within_seconds: int = 120) -> dict | None:
+    if not cycle_id or within_seconds <= 0:
+        return None
+    now = datetime.now(timezone.utc)
+    for event in iter_jsonl_reverse(STATE_EVENTS_FILE):
+        if event.get("type") != "PhaseCompleted":
+            continue
+        if event.get("cycle_id") != cycle_id:
+            continue
+        payload = event.get("payload", {}) or {}
+        if payload.get("pipeline") != "consolidate-state":
+            continue
+        if str(payload.get("status") or "").lower() not in {"completed", "degraded"}:
+            continue
+        ts = _parse_iso_timestamp(str(event.get("ts") or ""))
+        if ts is None:
+            continue
+        age_seconds = int((now - ts).total_seconds())
+        if age_seconds <= within_seconds:
+            return {
+                "age_seconds": age_seconds,
+                "artifact": event.get("artifact"),
+                "phase": payload.get("phase"),
+                "operation": payload.get("operation"),
+                "status": payload.get("status"),
+                "ts": event.get("ts"),
+            }
+        return None
+    return None
+
+
 def _print_backend_output(output: str) -> None:
     if not output:
         return
@@ -628,6 +689,35 @@ def invoke_backend(
         return proc.returncode, output
     except subprocess.TimeoutExpired:
         target = args.skill if args.cmd == "skill" else "prompt"
+        grace_seconds = resolve_timeout_progress_grace_seconds()
+        max_extensions = resolve_timeout_progress_max_extensions()
+        for extension_index in range(max_extensions):
+            progress = recent_consolidate_progress(cycle_id, within_seconds=120)
+            if not progress or grace_seconds <= 0:
+                break
+            emit_shadow_event(
+                "SkillSubprocessTimeoutExtended",
+                actor="edge-runner",
+                cycle_id=cycle_id,
+                payload={
+                    "target": target,
+                    "mode": args.cmd,
+                    "timeout_seconds": timeout_seconds,
+                    "grace_seconds": grace_seconds,
+                    "extension_index": extension_index + 1,
+                    "max_extensions": max_extensions,
+                    "pid": proc.pid,
+                    "progress": progress,
+                },
+            )
+            try:
+                output, _ = proc.communicate(timeout=grace_seconds)
+                output = output or ""
+                if echo_output:
+                    _print_backend_output(output)
+                return proc.returncode, output
+            except subprocess.TimeoutExpired:
+                continue
         emit_shadow_event(
             "SkillSubprocessTimeout",
             actor="edge-runner",


### PR DESCRIPTION
Fixes #505.

## Summary
- add bounded watchdog grace when a backend timeout coincides with recent `consolidate-state` phase progress for the same cycle
- emit `SkillSubprocessTimeoutExtended` before granting grace
- keep the existing hard timeout behavior when no recent publication progress exists
- cover the progress-grace path in `test_edge_runner.sh`

## Validation
- `python3 -m py_compile tools/edge-runner`
- `./tests/test_edge_runner.sh`
- `./tests/test_consolidate_adversarial_phase.sh`
- `git diff --check`