### PR TITLE
[codex] Recognize pipeline standdown state

### DIFF
--- a/tests/test_pipeline_state_projection.sh
+++ b/tests/test_pipeline_state_projection.sh
@@ -19,6 +19,7 @@ cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
 {"ts":"2026-04-26T15:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-no-artifact","payload":{"pipeline":"consolidate-state","phase":"1","ok":true},"prev_hash":"sha256:h"}
 {"ts":"2026-04-26T16:00:00+00:00","type":"PhaseCompleted","actor":"edge-runner","cycle_id":"cycle-runtime","artifact":"blog/entries/runtime.md","payload":{"pipeline":"runtime-stdout-artifact","phase":"pipeline","ok":true,"auto_published":true},"prev_hash":"sha256:i"}
 {"ts":"2026-04-26T16:01:00+00:00","type":"ArtifactPublished","actor":"continuity","cycle_id":"cycle-runtime","artifact":"blog/entries/runtime.md","payload":{"hash":"sha256:runtime","source_skill":"report","pipeline":"runtime-stdout-artifact","auto_published":true},"prev_hash":"sha256:j"}
+{"ts":"2026-04-26T17:00:00+00:00","type":"ArtifactStanddownRecorded","actor":"edge-runner","cycle_id":"cycle-standdown","artifact":"state/runtime/standdowns/cycle-standdown-research.md","payload":{"source_skill":"research","skill":"research","status":"standdown","reason":"principled_standdown"},"prev_hash":"sha256:k"}
 JSONL
 
 echo "=== pipeline state projection test ==="
@@ -35,11 +36,12 @@ projection = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 summary = projection["summary"]
 by_artifact = {item["artifact"]: item for item in projection["recent_artifacts"]}
 
-assert summary["artifacts_total"] == 6, summary
+assert summary["artifacts_total"] == 7, summary
 assert summary["artifacts_attention"] == 5, summary
 assert summary["orphan_events_without_artifact"] == 1, summary
 assert summary["counts_by_status"]["complete"] == 1, summary
 assert summary["counts_by_status"]["partial"] == 1, summary
+assert summary["counts_by_status"]["standdown"] == 1, summary
 assert summary["counts_by_status"]["blocked"] == 1, summary
 assert summary["counts_by_status"]["failed"] == 1, summary
 assert summary["counts_by_status"]["orphaned_publish"] == 1, summary
@@ -74,6 +76,13 @@ assert runtime["status"] == "runtime_bypass"
 assert runtime["published"] is False
 assert runtime["runtime_stdout_artifact"] is True
 assert runtime["reasons"] == ["runtime_stdout_artifact_rejected"]
+
+standdown = by_artifact["state/runtime/standdowns/cycle-standdown-research.md"]
+assert standdown["status"] == "standdown"
+assert standdown["standdown"] is True
+assert standdown["standdown_reason"] == "principled_standdown"
+assert standdown["source_skill"] == "research"
+assert standdown["event_counts"]["ArtifactStanddownRecorded"] == 1
 PY
 
 EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" \
@@ -83,12 +92,12 @@ python3 - <<'PY' /tmp/edge-replay-pipeline-state.json
 import json
 import sys
 payload = json.load(open(sys.argv[1], encoding="utf-8"))
-assert payload["summary"]["artifacts_total"] == 6
+assert payload["summary"]["artifacts_total"] == 7
 assert payload["summary"]["artifacts_attention"] == 5
 PY
 
 SUMMARY_OUTPUT="$(EDGE_REPO_DIR="$EDGE_DIR" EDGE_STATE_DIR="$TMP_STATE" "$EDGE_DIR/tools/edge-replay" pipeline-state --no-write)"
-if echo "$SUMMARY_OUTPUT" | grep -q "complete=1" && echo "$SUMMARY_OUTPUT" | grep -q "blocked=1"; then
+if echo "$SUMMARY_OUTPUT" | grep -q "complete=1" && echo "$SUMMARY_OUTPUT" | grep -q "standdown=1" && echo "$SUMMARY_OUTPUT" | grep -q "blocked=1"; then
   echo "PASS: edge-replay pipeline-state summarizes projection counts"
 else
   echo "$SUMMARY_OUTPUT"

