### PR TITLE
[codex] Wait for pending pipeline state in postflight

### DIFF
--- a/tests/test_postflight_pipeline_state.sh
+++ b/tests/test_postflight_pipeline_state.sh
@@ -22,12 +22,17 @@ export HOME="$TMP_HOME"
 export EDGE_REPO_DIR="$EDGE_DIR"
 export EDGE_STATE_DIR="$TMP_STATE"
 export EDGE_CODENAME="postflight-pipeline-test"
+export EDGE_POSTFLIGHT_PIPELINE_SETTLE_ATTEMPTS=2
+export EDGE_POSTFLIGHT_PIPELINE_SETTLE_INTERVAL_SEC=0
+export EDGE_POSTFLIGHT_PIPELINE_SETTLE_MAX_EVENT_AGE_SEC=999999999
 
 cat >"$TMP_STATE/state/events/log.jsonl" <<'JSONL'
 {"ts":"2026-04-26T10:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-ok","artifact":"blog/entries/ok.md","payload":{"pipeline":"consolidate-state","phase":"pipeline","ok":true},"prev_hash":"sha256:root"}
 {"ts":"2026-04-26T10:01:00+00:00","type":"ArtifactPublished","actor":"continuity","cycle_id":"cycle-ok","artifact":"blog/entries/ok.md","payload":{"source_skill":"research"},"prev_hash":"sha256:a"}
 {"ts":"2026-04-26T11:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-bad","artifact":"blog/entries/bad.md","payload":{"pipeline":"consolidate-state","phase":"3","ok":false,"reason":"verification failed"},"prev_hash":"sha256:b"}
 {"ts":"2026-04-26T12:00:00+00:00","type":"ArtifactStanddownRecorded","actor":"edge-runner","cycle_id":"cycle-standdown","artifact":"state/runtime/standdowns/cycle-standdown-discovery.md","payload":{"source_skill":"discovery","skill":"discovery","status":"standdown","reason":"principled_standdown"},"prev_hash":"sha256:c"}
+{"ts":"2026-04-26T13:00:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-pending","artifact":"blog/entries/pending.md","payload":{"pipeline":"consolidate-state","phase":"0a","ok":true},"prev_hash":"sha256:d"}
+{"ts":"2026-04-26T13:01:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-pending","artifact":"blog/entries/pending.md","payload":{"pipeline":"consolidate-state","phase":"0.3","ok":false,"reason":"review generated; pending resolution"},"prev_hash":"sha256:e"}
 JSONL
 
 echo "=== postflight pipeline-state Smoke Test ==="
@@ -114,6 +119,49 @@ then
     pass "postflight pipeline-state step is OK for accepted standdown cycles"
 else
     fail "postflight pipeline-state step is OK for accepted standdown cycles"
