### PR TITLE
[codex] Restore durable artifact supervisor retry

### DIFF
--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -170,6 +170,13 @@ if [ "${MOCK_CLAUDE_FAIL_ONCE:-0}" = "1" ]; then
     exit "${MOCK_CLAUDE_FAIL_ONCE_EXIT_CODE:-1}"
   fi
 fi
+if [ "${MOCK_CLAUDE_SKIP_ARTIFACT_ONCE:-0}" = "1" ]; then
+  INVOCATIONS="$(grep -c '^__INVOCATION__$' "${MOCK_CLAUDE_ARGS_OUT:?}" 2>/dev/null || true)"
+  if [ "$INVOCATIONS" = "1" ]; then
+    printf '%s\n' "${MOCK_CLAUDE_SKIP_ARTIFACT_ONCE_OUTPUT:-consolidate-state failed before durable publication; retry required}"
+    exit 0
+  fi
+fi
 prompt_has_skill() {
   local skill="$1"
   [[ "$PROMPT" == *"/$skill"* || "$PROMPT" == "$skill"$'\n'* ]]
@@ -647,6 +654,70 @@ then
     pass "runtime-stdout ArtifactPublished is rejected as publication evidence"
 else
     fail "runtime-stdout ArtifactPublished is rejected as publication evidence"
+fi
+
+echo "--- Test 1f: artifact supervisor retry still requires durable publication ---"
+export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id-durable-retry.txt"
+export MOCK_CLAUDE_ARGS_OUT="$TMP_BASE/args-durable-retry.txt"
+rm -f "$MOCK_CLAUDE_ENV_OUT" "$MOCK_CLAUDE_ARGS_OUT" "$TMP_BASE/durable-retry.out"
+export MOCK_CLAUDE_SKIP_ARTIFACT_ONCE=1
+export MOCK_CLAUDE_HEARTBEAT_FLOW=1
+"$RUNNER_TOOL" skill \
+    --skill /research \
+    --dispatch-trigger operator \
+    --dispatch-policy operator \
+    --dispatch-routing-mode explicit \
+    --dispatch-preflight-profile heartbeat_default \
+    --dispatch-postflight-profile standard \
+    --dispatch-force >"$TMP_BASE/durable-retry.out"
+unset MOCK_CLAUDE_SKIP_ARTIFACT_ONCE MOCK_CLAUDE_HEARTBEAT_FLOW || true
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$TMP_BASE/durable-retry.out" "$TMP_BASE/args-durable-retry.txt"
+import json
+import sys
+from pathlib import Path
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+runner_stdout = Path(sys.argv[3]).read_text(encoding="utf-8")
+args_log = Path(sys.argv[4]).read_text(encoding="utf-8")
+cycle_id = dispatch["cycle_id"]
+
+assert dispatch["request"]["skill"] == "research"
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "completed"
+assert args_log.count("__INVOCATION__") == 2
+assert "ARTIFACT SUPERVISOR RETRY" in args_log
+assert "Stdout-only prose is diagnostic output only" in args_log
+assert "runtime can publish it" not in args_log
+retry_started = [
+    event for event in events
+    if event.get("type") == "ArtifactSupervisionRetryStarted"
+    and event.get("cycle_id") == cycle_id
+]
+retry_completed = [
+    event for event in events
+    if event.get("type") == "ArtifactSupervisionRetryCompleted"
+    and event.get("cycle_id") == cycle_id
+]
+assert retry_started
+assert retry_started[-1]["payload"]["publish_reason"] == "stdout_artifact_disabled"
+assert retry_completed
+assert retry_completed[-1]["payload"]["published"] is True
+published = [
+    event for event in events
+    if event.get("type") == "ArtifactPublished"
+    and event.get("cycle_id") == cycle_id
+]
+assert published
+assert all((event.get("payload") or {}).get("auto_published") is not True for event in published)
+assert all((event.get("payload") or {}).get("pipeline") != "runtime-stdout-artifact" for event in published)
+assert "edge-runner: published artifact blog/entries/" not in runner_stdout
+PY
+then
+    pass "artifact supervisor retry publishes only durable artifacts"
+else
+    fail "artifact supervisor retry publishes only durable artifacts"
 fi
 
 echo "--- Test 2: dispatched skill success without artifact closes as failed ---"

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -895,13 +895,11 @@ def should_retry_artifact_skill(skill: str | None, cycle_id: str | None, exit_co
     if not cycle_id:
         return False
     normalized = normalize_skill_name(skill)
-    if not skill_accepts_stdout_artifact(normalized, instance=EDGE_INSTANCE):
+    if not skill_requires_artifact_publication(normalized, instance=EDGE_INSTANCE):
         return False
     if artifact_published_for_cycle(cycle_id):
         return False
-    if exit_code != 0:
-        return True
-    return str(publish_result.get("reason") or "") == "missing_markdown_artifact"
+    return not bool(publish_result.get("published"))
 
 
 def should_echo_backend_output(skill: str | None) -> bool:


### PR DESCRIPTION
## Summary

Restores the artifact supervisor retry path for artifact-producing skills while keeping runtime stdout publication blocked.

Closes #512.

## Root Cause

PR #511 correctly disabled stdout auto-publication, but `should_retry_artifact_skill()` still used `skill_accepts_stdout_artifact()` as its retry eligibility check. Since stdout is now never accepted, the supervisor retry became unreachable for substantive skills. Fleet heartbeat exposed this as `pipeline_blocked_before_publish` after `consolidate-state` failures, with stdout rejected and no second attempt.

## Changes

- Retry eligibility now uses `skill_requires_artifact_publication()`.
- If no durable artifact has been published for the cycle, the runner retries once with the durable-publication retry prompt.
- Added a smoke test proving the retry path publishes only a first-class `ArtifactPublished` event and never `runtime-stdout-artifact`.

## Validation

- `python3 -m py_compile tools/edge-runner`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_pipeline_state_projection.sh`