### PR TITLE
[genotype] #2a validate_rite: validador estrutural puro do Artifact Rite

### DIFF
--- a/tools/_shared/artifact_rite.py
+++ b/tools/_shared/artifact_rite.py
@@ -1,0 +1,71 @@
+"""Structural validator for the Artifact Rite (the uniform format floor).
+
+`validate_rite(spec)` is a pure function: a loaded report YAML spec in, a list
+of violation codes out (empty list == conforms). It owns *form* deterministically;
+*merit* stays with the LLM review gate.
+
+Mandatory sections are identified by an explicit `role` on the section
+(`lineage` | `gaps` | `glossary`) plus a position co-assertion, not by title
+(titles drift across PT/EN). Wiring this into the publish pipeline, emitting
+`role` from the skills, and trimming the review-gate prompt are a separate step.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+VISUAL_BLOCK_TYPES = {"bar-chart", "line-chart"}
+_RAW_HTML_FIELDS = ("html", "content", "svg", "raw")
+
+
+def _has_svg(sections: list[dict[str, Any]]) -> bool:
+    for section in sections:
+        for block in section.get("blocks") or []:
+            if not isinstance(block, dict):
+                continue
+            btype = str(block.get("type") or "").strip()
+            if btype in VISUAL_BLOCK_TYPES:
+                return True
+            if btype == "raw-html":
+                blob = " ".join(str(block.get(field) or "") for field in _RAW_HTML_FIELDS)
+                if "<svg" in blob.lower():
+                    return True
+    return False
+
+
+def _role_index(sections: list[dict[str, Any]], role: str) -> int:
+    for index, section in enumerate(sections):
+        if str(section.get("role") or "").strip() == role:
+            return index
+    return -1
+
+
+def validate_rite(spec: dict[str, Any]) -> list[str]:
+    """Return the list of Rite violation codes for a report spec (empty == ok)."""
+    violations: list[str] = []
+
+    if not spec.get("executive_summary"):
+        violations.append("missing_executive_summary")
+    if not spec.get("metrics"):
+        violations.append("missing_metrics")
+    if not spec.get("bibliography"):
+        violations.append("missing_bibliography")
+
+    sections = [s for s in (spec.get("sections") or []) if isinstance(s, dict)]
+    n = len(sections)
+    # (role, expected position, code-if-misplaced, code-if-absent)
+    positioned = [
+        ("lineage", 0, "lineage_not_first", "missing_lineage"),
+        ("gaps", n - 2, "gaps_not_penultimate", "missing_gaps"),
+        ("glossary", n - 1, "glossary_not_last", "missing_glossary"),
+    ]
+    for role, expected_index, misplaced_code, absent_code in positioned:
+        index = _role_index(sections, role)
+        if index < 0:
+            violations.append(absent_code)
+        elif index != expected_index:
+            violations.append(misplaced_code)
+
+    if not _has_svg(sections):
+        violations.append("no_svg")
+
+    return violations

--- a/tools/_shared/test_artifact_rite.py
+++ b/tools/_shared/test_artifact_rite.py
@@ -1,0 +1,94 @@
+"""Red-green tests for the structural Artifact Rite validator (candidate #2a).
+
+validate_rite is a pure function: a loaded YAML spec in, a list of violation
+codes out (empty == conforms). It is the deterministic form gate; merit stays
+with the LLM review gate.
+"""
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+from tools._shared.artifact_rite import validate_rite  # noqa: E402
+
+
+def valid_spec():
+    return {
+        "executive_summary": ["summary point"],
+        "metrics": [{"value": "1", "label": "thing"}],
+        "bibliography": [{"title": "a source"}],
+        "sections": [
+            {"role": "lineage", "title": "Linhagem", "blocks": [{"type": "paragraph", "text": "x"}]},
+            {"title": "Body", "blocks": [{"type": "bar-chart", "title": "c", "items": []}]},
+            {"role": "gaps", "title": "O que Não Sei", "blocks": [{"type": "paragraph", "text": "x"}]},
+            {"role": "glossary", "title": "Glossário", "blocks": [{"type": "glossary", "terms": []}]},
+        ],
+    }
+
+
+class ValidateRite(unittest.TestCase):
+    def test_valid_spec_passes(self):
+        self.assertEqual(validate_rite(valid_spec()), [])
+
+    def test_missing_executive_summary(self):
+        s = valid_spec(); del s["executive_summary"]
+        self.assertIn("missing_executive_summary", validate_rite(s))
+
+    def test_missing_metrics(self):
+        s = valid_spec(); del s["metrics"]
+        self.assertIn("missing_metrics", validate_rite(s))
+
+    def test_missing_bibliography(self):
+        s = valid_spec(); s["bibliography"] = []
+        self.assertIn("missing_bibliography", validate_rite(s))
+
+    def test_missing_lineage(self):
+        s = valid_spec(); s["sections"][0].pop("role")
+        codes = validate_rite(s)
+        self.assertIn("missing_lineage", codes)
+
+    def test_lineage_not_first(self):
+        s = valid_spec()
+        s["sections"][0], s["sections"][1] = s["sections"][1], s["sections"][0]
+        self.assertIn("lineage_not_first", validate_rite(s))
+
+    def test_missing_gaps(self):
+        s = valid_spec(); s["sections"][2].pop("role")
+        self.assertIn("missing_gaps", validate_rite(s))
+
+    def test_gaps_not_penultimate(self):
+        s = valid_spec()
+        # move gaps to first-ish position (index 1) so it's no longer penultimate
+        gaps = s["sections"].pop(2)
+        s["sections"].insert(1, gaps)
+        self.assertIn("gaps_not_penultimate", validate_rite(s))
+
+    def test_missing_glossary(self):
+        s = valid_spec(); s["sections"][3].pop("role")
+        self.assertIn("missing_glossary", validate_rite(s))
+
+    def test_glossary_not_last(self):
+        s = valid_spec()
+        extra = {"title": "After", "blocks": [{"type": "paragraph", "text": "x"}]}
+        s["sections"].append(extra)  # glossary no longer last
+        self.assertIn("glossary_not_last", validate_rite(s))
+
+    def test_no_svg(self):
+        s = valid_spec()
+        s["sections"][1]["blocks"] = [{"type": "paragraph", "text": "x"}]
+        self.assertIn("no_svg", validate_rite(s))
+
+    def test_svg_via_raw_html_counts(self):
+        s = valid_spec()
+        s["sections"][1]["blocks"] = [{"type": "raw-html", "html": "<svg viewBox='0 0 1 1'></svg>"}]
+        self.assertNotIn("no_svg", validate_rite(s))
+
+    def test_line_chart_counts_as_svg(self):
+        s = valid_spec()
+        s["sections"][1]["blocks"] = [{"type": "line-chart", "points": []}]
+        self.assertNotIn("no_svg", validate_rite(s))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fatia verde do #2. Núcleo puro `validate_rite(spec) -> list[code]` (form gate determinístico; mérito segue no review-gate LLM).

Checa: `executive_summary`/`metrics`/`bibliography` top-level · seção `role: lineage` 1ª, `gaps` penúltima, `glossary` última · ≥1 bloco visual (`bar-chart`/`line-chart`/`raw-html` com `<svg`).

**TDD greenfield:** 13 testes unittest (red→green). Validator ainda **não é invocado** — fundação testada.

**Fora de escopo (PR2):** gate fail-fast no `consolidate-state.sh`, emitir `role` nas skills, aparar checagens estruturais do prompt do review-gate.

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)