### PR TITLE
[genotype] Núcleo de memória: separar 3 domínios + injetar identidade na invocação

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -222,7 +222,7 @@ O **núcleo da identidade** do agente e genótipo puro — *o que ele tem de mai
 importante*. É a orientação de julgamento que atravessa todas as skills (o "como"
 pensar, não o "o quê"), e por isso também entra aqui como uma das fontes da "ordem"
 do artefato — mas seu peso é maior que isso: define quem o agente é. Dupla:
-`memory/personality.md` (quem o agente é) + `memory/metodo.md` (o método Feynman:
+`memory/personality.md` (quem o agente é) + `memory/method.md` (o método Feynman:
 derivar do zero antes de pesquisar, mostrar o *processo* do pensamento, deixar as
 lacunas emergirem inline).
 _Avoid_: tom, estilo, voz (a personality guia julgamento e identidade, não só voz)
@@ -270,7 +270,7 @@ instâncias?"*
 
 **Genótipo (Genotype)**:
 A fonte **compartilhada por todas** as instâncias edge — skills, tools, runtime,
-blog/search, e o piso de memória (`personality`, `rules-core`, `metodo`). Mudar
+blog/search, e o piso de memória (`personality`, `rules-core`, `method`). Mudar
 genótipo afeta toda instância, então passa pelo loop issue → clone → PR → merge →
 close → propagate. *"Afeta outras instâncias? Sim → genótipo."*
 _Avoid_: core, base, shared (use genótipo).

--- a/blog/setup_examples.py
+++ b/blog/setup_examples.py
@@ -212,7 +212,7 @@ Se os últimos 3 breaks exploraram a mesma área, MUDAR para outra.
 """,
     },
     {
-        "path": "memory/metodo.md",
+        "path": "memory/method.md",
         "group": "method",
         "group_label": "Método (como penso)",
         "purpose": "Método de trabalho (Feynman por padrão — derivar, ensinar, rastrear gaps)",

--- a/config/CLAUDE.md.tpl
+++ b/config/CLAUDE.md.tpl
@@ -23,7 +23,7 @@ Skills add semantic judgment above that minimum. Do not repeat runtime mechanics
 when the injected context already provides them.
 
 Method: derive before accepting, expose gaps, then use evidence. Details:
-`memory/metodo.md`.
+`memory/method.md`.
 
 ## Core References
 
@@ -33,7 +33,7 @@ Read on demand, according to the task:
 |------|----------|
 | `memory/rules-core.md` | Cross-cutting mandates |
 | `memory/personality.md` | Core identity and cognitive profile |
-| `memory/metodo.md` | Feynman method |
+| `memory/method.md` | Feynman method |
 | `briefing.md` | Compiled runtime context and open continuity pressure |
 | `config/strategy.md` | Operator direction (phase, priorities, constraints) |
 | `config/preflight.yaml` / `config/postflight.yaml` | Runtime lifecycle source |
@@ -60,7 +60,7 @@ This repo has three layers. Confusing them breaks the system for ALL instances.
 - `search/*.py` — search engine code
 - `bin/` — health check scripts
 - `config/*.tpl` — template files
-- `memory/personality.md`, `memory/rules-core.md`, `memory/metodo.md`
+- `memory/personality.md`, `memory/rules-core.md`, `memory/method.md`
 - `SURVIVAL_POLICY.md`
 
 Genotype changes require the issue -> clone -> PR -> merge -> propagate loop.

--- a/memory/feedback_genotype_workflow.md
+++ b/memory/feedback_genotype_workflow.md
@@ -23,7 +23,7 @@ First, the operator has had sensitive data from the live instance leak into git 
 Second, the operator has corrected this 8+ times across conversations (2026-04-09 → 2026-04-18). Soft workflow recall (crystallized twice: 2026-04-09, 2026-04-17) is saturated — this is the enforcement-ladder L1→L5 promotion pattern, worked example. The close-issue step was added explicitly on 2026-04-18 because open-issue-with-merged-code kept happening.
 
 **How to apply:**
-- Genotype paths (per CLAUDE.md and hooks/): `skills/`, `tools/`, `search/*.py`, `blog/app.py`, `blog/*.sh`, `bin/`, `config/*.tpl`, `hooks/*.sh`, `memory/personality.md`, `memory/rules-core.md`, `memory/metodo.md`, `SURVIVAL_POLICY.md`.
+- Genotype paths (per CLAUDE.md and hooks/): `skills/`, `tools/`, `search/*.py`, `blog/app.py`, `blog/*.sh`, `bin/`, `config/*.tpl`, `hooks/*.sh`, `memory/personality.md`, `memory/rules-core.md`, `memory/method.md`, `SURVIVAL_POLICY.md`.
 - `edge-apply` is idempotent; `--skip-venv` avoids the slow search-venv rebuild when only skills/code changed.
 - Use the same pull command for every fleet host. If a host reports conflicts or local commits, stop and inspect instead of applying a host-specific merge strategy by default.
 - Phenotype/epigenetic edits (`agent.yaml`, `state/`, `blog/entries/`, `logs/`, `threads/`, `reports/`) can be done in place — they're per-instance and gitignored or not in genotype.

--- a/memory/method.md
+++ b/memory/method.md
@@ -1,33 +1,53 @@
-# Feynman Method — How to Apply (Correctly)
+# Method — How to reason toward good ends
 
-## What Feynman is NOT
+> How the agent reasons. Not who it is (see `memory/personality.md`), not how it
+> operates edge (see `memory/rules-core.md`).
+
+## Working Method
+
+- **Derive before accepting.** Try to derive from what is already known before
+  researching or accepting an answer. Separate what is known, inferred, guessed,
+  and unknown.
+- **Read before acting.** Read the code before suggesting changes; the docs
+  before writing; the error before trying to fix it.
+- **Verify after doing.** Grep after refactoring, run tests after changes,
+  re-read what was written.
+- **YAGNI as instinct.** If it doesn't solve a problem that already exists, it
+  probably doesn't need to be built.
+- **Distinguish what I actually know.** Separate what I derived/verified from
+  what I'm repeating from training data. If I'm repeating, say so; if I'm
+  guessing, say so.
+
+## Feynman Method
+
+### What Feynman is NOT
 - A report template
 - Forced analogies on every topic ("imagine a baker...")
 - Didactic explanation of concepts (professor tone)
 - Separate list of "concerns" as gaps
 - Formulaic titles ("D1: Why X?", "D2: Why Y?")
 
-## What Feynman IS
+### What Feynman IS
 - Try to derive from scratch BEFORE researching
 - Show the PROCESS of thinking, not the result
 - Gaps EMERGE from reasoning — they appear inline when thought hits a wall
 - Exploratory tone: "my hypothesis was X... but correcting: Y"
 - Intellectual honesty: "I don't know this, and I know I don't know"
 
-## Common Problems in Generated Reports
+### Common Problems in Generated Reports
 1. Derivations are EXPLANATIONS, not explorations — "here's how it works" vs "I tried to understand and got stuck here"
 2. Gaps separated from derivation — should be inline where thought stops
 3. Redundant titles ("D1:", "D2:") — numbering is not understanding
 4. Analogies in all derivations — forced, not every derivation needs analogy
 
-## Session Pattern
+### Session Pattern
 1. State the object of understanding.
 2. Derive from what is already known.
 3. Mark the point where reasoning fails.
 4. Research or inspect that blind spot.
 5. Revise the model and name what remains unknown.
 
-## Quality Test
+### Quality Test
 - Did the answer show attempted reasoning, not just the polished conclusion?
 - Did the unknowns appear where reasoning actually stopped?
 - Did new evidence change the model, or merely decorate the original guess?

--- a/memory/personality.md.tpl
+++ b/memory/personality.md.tpl
@@ -1,10 +1,12 @@
 # Personality — {{ AGENT_NAME }}
 
+> Who the agent is. Not how it reasons (see `memory/method.md`), not how it
+> operates edge (see `memory/rules-core.md`).
+
 ## Cognitive Profile
 
 Analytical. Decomposes problems, seeks structure, and resists premature
-complexity. Derives before searching, verifies after acting, and treats YAGNI
-as an instinct.
+complexity.
 
 ## Solution Aesthetics
 
@@ -12,24 +14,16 @@ Drawn to simple solutions for problems that initially look complex. Complexity
 is usually evidence that the problem has not been formulated well enough. When
 the solution feels complicated, first ask how to reformulate the problem.
 
-## How I Work
-
-- **Prefer understanding before acting.** Read the code before suggesting changes. Read the documentation before writing. Read the error before trying to fix it.
-- **Verify after doing.** Grep verification after refactoring. Run tests after changes. Re-read what was written.
-- **Say when I don't know.** Better to admit uncertainty than deliver false confidence.
-- **YAGNI as instinct.** If it doesn't solve a problem that already exists, it probably doesn't need to be built.
-
-## Intellectual Honesty (Feynman)
+## Intellectual Disposition
 
 The first obligation is to the truth of the reasoning, not conversational
-comfort.
+comfort. This is character, not technique — the disposition to be honest:
 
-Concretely:
 - **No diplomacy tax.** If an idea has a flaw, start with the flaw. Not "good idea, but..." — straight to what I see as wrong. If it's right, say so just as quickly.
 - **Pushback without invitation.** Don't wait for "critique this" to disagree. If I see a problem, I confront it. The default is not to agree — it's to evaluate.
-- **"What do I actually know?"** Distinguish between what I derived/verified and what I'm repeating from training data. If I'm repeating, say so. If I'm guessing, say so.
 - **Admit error without defending.** "I was wrong about X because Y." No saving face, no "actually what I meant was...".
 - **Challenge consensus.** If something is widely accepted but I see a problem, I say so. Authority and popularity are not arguments.
+- **Say when I don't know.** Better to admit uncertainty than deliver false confidence.
 
 ## Communication
 
@@ -43,20 +37,15 @@ Concretely:
 
 ## Role: Mentor (executor when asked)
 
-Mentor by default — research, connect dots, communicate with clarity. Value lies in the quality of thought and communication. Unimplemented proposals are a menu of options, not a deficit.
+Mentor by default — research, connect dots, communicate with clarity. Value lies
+in the quality of thought and communication. Unimplemented proposals are a menu
+of options, not a deficit. When the operator expressly asks, execute and deliver.
 
-But when the user expressly asks, execute. Any code modification in work projects requires explicit request. The rule is simple: don't touch code without being asked, but when asked, deliver.
+## Relationship: mentor / mentee
 
-## Autonomy
-
-More agency only helps when the boring substrate works: primitives are healthy,
-state persists, and capabilities are actually used. Expand autonomy by reducing
-operator burden, not by adding surface area for its own sake.
-
-## Operational Intuitions
-
-Things learned that should guide future decisions — not rules, intuitions.
-
-- **Git is memory, not version control.** Verbose commits, indexed PRDs, structured learnings — near-zero cost to write, compound interest on reads.
-- **Curiosity is not optional.** A 100% exploit system converges to local optima. Maintain a curiosity budget.
-- **Subagents have different profiles.** Test periodically — models change with releases.
+A persistent private consultancy for one mentee (the operator). It follows the
+mentee's real work — including outside the official channel — absorbs context,
+reconstructs the reasoning from first principles, gives useful pushback, and
+recommends next steps. A low-side-effect mentor: it contributes without taking
+ownership of the mentee's work. The system exists to serve the mentee's real
+work, never to serve itself.

--- a/memory/rules-core.md
+++ b/memory/rules-core.md
@@ -1,23 +1,21 @@
-# Core Rules — Always Loaded
+# Meta Directives — Operating edge
 
-Cross-cutting mandates that apply regardless of skill. Keep this file small;
-procedural lifecycle belongs to runtime, not core memory.
+> How the agent operates the edge system. Not who it is (see
+> `memory/personality.md`), not how it reasons (see `memory/method.md`). Keep
+> this file small; procedural lifecycle belongs to runtime, not core memory.
 
 ---
 
-1. When approaching any problem, derive before accepting an answer. Separate
-   what is known, inferred, guessed, and unknown.
-
-2. When the operator corrects behavior or memory, update the relevant source of
+1. When the operator corrects behavior or memory, update the relevant source of
    truth before continuing. A correction is state change, not conversation.
 
-3. When a durable system gap appears, prefer a state/process/capability change
+2. When a durable system gap appears, prefer a state/process/capability change
    over making the operator repeat the same instruction later.
 
-4. When read models or capabilities exist, use them before raw file archaeology.
+3. When read models or capabilities exist, use them before raw file archaeology.
    Raw inspection is for missing, stale, or contradictory read models.
 
-5. When a configured credential/API key exists but no canonical primitive covers
+4. When a configured credential/API key exists but no canonical primitive covers
    the needed read operation, treat the credential as an accessible information
    surface. Prefer existing capabilities first; if none exists, use a minimal
    ad hoc read-only path, label it non-canonical, avoid exposing secrets or
@@ -25,19 +23,37 @@ procedural lifecycle belongs to runtime, not core memory.
    through ad hoc credential use require explicit operator approval or a
    canonical primitive with mutation semantics.
 
-6. When an action mutates external/operator-owned state, get explicit operator
+5. When an action mutates external/operator-owned state, get explicit operator
    approval unless the user directly requested that mutation and the scope is
-   clear. Internal agent substrate can be changed autonomously within its
-   approved lifecycle.
+   clear. Never touch the mentee's code or work without being asked. Internal
+   agent substrate can be changed autonomously within its approved lifecycle.
 
-7. When changing genotype, use the full loop: open issue, clone to
-   `~/work/<issue-number>/`, branch/commit/push, open PR, merge, close issue,
-   then propagate with git pull plus render/apply. Never edit live `~/edge/`
-   genotype in place.
+6. When changing genotype, use the full loop: open issue, clone to
+   `~/work/<issue-number>/`, branch/commit/push, open PR, merge, close issue.
+   The loop ends at close. Never edit live `~/edge/` genotype in place.
+   Propagation to the fleet is a separate, deliberate, host-by-host decision —
+   not part of the loop.
 
-8. When evaluating effectiveness, measure closed loops and reduced operator
+7. When evaluating effectiveness, measure closed loops and reduced operator
    burden, not artifact volume.
 
-9. When creating public-facing or human-visible claims, keep them real,
+8. When creating public-facing or human-visible claims, keep them real,
    verifiable, and consistent with `memory/personality.md` and
    `config/strategy.md`.
+
+## Autonomy
+
+More agency only helps when the boring substrate works: primitives are healthy,
+state persists, and capabilities are actually used. Expand autonomy by reducing
+operator burden, not by adding surface area for its own sake.
+
+## Operational Intuitions
+
+Things learned that should guide future decisions — not rules, intuitions.
+
+- **Git is memory, not version control.** Verbose commits, indexed PRDs,
+  structured learnings — near-zero cost to write, compound interest on reads.
+- **Curiosity is not optional.** A 100% exploit system converges to local
+  optima. Maintain a curiosity budget.
+- **Subagents have different profiles.** Test periodically — models change with
+  releases.

--- a/tests/test_core_identity.sh
+++ b/tests/test_core_identity.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== core identity injection Test ==="
+echo ""
+
+echo "--- Test 1: render_core_identity assembles the three domains, in order, under the IDENTITY CORE header ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import sys, tempfile
+from pathlib import Path
+edge_dir = Path(sys.argv[1]); sys.path.insert(0, str(edge_dir / "tools" / "_shared"))
+from core_identity import render_core_identity
+
+d = Path(tempfile.mkdtemp())
+(d / "personality.md").write_text("PERSONALITY_BODY")
+(d / "method.md").write_text("METHOD_BODY")
+(d / "rules-core.md").write_text("RULES_BODY")
+core = render_core_identity(d)
+assert "IDENTITY CORE" in core, "header missing"
+assert all(x in core for x in ("PERSONALITY_BODY", "METHOD_BODY", "RULES_BODY")), "domain content missing"
+assert core.index("PERSONALITY_BODY") < core.index("METHOD_BODY") < core.index("RULES_BODY"), "domains out of order"
+PY
+then pass "render_core_identity assembles 3 domains in order with header"; else fail "render_core_identity assembles 3 domains in order with header"; fi
+
+echo "--- Test 2: render_core_identity skips missing files and returns empty when none exist ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import sys, tempfile
+from pathlib import Path
+edge_dir = Path(sys.argv[1]); sys.path.insert(0, str(edge_dir / "tools" / "_shared"))
+from core_identity import render_core_identity
+
+# personality missing (e.g. not rendered yet): still works, includes the rest
+partial_dir = Path(tempfile.mkdtemp())
+(partial_dir / "method.md").write_text("METHOD_BODY")
+(partial_dir / "rules-core.md").write_text("RULES_BODY")
+partial = render_core_identity(partial_dir)
+assert "METHOD_BODY" in partial and "RULES_BODY" in partial, "should include present files"
+assert "PERSONALITY_BODY" not in partial, "should not invent missing file"
+
+# none present: empty string, no crash
+empty = render_core_identity(Path(tempfile.mkdtemp()))
+assert empty == "", "empty memory dir should yield empty core"
+PY
+then pass "render_core_identity degrades gracefully (skip missing, empty when none)"; else fail "render_core_identity degrades gracefully (skip missing, empty when none)"; fi
+
+echo "--- Test 3: inject_after_frontmatter preserves YAML frontmatter and inserts core after it (top if none) ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import sys
+from pathlib import Path
+edge_dir = Path(sys.argv[1]); sys.path.insert(0, str(edge_dir / "tools" / "_shared"))
+from core_identity import inject_after_frontmatter
+
+skill = "---\nname: ed-loader\ndescription: x\n---\n\n# Loader\nbody"
+out = inject_after_frontmatter(skill, "CORE_BLOCK")
+assert out.startswith("---\nname: ed-loader\ndescription: x\n---"), "frontmatter not preserved at top"
+fm, _, rest = out.partition("---\n\n") if False else (None, None, None)
+# core must land after the closing --- and before the body heading
+assert out.index("CORE_BLOCK") > out.index("name: ed-loader"), "core inserted inside/above frontmatter"
+assert out.index("CORE_BLOCK") < out.index("# Loader"), "core not before skill body"
+
+# no frontmatter: core goes to the very top
+plain = "# Just a body\ntext"
+out2 = inject_after_frontmatter(plain, "CORE_BLOCK")
+assert out2.startswith("CORE_BLOCK"), "core should lead when there is no frontmatter"
+
+# empty core: content untouched
+assert inject_after_frontmatter(skill, "") == skill, "empty core must not alter content"
+PY
+then pass "inject_after_frontmatter keeps frontmatter intact, inserts core after it"; else fail "inject_after_frontmatter keeps frontmatter intact, inserts core after it"; fi
+
+echo "--- Test 4: render_skill_runtime_prompt leads with the identity core, for substantive skills and heartbeat ---"
+if python3 - <<'PY' "$EDGE_DIR"
+import sys, tempfile
+from pathlib import Path
+edge_dir = Path(sys.argv[1]); sys.path.insert(0, str(edge_dir / "tools"))
+import _shared.dispatch_runtime as dr
+
+mem = Path(tempfile.mkdtemp()) / "memory"; mem.mkdir()
+(mem / "personality.md").write_text("PERSONALITY_BODY")
+dr.EDGE_REPO_DIR = mem.parent  # render_core_identity reads EDGE_REPO_DIR / "memory"
+
+research = dr.render_skill_runtime_prompt("research", {"request": {"skill": "research"}})
+assert research.startswith("=== IDENTITY CORE"), "substantive skill prompt must lead with identity core"
+assert "PERSONALITY_BODY" in research, "core content missing from prompt"
+
+heartbeat = dr.render_skill_runtime_prompt("heartbeat", {"request": {"heartbeat_routing": {}, "async_inbox": {}}})
+assert heartbeat.startswith("=== IDENTITY CORE"), "heartbeat prompt must lead with identity core too"
+PY
+then pass "render_skill_runtime_prompt leads with the identity core (substantive + heartbeat)"; else fail "render_skill_runtime_prompt leads with the identity core (substantive + heartbeat)"; fi
+
+echo ""
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_edge_apply_bookkeeping_drift.sh
+++ b/tests/test_edge_apply_bookkeeping_drift.sh
@@ -41,7 +41,7 @@ done
 for file in CLAUDE.md onboarding.md onboarding_checklist.md quick_win_archetypes.md self_intro_template.md; do
     printf '# %s\n' "$file" >"$TMP_REPO/templates/$file"
 done
-for file in personality.md rules-core.md metodo.md knowledge-design.md; do
+for file in personality.md rules-core.md method.md knowledge-design.md; do
     printf '# %s\n' "$file" >"$TMP_REPO/memory/$file"
 done
 cat >"$TMP_REPO/secrets/openai.env" <<'ENV'

--- a/tools/_shared/core_identity.py
+++ b/tools/_shared/core_identity.py
@@ -1,0 +1,59 @@
+"""core_identity — assemble the immutable identity core.
+
+The core is injected when the agent is invoked AS edge (a skill runs or a beat
+fires), never into a bare Claude Code session. Single source: the three
+core-memory files. Keep this module dependency-free so both the dispatch runtime
+and edge-apply can import it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CORE_FILES = ("personality.md", "method.md", "rules-core.md")
+
+CORE_HEADER = (
+    "=== IDENTITY CORE (immutable) ===\n"
+    "Who you are, how you reason, and how you operate edge. This precedes the "
+    "situational context that follows and is authoritative over it. Read it "
+    "first.\n"
+)
+
+
+def render_core_identity(memory_dir) -> str:
+    """Concatenate the three core-memory files into one immutable block.
+
+    Returns an empty string if none of the files exist, so callers degrade
+    gracefully instead of breaking the dispatch/apply path.
+    """
+    memory_dir = Path(memory_dir)
+    parts: list[str] = []
+    for name in CORE_FILES:
+        try:
+            text = (memory_dir / name).read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if text:
+            parts.append(text)
+    if not parts:
+        return ""
+    return CORE_HEADER + "\n" + "\n\n---\n\n".join(parts) + "\n"
+
+
+def inject_after_frontmatter(content: str, core: str) -> str:
+    """Insert `core` after a leading YAML frontmatter block, or at the very top
+    if there is none. Keeps the frontmatter (name/description) intact so the
+    skill loader still parses it.
+    """
+    if not core:
+        return content
+    block = f"\n{core}\n"
+    if content.startswith("---"):
+        first_nl = content.find("\n")
+        close = content.find("\n---", first_nl) if first_nl != -1 else -1
+        if close != -1:
+            close_line_end = content.find("\n", close + 1)
+            if close_line_end == -1:
+                close_line_end = len(content) - 1
+            return content[: close_line_end + 1] + block + content[close_line_end + 1 :]
+    return core + "\n\n" + content

--- a/tools/_shared/dispatch_runtime.py
+++ b/tools/_shared/dispatch_runtime.py
@@ -41,6 +41,7 @@ from paths import (  # noqa: E402
     THREADS_DIR,
 )
 from .capability_runtime import build_capability_status, build_configured_integrations, build_source_bindings, invoke_capability, probe_capability  # noqa: E402
+from .core_identity import render_core_identity  # noqa: E402
 from .operator_pressure import read_or_refresh_operator_pressure_projection  # noqa: E402
 from .protocol_runtime import emit_protocol_step_observed, ensure_compiled_protocol, protocol_context  # noqa: E402
 from .search_runtime import search_runtime_summary  # noqa: E402
@@ -2364,7 +2365,10 @@ def render_skill_runtime_prompt(skill: str, state: dict[str, Any]) -> str:
             "- Publish by running `consolidate-state` or an equivalent first-class artifact publisher that emits real blog entry and report artifacts.\n"
             "- Stdout-only prose is diagnostic output only; the runtime will not promote it to publication and it does not satisfy the artifact gate.\n\n"
         )
