### PR TITLE
[codex] Block runtime stdout artifact publication

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -170,8 +170,12 @@ if [ "${MOCK_CLAUDE_FAIL_ONCE:-0}" = "1" ]; then
     exit "${MOCK_CLAUDE_FAIL_ONCE_EXIT_CODE:-1}"
   fi
 fi
+prompt_has_skill() {
+  local skill="$1"
+  [[ "$PROMPT" == *"/$skill"* || "$PROMPT" == "$skill"$'\n'* ]]
+}
 if [ "${MOCK_CLAUDE_HEARTBEAT_FLOW:-0}" = "1" ]; then
-  if [[ "$PROMPT" == *"/ed-heartbeat"* ]]; then
+  if prompt_has_skill "ed-heartbeat"; then
     "${EDGE_REPO_DIR:?}/tools/edge-dispatch" dispatch --skill discovery >/dev/null
     if [ "${MOCK_CLAUDE_HEARTBEAT_INLINE_DONE:-0}" = "1" ]; then
       python3 - <<'PY'
@@ -192,7 +196,7 @@ path.write_text(json.dumps(state, indent=2, ensure_ascii=False) + "\n", encoding
 PY
       publish_mock_artifact discovery
     fi
-  elif [[ "$PROMPT" == *"/discovery"* ]]; then
+  elif prompt_has_skill "discovery"; then
     for step in direction explore application persistence; do
       "${EDGE_REPO_DIR:?}/tools/edge-skill-step" discovery "$step" >/dev/null
     done
@@ -200,7 +204,7 @@ PY
     publish_mock_artifact discovery
   elif [ -z "${MOCK_CLAUDE_ARTIFACT_MARKDOWN:-}" ]; then
     for skill in autonomy report research planner sources; do
-      if [[ "$PROMPT" == *"/$skill"* ]]; then
+      if prompt_has_skill "$skill"; then
         publish_mock_artifact "$skill"
         break
       fi
@@ -334,6 +338,8 @@ assert "operator_pressure_digest" in invocations[0]
 assert "beat_launch_context" in invocations[0]
 assert "delta_prerequisite" in invocations[0]
 assert "DELTA PREREQUISITE" in invocations[0]
+assert "Stdout-only prose is diagnostic output only" in invocations[0]
+assert "runtime can publish it" not in invocations[0]
 assert "search_protocol" in invocations[0]
 assert "epistemic_protocol" in invocations[0]
 assert "exploration_pack" in invocations[0]
@@ -374,7 +380,6 @@ cat >"$TMP_EDGE/state/dispatch-queue.json" <<'JSON'
 ]
 JSON
 export MOCK_CLAUDE_HEARTBEAT_FLOW=1
-export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'# Queued Report Priority\n\nThis queued report artifact is intentionally long enough for the stdout publication bridge to accept it as a valid runtime artifact during the deterministic heartbeat routing test.'
 "$RUNNER_TOOL" skill \
     --skill /ed-heartbeat \
     --dispatch-trigger heartbeat \
@@ -383,7 +388,6 @@ export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'# Queued Report Priority\n\nThis queued r
     --dispatch-preflight-profile heartbeat_default \
     --dispatch-postflight-profile standard \
     --dispatch-force >/dev/null
-unset MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
 
 if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$TMP_EDGE/logs/events.jsonl" "$TMP_BASE/cycle-id-inline.txt" "$TMP_BASE/args-inline.txt" "$TMP_EDGE/state/dispatch-queue.json"
 import json
@@ -444,19 +448,14 @@ else
     fail "heartbeat router prioritizes queued dispatch before fairness"
 fi
 
-echo "--- Test 1c: non-heartbeat skills publish stdout through the shared runtime bridge ---"
-PUBLISH_SKILLS=(discovery research report planner autonomy sources test-agent-autonomy)
+echo "--- Test 1c: non-heartbeat skills must publish durable artifacts themselves ---"
+PUBLISH_SKILLS=(discovery research report planner autonomy sources)
 PUBLISH_OK=1
 for skill in "${PUBLISH_SKILLS[@]}"; do
     export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id-publish-$skill.txt"
     export MOCK_CLAUDE_ARGS_OUT="$TMP_BASE/args-publish-$skill.txt"
     rm -f "$MOCK_CLAUDE_ENV_OUT" "$MOCK_CLAUDE_ARGS_OUT"