--- a/tests/test_postflight_pipeline_state.sh
+++ b/tests/test_postflight_pipeline_state.sh
@@ -27,6 +27,7 @@ cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
 {"ts":"2026-04-26T10:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-ok","artifact":"blog/entries/ok.md","payload":{"pipeline":"consolidate-state","phase":"pipeline","ok":true},"prev_hash":"sha256:root"}
 {"ts":"2026-04-26T10:01:00+00:00","type":"ArtifactPublished","actor":"continuity","cycle_id":"cycle-ok","artifact":"blog/entries/ok.md","payload":{"source_skill":"research"},"prev_hash":"sha256:a"}
 {"ts":"2026-04-26T11:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-bad","artifact":"blog/entries/bad.md","payload":{"pipeline":"consolidate-state","phase":"3","ok":false,"reason":"verification failed"},"prev_hash":"sha256:b"}
+{"ts":"2026-04-26T12:00:00+00:00","type":"ArtifactStanddownRecorded","actor":"edge-runner","cycle_id":"cycle-standdown","artifact":"state/runtime/standdowns/cycle-standdown-discovery.md","payload":{"source_skill":"discovery","skill":"discovery","status":"standdown","reason":"principled_standdown"},"prev_hash":"sha256:c"}
 JSONL
 
 echo "=== postflight pipeline-state Smoke Test ==="
@@ -85,6 +86,34 @@ then
     pass "postflight pipeline-state step warns on current-cycle blocked artifacts"
 else
     fail "postflight pipeline-state step warns on current-cycle blocked artifacts"
+fi
+
+echo "--- Test 3: current-cycle accepted standdown satisfies pipeline-state step ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+loader = importlib.machinery.SourceFileLoader("edge_postflight", str(edge_dir / "tools" / "edge-postflight"))
+spec = importlib.util.spec_from_loader("edge_postflight", loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+result = module._execute_postflight_step(
+    {"id": "pipeline-state", "kind": "pipeline_state.refresh"},
+    {"cycle_id": "cycle-standdown", "request": {}, "state": {}},
+)
+assert result["status"] == "ok", result
+assert result["satisfied"] is True, result
+assert result["payload"]["summary"]["counts_by_status"]["standdown"] == 1
+assert result.get("current_attention") in (None, []), result
+PY
+then
+    pass "postflight pipeline-state step is OK for accepted standdown cycles"
+else
+    fail "postflight pipeline-state step is OK for accepted standdown cycles"
 fi
 
 echo ""

--- a/tools/audit-cqrs-migration.py
+++ b/tools/audit-cqrs-migration.py
@@ -68,6 +68,7 @@ def _run_projection() -> Check:
         f"artifacts={summary.get('artifacts_total', 0)} "
         f"attention={summary.get('artifacts_attention', 0)} "
         f"complete={counts.get('complete', 0)} "
+        f"standdown={counts.get('standdown', 0)} "
         f"blocked={counts.get('blocked', 0)} "
         f"failed={counts.get('failed', 0)} "
         f"orphaned_publish={counts.get('orphaned_publish', 0)}"

--- a/tools/edge-doctor
+++ b/tools/edge-doctor
@@ -478,6 +478,7 @@ def check_pipeline_state():
         f"attention={summary.get('artifacts_attention', 0)}, "
         f"complete={counts.get('complete', 0)}, "
         f"partial={counts.get('partial', 0)}, "
+        f"standdown={counts.get('standdown', 0)}, "
         f"blocked={counts.get('blocked', 0)}, "
         f"failed={counts.get('failed', 0)}, "
         f"orphaned_publish={counts.get('orphaned_publish', 0)}"

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -328,6 +328,7 @@ def refresh_pipeline_state(cycle_id: str | None = None) -> dict[str, Any]:
         f"artifacts={summary.get('artifacts_total', 0)} "
         f"attention={summary.get('artifacts_attention', 0)} "
         f"complete={counts.get('complete', 0)} "
+        f"standdown={counts.get('standdown', 0)} "
         f"blocked={counts.get('blocked', 0)} "
         f"failed={counts.get('failed', 0)} "
         f"current_attention={len(attention)}"

--- a/tools/edge-replay
+++ b/tools/edge-replay
@@ -117,6 +117,7 @@ def cmd_pipeline_state(args: argparse.Namespace) -> int:
             f"attention={summary['artifacts_attention']} "
             f"complete={counts.get('complete', 0)} "
             f"partial={counts.get('partial', 0)} "
+            f"standdown={counts.get('standdown', 0)} "
             f"blocked={counts.get('blocked', 0)} "
             f"failed={counts.get('failed', 0)} "
             f"orphaned_publish={counts.get('orphaned_publish', 0)}"

--- a/tools/rollup-pipeline-state.py
+++ b/tools/rollup-pipeline-state.py
@@ -18,7 +18,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "config"))
 from paths import PIPELINE_STATE_FILE, STATE_EVENTS_FILE  # noqa: E402
 