+fi
+
+echo "--- Test 4: current-cycle pending review is retried before warning ---"
+if python3 - <<'PY' "$EDGE_DIR" "$TMP_STATE"
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+edge_dir = Path(sys.argv[1])
+state_dir = Path(sys.argv[2])
+loader = importlib.machinery.SourceFileLoader("edge_postflight", str(edge_dir / "tools" / "edge-postflight"))
+spec = importlib.util.spec_from_loader("edge_postflight", loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+original = module.run_subprocess
+calls = {"n": 0}
+
+def wrapped(cmd):
+    calls["n"] += 1
+    result = original(cmd)
+    if calls["n"] == 1:
+        with (state_dir / "state" / "events" / "log.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write('{"ts":"2026-04-26T13:02:00+00:00","type":"PhaseCompleted","actor":"consolidate-state","cycle_id":"cycle-pending","artifact":"blog/entries/pending.md","payload":{"pipeline":"consolidate-state","phase":"pipeline","ok":true},"prev_hash":"sha256:f"}\n')
+            handle.write('{"ts":"2026-04-26T13:03:00+00:00","type":"ArtifactPublished","actor":"consolidate-state","cycle_id":"cycle-pending","artifact":"blog/entries/pending.md","payload":{"source_skill":"report","pipeline":"consolidate-state"},"prev_hash":"sha256:g"}\n')
+    return result
+
+module.run_subprocess = wrapped
+result = module._execute_postflight_step(
+    {"id": "pipeline-state", "kind": "pipeline_state.refresh"},
+    {"cycle_id": "cycle-pending", "request": {}, "state": {}},
+)
+assert calls["n"] >= 2, calls
+assert result["status"] == "ok", result
+assert result["satisfied"] is True, result
+assert "settle_attempts=1" in result["detail"], result
+assert result.get("current_attention") in (None, []), result
+PY
+then
+    pass "postflight retries pending current-cycle pipeline attention before warning"
+else
+    fail "postflight retries pending current-cycle pipeline attention before warning"
 fi
 
 echo ""

--- a/tools/edge-postflight
+++ b/tools/edge-postflight
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,9 @@ from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
 
 POST_SKILL_LOG = LOGS_DIR / "post-skill.log"
 DEFAULT_OPEN_GAPS_PROJECTION_MAX_AGE_SECONDS = 6 * 60 * 60
+DEFAULT_PIPELINE_SETTLE_ATTEMPTS = 12
+DEFAULT_PIPELINE_SETTLE_INTERVAL_SECONDS = 30.0
+DEFAULT_PIPELINE_SETTLE_MAX_EVENT_AGE_SECONDS = 10 * 60
 
 
 def now_iso() -> str:
@@ -49,6 +53,20 @@ def append_postskill_log(name: str, status: str, detail: str = "") -> None:
 def run_subprocess(cmd: list[str]) -> tuple[int, str, str]:
     result = subprocess.run(cmd, cwd=str(EDGE_REPO_DIR), capture_output=True, text=True)
     return result.returncode, (result.stdout or "").strip(), (result.stderr or "").strip()
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
 
 
 def _read_json_file(path: Path, default: Any) -> Any:
@@ -310,29 +328,111 @@ def refresh_open_gaps_status() -> dict[str, Any]:
 
 
 def refresh_pipeline_state(cycle_id: str | None = None) -> dict[str, Any]:
-    code, stdout, stderr = run_subprocess([sys.executable, str(EDGE_REPO_DIR / "tools" / "rollup-pipeline-state.py"), "--json"])
-    if code != 0:
-        detail = (stderr or stdout or f"exit={code}").splitlines()[-1]
-        append_postskill_log("pipeline_state", "FAIL", detail)
-        return {"ok": False, "status": "failed", "detail": detail, "payload": {}, "current_attention": []}
+    def run_rollup() -> tuple[dict[str, Any], str | None]:
+        code, stdout, stderr = run_subprocess([sys.executable, str(EDGE_REPO_DIR / "tools" / "rollup-pipeline-state.py"), "--json"])
+        if code != 0:
+            return {}, (stderr or stdout or f"exit={code}").splitlines()[-1]
+        try:
+            return (json.loads(stdout) if stdout else {}), None
+        except json.JSONDecodeError as exc:
+            return {}, str(exc)
 
-    payload = json.loads(stdout) if stdout else {}
-    summary = payload.get("summary") or {}
-    counts = summary.get("counts_by_status") or {}
-    attention = [
-        item
-        for item in (payload.get("attention_artifacts") or [])
-        if cycle_id and item.get("cycle_id") == cycle_id
-    ]
-    detail = (
-        f"artifacts={summary.get('artifacts_total', 0)} "
-        f"attention={summary.get('artifacts_attention', 0)} "
-        f"complete={counts.get('complete', 0)} "
-        f"standdown={counts.get('standdown', 0)} "
-        f"blocked={counts.get('blocked', 0)} "
-        f"failed={counts.get('failed', 0)} "
-        f"current_attention={len(attention)}"
-    )
+    def current_attention(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        return [
+            item
+            for item in (payload.get("attention_artifacts") or [])
+            if cycle_id and item.get("cycle_id") == cycle_id
+        ]
+
+    def parse_ts(value: Any) -> datetime | None:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+
+    def is_recent_current_artifact(item: dict[str, Any]) -> bool:
+        max_age = _env_int(
+            "EDGE_POSTFLIGHT_PIPELINE_SETTLE_MAX_EVENT_AGE_SEC",
+            DEFAULT_PIPELINE_SETTLE_MAX_EVENT_AGE_SECONDS,
+        )
+        if max_age <= 0:
+            return True
+        last_seen = parse_ts(item.get("last_event_at") or item.get("published_at") or item.get("first_event_at"))
+        if last_seen is None:
+            return True
+        return (datetime.now(timezone.utc) - last_seen).total_seconds() <= max_age
+
+    def is_settleable(item: dict[str, Any]) -> bool:
+        if not is_recent_current_artifact(item):
+            return False
+        if str(item.get("pipeline") or "") != "consolidate-state":
+            return False
+        if item.get("published") or item.get("standdown"):
+            return False
+        status = str(item.get("status") or "")
+        if status not in {"partial", "blocked", "unknown"}:
+            return False
+        terminal = str(item.get("terminal_phase_status") or "").strip()
+        if terminal in {"ok", "failed"}:
+            return False
+        event_counts = item.get("event_counts") or {}
+        if int(event_counts.get("ArtifactPublished") or 0) > 0:
+            return False
+        reasons = " ".join(str(reason) for reason in (item.get("reasons") or [])).lower()
+        if "pending" in reasons or "in flight" in reasons or "in-flight" in reasons:
+            return True
+        phase_counts = item.get("phase_counts") or {}
+        return int(phase_counts.get("failed") or 0) == 0
+
+    def detail_for(payload: dict[str, Any], attention: list[dict[str, Any]], settle_attempts: int = 0) -> str:
+        summary = payload.get("summary") or {}
+        counts = summary.get("counts_by_status") or {}
+        detail = (
+            f"artifacts={summary.get('artifacts_total', 0)} "
+            f"attention={summary.get('artifacts_attention', 0)} "
+            f"complete={counts.get('complete', 0)} "
+            f"standdown={counts.get('standdown', 0)} "
+            f"blocked={counts.get('blocked', 0)} "
+            f"failed={counts.get('failed', 0)} "
+            f"current_attention={len(attention)}"
+        )
+        if settle_attempts:
+            detail += f" settle_attempts={settle_attempts}"
+        return detail
+
+    payload, error = run_rollup()
+    if error is not None:
+        append_postskill_log("pipeline_state", "FAIL", error)
+        return {"ok": False, "status": "failed", "detail": error, "payload": {}, "current_attention": []}
+
+    attention = current_attention(payload)
+    settle_attempts = 0
+    max_attempts = max(0, _env_int("EDGE_POSTFLIGHT_PIPELINE_SETTLE_ATTEMPTS", DEFAULT_PIPELINE_SETTLE_ATTEMPTS))
+    interval = max(0.0, _env_float("EDGE_POSTFLIGHT_PIPELINE_SETTLE_INTERVAL_SEC", DEFAULT_PIPELINE_SETTLE_INTERVAL_SECONDS))
+    while attention and settle_attempts < max_attempts and all(is_settleable(item) for item in attention):
+        settle_attempts += 1
+        append_postskill_log(
+            "pipeline_state",
+            "WAIT",
+            detail_for(payload, attention, settle_attempts),
+        )
+        if interval > 0:
+            time.sleep(interval)
+        payload, error = run_rollup()
+        if error is not None:
+            append_postskill_log("pipeline_state", "FAIL", error)
+            return {"ok": False, "status": "failed", "detail": error, "payload": {}, "current_attention": []}
+        attention = current_attention(payload)
+
+    detail = detail_for(payload, attention, settle_attempts)
     ok = len(attention) == 0
     append_postskill_log("pipeline_state", "OK" if ok else "WARN", detail)
     return {


### PR DESCRIPTION
## Summary

Fixes #532.

Postflight now gives current-cycle consolidate-state artifacts a bounded settle window before marking `pipeline-state` as warning. This handles the race where adversarial review has emitted `review generated; pending resolution`, but the same artifact is still actively progressing and later publishes cleanly.

The retry is limited to current-cycle consolidate-state attention that looks in-flight or pending. Hard blocked artifacts, terminal failed artifacts, runtime bypasses, stale attention, and non-current-cycle attention still warn as before.

## Validation

- `python3 -m py_compile tools/edge-postflight tools/rollup-pipeline-state.py`
- `bash tests/test_postflight_pipeline_state.sh`
- `bash tests/test_pipeline_state_projection.sh`
- `bash tests/test_postflight_resilience.sh`