### PR TITLE
[codex] Repair legacy thread frontmatter

### DIFF
--- a/tests/test_edge_curation.sh
+++ b/tests/test_edge_curation.sh
@@ -18,6 +18,7 @@ trap cleanup EXIT
 
 mkdir -p "$TMP_REPO/tools" "$TMP_REPO/config" "$TMP_REPO/threads" "$TMP_REPO/topics" "$TMP_REPO/blog/entries" "$TMP_STATE/state/operator-pressure" "$TMP_STATE/state/projections"
 cp "$EDGE_DIR/tools/edge-curation" "$TMP_REPO/tools/edge-curation"
+cp "$EDGE_DIR/tools/edge-state-lint" "$TMP_REPO/tools/edge-state-lint"
 cp -R "$EDGE_DIR/tools/_shared" "$TMP_REPO/tools/_shared"
 cp "$EDGE_DIR/config/paths.py" "$TMP_REPO/config/paths.py"
 cp "$EDGE_DIR/config/branding.py" "$TMP_REPO/config/branding.py"
@@ -30,7 +31,7 @@ cat >"$EDGE_STATE_DIR/state/curadoria-candidates.json" <<'JSON'
 {"total_docs": 3, "stale_candidates": 1, "archive_auto": [], "merge_review": [], "strengthen_targets": []}
 JSON
 SH
-chmod +x "$TMP_REPO/tools/curadoria-compute" "$TMP_REPO/tools/edge-curation"
+chmod +x "$TMP_REPO/tools/curadoria-compute" "$TMP_REPO/tools/edge-curation" "$TMP_REPO/tools/edge-state-lint"
 
 cat >"$TMP_REPO/search-edge-index" <<'SH'
 #!/usr/bin/env bash
@@ -56,6 +57,53 @@ generated_by: edge-curation
 ---
 
 Existing generated curation stub.
+MD
+cat >"$TMP_STATE/threads/legacy-active.md" <<'MD'
+---
+id: legacy-active
+title: Legacy Active
+status: active
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+Legacy active thread missing required metadata.
+MD
+cat >"$TMP_STATE/threads/colon-title.md" <<'MD'
+---
+id: colon-title
+title: Artigo: Indexacao de Instrucoes
+status: active
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+Legacy thread with a colon title that needs YAML quoting.
+MD
+cat >"$TMP_STATE/threads/-.md" <<'MD'
+---
+id: -
+title:
+status: active
+created: 2026-05-01
+updated: 2026-05-01
+generated_by: edge-curation
+---
+
+Generated thread with a dash id and blank title.
+MD
+cat >"$TMP_STATE/threads/parked-thread.md" <<'MD'
+---
+id: parked-thread
+title: Parked Thread
+status: parked
+owner: edge
+created: 2026-05-01
+updated: 2026-05-01
+resurface: null
+---
+
+Parked legacy thread.
 MD
 
 cat >"$TMP_STATE/state/operator-pressure/hot-digest.json" <<'JSON'
@@ -128,17 +176,25 @@ assert digest["operator_pressure"]["pre_skill_context_total"] == 1
 assert digest["operator_pressure"]["topics_created"] >= 1
 assert digest["operator_pressure"]["threads_created"] >= 1
 assert digest["operator_pressure"]["pre_skill_context"]["candidates"][0]["judgement"] == "pre_skill_context"
-assert digest["hot_state"]["threads"]["repaired_total"] == 1
+assert digest["hot_state"]["threads"]["repaired_total"] >= 4
 assert not list((state_root / "blog" / "entries").glob("*.md"))
 for thread_path in [
     state_root / "threads" / "meta-evidence.md",
     state_root / "threads" / "existing-generated.md",
+    state_root / "threads" / "legacy-active.md",
+    state_root / "threads" / "colon-title.md",
+    state_root / "threads" / "-.md",
 ]:
     assert thread_path.exists()
     text = thread_path.read_text(encoding="utf-8")
     assert "\nowner: edge\n" in text
     assert "\nresurface:" in text
+assert "title: Generated Thread" in (state_root / "threads" / "-.md").read_text(encoding="utf-8")
+assert "title: 'Artigo: Indexacao de Instrucoes'" in (state_root / "threads" / "colon-title.md").read_text(encoding="utf-8")
 assert (state_root / "topics" / "meta-evidence.md").exists()
+code, stdout, stderr = module._run([str(Path(os.environ["EDGE_REPO_DIR"]) / "tools" / "edge-state-lint"), "--json", "--check", "threads"])
+lint = json.loads(stdout)
+assert lint.get("by_severity", {}).get("error", 0) == 0, lint
 PY
 then
     pass "sync builds digest and migrates operator guidance to topics/pre-skill context"

--- a/tools/edge-curation
+++ b/tools/edge-curation
@@ -69,7 +69,21 @@ def _load_frontmatter(path: Path) -> dict[str, Any]:
     parts = raw.split("---", 2)
     if len(parts) < 3:
         return {}