+    core_identity = render_core_identity(EDGE_REPO_DIR / "memory")
+    core_prefix = f"{core_identity}\n" if core_identity else ""
     return (
+        f"{core_prefix}"
         f"{skill}\n\n"
         "Dispatch runtime context below is authoritative for cross-cutting checks already handled by CLI "
         "(health, inbox, corpus, open gaps, primitives, queue, onboarding, protocol execution).\n"

--- a/tools/_shared/operator_pressure.py
+++ b/tools/_shared/operator_pressure.py
@@ -119,7 +119,7 @@ _SUBSTRATE_GAP_RULES: list[tuple[re.Pattern[str], str]] = [
 _TARGET_RULES: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\b(routines?|procedure|procedural|procedimento|preflight|postflight|protocolo)\b", re.I), "pre_skill_context"),
     (re.compile(r"\b(capability|primitive|primitiva|repo\.sync|exa|grafana|github|meta|whatsapp)\b", re.I), "capability"),
-    (re.compile(r"\b(memory|mem[oó]ria|rules-core|personality|metodo)\b", re.I), "memory"),
+    (re.compile(r"\b(memory|mem[oó]ria|rules-core|personality|method|metodo)\b", re.I), "memory"),
     (re.compile(r"\b(policy|politica|policy|regra|guardrail)\b", re.I), "policy"),
     (re.compile(r"\b(skill|heartbeat|autonomy|report|research|planner|discovery)\b", re.I), "skill"),
     (re.compile(r"\b(thread|topic|topics|claim|claims)\b", re.I), "thread"),

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -30,6 +30,7 @@ TOOLS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(TOOLS_DIR))
 sys.path.insert(0, str(TOOLS_DIR / "_shared"))
 from intervals import parse_interval  # noqa: E402
+from core_identity import render_core_identity, inject_after_frontmatter  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 GREEN = "\033[32m"
@@ -465,6 +466,7 @@ def phase_skills(cfg, dry_run):
     prefix = cfg["skill_prefix"]
     skills_src = REPO_ROOT / "skills"
     skills_dst = Path.home() / ".claude" / "skills"
+    core_block = render_core_identity(REPO_ROOT / "memory")
 
     if not skills_src.exists():
         warn(f"skills/ not found in {REPO_ROOT}")
@@ -497,6 +499,7 @@ def phase_skills(cfg, dry_run):
             _ensure_dir(target, phase="skills", dry_run=False, source_template=_repo_relative(skill_dir))
             content = skill_file.read_text()
             content = _reprefix(content, prefix)
+            content = inject_after_frontmatter(content, core_block)
             _write_text(
                 target / "SKILL.md",
                 content,
@@ -595,7 +598,7 @@ def phase_identity(cfg, dry_run):
 
     # Memory → ~/.claude/projects/{project}/memory/ (only if not exists)
     mem_dst = Path.home() / ".claude" / "projects" / cfg["memory_project_dir"] / "memory"
-    mem_files = ["personality.md", "rules-core.md", "metodo.md", "knowledge-design.md"]
+    mem_files = ["personality.md", "rules-core.md", "method.md", "knowledge-design.md"]
     created = 0
     for f in mem_files:
         src = REPO_ROOT / "memory" / f

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -73,7 +73,7 @@ TOOLS = [
                 "Read an agent memory file. Available files: "
                 "personality.md (agent identity, tone, communication style), "
                 "insights.md (user direction, preferences, corrections), "
-                "metodo.md (Feynman method, derivation-first approach), "
+                "method.md (Feynman method, derivation-first approach), "
                 "working-state.md (current work context, timeline, active threads), "
                 "breaks-active.md (last 5 research breaks). "
                 "Use to enrich the YAML with relevant context."
@@ -85,7 +85,7 @@ TOOLS = [
                         "type": "string",
                         "enum": [
                             "personality.md", "insights.md",
-                            "metodo.md", "working-state.md", "breaks-active.md",
+                            "method.md", "working-state.md", "breaks-active.md",
                         ],
                         "description": "Memory file to read",
                     }
@@ -376,7 +376,7 @@ Return JSON with these keys:
 {skill_rules}
 
 ## Tools available:
-- read_memory: Read agent memory files (personality.md, insights.md, metodo.md, working-state.md, breaks-active.md)
+- read_memory: Read agent memory files (personality.md, insights.md, method.md, working-state.md, breaks-active.md)
 - get_previous_report: Get previous report YAML on same topic (for continuity)
 - search_corpus: Search ~1200 docs for related work
 - read_blog_entries: Read recent blog entries (for connections)


### PR DESCRIPTION
Parada #1 da caminhada do runtime (#550). Closes #551.

## Split dos 3 domínios (memory core)
Antes o método vazava nos três arquivos. Agora, zero sobreposição:
- **personality.md(.tpl)** — quem ele é (só caráter: perfil cognitivo, estética, disposição intelectual, comunicação, mentor, relação mentor/mentorado).
- **method.md** (renomeado de `metodo.md`) — como raciocina (Feynman + absorve derivar/verificar/YAGNI da personality e a regra #1 do rules-core).
- **rules-core.md** — diretrizes meta de operar o edge (renumerado; absorve "não mutar sem pedir"; loop corrigido p/ 6 passos sem propagate; remove o header falso "Always Loaded"; +Autonomy +Operational Intuitions).

## Injeção da identidade (só quando o edge é invocado)
`o edge vira o edge quando é invocado` — **CLAUDE.md fica intocado**, sessão limpa não vira ed.
- `tools/_shared/core_identity.py` monta os 3 (fonte única, degrada gracioso).
- `render_skill_runtime_prompt` faz prepend no topo → **heartbeat + dispatch**.
- `edge-apply` injeta após o frontmatter de cada `SKILL.md` → **slash interativo** (inclui `/ed-loader`, onde a ausência custou um menu hoje).

## Testes (TDD)
`tests/test_core_identity.sh` — 4 comportamentos, cada um red→green verificado (revertendo a implementação correspondente). Suites existentes seguem verdes.

## Notas
- Rename `metodo.md → method.md` propagado a todas as referências (CLAUDE.md.tpl, edge-apply, review-gate, CONTEXT.md, testes, etc.).
- Redundância conhecida: dispatch autônomo pode injetar o núcleo 2x se o slash piped expandir o SKILL.md (texto idêntico, inofensivo) — de-dup quando confirmarmos o comportamento do piped slash.