-    unset MOCK_CLAUDE_HEARTBEAT_FLOW || true
-    export MOCK_CLAUDE_ARTIFACT_MARKDOWN="# Runtime Artifact ${skill}
-
-This is a complete markdown artifact emitted by the backend for ${skill}.
-
-It should be published by the runtime bridge, not by the individual skill."
+    export MOCK_CLAUDE_HEARTBEAT_FLOW=1
     if ! "$RUNNER_TOOL" skill \
         --skill "$skill" \
         --dispatch-trigger operator \
@@ -481,7 +480,7 @@ skill = sys.argv[5]
 cycle_id = dispatch["cycle_id"]
 
 expected_skill = skill
-expected_source_skill = "autonomy" if skill == "test-agent-autonomy" else skill
+expected_source_skill = skill
 
 assert dispatch["request"]["skill"] == expected_skill
 assert dispatch["state"]["active"] is False
@@ -493,45 +492,39 @@ published = [
     if event.get("cycle_id") == cycle_id
     and event.get("type") == "ArtifactPublished"
     and (event.get("payload") or {}).get("source_skill") == expected_source_skill
-    and (event.get("payload") or {}).get("auto_published") is True
+    and (event.get("payload") or {}).get("auto_published") is not True
+    and (event.get("payload") or {}).get("pipeline") != "runtime-stdout-artifact"
 ]
-assert published, f"no auto-published artifact for {skill}"
+assert published, f"no durable artifact for {skill}"
 artifact = published[-1]["artifact"]
 assert artifact.startswith("blog/entries/")
-entry_path = entries_dir / Path(artifact).name
-assert entry_path.exists()
-entry = entry_path.read_text(encoding="utf-8")
-assert "runtime-published" in entry
-assert f"source_skill: {expected_source_skill}" in entry
-report_name = (published[-1].get("payload") or {})["report"]
-assert (reports_dir / report_name).exists()
 
 phase_events = [
     event for event in events
     if event.get("cycle_id") == cycle_id
     and event.get("type") == "PhaseCompleted"
     and (event.get("payload") or {}).get("pipeline") == "runtime-stdout-artifact"
-    and (event.get("payload") or {}).get("ok") is True
 ]
-assert phase_events
+assert not phase_events
 PY
         PUBLISH_OK=0
         break
     fi
 done
-unset MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
+unset MOCK_CLAUDE_HEARTBEAT_FLOW || true
 
 if [[ "$PUBLISH_OK" -eq 1 ]]; then
-    pass "non-heartbeat skills publish stdout through the shared runtime bridge"
+    pass "non-heartbeat skills close only after durable artifact publication"
 else
-    fail "non-heartbeat skills publish stdout through the shared runtime bridge"
+    fail "non-heartbeat skills close only after durable artifact publication"
 fi
 
-echo "--- Test 1d: plain terminal prose is captured as an artifact without dumping the body ---"
+echo "--- Test 1d: stdout-only prose does not satisfy the artifact gate ---"
 export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id-plain-stdout.txt"
 export MOCK_CLAUDE_ARGS_OUT="$TMP_BASE/args-plain-stdout.txt"
 rm -f "$MOCK_CLAUDE_ENV_OUT" "$MOCK_CLAUDE_ARGS_OUT" "$TMP_BASE/plain-stdout.out"
-export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'Plain Runtime Report\n\nThis report intentionally has no markdown heading. The runtime should still capture the terminal prose as a durable artifact instead of letting an artifact-producing skill close with text only in stdout. The body is long enough to satisfy the artifact bridge threshold.'
+export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'Plain Runtime Report\n\nThis report intentionally has no markdown heading. The runtime must not capture terminal prose as a durable artifact or let an artifact-producing skill close with text only in stdout. The body is long enough to prove stdout is only diagnostic output.'
+set +e
 "$RUNNER_TOOL" skill \
     --skill /report \
     --dispatch-trigger operator \
@@ -540,9 +533,11 @@ export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'Plain Runtime Report\n\nThis report inten
     --dispatch-preflight-profile heartbeat_default \
     --dispatch-postflight-profile standard \
     --dispatch-force >"$TMP_BASE/plain-stdout.out"
+STATUS=$?
+set -e
 unset MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
 
-if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$TMP_EDGE/blog/entries" "$TMP_BASE/plain-stdout.out"
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$TMP_EDGE/blog/entries" "$TMP_BASE/plain-stdout.out" "$STATUS"
 import json
 import sys
 from pathlib import Path