-    payload = yaml.safe_load(parts[1]) or {}
+    frontmatter = parts[1]
+    try:
+        payload = yaml.safe_load(frontmatter) or {}
+    except Exception:
+        payload = {}
+        for line in frontmatter.splitlines():
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            key = key.strip()
+            if not key:
+                continue
+            payload[key] = value.strip().strip('"').strip("'")
+        if payload:
+            payload["_frontmatter_repair_required"] = True
     return payload if isinstance(payload, dict) else {}
 
 
@@ -84,7 +98,7 @@ def _coerce_list(value: Any) -> list[str]:
 
 
 def _slug_title(slug: str) -> str:
-    return re.sub(r"[-_]+", " ", str(slug or "").strip()).strip().title()
+    return re.sub(r"[-_]+", " ", str(slug or "").strip()).strip().title() or "Generated Thread"
 
 
 def _normalize_ascii(value: str) -> str:
@@ -214,11 +228,15 @@ def _write_thread_stub(thread_id: str, open_gaps_digest: dict[str, Any]) -> Path
 
 
 def _frontmatter_scalar(value: Any) -> str:
-    if isinstance(value, list):
-        return "[" + ", ".join(str(item) for item in value) + "]"
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    return str(value)
+    dumped = yaml.safe_dump(
+        value,
+        allow_unicode=True,
+        default_flow_style=True,
+        sort_keys=False,
+    ).strip()
+    if "\n..." in dumped:
+        dumped = dumped.split("\n...", 1)[0].strip()
+    return dumped
 
 
 def _rewrite_frontmatter(raw: str, frontmatter: dict[str, Any]) -> str:
@@ -234,7 +252,7 @@ def _rewrite_frontmatter(raw: str, frontmatter: dict[str, Any]) -> str:
     return "\n".join(lines) + body
 
 
-def _repair_generated_thread_stubs() -> list[dict[str, str]]:
+def _repair_thread_frontmatter() -> list[dict[str, str]]:
     repairs: list[dict[str, str]] = []
     if not THREADS_DIR.exists():
         return repairs
@@ -247,19 +265,29 @@ def _repair_generated_thread_stubs() -> list[dict[str, str]]:
             fm = _load_frontmatter(path)
         except Exception:
             continue
-        if str(fm.get("generated_by") or "") != "edge-curation":
-            continue
 
         updated: list[str] = []
+        if fm.pop("_frontmatter_repair_required", False):
+            updated.append("yaml")
+        if not str(fm.get("title") or "").strip():
+            fm["title"] = _slug_title(path.stem)
+            updated.append("title")
+
+        status = str(fm.get("status") or "").strip().lower()
+        resurface_default: Any = None if status in {"archived", "parked", "done", "dormant"} else resurface
         defaults = {
             "owner": "edge",
             "created": today,
             "updated": today,
-            "resurface": resurface,
+            "resurface": resurface_default,
         }
         for key, value in defaults.items():
-            if str(fm.get(key) or "").strip():
-                continue
+            if key in fm:
+                current = fm.get(key)
+                if key == "resurface" and current is None and value is None:
+                    continue
+                if str(current or "").strip():
+                    continue
             fm[key] = value
             updated.append(key)
 
@@ -1028,7 +1056,7 @@ def build_curation_digest(window_days: int) -> dict[str, Any]:
     corpus_payload, corpus_warnings = _refresh_corpus_health()
     open_gaps_digest = _read_json(OPEN_GAPS_DIGEST_FILE, {})
     operator_pressure_digest = _read_json(OPERATOR_PRESSURE_HOT_DIGEST_FILE, {})
-    thread_repairs = _repair_generated_thread_stubs()
+    thread_repairs = _repair_thread_frontmatter()
     hot_state = _curate_hot_state(open_gaps_digest)
     operator_pressure = _curate_operator_pressure(operator_pressure_digest)
     hot_state.setdefault("threads", {})["repaired_total"] = len(thread_repairs)

--- a/tools/edge-state-lint
+++ b/tools/edge-state-lint
@@ -56,7 +56,7 @@ def check_threads():
         return
 
     required_fields = {"id", "title", "status", "owner", "created", "updated", "resurface"}
-    valid_statuses = {"active", "dormant", "waiting", "done"}
+    valid_statuses = {"active", "dormant", "waiting", "done", "parked", "archived"}
     # Read agent name from agent.yaml to allow fleet instance owners
     agent_name = "edge"
     try:


### PR DESCRIPTION
## Summary

Closes #522.

- repair legacy thread frontmatter during `edge-curation sync`, not only generated stubs
- tolerate simple invalid frontmatter so colon titles and dash ids can be rewritten safely
- quote YAML scalars when curation rewrites thread metadata
- fill blank thread titles with a deterministic fallback
- accept existing fleet statuses `parked` and `archived` in `edge-state-lint`
- add regression coverage for missing metadata, colon titles, dash ids, and parked status

## Root Cause

After #519 cleared the generated-stub case on gauss, other hosts still had legacy thread files that lint treated as hard errors. Those hygiene errors kept `state-anchor-monitor` planner queues hot even though they were not meaningful planner work.

## Validation

- `python3 -m py_compile tools/edge-curation tools/edge-state-lint`
- `bash tests/test_edge_curation.sh`
- `bash tests/test_edge_state_dispatch.sh`
- `bash tests/test_heartbeat_routing.sh`