### PR TITLE
[genotype] #2b-2 Artifact Rite gate (warn-only) + role + trim review-gate

### DIFF
--- a/blog/consolidate-state.sh
+++ b/blog/consolidate-state.sh
@@ -808,6 +808,26 @@ else
     :  # No matching note — skip silently
 fi
 
+# ─── PHASE 0.2: Artifact Rite (structural form gate, warn-only) ───
+# Deterministic structural check of the report spec (lineage/gaps/glossary by
+# role + position, executive_summary/metrics/bibliography, >=1 visual block).
+# WARN-ONLY for now: it logs violations but never blocks publish, because the
+# skills are still being migrated to emit `role`. Flip to hard-fail (drop
+# --warn) once real beats show RITE_OK. Form lives here; merit stays with the
+# LLM gates below.
+if [[ -n "$REPORT_INPUT" && ( "$REPORT_INPUT" == *.yaml || "$REPORT_INPUT" == *.yml ) ]]; then
+    echo "── Phase 0.2: Artifact Rite (structural, warn-only) ──"
+    rite_check=("$TOOLS_DIR/edge-rite-check")
+    if command -v edge-rite-check &>/dev/null; then
+        rite_check=(edge-rite-check)
+    fi
+    if "${rite_check[@]}" "$REPORT_INPUT" --warn; then
+        emit_run_step_event "phase-0.2" "completed" "artifact_rite" "structural rite check (warn-only)"
+    else
+        emit_run_step_event "phase-0.2" "warned" "artifact_rite" "rite check could not run"
+    fi
+fi
+
 # ─── PHASE 0.3: Adversarial Review Enforcement ───
 # Every content artifact path must pass the same pre-publication gates. YAML
 # specs and pre-rendered HTML both become reader-visible reports, so neither

--- a/skills/_shared/report-rite-example.yaml
+++ b/skills/_shared/report-rite-example.yaml
@@ -1,0 +1,53 @@
+title: "Rite reference: a conformant report skeleton"
+subtitle: "Canonical example the Artifact Rite validator accepts — copy its shape, not its words"
+date: "30/05/2026"
+
+executive_summary:
+  - "**Purpose:** the minimal conformant report spec — used as the reference for the Rite and as the regression fixture for validate_rite."
+  - "**Shape:** lineage first, 'O que Não Sei' penultimate, glossary last, each marked with an explicit `role`; plus executive_summary, metrics, bibliography, and at least one visual block."
+
+metrics:
+  - value: "3"
+    label: "mandatory role-marked sections (lineage, gaps, glossary)"
+  - value: "1"
+    label: "minimum visual blocks per report"
+
+sections:
+  - role: lineage
+    title: "Linhagem"
+    lead: "How this artifact connects to prior work."
+    blocks:
+      - type: table
+        headers: ["Previous Action", "What It Brought", "Connection"]
+        rows:
+          - ["Prior report", "Established the vocabulary", "Reused here as display vocabulary."]
+
+  - title: "Body"
+    lead: "The substantive analysis. Any number of non-role sections may sit here."
+    blocks:
+      - type: bar-chart
+        title: "Illustrative comparison"
+        unit: "count"
+        items:
+          - {label: "A", value: 2}
+          - {label: "B", value: 5}
+
+  - role: gaps
+    title: "O que Não Sei"
+    lead: "Genuine, specific open questions — not boilerplate."
+    blocks:
+      - type: gap-table
+        rows:
+          - {id: "G1", text: "What evidence would confirm the central claim."}
+
+  - role: glossary
+    title: "Contextualização e Glossário"
+    lead: "Terms a newcomer needs."
+    blocks:
+      - type: glossary
+        terms:
+          - {term: "Rite", definition: "The uniform format floor every report must satisfy."}
+
+bibliography:
+  - title: "Artifact Rite contract"
+    note: "skills/_shared/report-template.md"

--- a/skills/_shared/report-template.md
+++ b/skills/_shared/report-template.md
@@ -184,6 +184,8 @@ Include: previous reports, breaks, discoveries, proposals, research, executions,
 
 If there is no relevant prior work, state explicitly: "First work on this topic."
 
+This first section MUST carry `role: lineage` (a top-level key on the section, alongside `title`). The structural Rite gate identifies it by `role`, not by title — so the title may be in any language.
+
 ---
 
 ## Golden Rule 1: Narrative Scaffolding (ALL skills)
@@ -237,6 +239,8 @@ SVG is not just for numbers — any information that communicates better as an i
 
 ### Second-to-last Section: "What I Don't Know" (MANDATORY — all skills)
 