@@ -551,93 +546,107 @@ dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
 events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
 entries_dir = Path(sys.argv[3])
 runner_stdout = Path(sys.argv[4]).read_text(encoding="utf-8")
+status = int(sys.argv[5])
 
 assert dispatch["request"]["skill"] == "report"
 assert dispatch["state"]["active"] is False
-assert dispatch["state"]["close_status"] == "completed"
+assert dispatch["state"]["close_status"] == "failed"
+assert dispatch["state"]["close_reason"] == "missing_artifact_published"
+assert status == 1
 published = [
     event for event in events
     if event.get("type") == "ArtifactPublished"
     and event.get("cycle_id") == dispatch["cycle_id"]
 ]
-assert published
-artifact = published[-1]["artifact"]
-entry = entries_dir / Path(artifact).name
-text = entry.read_text(encoding="utf-8")
-assert "Plain Runtime Report" in text
-assert "\n# Plain Runtime Report" not in text
-assert "artifact-producing skill close with text only in stdout" in text
-assert "edge-runner: published artifact blog/entries/" in runner_stdout
-assert "artifact-producing skill close with text only in stdout" not in runner_stdout
+auto_published = [
+    event for event in published
+    if (event.get("payload") or {}).get("auto_published") is True
+    or (event.get("payload") or {}).get("pipeline") == "runtime-stdout-artifact"
+]
+assert not auto_published
+assert not any("Plain Runtime Report" in path.read_text(encoding="utf-8") for path in entries_dir.glob("*.md"))
+assert "edge-runner: published artifact blog/entries/" not in runner_stdout
+assert "artifact-producing skill close with text only in stdout" in runner_stdout
 PY
 then
-    pass "plain terminal prose is captured as an artifact without dumping the body"
+    pass "stdout-only prose is rejected as publication evidence"
 else
-    fail "plain terminal prose is captured as an artifact without dumping the body"
+    fail "stdout-only prose is rejected as publication evidence"
 fi
 
-echo "--- Test 1e: artifact supervisor retries acknowledgement-only backend failure ---"
-export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id-retry.txt"
-export MOCK_CLAUDE_ARGS_OUT="$TMP_BASE/args-retry.txt"
-rm -f "$MOCK_CLAUDE_ENV_OUT" "$MOCK_CLAUDE_ARGS_OUT" "$TMP_BASE/retry.out"
-export MOCK_CLAUDE_FAIL_ONCE=1
-export MOCK_CLAUDE_FAIL_ONCE_OUTPUT="Acknowledged — staying out of Frostpeck's way."
-export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'# Retry Published Report\n\nThe artifact supervisor retried a backend response that only acknowledged and did not publish. This second attempt produces a complete runtime-published report artifact.'
-"$RUNNER_TOOL" skill \
-    --skill /research \
-    --dispatch-trigger operator \
-    --dispatch-policy operator \
-    --dispatch-routing-mode explicit \
-    --dispatch-preflight-profile heartbeat_default \
-    --dispatch-postflight-profile standard \
-    --dispatch-force >"$TMP_BASE/retry.out"
-unset MOCK_CLAUDE_FAIL_ONCE MOCK_CLAUDE_FAIL_ONCE_OUTPUT MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
-
-if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$TMP_EDGE/blog/entries" "$TMP_BASE/retry.out" "$TMP_BASE/args-retry.txt"
+echo "--- Test 1e: runtime-stdout ArtifactPublished evidence is rejected ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_BASE/runtime-stdout-events.jsonl"
+import importlib.machinery
+import importlib.util
 import json
+import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
-dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
-events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
-entries_dir = Path(sys.argv[3])
-runner_stdout = Path(sys.argv[4]).read_text(encoding="utf-8")
-args_log = Path(sys.argv[5]).read_text(encoding="utf-8")
+edge_dir = Path(sys.argv[1])
+events_path = Path(sys.argv[2])
+cycle_id = "cycle-runtime-stdout"
+events_path.write_text(
+    json.dumps({
+        "ts": "2026-05-03T00:00:10+00:00",
+        "type": "PhaseCompleted",
+        "cycle_id": cycle_id,
+        "artifact": "blog/entries/runtime.md",
+        "payload": {
+            "pipeline": "runtime-stdout-artifact",
+            "phase": "pipeline",
+            "ok": True,
+            "auto_published": True,
+        },
+    }) + "\n" +
+    json.dumps({
+        "ts": "2026-05-03T00:00:11+00:00",
+        "type": "ArtifactPublished",
+        "cycle_id": cycle_id,
+        "artifact": "blog/entries/runtime.md",
+        "payload": {
+            "source_skill": "report",
+            "pipeline": "runtime-stdout-artifact",
+            "auto_published": True,
+        },
+    }) + "\n",
+    encoding="utf-8",
+)
 
