### PR TITLE
Fix suspended primitive health handling (#507)

### DIFF
--- a/tests/test_edge_cap_status.sh
+++ b/tests/test_edge_cap_status.sh
@@ -49,6 +49,9 @@ sources:
   - name: arxiv
     description: Academic preprints
     status: active
+  - name: publer
+    description: Social publishing
+    status: suspended
 YAML
 cat >"$TMP_STATE/libexec/captest/arxiv" <<'EOF'
 #!/usr/bin/env bash
@@ -58,6 +61,15 @@ chmod +x "$TMP_STATE/libexec/captest/arxiv"
 cat >"$TMP_STATE/libexec/captest/arxiv.meta.yaml" <<'YAML'
 name: arxiv
 description: Academic preprints
+YAML
+cat >"$TMP_STATE/libexec/captest/publer" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$TMP_STATE/libexec/captest/publer"
+cat >"$TMP_STATE/libexec/captest/publer.meta.yaml" <<'YAML'
+name: publer
+description: Social publishing
 YAML
 
 echo "=== edge-cap status Smoke Test ==="
@@ -79,10 +91,14 @@ assert names["repo.status"]["effective_status"] == "available"
 assert names["repo.sync"]["effective_status"] == "available"
 assert names["storage.sync"]["effective_status"] == "degraded"
 assert names["source.arxiv"]["effective_status"] in {"active", "probed"}
+assert names["source.publer"]["effective_status"] == "suspended"
+assert payload["summary"]["broken_total"] == 0
 source_bindings = payload["source_bindings"]
-assert source_bindings["summary"]["source_total"] == 1
-assert source_bindings["bindings"][0]["source"] == "arxiv"
-assert source_bindings["bindings"][0]["binding_status"] == "present"
+assert source_bindings["summary"]["source_total"] == 2
+bindings = {item["source"]: item for item in source_bindings["bindings"]}
+assert bindings["arxiv"]["binding_status"] == "present"
+assert bindings["publer"]["binding_status"] == "suspended"
+assert source_bindings["summary"]["suspended_total"] == 1
 recommended = {item["name"] for item in payload["recommended"]}
 assert "search.corpus" in recommended
 assert "sources.aggregate" in recommended
@@ -98,9 +114,12 @@ SOURCE_BINDINGS_OUTPUT=$(PATH="$TMP_BIN" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DI
 if python3 - <<'PY' "$SOURCE_BINDINGS_OUTPUT"
 import json, sys
 payload = json.loads(sys.argv[1])
-assert payload["summary"]["source_total"] == 1
+assert payload["summary"]["source_total"] == 2
 assert payload["summary"]["bound_total"] == 1
-assert payload["bindings"][0]["capability"] == "sources.aggregate"
+assert payload["summary"]["suspended_total"] == 1
+bindings = {item["source"]: item for item in payload["bindings"]}
+assert bindings["arxiv"]["capability"] == "sources.aggregate"
+assert bindings["publer"]["binding_status"] == "suspended"
 PY
 then
   pass "source binding surface resolves manifest sources"

--- a/tests/test_health_v2.sh
+++ b/tests/test_health_v2.sh
@@ -67,13 +67,14 @@ cat >"$TMP_STATE/state/primitives-status.json" <<'JSON'
   "summary": {
     "health_status": "degraded",
     "declared_total": 3,
-    "broken_total": 1,
+    "broken_total": 2,
     "degraded_total": 1,
     "usage_30d_total": 9
   },
   "sources": [
     {"name":"arxiv","effective_status":"active","usage_30d":4},
     {"name":"exa","effective_status":"broken","usage_30d":0},
+    {"name":"publer","effective_status":"broken","manifest_status":"suspended","usage_30d":0},
     {"name":"grafana","effective_status":"degraded","usage_30d":0}
   ]
 }
@@ -86,7 +87,7 @@ cat >"$TMP_STATE/state/capabilities-status.json" <<'JSON'
     "capability_total": 4,
     "available_total": 2,
     "degraded_total": 1,
-    "broken_total": 1,
+    "broken_total": 2,
     "required_degraded_total": 0,
     "optional_degraded_total": 1
   },
@@ -94,6 +95,7 @@ cat >"$TMP_STATE/state/capabilities-status.json" <<'JSON'
     {"name":"source.arxiv","effective_status":"available","invoke_30d":0},
     {"name":"source.github","effective_status":"available","invoke_30d":2},
     {"name":"search.corpus","effective_status":"broken","invoke_30d":1},
