### PR TITLE
Gitignore nested epigenetic state paths (#563)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ state/*.md
 state/*.json
 state/events/
 state/signals/
+# Nested epigenetic output — per-host, never replicate (issue #563)
+state/blog/entries/
+state/reports/
+state/audits/
 !state/.gitkeep
 autonomy/*.md
 !autonomy/.gitkeep

--- a/tools/test_gitignore_epigenetic.py
+++ b/tools/test_gitignore_epigenetic.py
@@ -1,0 +1,45 @@
+"""Guards that nested epigenetic state paths stay out of the genotype repo.
+
+Each host produces private runtime output under nested `state/` and `reports/`
+paths. The top-level `.gitignore` patterns (`state/*.md`, `reports/*.yaml`) are
+non-recursive and let the *nested* artifact paths leak into shared commits.
+These tests pin the operator-named nested paths as git-ignored so new per-host
+output can never be tracked.
+"""
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Operator-named nested epigenetic paths (issue #563). Representative files.
+LEAKING_PATHS = [
+    "state/blog/entries/some-entry.md",
+    "state/reports/some-report.yaml",
+    "state/reports/some-report.html",
+    "state/audits/some-entry.state-audit.yaml",
+]
+
+
+class NestedEpigeneticStateIgnored(unittest.TestCase):
+    def assert_ignored(self, path):
+        result = subprocess.run(
+            ["git", "check-ignore", path],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"{path!r} is NOT git-ignored — nested epigenetic state leaks into genotype",
+        )
+
+    def test_named_nested_paths_are_ignored(self):
+        for path in LEAKING_PATHS:
+            with self.subTest(path=path):
+                self.assert_ignored(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #563.

## What

Adds recursive ignore patterns for the three operator-named nested epigenetic paths:

```
state/blog/entries/
state/reports/
state/audits/
```

The existing `state/*.md` / `reports/*.yaml` patterns are non-recursive and miss the nested paths where artifacts actually land. Confirmed via `git check-ignore` (red) and the most recent live-host publish commit, which added `state/reports/.../*.state-audit.yaml`.

## Safety

- **Ignore-only.** No `git rm --cached`. Already-tracked files stay tracked; pulling this on any host deletes nothing.
- Stops *new* per-host output from being tracked (~55 files/beat on one host → 0 for these paths).

## Out of scope (operator decision)

De-tracking the ~99 already-committed private files. A pulled deletion can remove other hosts' identically-named artifacts — unresolved cross-host hazard, not in this PR.

## Test

`tools/test_gitignore_epigenetic.py` — `git check-ignore` assertions, red before the patch, green after.