-assert dispatch["request"]["skill"] == "research"
-assert dispatch["state"]["active"] is False
-assert dispatch["state"]["close_status"] == "completed"
-assert args_log.count("__INVOCATION__") == 2
-assert "ARTIFACT SUPERVISOR RETRY" in args_log
-retry_started = [
-    event for event in events
-    if event.get("type") == "ArtifactSupervisionRetryStarted"
-    and event.get("cycle_id") == dispatch["cycle_id"]
-]
-retry_completed = [
-    event for event in events
-    if event.get("type") == "ArtifactSupervisionRetryCompleted"
-    and event.get("cycle_id") == dispatch["cycle_id"]
-]
-assert retry_started
-assert retry_completed
-assert retry_completed[-1]["payload"]["published"] is True
-published = [
-    event for event in events
-    if event.get("type") == "ArtifactPublished"
-    and event.get("cycle_id") == dispatch["cycle_id"]
-]
-assert published
-artifact = published[-1]["artifact"]
-entry = entries_dir / Path(artifact).name
-assert "Retry Published Report" in entry.read_text(encoding="utf-8")
-assert "edge-runner: published artifact blog/entries/" in runner_stdout
-assert "Frostpeck" not in runner_stdout
+loader = importlib.machinery.SourceFileLoader("edge_runner", str(edge_dir / "tools" / "edge-runner"))
+spec = importlib.util.spec_from_loader("edge_runner", loader)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+module.STATE_EVENTS_FILE = events_path
+module.read_dispatch_state = lambda: {
+    "cycle_id": cycle_id,
+    "request": {"skill": "report"},
+    "state": {"skill_dispatched": True, "dispatched_at": "2026-05-03T00:00:00+00:00"},
+}
+assert module.artifact_published_for_cycle(cycle_id) is False
+
+sys.path.insert(0, str(edge_dir / "tools"))
+from _shared.artifact_supervisor import supervise_artifact_publication
+
+result = supervise_artifact_publication(
+    {
+        "cycle_id": cycle_id,
+        "request": {"skill": "report"},
+        "state": {"skill_dispatched": True, "dispatched_at": "2026-05-03T00:00:00+00:00"},
+    },
+    events_path=events_path,
+)
+assert result["ok"] is False
+assert result["status"] == "blocked"
+assert result["reason"] == "pipeline_blocked_before_publish"
+assert result["pipeline_evidence"]["reason"] == "runtime_stdout_artifact_rejected"
 PY
 then
-    pass "artifact supervisor retries acknowledgement-only backend failure"
+    pass "runtime-stdout ArtifactPublished is rejected as publication evidence"
 else
-    fail "artifact supervisor retries acknowledgement-only backend failure"
+    fail "runtime-stdout ArtifactPublished is rejected as publication evidence"
 fi
 
 echo "--- Test 2: dispatched skill success without artifact closes as failed ---"
@@ -889,7 +898,7 @@ unset MOCK_CLAUDE_HEARTBEAT_FLOW || true
 unset MOCK_CLAUDE_EXIT_CODE || true
 export MOCK_CLAUDE_SLEEP_SECONDS=2
 export MOCK_CLAUDE_PHASE_PROGRESS_ON_START=1
-export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'# Progress Grace Report\n\nThis artifact proves the backend was allowed to finish after the initial timeout because consolidate-state had recent phase progress.'
+export MOCK_CLAUDE_HEARTBEAT_FLOW=1
 export EDGE_RUNNER_SKILL_TIMEOUT_SEC=1
 export EDGE_RUNNER_TIMEOUT_PROGRESS_GRACE_SEC=4
 export EDGE_RUNNER_TIMEOUT_PROGRESS_MAX_EXTENSIONS=1
