### PR TITLE
[genotype] #2b-1 edge-rite-check: CLI testado sobre validate_rite

### DIFF
--- a/tools/edge-rite-check
+++ b/tools/edge-rite-check
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""edge-rite-check — structural Artifact Rite gate over a report YAML spec.
+
+Usage:
+    edge-rite-check <report.yaml> [--warn]
+
+Thin IO shell over validate_rite (the pure form gate). Loads the spec, reports
+violation codes, and signals via exit code.
+
+Exit codes:
+    0  conforms, or skipped (non-YAML report), or --warn with violations
+    1  violations found (blocking)
+    2  usage / load error
+
+--warn never blocks: it prints violations and exits 0. Use it while migrating,
+then drop it to make the gate hard-fail.
+"""
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+from _shared.artifact_rite import validate_rite  # noqa: E402
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+
+def main(argv: list[str]) -> int:
+    warn = "--warn" in argv
+    positional = [arg for arg in argv if not arg.startswith("-")]
+    if len(positional) != 1:
+        print("usage: edge-rite-check <report.yaml> [--warn]", file=sys.stderr)
+        return 2
+
+    path = Path(positional[0])
+    if path.suffix.lower() not in {".yaml", ".yml"}:
+        print(f"RITE_SKIP non-yaml report: {path.name}")
+        return 0
+    if not path.exists():
+        print(f"RITE_ERROR missing file: {path}", file=sys.stderr)
+        return 2
+    if yaml is None:
+        print("RITE_ERROR pyyaml unavailable", file=sys.stderr)
+        return 2
+    try:
+        spec = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        print(f"RITE_ERROR cannot parse {path}: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(spec, dict):
+        print(f"RITE_ERROR spec is not a mapping: {path}", file=sys.stderr)
+        return 2
+
+    violations = validate_rite(spec)
+    if not violations:
+        print("RITE_OK")
+        return 0
+    for code in violations:
+        print(f"RITE_VIOLATION {code}", file=sys.stderr)
+    if warn:
+        print(f"RITE_WARN {len(violations)} violation(s); not blocking (--warn)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/test_edge_rite_check.py
+++ b/tools/test_edge_rite_check.py
@@ -1,0 +1,87 @@
+"""Subprocess tests for the edge-rite-check CLI (candidate #2b-1).
+
+Exercises the IO shell + exit-code contract around validate_rite.
+"""
+import copy
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+CLI = REPO / "tools" / "edge-rite-check"
+
+VALID = {
+    "executive_summary": ["summary point"],
+    "metrics": [{"value": "1", "label": "thing"}],
+    "bibliography": [{"title": "a source"}],
+    "sections": [
+        {"role": "lineage", "title": "Linhagem", "blocks": [{"type": "paragraph", "text": "x"}]},
+        {"title": "Body", "blocks": [{"type": "bar-chart", "title": "c", "items": []}]},
+        {"role": "gaps", "title": "O que Não Sei", "blocks": [{"type": "paragraph", "text": "x"}]},
+        {"role": "glossary", "title": "Glossário", "blocks": [{"type": "glossary", "terms": []}]},
+    ],
+}
+
+
+def _run(path, *flags):
+    return subprocess.run(
+        [sys.executable, str(CLI), str(path), *flags],
+        capture_output=True, text=True,
+    )
+
+
+class EdgeRiteCheckCLI(unittest.TestCase):
+    _tmp = []
+
+    def _write(self, spec, suffix=".yaml"):
+        fd, name = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(yaml.safe_dump(spec))
+        self._tmp.append(name)
+        return name
+
+    def _write_raw(self, text, suffix=".html"):
+        fd, name = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        self._tmp.append(name)
+        return name
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in cls._tmp:
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+    def test_valid_exit_0(self):
+        r = _run(self._write(copy.deepcopy(VALID)))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("RITE_OK", r.stdout)
+
+    def test_violation_exit_1(self):
+        s = copy.deepcopy(VALID); del s["metrics"]
+        r = _run(self._write(s))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("missing_metrics", r.stderr)
+
+    def test_warn_does_not_block(self):
+        s = copy.deepcopy(VALID); del s["metrics"]
+        r = _run(self._write(s), "--warn")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("missing_metrics", r.stderr)
+
+    def test_non_yaml_skips(self):
+        r = _run(self._write_raw("<html><body>report</body></html>"))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("RITE_SKIP", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Casca de IO sobre `validate_rite` (#2a): `edge-rite-check <report.yaml> [--warn]`. Exit 0 ok/skip · 1 violação · 2 erro; `--warn` não bloqueia. Testes subprocess (unittest) verdes + smoke em spec real. Não fia nada ainda (gate/role/prompt = 2b-2). Closes #559