+    {"name":"source.publer","primitive_name":"publer","effective_status":"broken","manifest_status":"suspended","invoke_30d":0},
     {"name":"storage.sync","effective_status":"degraded","invoke_30d":0}
   ]
 }
@@ -149,6 +151,11 @@ if env HOME="$TMP_HOME" EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" py
     pass "substrate discipline captured primitive bypass"
   else
     fail "primitive bypass count wrong"
+  fi
+  if [[ "$(jq -r '.dimensions.capabilities.metrics.broken_capabilities' "$TMP_STATE/health/current.json")" == "1" && "$(jq -r '.dimensions.capabilities.metrics.broken_primitives' "$TMP_STATE/health/current.json")" == "1" ]]; then
+    pass "capabilities health excludes suspended broken rows"
+  else
+    fail "capabilities health counted suspended rows as broken"
   fi
   if grep -q '"type": "HealthSnapshotComputed"' "$TMP_STATE/state/events/log.jsonl"; then
     pass "health snapshot emission wrote HealthSnapshotComputed"

--- a/tests/test_primitives_status.sh
+++ b/tests/test_primitives_status.sh
@@ -196,7 +196,40 @@ else
     fail "status reports degraded when active binary disappears"
 fi
 
-echo "--- Test 6: checkup probes materialized primitives with probe operation ---"
+echo "--- Test 6: suspended primitives do not become broken after failed probes ---"
+cat >"$LIBEXEC_DIR/arxiv" <<'SH'
+#!/usr/bin/env bash
+printf 'suspended primitive should not count as broken\n' >&2
+exit 1
+SH
+chmod +x "$LIBEXEC_DIR/arxiv"
+EDGE_CYCLE_ID="primitive-status:test-suspended" "$LIFECYCLE_TOOL" materialize arxiv --status suspended --ensure-executable >/dev/null
+set +e
+EDGE_CYCLE_ID="primitive-status:test-suspended-probe" "$LIFECYCLE_TOOL" probe arxiv --operation search --command "$LIBEXEC_DIR/arxiv" >/dev/null 2>&1
+SUSPENDED_PROBE_RC=$?
+set -e
+
+if python3 - <<'PY' "$STATUS_TOOL" "$SUSPENDED_PROBE_RC"
+import json
+import subprocess
+import sys
+
+tool, probe_rc = sys.argv[1:]
+assert int(probe_rc) != 0
+payload = json.loads(subprocess.run([tool, "status", "--json"], capture_output=True, text=True, check=True).stdout)
+rows = {row["name"]: row for row in payload["sources"]}
+assert rows["arxiv"]["manifest_status"] == "suspended"
+assert rows["arxiv"]["effective_status"] == "suspended"
+assert payload["summary"]["broken_total"] == 0
+assert payload["summary"]["counts_by_effective_status"]["suspended"] == 1
+PY
+then
+    pass "suspended primitive is excluded from broken totals"
+else
+    fail "suspended primitive is excluded from broken totals"
+fi
+
+echo "--- Test 7: checkup probes materialized primitives with probe operation ---"
 cat >"$LIBEXEC_DIR/arxiv" <<'SH'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "probe" ]]; then
@@ -207,7 +240,7 @@ printf 'expected probe operation, got %s\n' "${1:-}" >&2
 exit 1
 SH
 chmod +x "$LIBEXEC_DIR/arxiv"
-EDGE_CYCLE_ID="primitive-status:test-rematerialize" "$LIFECYCLE_TOOL" materialize arxiv --ensure-executable >/dev/null
+EDGE_CYCLE_ID="primitive-status:test-rematerialize" "$LIFECYCLE_TOOL" materialize arxiv --status active --ensure-executable >/dev/null
 
 if OUTPUT=$("$STATUS_TOOL" status --json --checkup --skill autonomy --skip-capability-probes); then
     if python3 - <<'PY' "$OUTPUT"
@@ -230,7 +263,7 @@ else
     fail "checkup probes materialized primitives with probe operation"
 fi
 
-echo "--- Test 7: checkup probes capabilities and reports candidate actions without aborting ---"
+echo "--- Test 8: checkup probes capabilities and reports candidate actions without aborting ---"
 if OUTPUT=$("$STATUS_TOOL" status --json --checkup --skill autonomy --skip-primitive-probes); then
     if python3 - <<'PY' "$OUTPUT"
 import json