@@ -903,7 +912,7 @@ export EDGE_RUNNER_TIMEOUT_PROGRESS_MAX_EXTENSIONS=1
     --dispatch-force >/dev/null
 unset MOCK_CLAUDE_SLEEP_SECONDS || true
 unset MOCK_CLAUDE_PHASE_PROGRESS_ON_START || true
-unset MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
+unset MOCK_CLAUDE_HEARTBEAT_FLOW || true
 unset EDGE_RUNNER_SKILL_TIMEOUT_SEC || true
 unset EDGE_RUNNER_TIMEOUT_PROGRESS_GRACE_SEC || true
 unset EDGE_RUNNER_TIMEOUT_PROGRESS_MAX_EXTENSIONS || true

--- a/tests/test_pipeline_state_projection.sh
+++ b/tests/test_pipeline_state_projection.sh
@@ -17,6 +17,8 @@ cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
 {"ts":"2026-04-26T13:01:00+00:00","type":"ArtifactPublished","actor":"continuity","cycle_id":"cycle-failed","artifact":"blog/entries/failed.md","payload":{"hash":"sha256:failed","source_skill":"report"},"prev_hash":"sha256:f"}
 {"ts":"2026-04-26T14:00:00+00:00","type":"ArtifactPublished","actor":"continuity","cycle_id":"cycle-orphan","artifact":"blog/entries/orphan.md","payload":{"hash":"sha256:orphan","source_skill":"reflection"},"prev_hash":"sha256:g"}
 {"ts":"2026-04-26T15:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-no-artifact","payload":{"pipeline":"consolidate-state","phase":"1","ok":true},"prev_hash":"sha256:h"}
+{"ts":"2026-04-26T16:00:00+00:00","type":"PhaseCompleted","actor":"edge-runner","cycle_id":"cycle-runtime","artifact":"blog/entries/runtime.md","payload":{"pipeline":"runtime-stdout-artifact","phase":"pipeline","ok":true,"auto_published":true},"prev_hash":"sha256:i"}
+{"ts":"2026-04-26T16:01:00+00:00","type":"ArtifactPublished","actor":"continuity","cycle_id":"cycle-runtime","artifact":"blog/entries/runtime.md","payload":{"hash":"sha256:runtime","source_skill":"report","pipeline":"runtime-stdout-artifact","auto_published":true},"prev_hash":"sha256:j"}
 JSONL
 
 echo "=== pipeline state projection test ==="
@@ -33,14 +35,15 @@ projection = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 summary = projection["summary"]
 by_artifact = {item["artifact"]: item for item in projection["recent_artifacts"]}
 
-assert summary["artifacts_total"] == 5, summary
-assert summary["artifacts_attention"] == 4, summary
+assert summary["artifacts_total"] == 6, summary
+assert summary["artifacts_attention"] == 5, summary
 assert summary["orphan_events_without_artifact"] == 1, summary
 assert summary["counts_by_status"]["complete"] == 1, summary
 assert summary["counts_by_status"]["partial"] == 1, summary
 assert summary["counts_by_status"]["blocked"] == 1, summary
 assert summary["counts_by_status"]["failed"] == 1, summary
 assert summary["counts_by_status"]["orphaned_publish"] == 1, summary
+assert summary["counts_by_status"]["runtime_bypass"] == 1, summary
 
 complete = by_artifact["blog/entries/complete.md"]
 assert complete["status"] == "complete"
@@ -65,6 +68,12 @@ assert failed["reasons"] == ["state_audit_failed"]
 orphaned = by_artifact["blog/entries/orphan.md"]
 assert orphaned["status"] == "orphaned_publish"
 assert orphaned["event_counts"]["PhaseCompleted"] == 0
+
+runtime = by_artifact["blog/entries/runtime.md"]
+assert runtime["status"] == "runtime_bypass"
+assert runtime["published"] is False
+assert runtime["runtime_stdout_artifact"] is True
+assert runtime["reasons"] == ["runtime_stdout_artifact_rejected"]
 PY
 
 EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" \
@@ -74,8 +83,8 @@ python3 - <<'PY' /tmp/edge-replay-pipeline-state.json
 import json
 import sys
 payload = json.load(open(sys.argv[1], encoding="utf-8"))
-assert payload["summary"]["artifacts_total"] == 5
-assert payload["summary"]["artifacts_attention"] == 4
+assert payload["summary"]["artifacts_total"] == 6
+assert payload["summary"]["artifacts_attention"] == 5
 PY
 
 SUMMARY_OUTPUT="$(EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$EDGE_DIR/tools/edge-replay" pipeline-state --no-write)"

