### PR TITLE
[codex] Handle heartbeat standdowns and stale postflight state

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -1068,6 +1068,7 @@ echo "── Phase 3: Verification ──"
 ledger_record "phase-3" "ok"
 emit_run_step_event "phase-3" "started" "verification" ""
 ALL_OK=true
+API_VISIBILITY_WARNING=false
 
 # Entry visible?
 VISIBLE=$(curl -s -m 5 $CURL_AUTH "${BLOG_URL}/blog/entries/" 2>/dev/null | python3 -c "
@@ -1083,7 +1084,7 @@ if [[ "$VISIBLE" == "OK" ]]; then
     ok "Entry visible in API"
 else
     warn "Entry NOT visible in API ($VISIBLE)"
-    ALL_OK=false
+    API_VISIBILITY_WARNING=true
 fi
 
 # Report linked in frontmatter?
@@ -1184,7 +1185,11 @@ PY
     fi
 fi
 if $ALL_OK && [[ "$REPORT_RESULT" != "fail" ]]; then
-    emit_run_step_event "phase-3" "completed" "verification" ""
+    if [[ "$API_VISIBILITY_WARNING" == "true" ]]; then
+        emit_run_step_event "phase-3" "degraded" "verification" "blog API visibility check failed after file publish"
+    else
+        emit_run_step_event "phase-3" "completed" "verification" ""
+    fi
 else
     emit_run_step_event "phase-3" "failed" "verification" "verification ended with warnings or failures"
     fail "Verification failed before state commit; publication will not be recorded as Published"

--- a/tests/test_consolidate_phase6_paths.sh
+++ b/tests/test_consolidate_phase6_paths.sh
@@ -27,6 +27,8 @@ non_git_commit_guard = first_index('skipping git commit')
 partial_degraded = first_index('emit_run_step_event "pipeline" "degraded" "pipeline_end" "partial publication"')
 complete_artifact_published = first_index('    emit_artifact_published_event')
 complete_pipeline_end = first_index('emit_run_step_event "pipeline" "completed" "pipeline_end" ""')
+api_visibility_warning = first_index('API_VISIBILITY_WARNING=true')
+api_visibility_degraded = first_index('blog API visibility check failed after file publish')
 report_materialization = first_index('emit_run_step_event "phase-0.9" "started" "report_materialization"')
 blog_publish = first_index('emit_run_step_event "phase-1" "started" "blog_publish"')
 report_confirmation = first_index('emit_run_step_event "phase-2" "started" "report_generation"')
@@ -51,6 +53,9 @@ assert phase6_start < non_git_commit_guard, "non-git EDGE_REPO_DIR must skip git
 assert phase6_start < partial_degraded, "partial publication must be degraded, not a hard pipeline failure"
 assert complete_artifact_published < complete_pipeline_end, (
     "complete consolidate-state publications must emit ArtifactPublished before terminal pipeline_end"
+)
+assert api_visibility_warning < api_visibility_degraded < complete_artifact_published, (
+    "blog API visibility failures after file publish must degrade phase-3 but continue to ArtifactPublished"
 )
 assert materialize_function < report_materialization < blog_publish, (
     "report materialization must happen before blog publish so entries cannot be published without reports"

--- a/tests/test_edge_close.sh
+++ b/tests/test_edge_close.sh
@@ -101,6 +101,36 @@ with open(path, "a", encoding="utf-8") as fh:
 PY
 }
 
+append_standdown_recorded() {
+    local cycle_id="$1"
+    local skill="$2"
+    local slug="$3"
+    mkdir -p "$TMP_EDGE/state/runtime/standdowns"
+    printf 'standdown for %s\n' "$skill" >"$TMP_EDGE/state/runtime/standdowns/$slug.md"
+    python3 - <<'PY' "$TMP_EDGE/state/events/log.jsonl" "$cycle_id" "$skill" "$slug"
+import json
+import sys
+from datetime import datetime, timezone
+
+path, cycle_id, skill, slug = sys.argv[1:5]
+event = {
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "type": "ArtifactStanddownRecorded",
+    "actor": "edge-runner",
+    "cycle_id": cycle_id,
+    "artifact": f"state/runtime/standdowns/{slug}.md",
+    "payload": {
+        "source_skill": skill,
+        "skill": skill,
+        "status": "standdown",
+        "reason": "principled_standdown",
+    },
+}
+with open(path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(event) + "\n")
+PY
+}
+
 append_phase_failed() {
     local cycle_id="$1"
     local slug="$2"
@@ -300,6 +330,44 @@ then
     pass "edge-close exempts heartbeat router from artifact publication"
 else
     fail "edge-close exempts heartbeat router from artifact publication"
+fi
+
+echo "--- Test 2b2: heartbeat standdown evidence satisfies artifact supervision ---"
+"$DISPATCH_TOOL" open --trigger heartbeat --cycle-id cycle-close-standdown --force >/dev/null
+"$DISPATCH_TOOL" dispatch --skill research >/dev/null
+for step in direction explore application persistence; do
+    EDGE_CYCLE_ID=cycle-close-standdown "$STEP_TOOL" research "$step" >/dev/null
+done
+EDGE_CYCLE_ID=cycle-close-standdown "$STEP_TOOL" research end >/dev/null
+append_standdown_recorded cycle-close-standdown research research-standdown
+"$CLOSE_TOOL" --status completed >/dev/null
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+
+assert dispatch["request"]["skill"] == "research"
+assert dispatch["request"]["trigger"] == "heartbeat"
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "completed"
+assert dispatch["state"]["postflight_status"] in {"completed", "warning"}
+assert dispatch["state"]["artifact_supervision_status"] == "standdown"
+assert dispatch["state"]["artifact_supervision_reason"] == "principled_standdown"
+assert dispatch["state"]["artifact_supervision_required"] is True
+assert any(
+    event.get("cycle_id") == "cycle-close-standdown"
+    and event.get("type") == "ArtifactSupervisionCompleted"
+    and (event.get("payload") or {}).get("status") == "standdown"
+    for event in events
+)
+PY
+then
+    pass "edge-close accepts durable heartbeat standdown evidence"
+else
+    fail "edge-close accepts durable heartbeat standdown evidence"
 fi
 
 echo "--- Test 2c: non-heartbeat skills require artifact publication regardless of prefix ---"

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -581,6 +581,61 @@ else
     fail "stdout-only prose is rejected as publication evidence"
 fi
 
+echo "--- Test 1d2: principled heartbeat standdown records durable terminal evidence ---"
+export MOCK_CLAUDE_ENV_OUT="$TMP_BASE/cycle-id-standdown.txt"
+export MOCK_CLAUDE_ARGS_OUT="$TMP_BASE/args-standdown.txt"
+rm -f "$MOCK_CLAUDE_ENV_OUT" "$MOCK_CLAUDE_ARGS_OUT" "$TMP_BASE/standdown.out"
+export MOCK_CLAUDE_ARTIFACT_MARKDOWN=$'# Research standdown\n\n**Decision:** not publishing because the operator pressure is already satisfied and republishing would be duplicate saturation.\n\n## Evidence\n\nVerified ground truth: the requested topic was already published today, there is no new signal, and the canonical feedback says to decline publication instead of manufacturing a duplicate artifact. This is a principled standdown, not a short acknowledgement. The runtime should record this as durable standdown evidence for the heartbeat cycle without emitting ArtifactPublished.'
+"$RUNNER_TOOL" skill \
+    --skill /research \
+    --dispatch-trigger heartbeat \
+    --dispatch-policy autonomous \
+    --dispatch-routing-mode explicit \
+    --dispatch-preflight-profile heartbeat_default \
+    --dispatch-postflight-profile standard \
+    --dispatch-force >"$TMP_BASE/standdown.out"
+unset MOCK_CLAUDE_ARTIFACT_MARKDOWN || true
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$TMP_EDGE/state/runtime/standdowns" "$TMP_BASE/args-standdown.txt"
+import json
+import sys
+from pathlib import Path
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+standdowns_dir = Path(sys.argv[3])
+args_log = Path(sys.argv[4]).read_text(encoding="utf-8")
+cycle_id = dispatch["cycle_id"]
+
+assert dispatch["request"]["skill"] == "research"
+assert dispatch["request"]["trigger"] == "heartbeat"
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "completed"
+assert dispatch["state"]["artifact_supervision_status"] == "standdown"
+assert dispatch["state"]["artifact_supervision_reason"] == "principled_standdown"
+assert args_log.count("__INVOCATION__") == 1
+standdown_events = [
+    event for event in events
+    if event.get("type") == "ArtifactStanddownRecorded"
+    and event.get("cycle_id") == cycle_id
+]
+assert standdown_events
+artifact = standdown_events[-1]["artifact"]
+standdown_file = standdowns_dir / Path(artifact).name
+assert standdown_file.exists()
+assert "not publishing" in standdown_file.read_text(encoding="utf-8")
+assert not any(
+    event.get("type") == "ArtifactPublished"
+    and event.get("cycle_id") == cycle_id
+    for event in events
+)
+PY
+then
+    pass "heartbeat standdown records durable terminal evidence"
+else
+    fail "heartbeat standdown records durable terminal evidence"
+fi
+
 echo "--- Test 1e: runtime-stdout ArtifactPublished evidence is rejected ---"
 if python3 - <<'PY' "$EDGE_DIR" "$TMP_BASE/runtime-stdout-events.jsonl"
 import importlib.machinery

--- a/tests/test_postflight_resilience.sh
+++ b/tests/test_postflight_resilience.sh
@@ -15,7 +15,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$TMP_EDGE/state/projections" "$TMP_EDGE/logs" "$TMP_EDGE/search"
+mkdir -p "$TMP_EDGE/state/projections" "$TMP_EDGE/logs" "$TMP_EDGE/search" "$TMP_EDGE/blog/entries"
 
 export EDGE_REPO_DIR="$EDGE_DIR"
 export EDGE_STATE_DIR="$TMP_EDGE"
@@ -77,6 +77,55 @@ then
     pass "postflight exceptions degrade to warning instead of aborting"
 else
     fail "postflight exceptions degrade to warning instead of aborting"
+fi
+
+echo "--- Test 1b: open-gaps refresh rebuilds stale projection before warning ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_EDGE"
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+state_dir = Path(sys.argv[2])
+entry = state_dir / "blog" / "entries" / "entry-with-gap.md"
+entry.write_text(
+    "---\n"
+    "title: Entry With Gap\n"
+    "threads: [runtime-observability]\n"
+    "open_gaps:\n"
+    "  - verify stale open gaps refresh\n"
+    "---\n\nbody\n",
+    encoding="utf-8",
+)
+digest = state_dir / "state" / "projections" / "open-gaps-digest.json"
+digest.parent.mkdir(parents=True, exist_ok=True)
+digest.write_text(json.dumps({"built_at": "old", "open_total": 0, "entries_with_gaps": 0}), encoding="utf-8")
+old = time.time() - 8 * 60 * 60
+os.utime(digest, (old, old))
+
+loader = importlib.machinery.SourceFileLoader("edge_postflight", str(edge_dir / "tools" / "edge-postflight"))
+spec = importlib.util.spec_from_loader("edge_postflight", loader)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+result = module.refresh_open_gaps_status()
+payload = result["payload"]
+assert result["status"] == "ok", result
+assert result["ok"] is True, result
+assert "rebuilt=true" in result["detail"], result
+assert payload["cache"]["status"] == "cached", payload
+assert payload["open_gaps"]["open_total"] == 1, payload
+assert payload["open_gaps"]["entries_with_gaps"] == 1, payload
+PY
+then
+    pass "open-gaps refresh rebuilds stale projection"
+else
+    fail "open-gaps refresh rebuilds stale projection"
 fi
 
 echo "--- Test 2: async inbox postflight responds before consuming captured chat ---"
@@ -203,7 +252,7 @@ module = importlib.util.module_from_spec(spec)
 assert spec and spec.loader
 spec.loader.exec_module(module)
 
-assert not hasattr(module, "refresh_continuity_projections")
+assert hasattr(module, "refresh_continuity_projections")
 module.OPEN_GAPS_DIGEST_FILE.parent.mkdir(parents=True, exist_ok=True)
 module.OPEN_GAPS_DIGEST_FILE.write_text(
     json.dumps({"open_total": 3, "entries_with_gaps": 2}),

--- a/tools/_shared/artifact_supervisor.py
+++ b/tools/_shared/artifact_supervisor.py
@@ -162,6 +162,21 @@ def supervise_artifact_publication(
             )
             return result
 
+        if etype == "ArtifactStanddownRecorded":
+            status = str(payload.get("status") or "").strip().lower()
+            if status == "standdown" and artifact:
+                result.update(
+                    {
+                        "ok": True,
+                        "status": "standdown",
+                        "reason": str(payload.get("reason") or "principled_standdown"),
+                        "artifact": artifact,
+                        "artifact_published_at": event.get("ts") or "",
+                        "source_skill": payload.get("source_skill") or payload.get("skill") or "",
+                    }
+                )
+                return result
+
         if etype == "ArtifactWriteRejected" and pipeline_failure is None:
             pipeline_failure = _pipeline_failure_evidence(event, payload)
         elif etype == "PhaseCompleted" and _phase_ok(payload) is False and pipeline_failure is None:

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -22,6 +22,7 @@ sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import EDGE_REPO_DIR, LOGS_DIR, OPEN_GAPS_DIGEST_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
 from _shared.capability_runtime import build_capability_status, invoke_capability, probe_capability  # noqa: E402
+from _shared.continuity import refresh_continuity_projections  # noqa: E402
 from _shared.dispatch_runtime import read_dispatch_state, write_dispatch_state  # noqa: E402
 from _shared.health_runtime import observe_cycle_health_events  # noqa: E402
 from _shared.protocol_runtime import emit_protocol_step_observed, ensure_compiled_protocol, protocol_context  # noqa: E402
@@ -258,6 +259,17 @@ def refresh_capabilities_status(skill: str | None = None) -> dict[str, Any]:
 
 
 def refresh_open_gaps_status() -> dict[str, Any]:
+    rebuilt = False
+    rebuild_error = ""
+    cache = _projection_cache_status(OPEN_GAPS_DIGEST_FILE)
+    cache_status = str(cache.get("projection_status") or "unknown")
+    if cache_status in {"missing", "stale_cached", "unknown"}:
+        try:
+            refresh_continuity_projections()
+            rebuilt = True
+        except Exception as exc:  # pragma: no cover - defensive
+            rebuild_error = str(exc)
+
     digest = _read_json_file(OPEN_GAPS_DIGEST_FILE, {})
     if not isinstance(digest, dict):
         digest = {}
@@ -272,8 +284,12 @@ def refresh_open_gaps_status() -> dict[str, Any]:
     )
     if cache_age is not None:
         detail += f" age={cache_age}s"
+    if rebuilt:
+        detail += " rebuilt=true"
+    if rebuild_error:
+        detail += f" rebuild_error={rebuild_error}"
 
-    status = "warning" if cache_status in {"stale_cached", "unknown"} else "ok"
+    status = "warning" if cache_status in {"stale_cached", "unknown"} or rebuild_error else "ok"
     append_postskill_log("open_gaps_digest", "OK" if cache_status in {"cached", "missing"} else "WARN", detail)
     return {
         "ok": cache_status != "unknown",

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -22,7 +23,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
-from paths import EDGE_INSTANCE, EDGE_REPO_DIR, SKILL_STEPS_FILE, STATE_EVENTS_FILE  # noqa: E402
+from paths import EDGE_INSTANCE, EDGE_REPO_DIR, SKILL_STEPS_FILE, STATE_DIR, STATE_EVENTS_FILE  # noqa: E402
 sys.path.insert(0, str(SCRIPT_DIR))
 from _shared.dispatch_runtime import HEARTBEAT_FAIRNESS_SKILLS, read_dispatch_state, render_skill_runtime_prompt, write_dispatch_state  # noqa: E402
 from _shared.jsonl_runtime import iter_jsonl_reverse  # noqa: E402
@@ -822,12 +823,141 @@ def artifact_published_for_cycle(cycle_id: str | None) -> bool:
     return False
 
 
+def standdown_recorded_for_cycle(cycle_id: str | None) -> bool:
+    if not cycle_id:
+        return False
+    state = dispatch_state_matches(cycle_id)
+    threshold = None
+    if state:
+        state_block = state.get("state", {}) or {}
+        threshold = state_block.get("dispatched_at") or state_block.get("opened_at")
+    for event in iter_jsonl_reverse(STATE_EVENTS_FILE):
+        if event.get("type") != "ArtifactStanddownRecorded":
+            continue
+        if event.get("cycle_id") != cycle_id:
+            continue
+        if threshold and not iso_ge(event.get("ts"), threshold):
+            continue
+        payload = event.get("payload", {}) or {}
+        if str(payload.get("status") or "").strip().lower() != "standdown":
+            continue
+        artifact = str(event.get("artifact") or payload.get("artifact") or payload.get("path") or "")
+        if artifact:
+            return True
+    return False
+
+
+def artifact_terminal_evidence_for_cycle(cycle_id: str | None) -> bool:
+    return artifact_published_for_cycle(cycle_id) or standdown_recorded_for_cycle(cycle_id)
+
+
 def _is_runtime_stdout_artifact(payload: dict) -> bool:
     payload = payload or {}
     return bool(
         payload.get("auto_published") is True
         or str(payload.get("pipeline") or "") == "runtime-stdout-artifact"
     )
+
+
+def _looks_like_principled_standdown(output: str) -> bool:
+    text = (output or "").strip()
+    if len(text) < 500:
+        return False
+    lower = text.lower()
+    decision_markers = [
+        "standdown",
+        "stand down",
+        "decline publication",
+        "decline the publication",
+        "not publishing",
+        "not calling consolidate-state",
+        "no artifact written",
+    ]
+    evidence_markers = [
+        "already satisfied",
+        "already published",
+        "duplicate",
+        "duplicat",
+        "saturation",
+        "saturação",
+        "operator pressure",
+        "no operator",
+        "no new signal",
+        "canonical",
+        "verified",
+        "ground truth",
+        "evidence",
+        "invariant",
+    ]
+    has_decision = any(marker in lower for marker in decision_markers)
+    has_evidence = any(marker in lower for marker in evidence_markers)
+    has_section_shape = bool(re.search(r"(?m)^#{1,3}\s+|^\*\*[^*\n]+:\*\*", text))
+    return has_decision and has_evidence and has_section_shape
+
+
+def _standdown_artifact_path(cycle_id: str, skill: str) -> tuple[Path, str]:
+    safe_skill = re.sub(r"[^a-z0-9-]+", "-", skill.lower()).strip("-") or "skill"
+    filename = f"{cycle_id}-{safe_skill}.md"
+    path = STATE_DIR / "runtime" / "standdowns" / filename
+    try:
+        artifact = str(path.relative_to(EDGE_REPO_DIR))
+    except ValueError:
+        artifact = str(path)
+    return path, artifact
+
+
+def maybe_record_standdown_artifact(skill: str, cycle_id: str | None, exit_code: int, output: str) -> dict:
+    normalized = normalize_skill_name(skill)
+    if not cycle_id or exit_code != 0:
+        return {"recorded": False, "reason": "not_standdown_exit", "skill": normalized}
+    if artifact_terminal_evidence_for_cycle(cycle_id):
+        return {"recorded": False, "reason": "artifact_evidence_already_present", "skill": normalized}
+    if not skill_requires_artifact_publication(normalized, instance=EDGE_INSTANCE):
+        return {"recorded": False, "reason": "skill_not_artifact_pipeline", "skill": normalized}
+    state = dispatch_state_matches(cycle_id) or {}
+    request = state.get("request", {}) or {}
+    if str(request.get("trigger") or "").strip() != "heartbeat":
+        return {"recorded": False, "reason": "standdown_only_allowed_for_heartbeat", "skill": normalized}
+    if not _looks_like_principled_standdown(output):
+        return {"recorded": False, "reason": "standdown_marker_missing", "skill": normalized}
+
+    path, artifact = _standdown_artifact_path(cycle_id, normalized)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = (output or "").strip() + "\n"
+    path.write_text(
+        f"---\ncycle_id: {cycle_id}\nskill: {normalized}\nstatus: standdown\n---\n\n{body}",
+        encoding="utf-8",
+    )
+    emit_shadow_event(
+        "ArtifactStanddownRecorded",
+        actor="edge-runner",
+        artifact=artifact,
+        cycle_id=cycle_id,
+        payload={
+            "skill": normalized,
+            "source_skill": normalized,
+            "status": "standdown",
+            "reason": "principled_standdown",
+            "artifact": artifact,
+            "bytes": len(body.encode("utf-8", errors="replace")),
+        },
+    )
+    log_run_step(
+        "edge-runner",
+        "standdown_artifact",
+        "completed",
+        run_id=cycle_id,
+        backend="runtime",
+        mode="artifact",
+        target=normalized,
+        close_reason="principled_standdown",
+    )
+    return {
+        "recorded": True,
+        "reason": "standdown_recorded",
+        "skill": normalized,
+        "artifact": artifact,
+    }
 
 
 def maybe_publish_stdout_artifact(skill: str, cycle_id: str | None, exit_code: int, output: str) -> dict:
@@ -838,6 +968,17 @@ def maybe_publish_stdout_artifact(skill: str, cycle_id: str | None, exit_code: i
         return {"published": False, "reason": "skill_not_artifact_pipeline", "skill": normalized}
     if artifact_published_for_cycle(cycle_id):
         return {"published": True, "reason": "already_published", "skill": normalized}
+    standdown_result = maybe_record_standdown_artifact(normalized, cycle_id, exit_code, output)
+    if standdown_result.get("recorded"):
+        return {
+            "published": False,
+            "satisfied": True,
+            "reason": "standdown_recorded",
+            "skill": normalized,
+            "artifact": standdown_result.get("artifact"),
+        }
+    if standdown_recorded_for_cycle(cycle_id):
+        return {"published": False, "satisfied": True, "reason": "standdown_recorded", "skill": normalized}
     result = {"published": False, "reason": "stdout_artifact_disabled", "skill": normalized}
     emit_shadow_event(
         "ArtifactStdoutPublicationRejected",
@@ -897,9 +1038,9 @@ def should_retry_artifact_skill(skill: str | None, cycle_id: str | None, exit_co
     normalized = normalize_skill_name(skill)
     if not skill_requires_artifact_publication(normalized, instance=EDGE_INSTANCE):
         return False
-    if artifact_published_for_cycle(cycle_id):
+    if artifact_terminal_evidence_for_cycle(cycle_id):
         return False
-    return not bool(publish_result.get("published"))
+    return not bool(publish_result.get("published") or publish_result.get("satisfied"))
 
 
 def should_echo_backend_output(skill: str | None) -> bool:


### PR DESCRIPTION
## Summary

Closes #524. Closes #525. Closes #526.

- record explicit heartbeat standdowns as durable `ArtifactStanddownRecorded` evidence under `state/runtime/standdowns/`
- accept durable standdown evidence in artifact supervision and close gates without emitting fake `ArtifactPublished`
- keep stdout-only prose rejected for normal artifact-producing skills
- rebuild stale open-gaps projections during `open_gaps.refresh` instead of leaving postflight degraded on stale cache
- degrade blog API visibility failures after file publication while continuing to state commit and `ArtifactPublished`

## Validation

- `python3 -m py_compile tools/edge-runner tools/_shared/artifact_supervisor.py tools/edge-postflight tools/edge-close`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_edge_close.sh`
- `bash tests/test_postflight_resilience.sh`
- `bash tests/test_consolidate_phase6_paths.sh`