### PR TITLE
[codex] Settle pending artifact supervision review

### DIFF
--- a/tests/test_edge_close.sh
+++ b/tests/test_edge_close.sh
@@ -73,6 +73,8 @@ YAML
 export EDGE_REPO_DIR="$EDGE_DIR"
 export EDGE_STATE_DIR="$TMP_EDGE"
 export EDGE_CODENAME="test-agent"
+export EDGE_ARTIFACT_SUPERVISION_SETTLE_ATTEMPTS=2
+export EDGE_ARTIFACT_SUPERVISION_SETTLE_INTERVAL_SEC=0
 
 DISPATCH_TOOL="$EDGE_DIR/tools/edge-dispatch"
 CLOSE_TOOL="$EDGE_DIR/tools/edge-close"
@@ -152,6 +154,34 @@ event = {
         "phase": "review",
         "ok": False,
         "reason": reason,
+    },
+}
+with open(path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(event) + "\n")
+PY
+}
+
+append_phase_pending() {
+    local cycle_id="$1"
+    local slug="$2"
+    python3 - <<'PY' "$TMP_EDGE/state/events/log.jsonl" "$cycle_id" "$slug"
+import json
+import sys
+from datetime import datetime, timezone
+
+path, cycle_id, slug = sys.argv[1:4]
+event = {
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "type": "PhaseCompleted",
+    "actor": "consolidate-state",
+    "cycle_id": cycle_id,
+    "artifact": f"blog/entries/{slug}.md",
+    "payload": {
+        "pipeline": "consolidate-state",
+        "phase": "0.3",
+        "operation": "adversarial_review_pending",
+        "ok": False,
+        "reason": "review generated; pending resolution",
     },
 }
 with open(path, "a", encoding="utf-8") as fh:
@@ -499,6 +529,47 @@ then
     pass "durable publication wins over earlier failed phase evidence"
 else
     fail "durable publication wins over earlier failed phase evidence"
+fi
+
+echo "--- Test 2g: pending publication pipeline is settled before close fails ---"
+"$DISPATCH_TOOL" open --trigger operator --cycle-id cycle-close-pipeline-pending --force >/dev/null
+"$DISPATCH_TOOL" dispatch --skill research >/dev/null
+append_skill_completed cycle-close-pipeline-pending research
+append_phase_pending cycle-close-pipeline-pending pending-report
+set +e
+"$CLOSE_TOOL" --status completed >/dev/null
+STATUS=$?
+set -e
+
+if python3 - <<'PY' "$TMP_EDGE/state/current-dispatch.json" "$TMP_EDGE/state/events/log.jsonl" "$STATUS"
+import json
+import sys
+
+dispatch = json.load(open(sys.argv[1], encoding="utf-8"))
+events = [json.loads(line) for line in open(sys.argv[2], encoding="utf-8") if line.strip()]
+status = int(sys.argv[3])
+
+assert status == 1
+assert dispatch["state"]["active"] is False
+assert dispatch["state"]["close_status"] == "failed"
+assert dispatch["state"]["close_reason"] == "pipeline_pending_before_publish"
+assert dispatch["state"]["artifact_supervision_status"] == "pending"
+assert dispatch["state"]["artifact_supervision_reason"] == "pipeline_pending_before_publish"
+step = dispatch["state"]["postflight_steps"][0]
+assert step["settle_attempts"] == 2
+assert step["pipeline_evidence"]["reason"] == "review generated; pending resolution"
+blocked = [
+    event for event in events
+    if event.get("cycle_id") == "cycle-close-pipeline-pending"
+    and event.get("type") == "ArtifactSupervisionBlocked"
+]
+assert blocked
+assert blocked[-1]["payload"]["reason"] == "pipeline_pending_before_publish"
+PY
+then
+    pass "edge-close settles pending pipeline evidence before failing"
+else
+    fail "edge-close settles pending pipeline evidence before failing"
 fi
 
 echo "--- Test 3: completed close succeeds with skill end evidence, artifact publication, and postflight ---"

--- a/tests/test_edge_runner.sh
+++ b/tests/test_edge_runner.sh
@@ -744,6 +744,8 @@ assert dispatch["state"]["close_status"] == "completed"
 assert args_log.count("__INVOCATION__") == 2
 assert "ARTIFACT SUPERVISOR RETRY" in args_log
 assert "Stdout-only prose is diagnostic output only" in args_log
+assert "review generated; pending resolution" in args_log
+assert "ArtifactPublished" in args_log
 assert "runtime can publish it" not in args_log
 retry_started = [
     event for event in events

--- a/tools/_shared/artifact_supervisor.py
+++ b/tools/_shared/artifact_supervisor.py
@@ -13,6 +13,7 @@ from .telemetry import emit_shadow_event
 
 TRUE_VALUES = {"1", "true", "yes", "ok", "success", "succeeded", "completed", "pass", "passed"}
 FALSE_VALUES = {"0", "false", "no", "fail", "failed", "error", "blocked", "aborted"}
+PENDING_MARKERS = {"pending", "in flight", "in-flight"}
 
 
 def iso_ge(left: str | None, right: str | None) -> bool:
@@ -79,6 +80,14 @@ def _pipeline_failure_evidence(event: dict[str, Any], payload: dict[str, Any]) -
     }
 
 
+def _pipeline_evidence_is_pending(payload: dict[str, Any]) -> bool:
+    text = " ".join(
+        str(payload.get(key) or "").strip().lower()
+        for key in ("operation", "reason", "status", "error")
+    )
+    return any(marker in text for marker in PENDING_MARKERS)
+
+
 def _is_runtime_stdout_artifact(payload: dict[str, Any]) -> bool:
     return bool(
         payload.get("auto_published") is True
@@ -128,6 +137,7 @@ def supervise_artifact_publication(
 
     threshold = str(result.get("threshold") or "") or None
     pipeline_failure: dict[str, Any] | None = None
+    pipeline_pending: dict[str, Any] | None = None
     for event in iter_jsonl_reverse(events_path):
         if event.get("cycle_id") != cycle_id:
             continue
@@ -177,10 +187,14 @@ def supervise_artifact_publication(
                 )
                 return result
 
-        if etype == "ArtifactWriteRejected" and pipeline_failure is None:
+        if etype == "ArtifactWriteRejected" and pipeline_failure is None and pipeline_pending is None:
             pipeline_failure = _pipeline_failure_evidence(event, payload)
-        elif etype == "PhaseCompleted" and _phase_ok(payload) is False and pipeline_failure is None:
-            pipeline_failure = _pipeline_failure_evidence(event, payload)
+        elif etype == "PhaseCompleted" and _phase_ok(payload) is False and pipeline_failure is None and pipeline_pending is None:
+            evidence = _pipeline_failure_evidence(event, payload)
+            if _pipeline_evidence_is_pending(payload):
+                pipeline_pending = evidence
+            else:
+                pipeline_failure = evidence
 
     if pipeline_failure:
         result.update(
@@ -188,6 +202,16 @@ def supervise_artifact_publication(
                 "status": "blocked",
                 "reason": "pipeline_blocked_before_publish",
                 "pipeline_evidence": pipeline_failure,
+            }
+        )
+        return result
+
+    if pipeline_pending:
+        result.update(
+            {
+                "status": "pending",
+                "reason": "pipeline_pending_before_publish",
+                "pipeline_evidence": pipeline_pending,
             }
         )
         return result

--- a/tools/edge-close
+++ b/tools/edge-close
@@ -12,6 +12,7 @@ import argparse
 import json
 import os
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -28,6 +29,8 @@ from _shared.jsonl_runtime import iter_jsonl_reverse  # noqa: E402
 from _shared.telemetry import emit_shadow_event, log_event  # noqa: E402
 
 POST_SKILL_LOG = LOGS_DIR / "post-skill.log"
+DEFAULT_ARTIFACT_SUPERVISION_SETTLE_ATTEMPTS = 12
+DEFAULT_ARTIFACT_SUPERVISION_SETTLE_INTERVAL_SECONDS = 30.0
 
 
 def now_iso() -> str:
@@ -74,6 +77,55 @@ def append_postskill_log(name: str, status: str, detail: str = "") -> None:
         message += f" | detail: {detail}"
     with open(POST_SKILL_LOG, "a", encoding="utf-8") as f:
         f.write(message + "\n")
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def supervise_artifact_publication_with_settle(state: dict) -> dict:
+    result = supervise_artifact_publication(
+        state,
+        events_path=STATE_EVENTS_FILE,
+        instance=EDGE_INSTANCE,
+    )
+    attempts = 0
+    max_attempts = max(
+        0,
+        _env_int("EDGE_ARTIFACT_SUPERVISION_SETTLE_ATTEMPTS", DEFAULT_ARTIFACT_SUPERVISION_SETTLE_ATTEMPTS),
+    )
+    interval = max(
+        0.0,
+        _env_float("EDGE_ARTIFACT_SUPERVISION_SETTLE_INTERVAL_SEC", DEFAULT_ARTIFACT_SUPERVISION_SETTLE_INTERVAL_SECONDS),
+    )
+    while result.get("status") == "pending" and attempts < max_attempts:
+        attempts += 1
+        evidence = result.get("pipeline_evidence") or {}
+        append_postskill_log(
+            "artifact_supervision",
+            "WAIT",
+            f"{result.get('reason') or 'pending'} artifact={evidence.get('artifact') or ''} attempt={attempts}",
+        )
+        if interval > 0:
+            time.sleep(interval)
+        result = supervise_artifact_publication(
+            state,
+            events_path=STATE_EVENTS_FILE,
+            instance=EDGE_INSTANCE,
+        )
+    if attempts:
+        result["settle_attempts"] = attempts
+    return result
 
 
 def check_skill_completion(state: dict) -> tuple[bool, str, dict]:
@@ -233,11 +285,7 @@ def main() -> int:
             exit_code = 1
         else:
             append_postskill_log("skill_run_completed", "OK", skill_reason)
-            artifact_result = supervise_artifact_publication(
-                state,
-                events_path=STATE_EVENTS_FILE,
-                instance=EDGE_INSTANCE,
-            )
+            artifact_result = supervise_artifact_publication_with_settle(state)
             record_artifact_supervision(state, artifact_result)
             if not artifact_result.get("ok"):
                 fail_close_with_postflight_reason(

--- a/tools/edge-runner
+++ b/tools/edge-runner
@@ -1023,6 +1023,8 @@ def build_artifact_supervisor_retry_prompt(
         "- Do not answer with only deference, standby text, topic choices, or a refusal to act because another persona/session appears active.\n"
         "- If no explicit topic was supplied, infer one bounded target from the runtime frame: exploration_pack, beat_launch_context, operator_pressure, health, open gaps, queue, or recent failures.\n"
         "- Produce a durable artifact now by running `consolidate-state` with a real blog entry and report artifact.\n"
+        "- If `consolidate-state` stops at adversarial review pending, incorporate the review feedback and rerun it; do not stop at `review generated; pending resolution`.\n"
+        "- Continue until the event log contains `ArtifactPublished` for this cycle, or until you record an explicit `ArtifactStanddownRecorded` standdown/failure report.\n"
         "- Stdout-only prose is diagnostic output only; it does not publish and does not satisfy the artifact gate.\n"
         "- If a real blocker remains, the artifact must be a failure report with the concrete command, missing access, or invariant that blocked completion.\n\n"
         "Previous backend output:\n"


### PR DESCRIPTION
## Summary

Fixes #534.

Artifact supervision now distinguishes pending consolidate-state review evidence from terminal pipeline failure. `edge-close` gives pending current-cycle artifact evidence a bounded settle window before failing, while hard failures still block immediately.

The artifact supervisor retry prompt also now explicitly tells the backend to resolve adversarial review pending and rerun `consolidate-state` until durable terminal evidence exists.

## Validation

- `python3 -m py_compile tools/_shared/artifact_supervisor.py tools/edge-close tools/edge-runner tools/edge-postflight`
- `bash tests/test_edge_close.sh`
- `bash tests/test_edge_runner.sh`
- `bash tests/test_postflight_pipeline_state.sh`
- `bash tests/test_consolidate_adversarial_phase.sh`