--- a/tools/_shared/artifact_supervisor.py
+++ b/tools/_shared/artifact_supervisor.py
@@ -79,6 +79,13 @@ def _pipeline_failure_evidence(event: dict[str, Any], payload: dict[str, Any]) -
     }
 
 
+def _is_runtime_stdout_artifact(payload: dict[str, Any]) -> bool:
+    return bool(
+        payload.get("auto_published") is True
+        or str(payload.get("pipeline") or "") == "runtime-stdout-artifact"
+    )
+
+
 def _base_result(state: dict[str, Any], *, instance: object) -> dict[str, Any]:
     request = state.get("request", {}) or {}
     state_block = state.get("state", {}) or {}
@@ -132,6 +139,17 @@ def supervise_artifact_publication(
         artifact = _artifact(event, payload)
 
         if etype == "ArtifactPublished" and artifact.startswith("blog/entries/"):
+            if _is_runtime_stdout_artifact(payload):
+                if pipeline_failure is None:
+                    pipeline_failure = {
+                        "event_type": etype,
+                        "ts": event.get("ts") or "",
+                        "artifact": artifact,
+                        "pipeline": str(payload.get("pipeline") or "runtime-stdout-artifact"),
+                        "phase": "",
+                        "reason": "runtime_stdout_artifact_rejected",
+                    }
+                continue
             result.update(
                 {
                     "ok": True,

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -2361,7 +2361,8 @@ def render_skill_runtime_prompt(skill: str, state: dict[str, Any]) -> str:
             "- This invocation must end with a durable artifact or a concrete failure report artifact. Acknowledgement-only text, standby text, topic-choice lists, or deference to another session is not completion.\n"
             "- If no explicit topic was supplied, infer one bounded target from `exploration_pack`, `beat_launch_context`, `operator_pressure`, health, open gaps, queue, or recent failures.\n"
             "- If another persona/session appears active, treat that as context only; the runtime already prevented unsafe concurrent dispatch ownership before invoking you.\n"
-            "- If the full publication pipeline cannot run, emit a complete Markdown artifact in stdout with a top-level `#` heading so the runtime can publish it.\n\n"
+            "- Publish by running `consolidate-state` or an equivalent first-class artifact publisher that emits real blog entry and report artifacts.\n"
+            "- Stdout-only prose is diagnostic output only; the runtime will not promote it to publication and it does not satisfy the artifact gate.\n\n"
         )
     return (
         f"{skill}\n\n"

--- a/tools/_shared/skill_policy.py
+++ b/tools/_shared/skill_policy.py
@@ -49,4 +49,11 @@ def skill_requires_artifact_publication(skill: object, *, instance: object = "")
 
 
 def skill_accepts_stdout_artifact(skill: object, *, instance: object = "") -> bool:
-    return skill_requires_artifact_publication(skill, instance=instance)
+    """Return whether stdout can be auto-promoted to a durable artifact.
+
+    Artifact-producing skills must publish through the real artifact pipeline
+    (`consolidate-state` or an equivalent first-class publisher). Capturing
+    terminal prose into a minimal runtime HTML wrapper hides publication
+    failures and lets poor reports bypass review/render gates.
+    """
+    return False

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -22,9 +22,8 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import EDGE_INSTANCE, EDGE_REPO_DIR, ENTRIES_DIR, REPORTS_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
+from paths import EDGE_INSTANCE, EDGE_REPO_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
-from _shared.artifact_runtime import publish_stdout_artifact  # noqa: E402
 from _shared.dispatch_runtime import HEARTBEAT_FAIRNESS_SKILLS, read_dispatch_state, render_skill_runtime_prompt, write_dispatch_state  # noqa: E402
 from _shared.jsonl_runtime import iter_jsonl_reverse  # noqa: E402
 from _shared.skill_policy import skill_accepts_stdout_artifact, skill_requires_artifact_publication  # noqa: E402
@@ -816,33 +815,44 @@ def artifact_published_for_cycle(cycle_id: str | None) -> bool:
             continue
         if threshold and not iso_ge(event.get("ts"), threshold):
             continue
-        artifact = str(event.get("artifact") or (event.get("payload", {}) or {}).get("artifact") or "")
-        if artifact.startswith("blog/entries/"):
+        payload = event.get("payload", {}) or {}
+        artifact = str(event.get("artifact") or payload.get("artifact") or "")
+        if artifact.startswith("blog/entries/") and not _is_runtime_stdout_artifact(payload):
             return True
     return False
+
+
+def _is_runtime_stdout_artifact(payload: dict) -> bool:
+    payload = payload or {}
+    return bool(
+        payload.get("auto_published") is True
+        or str(payload.get("pipeline") or "") == "runtime-stdout-artifact"
+    )
 
 
 def maybe_publish_stdout_artifact(skill: str, cycle_id: str | None, exit_code: int, output: str) -> dict:
     if not cycle_id or exit_code != 0:
         return {"published": False, "reason": "not_publishable_exit", "skill": normalize_skill_name(skill)}
     normalized = normalize_skill_name(skill)
-    if not skill_accepts_stdout_artifact(normalized, instance=EDGE_INSTANCE):
+    if not skill_requires_artifact_publication(normalized, instance=EDGE_INSTANCE):
         return {"published": False, "reason": "skill_not_artifact_pipeline", "skill": normalized}
     if artifact_published_for_cycle(cycle_id):
         return {"published": True, "reason": "already_published", "skill": normalized}
-    result = publish_stdout_artifact(
-        skill=normalized,
+    result = {"published": False, "reason": "stdout_artifact_disabled", "skill": normalized}
+    emit_shadow_event(
+        "ArtifactStdoutPublicationRejected",
+        actor="edge-runner",
         cycle_id=cycle_id,
-        output=output,
-        entries_dir=ENTRIES_DIR,
-        reports_dir=REPORTS_DIR,
-        instance=EDGE_INSTANCE,
+        payload={
+            "skill": normalized,
+            "reason": "stdout_artifact_disabled",
+            "output_bytes": len((output or "").encode("utf-8", errors="replace")),
+        },
     )
-    status = "completed" if result.get("published") else "warning"
     log_run_step(
         "edge-runner",
         "stdout_artifact_publish",
-        status,
+        "blocked",
         run_id=cycle_id,
         backend="runtime",
         mode="artifact",
@@ -871,7 +881,8 @@ def build_artifact_supervisor_retry_prompt(
         "- This is a substantive artifact-producing skill invocation, not an acknowledgement channel.\n"
         "- Do not answer with only deference, standby text, topic choices, or a refusal to act because another persona/session appears active.\n"
         "- If no explicit topic was supplied, infer one bounded target from the runtime frame: exploration_pack, beat_launch_context, operator_pressure, health, open gaps, queue, or recent failures.\n"
-        "- Produce a durable artifact now. If the full publication pipeline is unavailable, emit a complete Markdown artifact in stdout with a top-level `#` heading so the runtime can publish it.\n"
+        "- Produce a durable artifact now by running `consolidate-state` with a real blog entry and report artifact.\n"
+        "- Stdout-only prose is diagnostic output only; it does not publish and does not satisfy the artifact gate.\n"
         "- If a real blocker remains, the artifact must be a failure report with the concrete command, missing access, or invariant that blocked completion.\n\n"
         "Previous backend output:\n"
         "```text\n"

--- a/tools/rollup-pipeline-state.py
+++ b/tools/rollup-pipeline-state.py
@@ -74,6 +74,13 @@ def _phase_ok(payload: dict[str, Any]) -> bool | None:
     return None
 
 
+def _is_runtime_stdout_artifact(payload: dict[str, Any]) -> bool:
+    return bool(
+        payload.get("auto_published") is True
+        or str(payload.get("pipeline") or "") == "runtime-stdout-artifact"
+    )
+
+
 def _build_empty_artifact(artifact: str) -> dict[str, Any]:
     return {
         "artifact": artifact,
@@ -86,6 +93,7 @@ def _build_empty_artifact(artifact: str) -> dict[str, Any]:
         "last_event_at": "",
         "published_at": "",
         "published": False,
+        "runtime_stdout_artifact": False,
         "terminal_phase_status": "",
         "terminal_phase_at": "",
         "phase_counts": {"ok": 0, "failed": 0, "unknown": 0},
@@ -116,7 +124,10 @@ def _apply_phase_completed(record: dict[str, Any], event: dict[str, Any], payloa
     record["event_counts"]["PhaseCompleted"] = int(record["event_counts"].get("PhaseCompleted") or 0) + 1
     _merge_first(record, "pipeline", payload.get("pipeline"))
 
-    ok = _phase_ok(payload)
+    runtime_stdout = _is_runtime_stdout_artifact(payload)
+    if runtime_stdout:
+        record["runtime_stdout_artifact"] = True
+    ok = False if runtime_stdout else _phase_ok(payload)
     if ok is True:
         phase_status = "ok"
     elif ok is False:
@@ -126,6 +137,8 @@ def _apply_phase_completed(record: dict[str, Any], event: dict[str, Any], payloa
     record["phase_counts"][phase_status] = int(record["phase_counts"].get(phase_status) or 0) + 1
 
     reason = str(payload.get("reason") or payload.get("error") or "").strip()
+    if runtime_stdout and not reason:
+        reason = "runtime_stdout_artifact_rejected"
     if reason:
         record["reasons"].append(reason)
 
@@ -149,7 +162,13 @@ def _apply_phase_completed(record: dict[str, Any], event: dict[str, Any], payloa
 def _apply_artifact_published(record: dict[str, Any], event: dict[str, Any], payload: dict[str, Any]) -> None:
     _touch_artifact(record, event)
     record["event_counts"]["ArtifactPublished"] = int(record["event_counts"].get("ArtifactPublished") or 0) + 1
-    record["published"] = True
+    runtime_stdout = _is_runtime_stdout_artifact(payload)
+    if runtime_stdout:
+        record["runtime_stdout_artifact"] = True
+        if "runtime_stdout_artifact_rejected" not in record["reasons"]:
+            record["reasons"].append("runtime_stdout_artifact_rejected")
+    else:
+        record["published"] = True
     if not record.get("published_at") or _timestamp(event) >= str(record.get("published_at") or ""):
         record["published_at"] = _timestamp(event)
     _merge_first(record, "source_skill", payload.get("source_skill") or payload.get("skill"))
@@ -162,6 +181,8 @@ def _classify(record: dict[str, Any]) -> str:
     failed = int((record.get("phase_counts") or {}).get("failed") or 0) > 0
     terminal = str(record.get("terminal_phase_status") or "").strip()
 
+    if record.get("runtime_stdout_artifact"):
+        return "runtime_bypass"
     if published and phase_total == 0:
         return "orphaned_publish"
     if terminal == "ok":
@@ -213,7 +234,7 @@ def build_projection(limit: int = 50, events_path: Path = STATE_EVENTS_FILE) -> 
         key=lambda item: item.get("last_event_at") or item.get("published_at") or item.get("first_event_at") or "",
         reverse=True,
     )
-    attention_statuses = {"partial", "blocked", "failed", "orphaned_publish", "unknown"}
+    attention_statuses = {"partial", "blocked", "failed", "orphaned_publish", "runtime_bypass", "unknown"}
     attention = [item for item in ordered if item.get("status") in attention_statuses]
     counts_by_status: dict[str, int] = {}
     counts_by_pipeline: dict[str, int] = {}


### PR DESCRIPTION
## Summary

Blocks the runtime stdout artifact bypass that was letting artifact-producing skills close with minimal HTML reports instead of durable `consolidate-state` publications.

## Root Cause

`edge-runner` could auto-promote backend stdout into `runtime-stdout-artifact` blog entries and reports when a skill exited successfully without a real artifact. The artifact supervisor and pipeline projection then accepted those runtime artifacts as valid publication evidence, so bad reports could close cycles without passing the real publication path.

## Changes

- Disable stdout auto-promotion for artifact-producing skills.
- Reject `runtime-stdout-artifact` evidence in `edge-runner` and `artifact_supervisor`.
- Mark runtime stdout artifacts as `runtime_bypass` attention items in `rollup-pipeline-state.py`.
- Update the runtime artifact contract to require `consolidate-state` or an equivalent first-class publisher.
- Update smoke/projection tests to cover durable artifacts and reject stdout-only publication.

## Validation

- `python3 -m py_compile tools/edge-runner tools/_shared/skill_policy.py tools/_shared/artifact_supervisor.py tools/_shared/dispatch_runtime.py tools/rollup-pipeline-state.py`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_pipeline_state_projection.sh`
- `bash tests/test_postflight_pipeline_state.sh`
- `bash tests/test_report_publication_completion.sh`
- `bash tests/test_research_publication_completion.sh`