-PIPELINE_EVENT_TYPES = {"PhaseCompleted", "ArtifactPublished"}
+PIPELINE_EVENT_TYPES = {"PhaseCompleted", "ArtifactPublished", "ArtifactStanddownRecorded"}
 TRUE_VALUES = {"1", "true", "yes", "ok", "success", "succeeded", "completed", "pass", "passed"}
 FALSE_VALUES = {"0", "false", "no", "fail", "failed", "error", "blocked", "aborted"}
 TERMINAL_PHASES = {"pipeline", "pipeline-end", "pipeline_end"}
@@ -93,12 +93,15 @@ def _build_empty_artifact(artifact: str) -> dict[str, Any]:
         "last_event_at": "",
         "published_at": "",
         "published": False,
+        "standdown": False,
+        "standdown_at": "",
+        "standdown_reason": "",
         "runtime_stdout_artifact": False,
         "terminal_phase_status": "",
         "terminal_phase_at": "",
         "phase_counts": {"ok": 0, "failed": 0, "unknown": 0},
         "phases": [],
-        "event_counts": {"PhaseCompleted": 0, "ArtifactPublished": 0},
+        "event_counts": {"PhaseCompleted": 0, "ArtifactPublished": 0, "ArtifactStanddownRecorded": 0},
         "event_lines": [],
         "reasons": [],
     }
@@ -175,6 +178,23 @@ def _apply_artifact_published(record: dict[str, Any], event: dict[str, Any], pay
     _merge_first(record, "hash", payload.get("hash"))
 
 
+def _apply_artifact_standdown(record: dict[str, Any], event: dict[str, Any], payload: dict[str, Any]) -> None:
+    _touch_artifact(record, event)
+    record["event_counts"]["ArtifactStanddownRecorded"] = (
+        int(record["event_counts"].get("ArtifactStanddownRecorded") or 0) + 1
+    )
+    record["standdown"] = True
+    if not record.get("standdown_at") or _timestamp(event) >= str(record.get("standdown_at") or ""):
+        record["standdown_at"] = _timestamp(event)
+    _merge_first(record, "pipeline", payload.get("pipeline") or event.get("actor"))
+    _merge_first(record, "source_skill", payload.get("source_skill") or payload.get("skill"))
+
+    reason = str(payload.get("reason") or payload.get("status") or "standdown").strip()
+    if reason:
+        record["standdown_reason"] = reason
+        record["reasons"].append(reason)
+
+
 def _classify(record: dict[str, Any]) -> str:
     phase_total = int(record["event_counts"].get("PhaseCompleted") or 0)
     published = bool(record.get("published"))
@@ -183,6 +203,8 @@ def _classify(record: dict[str, Any]) -> str:
 
     if record.get("runtime_stdout_artifact"):
         return "runtime_bypass"
+    if record.get("standdown"):
+        return "standdown"
     if published and phase_total == 0:
         return "orphaned_publish"
     if terminal == "ok":
@@ -223,6 +245,8 @@ def build_projection(limit: int = 50, events_path: Path = STATE_EVENTS_FILE) -> 
             _apply_phase_completed(record, event, payload)
         elif etype == "ArtifactPublished":
             _apply_artifact_published(record, event, payload)
+        elif etype == "ArtifactStanddownRecorded":
+            _apply_artifact_standdown(record, event, payload)
 
     for record in artifacts.values():
         record["status"] = _classify(record)
@@ -294,6 +318,7 @@ def main() -> int:
             f"attention={summary['artifacts_attention']} "
             f"complete={counts.get('complete', 0)} "
             f"partial={counts.get('partial', 0)} "
+            f"standdown={counts.get('standdown', 0)} "
             f"blocked={counts.get('blocked', 0)} "
             f"failed={counts.get('failed', 0)} "
             f"orphaned_publish={counts.get('orphaned_publish', 0)})"


### PR DESCRIPTION
## Summary

Closes #528.

- Teach `rollup-pipeline-state` to consume `ArtifactStanddownRecorded` events and classify accepted heartbeat standdowns as `standdown` instead of attention.
- Include the standdown count in replay, postflight, doctor, and CQRS audit summaries.
- Add regression coverage for projection and postflight behavior so current-cycle accepted standdowns no longer create `pipeline-state` warnings.

## Validation

- `python3 -m py_compile tools/rollup-pipeline-state.py tools/edge-postflight tools/edge-replay tools/edge-doctor tools/audit-cqrs-migration.py`
- `bash tests/test_pipeline_state_projection.sh`
- `bash tests/test_postflight_pipeline_state.sh`