### PR TITLE
[codex] Repair generated curation stubs

### DIFF
--- a/tests/test_edge_curation.sh
+++ b/tests/test_edge_curation.sh
@@ -44,6 +44,20 @@ exit 0
 SH
 chmod +x "$TMP_REPO/search/edge-index"
 
+mkdir -p "$TMP_STATE/threads"
+cat >"$TMP_STATE/threads/existing-generated.md" <<'MD'
+---
+id: existing-generated
+title: Existing Generated
+status: active
+created: 2026-05-01
+updated: 2026-05-01
+generated_by: edge-curation
+---
+
+Existing generated curation stub.
+MD
+
 cat >"$TMP_STATE/state/operator-pressure/hot-digest.json" <<'JSON'
 {
   "schema_version": 6,
@@ -114,8 +128,16 @@ assert digest["operator_pressure"]["pre_skill_context_total"] == 1
 assert digest["operator_pressure"]["topics_created"] >= 1
 assert digest["operator_pressure"]["threads_created"] >= 1
 assert digest["operator_pressure"]["pre_skill_context"]["candidates"][0]["judgement"] == "pre_skill_context"
+assert digest["hot_state"]["threads"]["repaired_total"] == 1
 assert not list((state_root / "blog" / "entries").glob("*.md"))
-assert (state_root / "threads" / "meta-evidence.md").exists()
+for thread_path in [
+    state_root / "threads" / "meta-evidence.md",
+    state_root / "threads" / "existing-generated.md",
+]:
+    assert thread_path.exists()
+    text = thread_path.read_text(encoding="utf-8")
+    assert "\nowner: edge\n" in text
+    assert "\nresurface:" in text
 assert (state_root / "topics" / "meta-evidence.md").exists()
 PY
 then

--- a/tests/test_edge_state_dispatch.sh
+++ b/tests/test_edge_state_dispatch.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_BASE="$(mktemp -d /tmp/edge-state-dispatch-XXXXXX)"
+TMP_REPO="$TMP_BASE/repo"
+TMP_STATE="$TMP_BASE/state"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_REPO/tools" "$TMP_REPO/config" "$TMP_REPO/memory" "$TMP_STATE/state" "$TMP_STATE/logs"
+cp "$EDGE_DIR/tools/edge-state-dispatch" "$TMP_REPO/tools/edge-state-dispatch"
+cp -R "$EDGE_DIR/tools/_shared" "$TMP_REPO/tools/_shared"
+cp "$EDGE_DIR/config/paths.py" "$TMP_REPO/config/paths.py"
+cp "$EDGE_DIR/config/branding.py" "$TMP_REPO/config/branding.py"
+chmod +x "$TMP_REPO/tools/edge-state-dispatch"
+
+cat >"$TMP_REPO/config/CLAUDE.md" <<'MD'
+# Runtime instructions
+MD
+cat >"$TMP_REPO/memory/MEMORY.md" <<'MD'
+# Memory
+MD
+
+export EDGE_REPO_DIR="$TMP_REPO"
+export EDGE_STATE_DIR="$TMP_STATE"
+export MEMORY_PROJECT_DIR=""
+
+cat >"$TMP_STATE/state/dispatch-queue.json" <<'JSON'
+[
+  {
+    "skill": "planner",
+    "source": "state-anchor-monitor",
+    "entry_id": "state-anchor-monitor:stale",
+    "reason": "State anchors changed | lint: 0 errors, 2 warnings",
+    "created_at": "2026-05-03T00:00:00+00:00"
+  }
+]
+JSON
+cat >"$TMP_REPO/tools/edge-state-lint" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{"timestamp":"2026-05-03T00:00:00","total":2,"by_severity":{"warn":2,"error":0},"findings":[]}
+JSON
+SH
+chmod +x "$TMP_REPO/tools/edge-state-lint"
+
+echo "=== edge-state-dispatch Test ==="
+echo ""
+
+echo "--- Test 1: stale state-anchor queue clears when lint has no errors ---"
+if "$TMP_REPO/tools/edge-state-dispatch" >/tmp/edge-state-dispatch.out && python3 - <<'PY' "$TMP_STATE/state/dispatch-queue.json" /tmp/edge-state-dispatch.out
+import json
+import sys
+from pathlib import Path
+
+queue = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+out = Path(sys.argv[2]).read_text(encoding="utf-8")
+assert queue == []
+assert "STATE_QUEUE planner cleared" in out
+PY
+then
+    pass "stale state-anchor queue clears when lint has no errors"
+else
+    fail "stale state-anchor queue clears when lint has no errors"
+fi
+
+cat >"$TMP_STATE/state/dispatch-queue.json" <<'JSON'
+[
+  {
+    "skill": "planner",
+    "source": "state-anchor-monitor",
+    "entry_id": "state-anchor-monitor:still-bad",
+    "reason": "State anchors changed | lint: 1 errors, 0 warnings",
+    "created_at": "2026-05-03T00:00:00+00:00"
+  }
+]
+JSON
+cat >"$TMP_REPO/tools/edge-state-lint" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{"timestamp":"2026-05-03T00:00:00","total":1,"by_severity":{"warn":0,"error":1},"findings":[]}
+JSON
+SH
+chmod +x "$TMP_REPO/tools/edge-state-lint"
+
+echo "--- Test 2: state-anchor queue remains when lint errors remain ---"
+if "$TMP_REPO/tools/edge-state-dispatch" >/tmp/edge-state-dispatch.out && python3 - <<'PY' "$TMP_STATE/state/dispatch-queue.json" /tmp/edge-state-dispatch.out
+import json
+import sys
+from pathlib import Path
+
+queue = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+out = Path(sys.argv[2]).read_text(encoding="utf-8")
+assert len(queue) == 1
+assert queue[0]["entry_id"] == "state-anchor-monitor:still-bad"
+assert "STATE_QUEUE planner cleared" not in out
+PY
+then
+    pass "state-anchor queue remains when lint errors remain"
+else
+    fail "state-anchor queue remains when lint errors remain"
+fi
+
+echo ""
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [[ $FAIL -ne 0 ]]; then
+    exit 1
+fi

--- a/tools/edge-curation
+++ b/tools/edge-curation
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import unicodedata
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -30,9 +30,19 @@ from paths import (  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
 from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
 
+THREAD_STUB_RESURFACE_DAYS = 7
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _today_iso() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _thread_stub_resurface_iso() -> str:
+    return (datetime.now(timezone.utc).date() + timedelta(days=THREAD_STUB_RESURFACE_DAYS)).isoformat()
 
 
 def _read_json(path: Path, default: Any) -> Any:
@@ -161,7 +171,8 @@ def _read_topic_files() -> dict[str, dict[str, Any]]:
 
 
 def _write_thread_stub(thread_id: str, open_gaps_digest: dict[str, Any]) -> Path:
-    today = datetime.now(timezone.utc).date().isoformat()
+    today = _today_iso()
+    resurface = _thread_stub_resurface_iso()
     title = _slug_title(thread_id)
     refs = _gap_refs_for_thread(open_gaps_digest, thread_id)
     lines = [
@@ -169,8 +180,10 @@ def _write_thread_stub(thread_id: str, open_gaps_digest: dict[str, Any]) -> Path
         f"id: {thread_id}",
         f"title: {title}",
         "status: active",
+        "owner: edge",
         f"created: {today}",
         f"updated: {today}",
+        f"resurface: {resurface}",
         "generated_by: edge-curation",
         "---",
         "",
@@ -198,6 +211,63 @@ def _write_thread_stub(thread_id: str, open_gaps_digest: dict[str, Any]) -> Path
     path = THREADS_DIR / f"{thread_id}.md"
     path.write_text("\n".join(lines), encoding="utf-8")
     return path
+
+
+def _frontmatter_scalar(value: Any) -> str:
+    if isinstance(value, list):
+        return "[" + ", ".join(str(item) for item in value) + "]"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _rewrite_frontmatter(raw: str, frontmatter: dict[str, Any]) -> str:
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?", raw, re.DOTALL)
+    body = raw[match.end():] if match else raw
+    preferred = ["id", "title", "status", "owner", "created", "updated", "resurface", "generated_by", "source"]
+    ordered_keys = [key for key in preferred if key in frontmatter]
+    ordered_keys.extend(key for key in frontmatter.keys() if key not in set(ordered_keys))
+    lines = ["---"]
+    for key in ordered_keys:
+        lines.append(f"{key}: {_frontmatter_scalar(frontmatter[key])}")
+    lines.extend(["---", ""])
+    return "\n".join(lines) + body
+
+
+def _repair_generated_thread_stubs() -> list[dict[str, str]]:
+    repairs: list[dict[str, str]] = []
+    if not THREADS_DIR.exists():
+        return repairs
+
+    today = _today_iso()
+    resurface = _thread_stub_resurface_iso()
+    for path in sorted(THREADS_DIR.glob("*.md")):
+        try:
+            raw = path.read_text(encoding="utf-8")
+            fm = _load_frontmatter(path)
+        except Exception:
+            continue
+        if str(fm.get("generated_by") or "") != "edge-curation":
+            continue
+
+        updated: list[str] = []
+        defaults = {
+            "owner": "edge",
+            "created": today,
+            "updated": today,
+            "resurface": resurface,
+        }
+        for key, value in defaults.items():
+            if str(fm.get(key) or "").strip():
+                continue
+            fm[key] = value
+            updated.append(key)
+
+        if not updated:
+            continue
+        path.write_text(_rewrite_frontmatter(raw, fm), encoding="utf-8")
+        repairs.append({"thread_id": path.stem, "path": str(path), "fields": ",".join(updated)})
+    return repairs
 
 
 def _write_topic_stub(thread_id: str, open_gaps_digest: dict[str, Any], thread_title: str) -> Path:
@@ -642,7 +712,8 @@ def _operator_evidence_lines(group: dict[str, Any]) -> list[str]:
 
 
 def _write_operator_thread_stub(group: dict[str, Any]) -> Path:
-    today = datetime.now(timezone.utc).date().isoformat()
+    today = _today_iso()
+    resurface = _thread_stub_resurface_iso()
     thread_id = str(group.get("thread_id") or "operator-pressure").strip()
     title = str(group.get("title") or _slug_title(thread_id)).strip()
     lines = [
@@ -650,8 +721,10 @@ def _write_operator_thread_stub(group: dict[str, Any]) -> Path:
         f"id: {thread_id}",
         f"title: {title}",
         "status: active",
+        "owner: edge",
         f"created: {today}",
         f"updated: {today}",
+        f"resurface: {resurface}",
         "generated_by: edge-curation",
         "source: operator-pressure",
         "---",
@@ -955,8 +1028,11 @@ def build_curation_digest(window_days: int) -> dict[str, Any]:
     corpus_payload, corpus_warnings = _refresh_corpus_health()
     open_gaps_digest = _read_json(OPEN_GAPS_DIGEST_FILE, {})
     operator_pressure_digest = _read_json(OPERATOR_PRESSURE_HOT_DIGEST_FILE, {})
+    thread_repairs = _repair_generated_thread_stubs()
     hot_state = _curate_hot_state(open_gaps_digest)
     operator_pressure = _curate_operator_pressure(operator_pressure_digest)
+    hot_state.setdefault("threads", {})["repaired_total"] = len(thread_repairs)
+    hot_state.setdefault("threads", {})["repaired"] = thread_repairs[:20]
     topic_index_warnings = _refresh_topics_index()
     topics = _topics_summary()
 

--- a/tools/edge-state-dispatch
+++ b/tools/edge-state-dispatch
@@ -79,6 +79,62 @@ def write_json(path: Path, payload: dict | list) -> None:
     )
 
 
+def state_anchor_queue_present() -> bool:
+    queue = load_json(QUEUE_PATH, [])
+    if not isinstance(queue, list):
+        return False
+    return any(item.get("source") == "state-anchor-monitor" for item in queue if isinstance(item, dict))
+
+
+def lint_counts(lint: dict) -> tuple[int, int]:
+    by_severity = lint.get("by_severity", {}) if isinstance(lint, dict) else {}
+    errors = int(by_severity.get("error", 0)) if isinstance(by_severity.get("error", 0), int) else 0
+    warnings = int(by_severity.get("warn", 0)) if isinstance(by_severity.get("warn", 0), int) else 0
+    return errors, warnings
+
+
+def clear_state_anchor_dispatch_if_lint_clean(lint: dict, checked_at: str) -> dict:
+    if lint.get("error"):
+        return {"removed": 0, "reason": "lint_unavailable"}
+    lint_errors, lint_warnings = lint_counts(lint)
+    if lint_errors != 0:
+        return {"removed": 0, "reason": "lint_errors_remain", "lint_errors": lint_errors, "lint_warnings": lint_warnings}
+
+    queue = load_json(QUEUE_PATH, [])
+    if not isinstance(queue, list):
+        return {"removed": 0, "reason": "queue_invalid", "lint_errors": lint_errors, "lint_warnings": lint_warnings}
+
+    kept = [item for item in queue if not (isinstance(item, dict) and item.get("source") == "state-anchor-monitor")]
+    removed = len(queue) - len(kept)
+    if not removed:
+        return {"removed": 0, "reason": "no_state_anchor_queue", "lint_errors": lint_errors, "lint_warnings": lint_warnings}
+
+    write_json(QUEUE_PATH, kept)
+    log_event(
+        "dispatch_queue_cleared",
+        actor="edge-state-dispatch",
+        source="state-anchor-monitor",
+        checked_at=checked_at,
+        removed=removed,
+        reason="lint_clean",
+        lint_errors=lint_errors,
+        lint_warnings=lint_warnings,
+    )
+    emit_shadow_event(
+        "DispatchQueueEntryCleared",
+        actor="edge-state-dispatch",
+        payload={
+            "source": "state-anchor-monitor",
+            "removed": removed,
+            "reason": "lint_clean",
+            "lint_errors": lint_errors,
+            "lint_warnings": lint_warnings,
+            "checked_at": checked_at,
+        },
+    )
+    return {"removed": removed, "reason": "lint_clean", "lint_errors": lint_errors, "lint_warnings": lint_warnings}
+
+
 def ensure_dirs() -> None:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
@@ -345,13 +401,22 @@ def main() -> int:
         print("STATE_BASELINE " + ", ".join(baselined))
 
     if not changed:
+        if state_anchor_queue_present():
+            lint = run_lint()
+            cleared = clear_state_anchor_dispatch_if_lint_clean(lint, checked_at)
+            if cleared.get("removed"):
+                print("STATE_CLEAN")
+                print(
+                    "STATE_QUEUE planner cleared "
+                    f"| lint_errors={cleared.get('lint_errors', 0)} "
+                    f"lint_warnings={cleared.get('lint_warnings', 0)}"
+                )
+                return 0
         print("STATE_CLEAN")
         return 0
 
     lint = run_lint()
-    by_severity = lint.get("by_severity", {}) if isinstance(lint, dict) else {}
-    lint_errors = int(by_severity.get("error", 0)) if isinstance(by_severity.get("error", 0), int) else 0
-    lint_warnings = int(by_severity.get("warn", 0)) if isinstance(by_severity.get("warn", 0), int) else 0
+    lint_errors, lint_warnings = lint_counts(lint)
     changed_labels = [item["label"] for item in changed]
 
     reason = "State anchors changed: " + ", ".join(changed_labels)


### PR DESCRIPTION
## Summary

Closes #518.

- add `owner: edge` and future `resurface` defaults to generated curation thread stubs
- repair existing `generated_by: edge-curation` thread stubs that are missing required frontmatter
- clear stale `state-anchor-monitor` planner queue entries when anchors are clean and `edge-state-lint` has no errors
- add regression coverage for curation stub repair and stale state-anchor queue cleanup

## Root Cause

`edge-curation` generated thread stubs without `owner` and `resurface`, which `edge-state-lint` treats as required fields. `edge-state-dispatch` could then leave a `state-anchor-monitor` planner queue entry active even after the underlying lint condition was repaired, forcing repeated planner heartbeats into standdown/review failure loops.

## Validation

- `python3 -m py_compile tools/edge-curation tools/edge-state-dispatch`
- `bash tests/test_edge_curation.sh`
- `bash tests/test_edge_state_dispatch.sh`
- `bash tests/test_heartbeat_routing.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_edge_runner.sh`