### PR TITLE
[codex] Emit consolidate ArtifactPublished fact

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -141,6 +141,93 @@ if status in {"completed", "failed", "degraded"} and (phase == "pipeline" or pha
 PYEOF
 }
 
+emit_artifact_published_event() {
+    python3 - "$SLUG" "${REPORT_FILENAME:-}" "$ENTRIES_DIR" "$ENTRY_PATH" <<'PYEOF' 2>/dev/null || true
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+slug, report_filename, entries_dir, staging_entry = sys.argv[1:5]
+tools_dir = Path(
+    os.environ.get("TOOLS_DIR")
+    or (
+        Path(
+            os.environ.get(
+                "EDGE_REPO_DIR",
+                os.environ.get("EDGE_DIR", str(Path.home() / "edge")),
+            )
+        ).expanduser()
+        / "tools"
+    )
+)
+sys.path.insert(0, str(tools_dir))
+try:
+    from _shared.telemetry import emit_shadow_event
+except Exception:
+    sys.exit(0)
+
+entry_path = Path(entries_dir) / f"{slug}.md"
+if not entry_path.exists() and staging_entry:
+    entry_path = Path(staging_entry)
+if not entry_path.exists():
+    sys.exit(0)
+
+raw_bytes = entry_path.read_bytes()
+raw = raw_bytes.decode("utf-8", errors="replace")
+frontmatter = {}
+if raw.startswith("---"):
+    try:
+        import yaml
+
+        parts = raw.split("---", 2)
+        frontmatter = yaml.safe_load(parts[1]) or {} if len(parts) >= 3 else {}
+    except Exception:
+        frontmatter = {}
+
+if not isinstance(frontmatter, dict):
+    frontmatter = {}
+
+source_skill = str(frontmatter.get("source_skill") or frontmatter.get("skill") or "").strip()
+if not source_skill:
+    known_skills = {"autonomy", "discovery", "planner", "report", "research", "sources"}
+    tags = frontmatter.get("tags") or []
+    if isinstance(tags, str):
+        tags = [tags]
+    for value in list(tags) + slug.split("-"):
+        token = str(value).strip()
+        if token in known_skills:
+            source_skill = token
+            break
+
+threads = frontmatter.get("threads") or []
+if isinstance(threads, str):
+    threads = [threads]
+elif not isinstance(threads, list):
+    threads = []
+
+digest = hashlib.sha256(raw_bytes).hexdigest()
+payload = {
+    "hash": f"sha256:{digest}",
+    "source_skill": source_skill,
+    "title": str(frontmatter.get("title") or entry_path.stem).strip(),
+    "pipeline": "consolidate-state",
+    "slug": slug,
+    "threads": [str(thread).strip() for thread in threads if str(thread).strip()],
+}
+if report_filename:
+    payload["report"] = report_filename
+
+emit_shadow_event(
+    "ArtifactPublished",
+    actor="consolidate-state",
+    artifact=f"blog/entries/{slug}.md",
+    cycle_id=os.environ.get("EDGE_CYCLE_ID") or None,
+    payload=payload,
+)
+PYEOF
+}
+
 run_adversarial_gate_review() {
     local review_question="${1:-}"
     local review_output=""
@@ -1759,6 +1846,7 @@ if $ALL_OK && [[ "$REPORT_RESULT" != "fail" ]]; then
     mkdir -p "$HEALTH_OK"
     printf '{"ts":"%s","slug":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SLUG" > "$HEALTH_OK/consolidate.ok"
     ledger_record "pipeline-end" "ok"
+    emit_artifact_published_event
     emit_run_step_event "pipeline" "completed" "pipeline_end" ""
     exit 0
 elif $ALL_OK; then

--- a/tests/test_consolidate_phase6_paths.sh
+++ b/tests/test_consolidate_phase6_paths.sh
@@ -25,6 +25,8 @@ audit_use = first_index('if audit_path.exists():')
 non_git_diff_guard = first_index('skipping scoped diff')
 non_git_commit_guard = first_index('skipping git commit')
 partial_degraded = first_index('emit_run_step_event "pipeline" "degraded" "pipeline_end" "partial publication"')
+complete_artifact_published = first_index('    emit_artifact_published_event')
+complete_pipeline_end = first_index('emit_run_step_event "pipeline" "completed" "pipeline_end" ""')
 report_materialization = first_index('emit_run_step_event "phase-0.9" "started" "report_materialization"')
 blog_publish = first_index('emit_run_step_event "phase-1" "started" "blog_publish"')
 report_confirmation = first_index('emit_run_step_event "phase-2" "started" "report_generation"')
@@ -47,6 +49,9 @@ assert phase6_start < audit_definition < audit_use, (
 assert phase6_start < non_git_diff_guard, "non-git EDGE_REPO_DIR must skip scoped diff in phase 6"
 assert phase6_start < non_git_commit_guard, "non-git EDGE_REPO_DIR must skip git commit in phase 6"
 assert phase6_start < partial_degraded, "partial publication must be degraded, not a hard pipeline failure"
+assert complete_artifact_published < complete_pipeline_end, (
+    "complete consolidate-state publications must emit ArtifactPublished before terminal pipeline_end"
+)
 assert materialize_function < report_materialization < blog_publish, (
     "report materialization must happen before blog publish so entries cannot be published without reports"
 )

--- a/tests/test_edge_close.sh
+++ b/tests/test_edge_close.sh
@@ -401,6 +401,38 @@ else
     fail "edge-close reports failed pipeline evidence through artifact supervision"
 fi
 
+echo "--- Test 2f: durable publication overrides earlier failed phase evidence ---"
+"$DISPATCH_TOOL" open --trigger operator --cycle-id cycle-close-published-after-failure --force >/dev/null
+"$DISPATCH_TOOL" dispatch --skill research >/dev/null
+append_skill_completed cycle-close-published-after-failure research
+append_phase_failed cycle-close-published-after-failure recovered-report scratchpad_archive_failed
+append_artifact_published cycle-close-published-after-failure research recovered-report
+"$CLOSE_TOOL" --status completed >/dev/null
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "completed"
+assert dispatch["state"].get("artifact_supervision_status") == "published"
+completed = [
+    event for event in events
+    if event.get("cycle_id") == "cycle-close-published-after-failure"
+    and event.get("type") == "ArtifactSupervisionCompleted"
+]
+assert completed
+assert completed[-1]["artifact"] == "blog/entries/recovered-report.md"
+PY
+then
+    pass "durable publication wins over earlier failed phase evidence"
+else
+    fail "durable publication wins over earlier failed phase evidence"
+fi
+
 echo "--- Test 3: completed close succeeds with skill end evidence, artifact publication, and postflight ---"
 "$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-complete --force >/dev/null
 "$DISPATCH_TOOL" dispatch --skill discovery >/dev/null


### PR DESCRIPTION
## Summary
- emit a canonical `ArtifactPublished` event when `consolidate-state` reaches a complete publish
- include the final entry hash, source skill, threads, report name, slug, and `pipeline=consolidate-state`
- cover the close-gate behavior where a durable publication overrides earlier failed phase evidence in the same cycle

## Root Cause
A complete `consolidate-state` run could append terminal `PhaseCompleted` evidence without a cycle-local durable `ArtifactPublished` fact. The stricter artifact supervisor then blocked close as `pipeline_blocked_before_publish` even though the content had passed the publication pipeline.

Closes #514.

## Validation
- `bash -n blog/consolidate-state.sh`
- `bash -n tests/test_edge_close.sh`
- `bash -n tests/test_consolidate_phase6_paths.sh`
- `bash tests/test_consolidate_phase6_paths.sh`
- `bash tests/test_pipeline_state_projection.sh`
- `bash tests/test_postflight_pipeline_state.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_edge_runner.sh`