### PR TITLE
Exclude suspended primitives from broken health count

### DIFF
--- a/tools/_shared/health_runtime.py
+++ b/tools/_shared/health_runtime.py
@@ -424,9 +424,31 @@ def _capabilities_dimension(events: list[dict[str, Any]], capabilities_status: d
 
     available = int(cap_summary.get("available_total", 0) or 0)
     degraded = int(cap_summary.get("degraded_total", 0) or 0)
-    broken = int(cap_summary.get("broken_total", 0) or 0)
-    primitive_broken = int(primitive_summary.get("broken_total", 0) or 0)
-    primitive_degraded = int(primitive_summary.get("degraded_total", 0) or 0)
+    # Exclude suspended primitives from broken/degraded counts — suspended is
+    # an intentional operator decision, not an operational failure.
+    suspended_names = {
+        str(s.get("name"))
+        for s in sources
+        if str(s.get("manifest_status", "")).lower() == "suspended"
+    }
+    broken = sum(
+        1
+        for row in cap_rows
+        if str(row.get("effective_status")) == "broken"
+        and str(row.get("primitive_name") or row.get("name", "")) not in suspended_names
+    )
+    primitive_broken = sum(
+        1
+        for s in sources
+        if str(s.get("effective_status")) == "broken"
+        and str(s.get("manifest_status", "")).lower() != "suspended"
+    )
+    primitive_degraded = sum(
+        1
+        for s in sources
+        if str(s.get("effective_status")) == "degraded"
+        and str(s.get("manifest_status", "")).lower() != "suspended"
+    )
     never_used_available = sum(
         1
         for row in cap_rows


### PR DESCRIPTION
## Summary
- Suspended primitives (manifest_status=suspended) no longer count as broken in the capabilities health dimension
- Fixes publer (intentionally suspended, expired API key) inflating the broken penalty by 30 points
- Capabilities score: 53 → 83, overall health: 76 → 82

Closes #507

## Test plan
- [x] `build_health_snapshot()` returns capabilities score=83 status=ok (was 53/fail)
- [x] Overall health score=82 (was 76)
- [ ] Verify next heartbeat cycle no longer triggers self-healing for publer

🤖 Generated with [Claude Code](https://claude.com/claude-code)