+This section MUST carry `role: gaps` and be the penultimate section.
+
 - `gap-table` with open gaps (status: open/partial)
 - `callout` variant=danger for critical uncertainties (that could invalidate a recommendation)
 - `callout` variant=warning for untested assumptions
@@ -244,6 +248,8 @@ SVG is not just for numbers — any information that communicates better as an i
 - Includes: missing data, untested hypotheses, unexplored alternatives, risks of being wrong
 
 ### Last Section: "Contextualization and Glossary" (MANDATORY)
+
+This section MUST carry `role: glossary` and be the last authored section (the References block auto-appends after it).
 
 - `paragraph` with 2-3 sentences providing context: for whom, at what moment, what prior knowledge helps
 - `glossary` with `context` field and `terms` field listing ALL technical terms with practical definitions

--- a/tools/_shared/test_artifact_rite_example.py
+++ b/tools/_shared/test_artifact_rite_example.py
@@ -1,0 +1,36 @@
+"""The canonical Rite example must conform — regression anchor for #2b-2.
+
+If validate_rite or the example drift apart, this fails. It also proves the
+reference the report-template/skills point to actually passes the gate.
+"""
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent.parent
+EXAMPLE = REPO / "skills" / "_shared" / "report-rite-example.yaml"
+CLI = REPO / "tools" / "edge-rite-check"
+
+sys.path.insert(0, str(REPO))
+from tools._shared.artifact_rite import validate_rite  # noqa: E402
+
+
+class RiteExampleConforms(unittest.TestCase):
+    def test_example_passes_validate_rite(self):
+        spec = yaml.safe_load(EXAMPLE.read_text(encoding="utf-8"))
+        self.assertEqual(validate_rite(spec), [])
+
+    def test_example_passes_cli(self):
+        r = subprocess.run(
+            [sys.executable, str(CLI), str(EXAMPLE)],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("RITE_OK", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/review-gate.py
+++ b/tools/review-gate.py
@@ -257,10 +257,12 @@ TOOL_DISPATCH = {
 
 DIMENSIONS = {
     "structural_completeness": (
-        "Required sections present: linhagem (first section), "
-        "'O que Nao Sei' (penultimate), glossario (last), "
-        "executive_summary, metrics, bibliography. "
-        "All blocks use valid types from the report template."
+        "Section PRESENCE and ORDERING are enforced upstream by the structural "
+        "Rite gate (edge-rite-check) — do NOT re-judge whether lineage/gaps/"
+        "glossary/executive_summary/metrics/bibliography exist or are positioned "
+        "correctly. Judge only what structure cannot: do the sections cohere into "
+        "a whole, does the lineage actually trace real prior work, do blocks use "
+        "types appropriate to their content."
     ),
     "content_depth": (
         "Sections have substance, not placeholders. "
@@ -435,11 +437,11 @@ Rate each dimension 0-5:
 
 ## Critical Issues (blocking)
 
-Flag as critical_issues if ANY of these:
-- Required section completely missing (linhagem, "O que Nao Sei", glossario)
-- executive_summary or metrics missing at top level, or no reader-visible equivalent in HTML
+Flag as critical_issues if ANY of these.
+(Note: pure structural presence/ordering — required sections, top-level keys,
+>=1 visualization — is enforced upstream by edge-rite-check. Do NOT re-flag those
+as critical here; judge merit. Empty/placeholder content IS still your concern.)
 - Empty sections (title present but no blocks/content)
-- Zero SVG-capable visualizations in entire spec (no bar-chart, line-chart, or raw-html inline SVG)
 - A report compares 3+ items/steps/metrics/risks/alternatives but has no chart, flow, matrix, timeline, or diagram representing that comparison visually
 - A report has multiple quantitative/trade-off comparisons but only one visual encoding and no clear reason for keeping the rest textual
 - Any non-reference section begins directly with a table, chart, metrics grid, diagram, comparison matrix, or gap table without a narrative `lead` or opening paragraph that explains how to read it


### PR DESCRIPTION
Fia `validate_rite`/`edge-rite-check` no pipeline em modo seguro.

- `consolidate-state.sh`: Phase 0.2 `edge-rite-check --warn` antes dos gates LLM. **Warn-only** (47/47 specs hoje violam só por `missing_role`; hard-fail travaria todo publish).
- `report-template.md`: `role` nas 3 Golden Rules + Base YAML + aponta exemplo.
- `report-rite-example.yaml` (novo): referência conformante + fixture.
- `test_artifact_rite_example.py` (novo): regressão.
- `review-gate.py`: trim — estrutura→Rite gate, review-gate fica com mérito (9 dimensions intactas).

**PR futuro:** flip `--warn`→hard-fail quando um beat real mostrar `RITE_OK`.

19 testes verdes; bash -n + py parse ok.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)