### PR TITLE
[codex] Skip same-file blog publish copy

### DIFF
--- a/blog/blog-publish.sh
+++ b/blog/blog-publish.sh
@@ -116,11 +116,22 @@ if [[ -z "${CALLED_FROM_CONSOLIDAR_ESTADO:-}" && -z "${CALLED_FROM_FULL_PUBLISH:
     exit 1
 fi
 
-if [[ "$ENTRY_PATH" != "$CANONICAL_ENTRY_PATH" ]]; then
-    mkdir -p "$ENTRIES_DIR"
+resolve_publish_path() {
+    python3 - "$1" <<'PYEOF'
+import sys
+from pathlib import Path
+
+print(Path(sys.argv[1]).expanduser().resolve(strict=False))
+PYEOF
+}
+
+mkdir -p "$ENTRIES_DIR"
+ENTRY_REAL_PATH="$(resolve_publish_path "$ENTRY_PATH")"
+CANONICAL_REAL_PATH="$(resolve_publish_path "$CANONICAL_ENTRY_PATH")"
+if [[ "$ENTRY_REAL_PATH" != "$CANONICAL_REAL_PATH" ]]; then
     cp "$ENTRY_PATH" "$CANONICAL_ENTRY_PATH"
-    ENTRY_PATH="$CANONICAL_ENTRY_PATH"
 fi
+ENTRY_PATH="$CANONICAL_ENTRY_PATH"
 
 echo "=== blog-publish: $SLUG ==="
 emit_publish_event "started" "publish_start" ""

--- a/tests/test_blog_publish_branding.sh
+++ b/tests/test_blog_publish_branding.sh
@@ -109,6 +109,52 @@ else
     fail "blog-publish reaches the normal publish flow without codename"
 fi
 
+echo "--- Test 3: blog-publish skips same-file canonical copy ---"
+mkdir -p "$TMP_RUNTIME/blog/entries"
+CANONICAL_ENTRY="$TMP_RUNTIME/blog/entries/same-file-smoke.md"
+cat >"$CANONICAL_ENTRY" <<'EOF'
+---
+title: "Same File Smoke"
+date: 2026-05-03
+tags: [blog-publish]
+threads: [issue-516]
+keywords: [blog-publish, same-file, canonical]
+report: reports/same-file.html
+---
+
+This smoke test entry is already inside the canonical blog entries directory.
+Publishing it must not try to copy the file onto itself.
+EOF
+
+set +e
+OUTPUT=$(env -u EDGE_STATE_DIR -u EDGE_HOME -u EDGE_CODENAME -u EDGE_INSTANCE HOME="$TMP_HOME" EDGE_REPO_DIR="$TMP_RUNTIME" CALLED_FROM_CONSOLIDAR_ESTADO=1 bash "$EDGE_DIR/blog/blog-publish.sh" "$CANONICAL_ENTRY" 2>&1)
+STATUS=$?
+set -e
+
+if python3 - <<'PY' "$STATUS" "$OUTPUT" "$TMP_RUNTIME/blog/changelog.md" "$CANONICAL_ENTRY"
+import pathlib
+import sys
+
+status = int(sys.argv[1])
+output = sys.argv[2]
+changelog = pathlib.Path(sys.argv[3])
+entry = pathlib.Path(sys.argv[4])
+
+assert status == 1
+assert "=== blog-publish: same-file-smoke ===" in output
+assert "are the same file" not in output.lower()
+assert "cp:" not in output.lower()
+assert "Publish verification failed" in output
+assert entry.exists()
+assert "Same File Smoke" in changelog.read_text(encoding="utf-8")
+PY
+then
+    pass "blog-publish treats canonical same-file publish as idempotent"
+else
+    echo "$OUTPUT"
+    fail "blog-publish treats canonical same-file publish as idempotent"
+fi
+
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS  FAIL: $FAIL"


### PR DESCRIPTION
## Summary
- resolve source and canonical blog entry paths before copying in `blog-publish.sh`
- skip the copy when the entry is already in the canonical `blog/entries` location
- add a regression smoke test for publishing an entry already inside the final entries directory

## Root Cause
Fleet heartbeat on petertosh exposed that `blog-publish.sh` can attempt `cp source destination` where both paths refer to the same file. In instances where `EDGE_STATE_DIR == EDGE_REPO_DIR`, this makes `cp` return non-zero, so `consolidate-state` records phase `1` as failed and `edge-close` blocks with `pipeline_blocked_before_publish` even though the artifact is materialized.

Closes #516.

## Validation
- `bash -n blog/blog-publish.sh`
- `bash -n tests/test_blog_publish_branding.sh`
- `bash tests/test_blog_publish_branding.sh`