--- a/tools/_shared/capability_runtime.py
+++ b/tools/_shared/capability_runtime.py
@@ -36,7 +36,8 @@ STATUS_ORDER = {
     "probed": 2,
     "active": 3,
     "available": 4,
-    "unknown": 5,
+    "suspended": 5,
+    "unknown": 6,
 }
 
 INTEGRATION_CATALOG: dict[str, dict[str, Any]] = {
@@ -433,7 +434,11 @@ def _primitive_capability_row(item: dict[str, Any], *, invocations: dict[str, An
     name = f"source.{item.get('name')}"
     probe_event = probes.get(name, {})
     invocation_event = invocations.get(name, {})
-    effective_status = _normalize_effective_status(item.get("effective_status"))
+    manifest_status = str(item.get("manifest_status") or item.get("status") or "").strip()
+    if manifest_status == "suspended":
+        effective_status = "suspended"
+    else:
+        effective_status = _normalize_effective_status(item.get("effective_status"))
     normalized_skill = _normalize_skill(skill)
     roles = _normalize_roles(item.get("roles")) or ["search"]
     if "source" not in roles:
@@ -619,6 +624,7 @@ def build_source_bindings(*, skill: str | None = None) -> dict[str, Any]:
         primitive_name = f"source.{source_name}"
         primitive = capability_rows.get(primitive_name) or {}
         primitive_status = str(primitive.get("effective_status") or "unknown")
+        manifest_status = str(source.get("status") or primitive.get("manifest_status") or "").strip()
         provider = _canonical_source_provider(source_name)
         source_roles_search = not roles or "search" in roles or "source" in roles
 
@@ -629,10 +635,14 @@ def build_source_bindings(*, skill: str | None = None) -> dict[str, Any]:
         evidence: dict[str, Any] = {
             "primitive_status": primitive_status,
             "aggregate_status": aggregate_status,
-            "manifest_status": source.get("status") or "",
+            "manifest_status": manifest_status,
         }
 
-        if source_roles_search and provider in AGGREGATE_SOURCE_PROVIDERS and aggregate_available:
+        if manifest_status == "suspended" or primitive_status == "suspended":
+            binding_status = "suspended"
+            binding_mode = "suspended"
+            problems = []
+        elif source_roles_search and provider in AGGREGATE_SOURCE_PROVIDERS and aggregate_available:
             binding_status = "present"
             binding_mode = "sources.aggregate"
             capability = "sources.aggregate"
@@ -677,6 +687,7 @@ def build_source_bindings(*, skill: str | None = None) -> dict[str, Any]:
         "generated_at": now.isoformat(),
         "source_total": len(bindings),
         "bound_total": counts.get("present", 0),
+        "suspended_total": counts.get("suspended", 0),
         "unbound_total": counts.get("absent", 0),
         "degraded_total": counts.get("degraded", 0),
         "counts_by_binding_status": dict(sorted(counts.items())),

--- a/tools/_shared/health_runtime.py
+++ b/tools/_shared/health_runtime.py
@@ -435,6 +435,7 @@ def _capabilities_dimension(events: list[dict[str, Any]], capabilities_status: d
         1
         for row in cap_rows
         if str(row.get("effective_status")) == "broken"
+        and str(row.get("manifest_status", "")).lower() != "suspended"
         and str(row.get("primitive_name") or row.get("name", "")) not in suspended_names
     )
     primitive_broken = sum(

--- a/tools/edge-primitives
+++ b/tools/edge-primitives
@@ -38,7 +38,8 @@ STATUS_ORDER = {
     "degraded": 1,
     "probed": 2,
     "active": 3,
-    "unknown": 4,
+    "suspended": 4,
+    "unknown": 5,
 }
 
 
@@ -229,6 +230,8 @@ def _effective_status(
     if binary_exists and not meta_exists and manifest_exists:
         problems.append("binary_without_meta")
 
+    if manifest_status == "suspended":
+        return "suspended", problems
     if binary_exists and probe_ok is False:
         return "broken", problems + ["last_probe_failed"]
     if problems:


### PR DESCRIPTION
## Summary
- Treat manifest `status: suspended` primitives as `effective_status=suspended` in primitive and capability read models.
- Keep source bindings from reporting suspended sources as absent/unbound failures.
- Make health v2 defensively recount broken capability/primitive rows while excluding suspended entries, even if an older snapshot has inflated `broken_total`.

## Test plan
- [x] `./tests/test_primitives_status.sh`
- [x] `./tests/test_edge_cap_status.sh`
- [x] `bash ./tests/test_health_v2.sh`
- [x] `python3 -m py_compile tools/_shared/health_runtime.py tools/_shared/capability_runtime.py`
- [x] `git diff --check`

Supersedes #508, #504, and #501.
Refs #507