### PR TITLE
[codex] Enforce review-gate pass in consolidate-state

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -956,6 +956,16 @@ try:
 except Exception:
     print(0)
 " 2>/dev/null)
+    REVIEW_PASS=$(echo "$REVIEW_JSON" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    fr = d.get('final_review', d)
+    value = fr.get('pass', d.get('pass', None))
+    print('true' if value is True else 'false')
+except Exception:
+    print('false')
+" 2>/dev/null)
     REVIEW_COST=$(echo "$REVIEW_JSON" | python3 -c "
 import json, sys, re
 try:
@@ -1006,6 +1016,12 @@ if suggestions:
         print(f'    - {str(s)[:120]}')
 " 2>/dev/null
         echo "  Feedback: $FEEDBACK_FILE"
+    fi
+
+    if [[ "$REVIEW_GATE_STATUS" != "degraded" && "$REVIEW_PASS" != "true" ]]; then
+        fail "Review gate failed: pass=false, score ${REVIEW_SCORE}/5.0"
+        emit_run_step_event "phase-0.5" "failed" "review_gate" "review-gate pass=false"
+        exit 3
     fi
 
     if [[ "$REVIEW_ONLY" == "true" ]]; then

--- a/tests/test_consolidate_adversarial_phase.sh
+++ b/tests/test_consolidate_adversarial_phase.sh
@@ -62,6 +62,7 @@ import json
 print(json.dumps({
   "final_review": {
     "overall": 4.2,
+    "pass": True,
     "critical_issues": [],
     "suggestions": [],
     "_meta": {"cost_estimate": "$0.0010"}
@@ -260,7 +261,74 @@ else
     fail "review-only HTML publish with generated review succeeds"
 fi
 
-echo "--- Test 4: heartbeat review-gate degradation records metadata and continues ---"
+echo "--- Test 4: review-gate pass=false blocks publication ---"
+TMP_FAIL_ENTRY="$TMP_STATE/blog/entries/failing-review-entry.md"
+TMP_FAIL_REPORT="$TMP_STATE/reports/spec-report-failing-review.yaml"
+cat >"$TMP_FAIL_ENTRY" <<'EOF'
+---
+title: "Failing review entry"
+date: "2026-04-23"
+tags: [test]
+open_gaps: []
+threads: [test-thread]
+---
+
+Test body for review-gate failure.
+EOF
+cat >"$TMP_FAIL_REPORT" <<'EOF'
+title: "Failing review report"
+subtitle: "Review gate false smoke"
+date: "23/04/2026"
+sections:
+  - title: "1. Test"
+    content: "This report should be blocked by review-gate pass=false."
+EOF
+cat >"${TMP_FAIL_REPORT%.yaml}.review.json" <<'EOF'
+{"resolved": true, "response": "already resolved"}
+EOF
+touch "${TMP_FAIL_REPORT%.yaml}.resolved"
+cat >"$TMP_BIN/review-gate" <<'EOF'
+#!/usr/bin/env python3
+import json
+print(json.dumps({
+  "final_review": {
+    "overall": 2.2,
+    "pass": False,
+    "critical_issues": ["blocking issue"],
+    "suggestions": ["fix the report"],
+    "_meta": {"cost_estimate": "$0.0010"}
+  },
+  "coauthor": {
+    "suggestions": [],
+    "_meta": {"cost_estimate": "$0.0010"}
+  },
+  "rounds": []
+}))
+EOF
+chmod +x "$TMP_BIN/review-gate"
+set +e
+"$CONSOLIDATE" "$TMP_FAIL_ENTRY" "$TMP_FAIL_REPORT" --review-only >"$TEST_LOG" 2>&1
+STATUS=$?
+set -e
+if python3 - <<'PY' "$STATUS" "$EVENTS_MIRROR_FILE"
+import json, pathlib, sys
+status = int(sys.argv[1])
+events_path = pathlib.Path(sys.argv[2])
+assert status == 3
+events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+steps = [e for e in events if e.get("type") == "run_step"]
+phase05 = [(e["phase"], e["status"], e.get("operation")) for e in steps if e["phase"] == "phase-0.5"]
+assert ("phase-0.5", "started", "review_gate") in phase05
+assert ("phase-0.5", "failed", "review_gate") in phase05
+PY
+then
+    pass "review-gate pass=false blocks phase-0.5"
+else
+    cat "$TEST_LOG"
+    fail "review-gate pass=false blocks phase-0.5"
+fi
+
+echo "--- Test 5: heartbeat review-gate degradation records metadata and continues ---"
 TMP_DEGRADED_ENTRY="$TMP_STATE/blog/entries/degraded-entry.md"
 TMP_DEGRADED_REPORT="$TMP_STATE/reports/spec-report-degraded-gate.yaml"
 cat >"$TMP_DEGRADED_ENTRY" <<'EOF'


### PR DESCRIPTION
## Summary
- Enforce `final_review.pass == true` in `blog/consolidate-state.sh` when `review-gate` returns normally.
- Preserve degraded review-gate handling for explicit provider/tool degradation paths.
- Add an adversarial consolidate-state regression test that proves `pass=false` blocks publication.

## Root cause
`review-gate.py` encodes approval in JSON and exits 0 even when `final_review.pass` is false. `consolidate-state` was reading score/cost but not enforcing the boolean pass result, so a failed review could still continue.

Fixes #536.

## Validation
- `bash -n blog/consolidate-state.sh tests/test_consolidate_adversarial_phase.sh`
- `git diff --check`
- `bash tests/test_consolidate_adversarial_phase.sh`