### PR TITLE
Frame do Artefato: usabilidade da página publicada (CSS + wrapper), sem tocar conteúdo

### DIFF
--- a/tests/test_base_css.py
+++ b/tests/test_base_css.py
@@ -38,5 +38,22 @@ class NeutralizedNoBrand(unittest.TestCase):
                         "system font stack missing")
 
 
+class PageFrame(unittest.TestCase):
+    """The page-level frame: the publisher emits `<article class="report">` bare
+    under <body>, so base.css must give it a reading column, a styled title/meta,
+    CSS section numbering, and the hooks page.js decorates (sumário, lightbox,
+    diff tint). All scoped to article.report — component classes embedded in
+    another shell are untouched."""
+
+    def test_article_frame_and_enhancement_hooks_present(self):
+        css = CSS.read_text()
+        for token in ("article.report", "counter(report-section)",
+                      ".report-toc", ".report-lightbox",
+                      ".diff-line-add", ".diff-line-del"):
+            self.assertIn(token, css, f"page-frame style missing: {token!r}")
+        # the frame must not reintroduce remote resources
+        self.assertNotIn("@import", css)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_base_css.py
+++ b/tests/test_base_css.py
@@ -1,0 +1,42 @@
+"""Shared Artefato rendering layer — the neutralized base.css (Story S3, ADR-0012 model).
+
+The Close-architecture rewrite ports the legacy 763-line base.css NEUTRALIZED: the
+institutional brand (Google-font @import, tricolor stripe, the #26247B/#008C44/#FFCB05
+tokens, the logo path-fill selectors) is stripped to a neutral slate/gray scale + a
+system font stack — fully self-contained, branding deferred. The SEMANTIC colors
+(status callouts, the Feynman derivation-purple / gap-amber) and EVERY component class
+name render.py emits are KEPT (functional, not brand). These tests pin that contract.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CSS = REPO / "tools" / "assets" / "base.css"
+
+
+class NeutralizedNoBrand(unittest.TestCase):
+    """The institutional brand is gone; the functional/semantic palette + the system
+    font stack remain. Brand stripped: no Google-font @import, none of the three
+    institutional tokens (#26247B/#008C44/#FFCB05), no tricolor .header-stripe, no
+    logo path-fill selectors. Kept: the Feynman derivation-purple (#7C3AED) and
+    gap-amber (#D97706), the .derivation block, the gap status badges, the danger
+    callout, and a system font stack (-apple-system)."""
+
+    def test_brand_stripped_semantics_and_system_font_kept(self):
+        css = CSS.read_text()
+        # REMOVED — institutional brand
+        for token in ("@import", "#26247B", "#008C44", "#FFCB05",
+                      ".header-stripe", "path[fill="):
+            self.assertNotIn(token, css, f"brand artifact still present: {token!r}")
+        # KEPT — functional / semantic palette + Feynman blocks
+        for token in ("#7C3AED", "#D97706", ".derivation",
+                      ".gap-status-open", ".callout-danger"):
+            self.assertIn(token, css, f"functional style missing: {token!r}")
+        # KEPT — system font stack (neutral, self-contained)
+        self.assertTrue("system" in css or "-apple-system" in css,
+                        "system font stack missing")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,0 +1,994 @@
+"""The publisher — the close pipeline's atomic publish seam (ADR-0012/0013).
+
+`publish` is `consolidate-state` minus session-digestion, de-YAML'd: it renders the
+Artefato body via render.spec_to_html, wraps it in a self-contained neutral HTML page
+that inlines tools/assets/base.css, writes it to blog/entries/<slug>.html, and ATOMICALLY
+records state via the eventlog — the published event + its intent kernel in one act, so
+`artefatos_without_kernel(log) == []` right after. C3 (no Artefato closes without a kernel)
+is enforced at this seam: publishing without an intent raises.
+
+These tests pin that seam offline (injected embed_fn, tempfile log + blog_dir).
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import close  # noqa: E402
+import eventlog  # noqa: E402
+import publisher  # noqa: E402
+
+_REAL_PROJECT = publisher.project_artefato
+_REAL_PUBLISH = publisher.publish
+
+
+def setUpModule():
+    """Keep the whole module OFFLINE: the default project_fn now connects to the LIVE graph, so a
+    publish in a test with a temp log would project a test Artefato into the install graph (Codex
+    P2 / pollution). Neutralize the default projection to a no-op for every test that does not
+    inject its own project_fn; the dedicated projection tests inject a fake or restore the real one.
+
+    ADR-0016: every publish now requires a fresh wake stamp (no wake, no publish). These tests
+    exercise the publisher's OTHER seams, so the harness stamps the wake on each call's log —
+    the no-wake gate itself is covered in tests/test_predispatch.py."""
+    publisher.project_artefato = lambda *a, **k: None
+
+    def stamped_publish(*a, **kw):
+        eventlog.dispatch_open(log=kw.get("log", eventlog.LOG))
+        return _REAL_PUBLISH(*a, **kw)
+    publisher.publish = stamped_publish
+
+
+def tearDownModule():
+    publisher.project_artefato = _REAL_PROJECT
+    publisher.publish = _REAL_PUBLISH
+
+
+def _fake_embed(text):
+    """An offline embedder: a tiny deterministic 2-vector, never an OpenAI call."""
+    return [float(len(text)), 1.0]
+
+
+def _passing_proof(slug, spec, intent, *, cites=None, proposes=None,
+                   distills=None, skill="report"):
+    """A BOUND passing proof for the exact payload — minted via close's PRIVATE `_mint_proof`
+    the same way `run_close` mints it (run_close-only token + sha256 digest of
+    slug+spec+intent+cites+proposes+distills+skill + both passing reviewer verdicts carrying
+    the CANONICAL reviewer identities). This is the explicit TEST-ONLY seam standing in for
+    run_close; it stamps the two canonical identities verify_proof requires. The publisher
+    refuses anything not bound to the payload (and identities) it is actually publishing."""
+    verdicts = [
+        {"pass": True, "scores": {}, "strikes": [], "overall": 4.0,
+         "reviewer": close.FEYNMAN_REVIEWER_ID},
+        {"pass": True, "scores": {}, "strikes": [], "overall": 4.0,
+         "reviewer": close.REGULAR_REVIEWER_ID},
+    ]
+    return close._mint_proof(verdicts, slug=slug, spec=spec, intent=intent,
+                             cites=cites or [], proposes=proposes or [],
+                             distills=distills, skill=skill)
+
+
+def _spec():
+    return {
+        "executive_summary": ["the seam holds"],
+        "sections": [{"title": "Body", "blocks": [
+            {"type": "paragraph", "text": "atomic publish plus kernel in one act."},
+        ]}],
+    }
+
+
+class PublishIsAtomicAndKerneled(unittest.TestCase):
+    """publish writes a self-contained neutral HTML page (inlined base.css, the meta line,
+    `<article class="report">`) AND records the published event + its kernel atomically, so
+    the C3 invariant holds right after; publishing with no intent raises."""
+
+    def test_writes_self_contained_page_and_records_kernel_atomically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "the-seam-holds"
+            cites = [{"ref": "arXiv:2507.02778", "kind": "mundo",
+                      "relevant": True, "snippet": "the blind-spot is measured"}]
+
+            intent = "next bet: pour the gate into the slot"
+            path = publisher.publish(
+                slug, _spec(), intent=intent,
+                skill="report", cites=cites, date="2026-06-08",
+                log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                verdict=_passing_proof(slug, _spec(), intent, cites=cites),
+            )
+
+            # the page exists and is self-contained + neutral, matching the entry shape
+            page = Path(path)
+            self.assertTrue(page.exists())
+            self.assertEqual(page, Path(tmp) / f"{slug}.html")
+            text = page.read_text()
+            self.assertIn(".derivation", text)        # inlined base.css token
+            self.assertIn("#7C3AED", text)            # functional derivation-purple, kept
+            self.assertIn('<article class="report">', text)
+            self.assertIn('<p class="meta">2026-06-08 · report</p>', text)
+            self.assertIn("atomic publish plus kernel in one act", text)
+
+            # state recorded ATOMICALLY: the C3 invariant holds right after
+            self.assertEqual(eventlog.artefatos_without_kernel(log=log), [])
+            corpus = eventlog.corpus_at(log=log)
+            self.assertEqual([c["slug"] for c in corpus], [slug])
+            self.assertEqual(corpus[0]["intent"], "next bet: pour the gate into the slot")
+
+            # the cite's source signal landed (offline, via embed_fn)
+            yields = eventlog.source_yield_at(log=log)
+            self.assertIn("arXiv:2507.02778", yields)
+            self.assertEqual(yields["arXiv:2507.02778"]["count"], 1)
+
+    def test_publish_without_intent_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            for missing in (None, "", "   "):
+                with self.assertRaises(ValueError):
+                    publisher.publish(
+                        "no-kernel", _spec(), intent=missing, skill="report",
+                        date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                        verdict=_passing_proof("no-kernel", _spec(), missing),
+                    )
+            # nothing published — C3 refused the close before any state landed
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+
+
+class PublishRefusesWithoutAPassingReviewProof(unittest.TestCase):
+    """#2 — the enforced close path. `publisher.publish` is no longer a callable producers
+    reach for directly: it REFUSES unless handed the proof of a passing review that only
+    `run_close` mints (both blind reviewers passed). A direct publish with no/failing
+    verdict raises and writes nothing; the enforced path publishes only after the gate
+    passes."""
+
+    def test_direct_publish_without_verdict_raises_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            with self.assertRaises(ValueError):
+                publisher.publish(
+                    "ungated", _spec(), intent="open: x; bet: y", skill="report",
+                    date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                )
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+            self.assertFalse((Path(tmp) / "ungated.html").exists())
+
+    def test_direct_publish_with_a_failing_verdict_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            failing = {"pass": False, "verdicts": [
+                {"pass": True, "strikes": []}, {"pass": False, "strikes": ["x"]}]}
+            with self.assertRaises(ValueError):
+                publisher.publish(
+                    "ungated", _spec(), intent="open: x; bet: y", skill="report",
+                    date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                    verdict=failing,
+                )
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+
+    def test_run_close_is_the_enforced_path_publishing_only_after_both_gates_pass(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "enforced"
+            art = {
+                "slug": slug,
+                "content": _spec(),
+                "cites": [],
+                "proposes": [],
+                "intent": "open: x; bet: y",
+                "skill": "report",
+            }
+            published = []
+
+            def publish_fn(artefato, verdict):
+                published.append(
+                    publisher.publish(
+                        artefato["slug"], artefato["content"], intent=artefato["intent"],
+                        skill=artefato["skill"], date="2026-06-08", log=log, blog_dir=tmp,
+                        embed_fn=_fake_embed, verdict=verdict,
+                    )
+                )
+
+            # the enforced path uses the REAL canonical reviewers, so the proof carries the
+            # two canonical identities verify_proof requires.
+            result = close.run_close(
+                art, produce_fn=lambda: art,
+                reviewers=(close.feynman_review, close.regular_review),
+                complete_fn=lambda *a, **k: '{"pass": true, "scores": {}, "strikes": []}',
+                publish_fn=publish_fn,
+            )
+            self.assertTrue(result["pass"])
+            self.assertEqual(len(published), 1)              # published exactly once
+            self.assertTrue((Path(tmp) / f"{slug}.html").exists())
+            self.assertEqual(eventlog.artefatos_without_kernel(log=log), [])
+
+    def test_hand_built_proof_at_the_seam_raises_and_writes_nothing(self):
+        # Codex re-review #2: a forged dict with pass:True + passing verdicts but NO
+        # run_close token (and no bound digest) must raise at the seam — the publisher is
+        # not fooled by a shape-only proof.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            forged = {"pass": True, "verdicts": [
+                {"pass": True}, {"pass": True}], "digest": "x", "token": "guessed"}
+            with self.assertRaises(ValueError):
+                publisher.publish(
+                    "forged", _spec(), intent="open: x; bet: y", skill="report",
+                    date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                    verdict=forged,
+                )
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+            self.assertFalse((Path(tmp) / "forged.html").exists())
+
+    def test_proof_for_artefato_A_cannot_publish_artefato_B_at_the_seam(self):
+        # the proof is BOUND to A's payload; handing it to publish B (digest mismatch)
+        # raises before any state/HTML lands.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            spec_a = {"sections": [{"title": "A", "blocks": [
+                {"type": "paragraph", "text": "artefato A content"}]}]}
+            spec_b = {"sections": [{"title": "B", "blocks": [
+                {"type": "paragraph", "text": "DIFFERENT artefato B content"}]}]}
+            proof_a = _passing_proof("artefato-a", spec_a, "open: a; bet: a")
+            with self.assertRaises(ValueError):
+                publisher.publish(
+                    "artefato-b", spec_b, intent="open: b; bet: b", skill="report",
+                    date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                    verdict=proof_a,  # A's proof, B's payload → digest mismatch
+                )
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+            self.assertFalse((Path(tmp) / "artefato-b.html").exists())
+
+    def test_single_reviewer_proof_at_the_seam_raises(self):
+        # a proof minted from only one reviewer must not publish — both configured
+        # reviewers must have passed.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            one = close._mint_proof(
+                [{"pass": True, "scores": {}, "strikes": [], "overall": 4.0,
+                  "reviewer": close.FEYNMAN_REVIEWER_ID}],
+                slug="single", spec=_spec(), intent="open: x; bet: y",
+                cites=[], proposes=[], distills=None, skill="report")
+            with self.assertRaises(ValueError):
+                publisher.publish(
+                    "single", _spec(), intent="open: x; bet: y", skill="report",
+                    date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                    verdict=one,
+                )
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+
+    def test_altered_distills_at_the_seam_raises_and_writes_nothing(self):
+        # Codex re-review #3: the proof binds `distills`. A proof-holder who alters distills
+        # at publish time (poisoning provenance) is rejected — the digest no longer matches.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "bound-distills"
+            reviewed_distills = [{"page": "memory", "body": "what was reviewed"}]
+            proof = _passing_proof(slug, _spec(), "open: x; bet: y",
+                                   distills=reviewed_distills)
+            with self.assertRaises(ValueError):
+                publisher.publish(
+                    slug, _spec(), intent="open: x; bet: y", skill="report",
+                    date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                    distills=[{"page": "memory", "body": "POISONED at publish"}],
+                    verdict=proof,
+                )
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+            self.assertFalse((Path(tmp) / f"{slug}.html").exists())
+
+    def test_altered_skill_at_the_seam_raises_and_writes_nothing(self):
+        # the proof binds `skill`; publishing under a different skill is rejected.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "bound-skill"
+            proof = _passing_proof(slug, _spec(), "open: x; bet: y", skill="report")
+            with self.assertRaises(ValueError):
+                publisher.publish(
+                    slug, _spec(), intent="open: x; bet: y", skill="plan",
+                    date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                    verdict=proof,
+                )
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+            self.assertFalse((Path(tmp) / f"{slug}.html").exists())
+
+    def test_bound_distills_publishes_when_unchanged(self):
+        # the matching distills/skill publishes cleanly (the bind does not over-reject).
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "matching-distills"
+            reviewed_distills = [{"page": "memory", "body": "what was reviewed"}]
+            proof = _passing_proof(slug, _spec(), "open: x; bet: y",
+                                   distills=reviewed_distills)
+            path = publisher.publish(
+                slug, _spec(), intent="open: x; bet: y", skill="report",
+                date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                distills=reviewed_distills, verdict=proof,
+            )
+            self.assertTrue(Path(path).exists())
+
+    def test_run_close_failing_gate_never_publishes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            art = {"slug": "blocked", "content": _spec(), "cites": [], "proposes": [],
+                   "intent": "open: x; bet: y"}
+            published = []
+
+            def publish_fn(artefato, verdict):
+                published.append(artefato)
+
+            def always_strike(artefato, complete_fn=None):
+                return {"pass": False, "scores": {}, "strikes": ["x"], "overall": 2.0}
+
+            result = close.run_close(
+                art, produce_fn=lambda: art, reviewers=(always_strike, always_strike),
+                complete_fn=lambda *a, **k: "", publish_fn=publish_fn,
+            )
+            self.assertFalse(result["pass"])
+            self.assertEqual(published, [])                  # the gate never let it publish
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+
+
+class ProjectAfterPublishIsAGuaranteedSideEffect(unittest.TestCase):
+    """#30 move 1 — project-after-publish lives IN the publisher (was prose in memory.md the
+    producer skipped). After the atomic commit, `publish` projects the Artefato into the graph
+    as a GUARANTEED, best-effort side-effect: it calls `project_fn` with the EXACT published
+    payload (slug + intent + skill + distills + proposes + cites). A failed projection is
+    REPORTED, never fatal (ADR-0011/0006: the log is truth; reproject next beat). `project_fn`
+    is injectable so the seam runs offline; the default `project_artefato` degrades safely when
+    neo4j/openai are absent (it never raises into the publish)."""
+
+    def test_project_fn_called_after_publish_with_the_published_payload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "projected"
+            intent = "open: x; bet: y"
+            cites = [{"ref": "arXiv:1", "kind": "mundo", "relevant": True, "snippet": "snip"}]
+            proposes = [{"body": "name it", "kind": "constraint"}]
+            distills = ["cluster:recall"]
+            seen = {}
+
+            def project_fn(s, i, *, skill, distills, proposes, cites, spec=None, log=None):
+                seen.update(slug=s, intent=i, skill=skill, distills=distills,
+                            proposes=proposes, cites=cites, spec=spec, log=log)
+
+            publisher.publish(
+                slug, _spec(), intent=intent, skill="report", cites=cites,
+                proposes=proposes, distills=distills, date="2026-06-08",
+                log=log, blog_dir=tmp, embed_fn=_fake_embed, project_fn=project_fn,
+                verdict=_passing_proof(slug, _spec(), intent, cites=cites,
+                                       proposes=proposes, distills=distills),
+            )
+            self.assertEqual(seen["slug"], slug)
+            self.assertEqual(seen["intent"], intent)
+            self.assertEqual(seen["skill"], "report")
+            self.assertEqual(seen["distills"], distills)
+            self.assertEqual(seen["proposes"], proposes)
+            self.assertEqual(seen["cites"], cites)
+            self.assertEqual(seen["spec"], _spec())   # the spec is passed for the content embed
+            self.assertEqual(seen["log"], log)         # the projection reads the SAME log (Codex P2)
+
+    def test_failed_projection_does_not_break_the_publish(self):
+        # ADR-0011: a projection write that fails is REPORTED, never fatal — the page + the
+        # atomic commit still land; the next beat reprojects.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "degrade-safe"
+            intent = "open: x; bet: y"
+
+            def boom_project(*a, **k):
+                raise RuntimeError("neo4j unreachable")
+
+            path = publisher.publish(
+                slug, _spec(), intent=intent, skill="report", date="2026-06-08",
+                log=log, blog_dir=tmp, embed_fn=_fake_embed, project_fn=boom_project,
+                verdict=_passing_proof(slug, _spec(), intent),
+            )
+            # publish succeeded despite the projection blowing up
+            self.assertTrue(Path(path).exists())
+            self.assertEqual([c["slug"] for c in eventlog.corpus_at(log=log)], [slug])
+            self.assertEqual(eventlog.artefatos_without_kernel(log=log), [])
+
+    def test_non_canonical_log_skips_the_destructive_backbone_rebuild(self):
+        # Codex P2: project_artefato with a CUSTOM (non-canonical) log must NOT run the destructive
+        # ANCHORS DELETE/rebuild against the install graph — an empty/offline log would wipe live
+        # Directions. The backbone sync is canonical-log only; a custom log projects ADD-only edges.
+        import inspect
+        src = inspect.getsource(_REAL_PROJECT)
+        self.assertIn("eventlog.LOG", src,
+                      "project_artefato must gate the backbone rebuild to the canonical log")
+        # the DELETE (the destructive rebuild) must be guarded, not unconditional
+        delete_idx = src.find("DELETE r")
+        canonical_guard = src.rfind("eventlog.LOG", 0, delete_idx)
+        self.assertNotEqual(canonical_guard, -1,
+                            "the ANCHORS DELETE must be guarded by a canonical-log check")
+
+    def test_reproject_graph_replays_committed_artefatos_to_the_graph(self):
+        # Codex P2: a transient graph outage at publish time must be recoverable — reproject_graph
+        # replays every committed Artefato through project_artefato (idempotent) so the "reproject
+        # next beat" path actually exists. Verify it calls the projection per committed corpus item.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            # commit two artefatos to the log (no graph projection — project_fn=None)
+            for slug in ("recov-a", "recov-b"):
+                publisher.publish(
+                    slug, _spec(), intent="open: x; bet: y", skill="report", date="2026-06-08",
+                    log=log, blog_dir=tmp, embed_fn=_fake_embed, project_fn=None,
+                    verdict=_passing_proof(slug, _spec(), "open: x; bet: y"))
+            projected = []
+
+            def fake_project(slug, intent, **k):
+                projected.append(slug)
+
+            publisher.reproject_graph(log=log, project_fn=fake_project,
+                                      present_slugs=lambda: {},  # hermetic: none present
+                                      backbone_fn=None)
+            self.assertEqual(sorted(projected), ["recov-a", "recov-b"])
+
+    def test_reproject_graph_replays_only_missing_slugs(self):
+        # Codex P2: steady-state must NOT re-embed the whole corpus each sweep — reproject_graph
+        # replays only the slugs MISSING (or STALE) in the graph. `present_slugs` maps each present
+        # slug to its projected_at; a slug present AND FRESH (projected_at >= log ts) is skipped.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            for slug in ("have-it", "missing-it"):
+                publisher.publish(
+                    slug, _spec(), intent="open: x; bet: y", skill="report", date="2026-06-08",
+                    log=log, blog_dir=tmp, embed_fn=_fake_embed, project_fn=None,
+                    verdict=_passing_proof(slug, _spec(), "open: x; bet: y"))
+            projected = []
+            publisher.reproject_graph(
+                log=log,
+                project_fn=lambda slug, *a, **k: projected.append(slug),
+                present_slugs=lambda: {"have-it": "9999-01-01T00:00:00+00:00"},  # present + FRESH
+                backbone_fn=None)
+            self.assertEqual(projected, ["missing-it"])  # only the missing one replays
+
+    def test_reproject_graph_replays_a_stale_present_slug(self):
+        # Codex P2: a republished slug whose graph node is STALE (projected_at older than the log's
+        # latest published ts) must be RE-projected, even though it is 'present' — the graph cannot
+        # keep an old kernel/edges forever after a republish whose projection never reached Neo4j.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            publisher.publish(
+                "republished", _spec(), intent="open: x; bet: y", skill="report", date="2026-06-08",
+                log=log, blog_dir=tmp, embed_fn=_fake_embed, project_fn=None,
+                verdict=_passing_proof("republished", _spec(), "open: x; bet: y"))
+            projected = []
+            publisher.reproject_graph(
+                log=log,
+                project_fn=lambda slug, *a, **k: projected.append(slug),
+                present_slugs=lambda: {"republished": "2000-01-01T00:00:00+00:00"},  # present but STALE
+                backbone_fn=None)
+            self.assertEqual(projected, ["republished"])  # stale node re-projected
+
+    def test_project_artefato_sets_completion_marker_last(self):
+        # Codex P2: completeness is `projection_complete` set as the LAST step (after all edges +
+        # embed), so a half-projected node (embed set, SERVES/edges not) is NOT treated as present.
+        import inspect
+        src = inspect.getsource(_REAL_PROJECT)
+        self.assertIn("projection_complete", src,
+                      "project_artefato must set a completion marker after all writes")
+        # the marker must be set AFTER the edge writes (CITES is the last edge loop). The final SET
+        # uses the `$done` param (gated on resolved distills), not a literal — match the param form.
+        self.assertGreater(src.find("projection_complete=$done"), src.rfind("[:CITES]->"),
+                           "the completion marker must be the LAST write, after the edge loops")
+        # and _graph_present_slugs reads the completion marker, not bare node/embedding presence
+        self.assertIn("projection_complete", inspect.getsource(publisher._graph_present_slugs))
+
+    def test_republish_clears_completion_marker_before_re_updating(self):
+        # Codex P2: a republish with a corrected payload must clear projection_complete FIRST, so a
+        # partial-failure mid-update leaves it incomplete (re-projected next sweep) and the graph
+        # cannot keep a stale kernel/edges forever. The clear (set false) is in the first MERGE; the
+        # set-true is the LAST step — so a failure between them leaves the marker false.
+        import inspect
+        src = inspect.getsource(_REAL_PROJECT)
+        clear_idx = src.find("projection_complete=false")  # cleared in the first MERGE
+        set_idx = src.find("projection_complete=$done")     # final SET (gated on resolved distills)
+        self.assertNotEqual(clear_idx, -1, "republish must CLEAR projection_complete before updating")
+        self.assertLess(clear_idx, src.rfind("[:CITES]->"),
+                        "the clear must precede the edge writes")
+        self.assertGreater(set_idx, src.rfind("[:CITES]->"),
+                           "the final marker SET must follow the edge writes (last)")
+        self.assertLess(clear_idx, set_idx, "clear-false precedes the final SET")
+
+    def test_projection_loads_the_openai_key_before_embedding(self):
+        # Codex P1: the embed key lives in the install/dev secrets and is not necessarily exported —
+        # project_artefato must load it (via _load_openai_key) before constructing OpenAI(), or every
+        # publish would fail the embed, never complete, and be filtered from recall forever.
+        import inspect
+        src = inspect.getsource(_REAL_PROJECT)
+        self.assertIn("_load_openai_key()", src,
+                      "project_artefato must load the OpenAI key before the embed (Codex P1)")
+        # the loader reads the install secret + the ~/.edge-sandbox-kit dev fallback
+        loader = inspect.getsource(publisher._load_openai_key)
+        self.assertIn("openai.env", loader)
+        self.assertIn("edge-sandbox-kit", loader)
+
+    def test_failed_embed_leaves_projection_incomplete(self):
+        # Codex P2: a FAILED embed (key/service down) must NOT mark the projection complete — the
+        # completion marker is gated on `embed_current`, so recovery retries the embed once creds
+        # recover instead of skipping the slug forever.
+        import inspect
+        src = inspect.getsource(_REAL_PROJECT)
+        self.assertIn("embed_current", src, "project_artefato must track embed success")
+        # the completion marker is gated on embed_current AND no unresolved distills
+        self.assertIn("embed_current and not unresolved_distills", src,
+                      "the completion marker must require a current embedding")
+
+    def test_unresolved_distill_leaves_projection_incomplete(self):
+        # Codex P2: a distill ref whose cluster is not in the graph yet must leave the projection
+        # INCOMPLETE (so recovery revisits once the grill attaches the cluster), not mark it done.
+        import inspect
+        src = inspect.getsource(_REAL_PROJECT)
+        self.assertIn("unresolved_distills", src,
+                      "project_artefato must track unresolved distills")
+        # the completion marker is conditional on no unresolved distills
+        self.assertIn("not unresolved_distills", src,
+                      "the completion marker must be gated on resolved distills")
+
+    def test_distill_resolution_uses_active_clusters_only(self):
+        # Codex P2: archived/merged entities are hidden by graph_clusters, so the projection must
+        # resolve distills against ACTIVE clusters only (never link/push a retired cluster).
+        import inspect
+        src = inspect.getsource(_REAL_PROJECT)
+        self.assertIn("coalesce(e.archived,false)=false", src)
+        self.assertIn("e.merged_into IS NULL", src)
+
+    def test_embedding_refreshed_on_content_change_skipped_when_unchanged(self):
+        # Codex P2: re-embed only when the embed input CHANGED — a republish with changed intent/spec
+        # refreshes the stale embedding; a pure edge-link revisit (same content) skips the re-embed.
+        # Keyed on a sha256 hash of (slug+intent+spec_text), not bare `IS NOT NULL`.
+        import inspect
+        src = inspect.getsource(_REAL_PROJECT)
+        self.assertIn("embedding_input_hash", src,
+                      "project_artefato must store an embed-input hash to detect content change")
+        self.assertIn("emb_hash", src)
+        # the re-embed condition compares the stored hash, not only embedding presence
+        self.assertIn('row["h"] == emb_hash', src,
+                      "re-embed must be gated on the embed-input hash, not just IS NOT NULL")
+
+    def test_backbone_ensures_every_artefato_serves_the_objective(self):
+        # Codex P2: an Artefato published BEFORE the Objective existed had SERVES no-op; the backbone
+        # (every canonical sweep) guarantees the hub link so it is reachable from space-0.
+        import inspect
+        src = inspect.getsource(publisher._project_backbone)
+        self.assertIn("[:SERVES]->", src,
+                      "the backbone must ensure every Artefato SERVES the objective (reachability)")
+
+    def test_reproject_graph_rebuilds_the_backbone_even_when_all_slugs_present(self):
+        # Codex P2: the spine backbone (ANCHORS rebuild) must run on EVERY canonical sweep so newly
+        # folded Directions get anchored — even when every artefato is already present (the steady
+        # state after publish-time projection). The per-slug embed work is skipped; the backbone is not.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            publisher.publish(
+                "present-one", _spec(), intent="open: x; bet: y", skill="report", date="2026-06-08",
+                log=log, blog_dir=tmp, embed_fn=_fake_embed, project_fn=None,
+                verdict=_passing_proof("present-one", _spec(), "open: x; bet: y"))
+            projected, backbones = [], []
+            publisher.reproject_graph(
+                log=log,
+                project_fn=lambda slug, *a, **k: projected.append(slug),
+                present_slugs=lambda: {"present-one": "9999-01-01T00:00:00+00:00"},  # present + fresh
+                backbone_fn=lambda log=None: backbones.append(True))
+            self.assertEqual(projected, [])                  # no per-slug re-embed (all present)
+            self.assertEqual(backbones, [True])              # but the backbone STILL rebuilt
+
+    def test_reproject_graph_default_skips_a_non_canonical_log(self):
+        # Codex P2: reproject_graph(log=temp_log) with the DEFAULT projector must NOT write into the
+        # live graph — it mirrors publish()'s hermeticity guard. The real projector is restored and a
+        # dead bolt URI would print a connection error IF it ran; default-skip means silence.
+        import io
+        from contextlib import redirect_stdout
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            publisher.publish(
+                "recov-c", _spec(), intent="open: x; bet: y", skill="report", date="2026-06-08",
+                log=log, blog_dir=tmp, embed_fn=_fake_embed, project_fn=None,
+                verdict=_passing_proof("recov-c", _spec(), "open: x; bet: y"))
+            prev_uri = os.environ.get("EDGE_NEO4J_URI")
+            os.environ["EDGE_NEO4J_URI"] = "bolt://127.0.0.1:1"
+            prev_proj = publisher.project_artefato
+            publisher.project_artefato = _REAL_PROJECT   # bypass the module no-op
+            buf = io.StringIO()
+            try:
+                with redirect_stdout(buf):
+                    publisher.reproject_graph(log=log)   # NO project_fn → default, non-canonical log
+            finally:
+                publisher.project_artefato = prev_proj
+                if prev_uri is None:
+                    os.environ.pop("EDGE_NEO4J_URI", None)
+                else:
+                    os.environ["EDGE_NEO4J_URI"] = prev_uri
+            self.assertNotIn("Couldn't connect", buf.getvalue())  # the projector never ran
+
+    def test_spec_text_flattens_content_for_the_embedding(self):
+        # Codex P2: the content embedding must include the body, not just the kernel — a concept in
+        # the body but not the kernel must still be in the embed input.
+        spec = {
+            "executive_summary": ["a summary sentence with CONCEPT_A"],
+            "sections": [{"title": "Body", "blocks": [
+                {"type": "paragraph", "text": "the body mentions CONCEPT_B in prose"},
+                {"type": "table", "headers": ["k"], "rows": [["CONCEPT_C"]]},
+            ]}],
+        }
+        text = publisher._spec_text(spec)
+        self.assertIn("CONCEPT_A", text)
+        self.assertIn("CONCEPT_B", text)
+        self.assertIn("CONCEPT_C", text)
+
+    def test_spec_text_is_empty_for_a_none_spec(self):
+        self.assertEqual(publisher._spec_text(None), "")
+
+    def test_spec_text_includes_top_level_metrics(self):
+        # Codex P2: render renders top-level `metrics`, so the embed must include their labels/values.
+        spec = {"metrics": [{"value": "0.81", "label": "RECALL_AT_FIVE"}], "sections": []}
+        text = publisher._spec_text(spec)
+        self.assertIn("RECALL_AT_FIVE", text)
+        self.assertIn("0.81", text)
+
+    def test_reproject_graph_restores_the_persisted_skill(self):
+        # Codex P2: the published event carries `skill`, so a recovery replay restores the REAL
+        # producer identity (even when the node does not exist yet — the publish-time-outage case
+        # this path is for). reproject_graph replays item['skill']; project_artefato coalesces it
+        # (a legacy None never clobbers an existing value).
+        import inspect
+        rg = inspect.getsource(publisher.reproject_graph)
+        self.assertIn('item.get("skill")', rg,
+                      "reproject_graph must replay the persisted skill from the log")
+        self.assertIn("coalesce", inspect.getsource(_REAL_PROJECT).lower(),
+                      "project_artefato must coalesce skill (a None never clobbers existing)")
+
+    def test_custom_log_default_skips_projection(self):
+        # Codex P2: a publish to a NON-canonical (temp) log with the DEFAULT project_fn must NOT
+        # project into the live graph — dry-runs/tests are hermetic by default. Restore the real
+        # project_artefato (the module no-op is bypassed) and confirm it is never reached: a dead
+        # bolt URI would print a connection error if it tried; default-skip means silence.
+        import io
+        from contextlib import redirect_stdout
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "custom-log-noproject"
+            prev_uri = os.environ.get("EDGE_NEO4J_URI")
+            os.environ["EDGE_NEO4J_URI"] = "bolt://127.0.0.1:1"   # would error IF projection ran
+            prev_proj = publisher.project_artefato
+            publisher.project_artefato = _REAL_PROJECT            # bypass the module no-op
+            buf = io.StringIO()
+            try:
+                with redirect_stdout(buf):
+                    publisher.publish(
+                        slug, _spec(), intent="open: x; bet: y", skill="report", date="2026-06-08",
+                        log=log, blog_dir=tmp, embed_fn=_fake_embed,  # NO project_fn → default
+                        verdict=_passing_proof(slug, _spec(), "open: x; bet: y"))
+            finally:
+                publisher.project_artefato = prev_proj
+                if prev_uri is None:
+                    os.environ.pop("EDGE_NEO4J_URI", None)
+                else:
+                    os.environ["EDGE_NEO4J_URI"] = prev_uri
+            # the projection never ran (no connection attempt → no error printed)
+            self.assertNotIn("Couldn't connect", buf.getvalue())
+            self.assertNotIn("project", buf.getvalue().lower())
+
+    def test_reproject_missing_pages_uses_the_persisted_skill(self):
+        # Codex P2: a recovered page uses the REAL producer skill from the log, not 'report'.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            blog = Path(tmp) / "entries"
+            slug = "skill-page"
+            # commit a `map` publish but force the page write to fail (recoverable)
+            orig_replace = os.replace
+            os.replace = lambda *a, **k: (_ for _ in ()).throw(OSError("boom"))
+            try:
+                with self.assertRaises(OSError):
+                    publisher.publish(
+                        slug, _spec(), intent="open: x; bet: y", skill="map", date="2026-06-08",
+                        log=log, blog_dir=blog, embed_fn=_fake_embed, project_fn=None,
+                        verdict=_passing_proof(slug, _spec(), "open: x; bet: y", skill="map"))
+            finally:
+                os.replace = orig_replace
+            publisher.reproject_missing_pages(log=log, blog_dir=blog, date="2026-06-08")
+            text = (blog / f"{slug}.html").read_text()
+            self.assertIn('<p class="meta">2026-06-08 · map</p>', text)  # the REAL skill, not report
+
+    def test_published_event_carries_skill_for_graph_recovery(self):
+        # the skill rides the atomic published event (the only recovery source), so a reproject
+        # after a publish-time outage restores the producer identity on a node that did not exist.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "skill-persisted"
+            publisher.publish(
+                slug, _spec(), intent="open: x; bet: y", skill="map", date="2026-06-08",
+                log=log, blog_dir=tmp, embed_fn=_fake_embed, project_fn=None,
+                verdict=_passing_proof(slug, _spec(), "open: x; bet: y", skill="map"))
+            self.assertEqual(eventlog.corpus_at(log=log)[0]["skill"], "map")
+
+    def test_project_artefato_clears_stale_edges_before_re_adding(self):
+        # Codex P2: a republish/replay with corrected distills/proposes/cites must not leave the
+        # slug's OLD edges behind — the projection rebuilds the slug's DISTILLS/PROPOSES/CITES.
+        import inspect
+        src = inspect.getsource(_REAL_PROJECT)
+        for rel in ("DISTILLS", "PROPOSES", "CITES"):
+            # each relationship is DELETEd for this slug before the MERGE re-adds the current set
+            self.assertTrue(f"[r:{rel}]" in src or f":{rel}]->() DELETE" in src
+                            or (f"{rel}" in src and "DELETE" in src),
+                            f"project_artefato must clear the slug's stale {rel} edges before re-adding")
+
+    def test_default_project_artefato_degrades_when_graph_unreachable(self):
+        # the default projection must NEVER raise into the publish even when the graph is
+        # unreachable — it is best-effort; it prints and returns. Point at a dead bolt port so
+        # this is the GENUINE unreachable-graph degrade path, deterministic and offline, and
+        # writes NOTHING to any live graph (no test pollution).
+        prev = os.environ.get("EDGE_NEO4J_URI")
+        os.environ["EDGE_NEO4J_URI"] = "bolt://127.0.0.1:1"
+        try:
+            # exercise the REAL projection (the module no-op patch is bypassed here), against a
+            # dead bolt port — the genuine unreachable-graph degrade path, offline, no pollution.
+            _REAL_PROJECT(
+                "deg", "open: x; bet: y", skill="report",
+                distills=["cluster:recall"], proposes=[], cites=[])
+        except Exception as e:  # noqa: BLE001
+            self.fail(f"project_artefato must degrade safely, raised {e!r}")
+        finally:
+            if prev is None:
+                os.environ.pop("EDGE_NEO4J_URI", None)
+            else:
+                os.environ["EDGE_NEO4J_URI"] = prev
+
+
+class WrapperMetadataIsEscapedAndSkillIsRostered(unittest.TestCase):
+    """Codex round-4 [high]: the page wrapper interpolates caller/spec values (date, skill,
+    title/slug) into raw HTML. Reviewers only see slug/content/cites; `skill` is proof-bound
+    but NOT sanitized — so a producer could supply markup in `skill` (the proof binds to it,
+    verify passes) and the public page would execute it. `date` is also unescaped. The fix:
+    reject an out-of-roster skill BEFORE anything is written, and `html.escape(quote=True)`
+    every wrapper value so no caller/spec value can inject markup."""
+
+    def test_out_of_roster_skill_is_rejected_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "xss-via-skill"
+            evil = "report</p><script>alert(1)</script>"
+            # the proof binds to the (malicious) skill, so verify_proof would PASS — the
+            # roster check is the gate that must stop it.
+            proof = _passing_proof(slug, _spec(), "open: x; bet: y", skill=evil)
+            with self.assertRaises(ValueError):
+                publisher.publish(
+                    slug, _spec(), intent="open: x; bet: y", skill=evil,
+                    date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                    verdict=proof,
+                )
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+            self.assertFalse((Path(tmp) / f"{slug}.html").exists())
+
+    def test_every_in_roster_skill_publishes_a_clean_meta_line(self):
+        for skill in publisher.PRODUCER_ROSTER:
+            with tempfile.TemporaryDirectory() as tmp:
+                log = Path(tmp) / "log.jsonl"
+                slug = f"clean-{skill}"
+                path = publisher.publish(
+                    slug, _spec(), intent="open: x; bet: y", skill=skill,
+                    date="2026-06-08", log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                    verdict=_passing_proof(slug, _spec(), "open: x; bet: y", skill=skill),
+                )
+                text = Path(path).read_text()
+                self.assertIn(f'<p class="meta">2026-06-08 · {skill}</p>', text)
+                self.assertNotIn("<script>", text)
+
+    def test_malicious_date_is_escaped_no_raw_markup_reaches_the_page(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            slug = "xss-via-date"
+            evil_date = "2026<script>alert(1)</script>"
+            path = publisher.publish(
+                slug, _spec(), intent="open: x; bet: y", skill="report",
+                date=evil_date, log=log, blog_dir=tmp, embed_fn=_fake_embed,
+                verdict=_passing_proof(slug, _spec(), "open: x; bet: y"),
+            )
+            text = Path(path).read_text()
+            self.assertNotIn("<script>alert(1)</script>", text)
+            self.assertIn("&lt;script&gt;", text)   # escaped, inert
+
+    def test_title_from_slug_is_escaped_in_wrapper(self):
+        # the title is derived from the slug; though the slug regex is strict, the wrapper
+        # must still escape it so no value reaches the page as raw markup.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            page = publisher._page("a-b", "<p>body</p>", skill="report",
+                                   date="2026-06-08", css="")
+            self.assertIn("<title>a b</title>", page)
+            self.assertIn("<h1>a b</h1>", page)
+
+
+class SlugIsContainedUnderBlogDir(unittest.TestCase):
+    """#4 — the slug names a file under blog_dir, nothing more. A `../`/`/`/empty/funny slug
+    is REJECTED (it must match `^[a-z0-9][a-z0-9-]*$`); a normal slug writes a file that
+    resolves UNDER blog_dir, via a temp file + atomic rename (no half-written page, no escape)."""
+
+    def test_traversal_and_malformed_slugs_are_rejected_and_write_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            blog = Path(tmp) / "entries"
+            for bad in ("../escape", "../../etc/passwd", "a/b", "", "   ",
+                        "Caps", "under_score", "-leading",
+                        "with space", "dot.slug"):
+                with self.assertRaises(ValueError, msg=f"slug {bad!r} should be rejected"):
+                    publisher.publish(
+                        bad, _spec(), intent="open: x; bet: y", skill="report",
+                        date="2026-06-08", log=log, blog_dir=blog, embed_fn=_fake_embed,
+                        verdict=_passing_proof(bad, _spec(), "open: x; bet: y"),
+                    )
+            # nothing escaped, nothing landed
+            self.assertFalse(Path(tmp, "escape.html").exists())
+            self.assertFalse(Path(tmp, "passwd").exists())
+            self.assertEqual(eventlog.corpus_at(log=log), [])
+
+    def test_normal_slug_writes_under_blog_dir_atomically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            blog = Path(tmp) / "entries"
+            out = publisher.publish(
+                "recall-report-2", _spec(), intent="open: x; bet: y", skill="report",
+                date="2026-06-08", log=log, blog_dir=blog, embed_fn=_fake_embed,
+                verdict=_passing_proof("recall-report-2", _spec(), "open: x; bet: y"),
+            )
+            out = Path(out).resolve()
+            self.assertEqual(out.parent, blog.resolve())          # contained under blog_dir
+            self.assertTrue(out.exists())
+            # atomic write left no temp-file litter
+            self.assertEqual(list(blog.glob("*.tmp")), [])
+
+    def test_a_failed_render_leaves_no_orphan_page_or_state(self):
+        """#3 ordering: the page is rendered, then state is recorded, then the HTML is written
+        (temp+rename). A render that raises mid-publish leaves NO orphan page (and no temp
+        litter), so the log's truth and the on-disk projection never disagree."""
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            blog = Path(tmp) / "entries"
+            # a spec render that raises mid-publish must not leave a half-written page
+            import render
+            orig = render.spec_to_html
+            render.spec_to_html = lambda spec: (_ for _ in ()).throw(RuntimeError("boom"))
+            try:
+                with self.assertRaises(RuntimeError):
+                    publisher.publish(
+                        "boom-slug", _spec(), intent="open: x; bet: y", skill="report",
+                        date="2026-06-08", log=log, blog_dir=blog, embed_fn=_fake_embed,
+                        verdict=_passing_proof("boom-slug", _spec(), "open: x; bet: y"),
+                    )
+            finally:
+                render.spec_to_html = orig
+            self.assertFalse((blog / "boom-slug.html").exists())
+            self.assertEqual(list(blog.glob("*.tmp")) if blog.exists() else [], [])
+
+
+class PublishIsRecoverableAfterTheCommit(unittest.TestCase):
+    """Codex round-10 [high]: the commit point is the atomic `artefato.published` (WITH the
+    spec) + `intent.kernel` append (ADR-0006: the log is truth). EVERYTHING after it — the page
+    write, the source signals — is a recoverable PROJECTION re-derivable from the logged spec +
+    cites. A failure after the commit (os.replace/write_text/_signal_cites raising) no longer
+    strands an UNRECOVERABLE state: `reproject_missing_pages` re-renders the missing page from
+    the logged spec (byte-identical to a normal publish) and re-emits any missing source signals."""
+
+    def test_page_write_failure_after_commit_is_recoverable_from_the_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            blog = Path(tmp) / "entries"
+            slug = "recoverable"
+            intent = "open: x; bet: y"
+            cites = [{"ref": "arXiv:1", "kind": "mundo", "snippet": "snip"}]
+            # force os.replace to raise AFTER the atomic commit (page never lands)
+            orig_replace = os.replace
+            os.replace = lambda *a, **k: (_ for _ in ()).throw(OSError("disk full"))
+            try:
+                with self.assertRaises(OSError):
+                    publisher.publish(
+                        slug, _spec(), intent=intent, skill="report", cites=cites,
+                        date="2026-06-08", log=log, blog_dir=blog, embed_fn=_fake_embed,
+                        verdict=_passing_proof(slug, _spec(), intent, cites=cites),
+                    )
+            finally:
+                os.replace = orig_replace
+
+            # NOT unrecoverable: the commit landed (log is truth) and it carries the spec
+            corpus = eventlog.corpus_at(log=log)
+            self.assertEqual([c["slug"] for c in corpus], [slug])
+            published = eventlog.read(types=["artefato.published"], log=log)
+            self.assertEqual(published[0]["payload"]["spec"], _spec())
+            # but the page is missing (the projection failed)
+            self.assertFalse((blog / f"{slug}.html").exists())
+
+            # recovery: reproject the missing page from the logged spec
+            redone = publisher.reproject_missing_pages(
+                log=log, blog_dir=blog, date="2026-06-08")
+            self.assertEqual([Path(p).name for p in redone], [f"{slug}.html"])
+            self.assertTrue((blog / f"{slug}.html").exists())
+
+    def test_reprojected_page_byte_matches_a_normal_publish(self):
+        spec = _spec()
+        intent = "open: x; bet: y"
+        cites = [{"ref": "arXiv:1", "kind": "mundo", "snippet": "snip"}]
+        # (1) a normal, clean publish → the reference page bytes
+        with tempfile.TemporaryDirectory() as tmp_ok:
+            log_ok = Path(tmp_ok) / "log.jsonl"
+            blog_ok = Path(tmp_ok) / "entries"
+            slug = "byte-match"
+            publisher.publish(
+                slug, spec, intent=intent, skill="report", cites=cites,
+                date="2026-06-08", log=log_ok, blog_dir=blog_ok, embed_fn=_fake_embed,
+                verdict=_passing_proof(slug, spec, intent, cites=cites))
+            reference = (blog_ok / f"{slug}.html").read_bytes()
+
+        # (2) a publish whose page write fails after the commit, then reproject
+        with tempfile.TemporaryDirectory() as tmp_bad:
+            log_bad = Path(tmp_bad) / "log.jsonl"
+            blog_bad = Path(tmp_bad) / "entries"
+            slug = "byte-match"
+            orig_replace = os.replace
+            os.replace = lambda *a, **k: (_ for _ in ()).throw(OSError("boom"))
+            try:
+                with self.assertRaises(OSError):
+                    publisher.publish(
+                        slug, spec, intent=intent, skill="report", cites=cites,
+                        date="2026-06-08", log=log_bad, blog_dir=blog_bad,
+                        embed_fn=_fake_embed,
+                        verdict=_passing_proof(slug, spec, intent, cites=cites))
+            finally:
+                os.replace = orig_replace
+            publisher.reproject_missing_pages(
+                log=log_bad, blog_dir=blog_bad, date="2026-06-08")
+            regenerated = (blog_bad / f"{slug}.html").read_bytes()
+
+        self.assertEqual(regenerated, reference)  # byte-identical projection
+
+    def test_signal_failure_after_commit_does_not_corrupt_the_page_and_is_recoverable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            blog = Path(tmp) / "entries"
+            slug = "signal-fails"
+            intent = "open: x; bet: y"
+            cites = [{"ref": "arXiv:1", "kind": "mundo", "snippet": "snip"}]
+            # force the source-signal emission to raise AFTER the commit + page write
+            orig_signal = eventlog.source_signal
+            eventlog.source_signal = lambda *a, **k: (_ for _ in ()).throw(
+                RuntimeError("signal store down"))
+            try:
+                path = publisher.publish(
+                    slug, _spec(), intent=intent, skill="report", cites=cites,
+                    date="2026-06-08", log=log, blog_dir=blog, embed_fn=_fake_embed,
+                    verdict=_passing_proof(slug, _spec(), intent, cites=cites))
+            finally:
+                eventlog.source_signal = orig_signal
+
+            # the page is published cleanly (a signal failure is non-fatal to the page)
+            self.assertTrue(Path(path).exists())
+            # the signal did not land (it failed) — but it is recoverable from the logged cites
+            self.assertEqual(eventlog.source_yield_at(log=log), {})
+            publisher.reproject_missing_pages(
+                log=log, blog_dir=blog, date="2026-06-08", embed_fn=_fake_embed)
+            yields = eventlog.source_yield_at(log=log)
+            self.assertIn("arXiv:1", yields)
+            self.assertEqual(yields["arXiv:1"]["count"], 1)
+
+    def test_reproject_is_a_noop_when_pages_and_signals_already_landed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            blog = Path(tmp) / "entries"
+            slug = "already-there"
+            intent = "open: x; bet: y"
+            cites = [{"ref": "arXiv:1", "kind": "mundo", "snippet": "snip"}]
+            publisher.publish(
+                slug, _spec(), intent=intent, skill="report", cites=cites,
+                date="2026-06-08", log=log, blog_dir=blog, embed_fn=_fake_embed,
+                verdict=_passing_proof(slug, _spec(), intent, cites=cites))
+            before = (blog / f"{slug}.html").read_bytes()
+            redone = publisher.reproject_missing_pages(
+                log=log, blog_dir=blog, date="2026-06-08", embed_fn=_fake_embed)
+            self.assertEqual(redone, [])  # nothing missing → nothing reprojected
+            self.assertEqual((blog / f"{slug}.html").read_bytes(), before)
+            # the signal count did not double (already-landed signals are not re-emitted)
+            self.assertEqual(eventlog.source_yield_at(log=log)["arXiv:1"]["count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -111,6 +111,12 @@ class PublishIsAtomicAndKerneled(unittest.TestCase):
             self.assertIn('<p class="meta">2026-06-08 · report</p>', text)
             self.assertIn("atomic publish plus kernel in one act", text)
 
+            # the wrapper declares the entries' language and inlines the
+            # page-frame enhancements (assets/page.js) — still self-contained
+            self.assertIn('<html lang="pt-BR">', text)
+            self.assertIn("<script>", text)
+            self.assertIn("report-lightbox", text)    # inlined page.js token
+
             # state recorded ATOMICALLY: the C3 invariant holds right after
             self.assertEqual(eventlog.artefatos_without_kernel(log=log), [])
             corpus = eventlog.corpus_at(log=log)
@@ -773,7 +779,10 @@ class WrapperMetadataIsEscapedAndSkillIsRostered(unittest.TestCase):
                 )
                 text = Path(path).read_text()
                 self.assertIn(f'<p class="meta">2026-06-08 · {skill}</p>', text)
-                self.assertNotIn("<script>", text)
+                # exactly ONE script element reaches the page: the repo-controlled
+                # inlined assets/page.js — nothing injected via the meta line.
+                self.assertEqual(text.count("<script>"), 1)
+                self.assertNotIn("alert(", text)
 
     def test_malicious_date_is_escaped_no_raw_markup_reaches_the_page(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -798,6 +807,20 @@ class WrapperMetadataIsEscapedAndSkillIsRostered(unittest.TestCase):
                                    date="2026-06-08", css="")
             self.assertIn("<title>a b</title>", page)
             self.assertIn("<h1>a b</h1>", page)
+
+    def test_inlined_js_cannot_close_its_own_script_element(self):
+        # page.js is repo-controlled, but defense in depth: a closing script tag
+        # inside it must not terminate the wrapper's script element early.
+        with tempfile.TemporaryDirectory():
+            page = publisher._page("a-b", "<p>body</p>", skill="report",
+                                   date="2026-06-08", css="",
+                                   js='var a = "</script>";')
+            self.assertEqual(page.count("</script>"), 1)  # the wrapper's own close tag
+
+    def test_empty_js_emits_no_script_element(self):
+        page = publisher._page("a-b", "<p>body</p>", skill="report",
+                               date="2026-06-08", css="")
+        self.assertNotIn("<script>", page)
 
 
 class SlugIsContainedUnderBlogDir(unittest.TestCase):

--- a/tools/assets/base.css
+++ b/tools/assets/base.css
@@ -1,25 +1,23 @@
-@import url('https://fonts.googleapis.com/css2?family=Libre+Franklin:ital,wght@0,100..900;1,100..900&display=swap');
-
 :root {
-  /* Brand colors */
-  --brand-blue: #26247B;
-  --brand-green: #008C44;
-  --brand-yellow: #FFCB05;
+  /* Neutral accent (brand deferred — config/branding.yaml later) */
+  --brand-blue: #334155;
+  --brand-green: #475569;
+  --brand-yellow: #64748B;
 
-  /* Web blues */
-  --brand-web-blue: #1C519B;
-  --brand-web-blue-dark: #1A3560;
-  --brand-logo-blue: #26145F;
+  /* Neutral accents (formerly the web-blue scale — same names, neutral values) */
+  --brand-web-blue: #475569;
+  --brand-web-blue-dark: #334155;
+  --brand-logo-blue: #1E293B;
 
-  /* Escala de azul */
-  --blue-50: #F2F6FD;
-  --blue-100: #E1EAFB;
-  --blue-200: #C3D5F7;
-  --blue-600: #1C519B;
-  --blue-700: #1A3560;
-  --blue-800: #1B3158;
-  --blue-900: #1C2C4A;
-  --blue-950: #112240;
+  /* Neutral accent scale (formerly "escala de azul" — same names, slate values) */
+  --blue-50: #F8FAFC;
+  --blue-100: #F1F5F9;
+  --blue-200: #E2E8F0;
+  --blue-600: #475569;
+  --blue-700: #334155;
+  --blue-800: #1E293B;
+  --blue-900: #0F172A;
+  --blue-950: #020617;
 
   /* Escala de cinza */
   --gray-50: #F9FAFB;
@@ -34,7 +32,7 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
-  font-family: 'Libre Franklin', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 15px;
   line-height: 1.6;
   color: var(--gray-700);
@@ -62,14 +60,6 @@ body {
   height: auto;
 }
 
-/* Forçar logo branco no header escuro */
-.header-content .logo svg path {
-  fill: white;
-}
-/* Manter cores do emblema */
-.header-content .logo svg path[fill="#F8C300"] { fill: #F8C300; }
-.header-content .logo svg path[fill="#007A37"] { fill: #007A37; }
-
 .header-text h1 {
   font-size: 28px;
   font-weight: 700;
@@ -81,11 +71,6 @@ body {
   font-size: 16px;
   font-weight: 400;
   color: rgba(255,255,255,0.92);
-}
-
-.header-stripe {
-  height: 4px;
-  background: linear-gradient(to right, var(--brand-green), var(--brand-yellow), var(--brand-web-blue));
 }
 
 /* --- MAIN CONTENT --- */
@@ -107,14 +92,6 @@ body {
   border-bottom: 2px solid var(--blue-200);
   padding-bottom: 8px;
   margin-bottom: 20px;
-}
-
-.section-lead {
-  font-size: 16px;
-  line-height: 1.7;
-  color: var(--gray-700);
-  margin: -4px 0 18px;
-  max-width: 860px;
 }
 
 .subsection-title {
@@ -236,7 +213,7 @@ tbody tr:hover {
 }
 
 .callout-info    { background: var(--blue-50); border-color: var(--brand-web-blue); }
-.callout-success { background: #DEF7EC; border-color: var(--brand-green); }
+.callout-success { background: #DEF7EC; border-color: #03543F; }
 .callout-warning { background: #FDF6B2; border-color: #D69E2E; }
 .callout-danger  { background: #FDE8E8; border-color: #E53E3E; }
 
@@ -389,7 +366,7 @@ td.cell-partial { background: #FDF6B2; }
   font-weight: 600;
   color: var(--gray-700);
   border-bottom: 1px solid var(--gray-200);
-  font-family: 'Libre Franklin', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 13px;
 }
 
@@ -758,7 +735,6 @@ a:hover {
 @media print {
   body { background: white; }
   .report-header { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-  .header-stripe { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
   .report-content { padding: 20px; }
   .card { box-shadow: none; border: 1px solid #ddd; break-inside: avoid; }
   table { page-break-inside: avoid; }

--- a/tools/assets/base.css
+++ b/tools/assets/base.css
@@ -731,6 +731,118 @@ a:hover {
   text-decoration: underline;
 }
 
+/* --- ARTICLE FRAME ---
+   The publisher emits `<article class="report">` directly under <body> with no
+   container element, so without these rules the text runs full-bleed on wide
+   screens and the slug-derived <h1> / <p class="meta"> render unstyled. All
+   rules are scoped to article.report: pages that embed the component classes
+   in another shell are untouched. */
+html {
+  scroll-behavior: smooth;
+}
+
+article.report {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 40px;
+  counter-reset: report-section;
+}
+
+article.report > h1 {
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--blue-900);
+  margin-bottom: 4px;
+}
+
+/* Slug-derived titles arrive all-lowercase; sentence-case at display time. */
+article.report > h1::first-letter {
+  text-transform: uppercase;
+}
+
+article.report > .meta {
+  font-size: 14px;
+  color: var(--gray-500);
+  padding-bottom: 16px;
+  margin-bottom: 32px;
+  border-bottom: 1px solid var(--gray-200);
+}
+
+/* Numbered sections: in-text cross-references ("seção 5") stay resolvable
+   without touching content, and the numbers match the generated Sumário. */
+article.report .section-title {
+  counter-increment: report-section;
+  scroll-margin-top: 16px;
+}
+
+article.report .section-title::before {
+  content: counter(report-section) ". ";
+  color: var(--blue-600);
+}
+
+/* --- TABLE OF CONTENTS (injected by page.js when the report has 3+ sections) --- */
+.report-toc {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 32px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+.report-toc-title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--gray-500);
+  margin-bottom: 8px;
+}
+
+.report-toc ol {
+  margin: 0;
+  padding-left: 24px;
+  font-size: 14px;
+  line-height: 1.9;
+}
+
+/* --- DIFF TINT (page.js, display-only) ---
+   Plain <pre> patches get per-line tinting reusing the diff palette. Block
+   spans so each line carries its own background. */
+pre .diff-line-add    { display: block; background: #DCFCE7; color: #14532D; }
+pre .diff-line-del    { display: block; background: #FEE2E2; color: #7F1D1D; }
+pre .diff-line-meta   { display: block; color: var(--gray-500); font-weight: 600; }
+
+/* --- LIGHTBOX (page.js) --- */
+article.report figure img {
+  cursor: zoom-in;
+}
+
+.report-lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  cursor: zoom-out;
+}
+
+.report-lightbox img {
+  max-width: 95vw;
+  max-height: 95vh;
+  border-radius: 6px;
+}
+
+/* --- RESPONSIVE --- */
+@media (max-width: 720px) {
+  article.report { padding: 24px 16px; }
+  article.report > h1 { font-size: 24px; }
+}
+
 /* --- PRINT --- */
 @media print {
   body { background: white; }
@@ -744,4 +856,6 @@ a:hover {
   .diff-insert, .diff-delete { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
   .metric-card { break-inside: avoid; }
   .next-step-card { break-inside: avoid; }
+  article.report { max-width: none; padding: 20px; }
+  pre .diff-line-add, pre .diff-line-del { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 }

--- a/tools/assets/page.js
+++ b/tools/assets/page.js
@@ -1,0 +1,93 @@
+/* Progressive enhancements for published Artefato pages (inlined by the
+   publisher next to base.css). Display-only by contract: the DOM the renderer
+   emitted is decorated, never reworded — and with scripts disabled the page
+   reads exactly as before. Each enhancement no-ops when the page lacks the
+   structure it keys on, so no report shape is ever required.
+   NOTE: this file is inlined inside a script element — it must never contain
+   a script tag literal, opening or closing (the publisher also escapes the
+   closing sequence as defense in depth). */
+(function () {
+  'use strict';
+
+  var article = document.querySelector('article.report');
+  if (!article) return;
+
+  /* --- Sumário: built from the section titles when the report is long
+     enough to need navigation. Numbering mirrors the CSS section counter. --- */
+  var sections = Array.prototype.slice.call(
+    article.querySelectorAll('.section-title'));
+  if (sections.length >= 3) {
+    var toc = document.createElement('nav');
+    toc.className = 'report-toc';
+    var tocTitle = document.createElement('p');
+    tocTitle.className = 'report-toc-title';
+    var lang = (document.documentElement.lang || '').toLowerCase();
+    tocTitle.textContent = lang.indexOf('pt') === 0 ? 'Sumário' : 'Contents';
+    toc.appendChild(tocTitle);
+    var list = document.createElement('ol');
+    sections.forEach(function (h, i) {
+      if (!h.id) h.id = 'secao-' + (i + 1);
+      var li = document.createElement('li');
+      var a = document.createElement('a');
+      a.href = '#' + h.id;
+      a.textContent = h.textContent;
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+    toc.appendChild(list);
+    var meta = article.querySelector('.meta');
+    if (meta) meta.insertAdjacentElement('afterend', toc);
+    else article.insertBefore(toc, article.firstChild);
+  }
+
+  /* --- Diff tint: per-line coloring for plain-text <pre> blocks that look
+     like unified diffs. Only text-only blocks are touched (a <pre> that
+     already carries markup — e.g. the .diff-block palette — is left alone). --- */
+  Array.prototype.slice.call(article.querySelectorAll('pre')).forEach(function (pre) {
+    if (pre.children.length > 0) return;
+    var lines = pre.textContent.split('\n');
+    var adds = 0, dels = 0;
+    lines.forEach(function (l) {
+      if (l.charAt(0) === '+') adds += 1;
+      if (l.charAt(0) === '-') dels += 1;
+    });
+    if (adds < 2 || dels < 1) return;
+    pre.textContent = '';
+    lines.forEach(function (l, i) {
+      var cls = '';
+      if (/^(\+\+\+|---|@@|diff )/.test(l)) cls = 'diff-line-meta';
+      else if (l.charAt(0) === '+') cls = 'diff-line-add';
+      else if (l.charAt(0) === '-') cls = 'diff-line-del';
+      if (cls) {
+        var span = document.createElement('span');
+        span.className = cls;
+        span.textContent = l;
+        pre.appendChild(span);
+      } else {
+        pre.appendChild(document.createTextNode(l + (i < lines.length - 1 ? '\n' : '')));
+      }
+    });
+  });
+
+  /* --- Lightbox: click a figure image to inspect it full-screen (screenshots
+     are evidence; the inline rendering is too small to read). --- */
+  function closeLightbox() {
+    var box = document.querySelector('.report-lightbox');
+    if (box) box.remove();
+  }
+  article.addEventListener('click', function (e) {
+    var img = e.target;
+    if (!(img.tagName === 'IMG' && img.closest('figure'))) return;
+    var box = document.createElement('div');
+    box.className = 'report-lightbox';
+    var full = document.createElement('img');
+    full.src = img.src;
+    full.alt = img.alt;
+    box.appendChild(full);
+    box.addEventListener('click', closeLightbox);
+    document.body.appendChild(box);
+  });
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') closeLightbox();
+  });
+})();

--- a/tools/publisher.py
+++ b/tools/publisher.py
@@ -47,6 +47,12 @@ from close import check_genus, verify_proof
 REPO = Path(__file__).resolve().parent.parent
 BLOG_DIR = REPO / "blog" / "entries"
 BASE_CSS = Path(__file__).resolve().parent / "assets" / "base.css"
+BASE_JS = Path(__file__).resolve().parent / "assets" / "page.js"
+
+# Entries are written for the mentee in PT-BR and the wrapper must say so (screen
+# readers, hyphenation and translators key on the lang attribute). One seam to
+# change if that ever stops being true — never sniffed per-entry from content.
+PAGE_LANG = "pt-BR"
 
 # A slug names a single file under blog_dir — lowercase alphanumerics + hyphens, no leading
 # or trailing hyphen, no dots/slashes/spaces. Anything else is rejected (#4: path traversal).
@@ -72,7 +78,7 @@ def _safe_target(slug, blog_dir):
     return target
 
 
-def _page(slug, body_html, *, skill, date, css):
+def _page(slug, body_html, *, skill, date, css, js=""):
     """Wrap the rendered body in a self-contained neutral HTML page (no tricolor stripe —
     the neutralized base.css has no .header-stripe). Matches the existing entry shape:
     `<article class="report">` with `<p class="meta">{date} · {skill}</p>`.
@@ -80,10 +86,21 @@ def _page(slug, body_html, *, skill, date, css):
     Codex round-4 [high]: reviewers only see slug/content/cites, so the wrapper's own
     caller/spec values (date, skill, the slug-derived title) reach the public page as raw
     HTML if not escaped. `html.escape(quote=True)` ALL wrapper text — no wrapper value may
-    inject markup. `body_html` is render.spec_to_html's already-sanitized output, untouched."""
+    inject markup. `body_html` is render.spec_to_html's already-sanitized output, untouched.
+
+    `js` is the repo-controlled assets/page.js (progressive display-only enhancements:
+    sumário, diff tint, lightbox), inlined like the css so the page stays self-contained.
+    It is NOT caller data and is inlined raw — the only sequence that could break out of
+    the <script> element is a closing script tag, which is escaped here as defense in
+    depth. Empty js (the default) emits no script element at all, so the page degrades
+    to the previous shape."""
     title = html.escape(slug.replace("-", " "), quote=True)
+    script = ""
+    if js:
+        safe_js = js.replace("</script>", "<\\/script>")
+        script = f"<script>\n{safe_js}\n</script>"
     return (
-        '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">\n'
+        f'<!DOCTYPE html><html lang="{PAGE_LANG}"><head><meta charset="utf-8">\n'
         f"<title>{title}</title>\n"
         f"<style>\n{css}\n</style></head>\n"
         '<body><article class="report">\n'
@@ -91,7 +108,7 @@ def _page(slug, body_html, *, skill, date, css):
         f'<p class="meta">{html.escape(date, quote=True)} · '
         f'{html.escape(skill, quote=True)}</p>\n\n'
         f"{body_html}\n"
-        "</article></body></html>\n"
+        f"</article>{script}</body></html>\n"
     )
 
 
@@ -115,7 +132,9 @@ def _render_page(slug, spec, *, skill, date):
     the logged spec) emit byte-identical pages. Returns (body_html, page_text)."""
     body_html = render.spec_to_html(spec)
     css = BASE_CSS.read_text()
-    page = _page(slug, body_html, skill=skill, date=date or _date.today().isoformat(), css=css)
+    js = BASE_JS.read_text()
+    page = _page(slug, body_html, skill=skill, date=date or _date.today().isoformat(),
+                 css=css, js=js)
     return body_html, page
 
 

--- a/tools/publisher.py
+++ b/tools/publisher.py
@@ -1,0 +1,628 @@
+"""The publisher — the close pipeline's atomic publish seam (ADR-0012/0013).
+
+`consolidate-state` minus session-digestion (0008 moved digestion to the pull-at-open
+sweep), de-YAML'd. One act: render the Artefato body (render.spec_to_html), wrap it in a
+self-contained neutral HTML page that INLINES the neutralized tools/assets/base.css, record
+state ATOMICALLY via the eventlog — the `artefato.published` event (carrying the proof-bound
+SPEC, so the page is fully regenerable from the log) AND its `intent.kernel` together in one
+indivisible write (eventlog.publish_artefato_atomic) — THEN write the page to
+blog/entries/<slug>.html via temp+rename, THEN emit a `source.signal` per cited snippet.
+
+ADR-0006: the log is truth, the page a re-derivable PROJECTION. The atomic event is the COMMIT
+POINT; everything after it is a recoverable projection. So a page-write/replace/signal failure
+after the commit no longer strands an UNRECOVERABLE state (Codex round-10 [high]): the logged
+spec re-renders the exact page and the logged cites re-emit the missing signals via
+`reproject_missing_pages`. Source-signal emission is non-fatal to the page (#4).
+
+Three gates at this seam: #2/#3 — the publisher REFUSES unless handed the UNFORGEABLE, BOUND
+proof `close.run_close` mints: `close.verify_proof` requires the run_close-only token, a sha256
+digest that BINDS to this exact publish payload (slug + spec + intent + cites + proposes +
+distills + skill — EVERY persisted publish arg, so distills/skill cannot be altered post-mint to
+poison provenance), both blind reviewers passed, AND the verdicts carry both CANONICAL reviewer
+identities — so a forged dict, a stale/cross-artefato proof (digest mismatch), a single-reviewer
+proof, or a proof built from fake/injected reviewers cannot back-door the gate. C3 — there is no path that publishes
+without the *why* (raises with no intent; the kernel rides the same atomic call so
+`artefatos_without_kernel(log) == []` right after). #4 — the slug is validated against a strict
+regex and contained under blog_dir (a `../` slug cannot escape).
+
+Pure import-clean spine: imports only eventlog + render + close (the close-role functions) at
+module scope; the impure embedder (embed_fn) and the graph projection (project_fn, the
+project-after-publish side-effect — #30) are injectable so a test runs offline. The default
+projection (`project_artefato`) imports neo4j/_identity/openai LAZILY and is fully degrade-safe:
+a missing group/driver/key prints and returns, never raising into the publish (ADR-0011/0006).
+"""
+import hashlib
+import html
+import os
+import re
+from datetime import date as _date
+from datetime import datetime as _dt
+from datetime import timezone as _tz
+from pathlib import Path
+
+import eventlog
+import render
+from close import check_genus, verify_proof
+
+REPO = Path(__file__).resolve().parent.parent
+BLOG_DIR = REPO / "blog" / "entries"
+BASE_CSS = Path(__file__).resolve().parent / "assets" / "base.css"
+
+# A slug names a single file under blog_dir — lowercase alphanumerics + hyphens, no leading
+# or trailing hyphen, no dots/slashes/spaces. Anything else is rejected (#4: path traversal).
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+# The allowed producer roster — the only skills that may close an Artefato (the beat's
+# producer-skills). `skill` is proof-bound but the proof binds whatever the producer supplies,
+# so an out-of-roster value (e.g. `report</p><script>…`) would verify cleanly; this roster is
+# the gate that rejects it BEFORE anything is written, and _page escapes it as defense in depth.
+PRODUCER_ROSTER = ("report", "research", "map", "plan", "discovery", "grill")
+
+
+def _safe_target(slug, blog_dir):
+    """Resolve the page path for `slug` and ASSERT it stays under blog_dir (#4). A slug that
+    fails the strict regex or whose resolved path escapes blog_dir raises ValueError before
+    anything is written — `../` cannot climb out, an empty/funny slug cannot land elsewhere."""
+    if not (isinstance(slug, str) and SLUG_RE.match(slug)):
+        raise ValueError(f"invalid slug {slug!r}: must match {SLUG_RE.pattern} (#4)")
+    blog_dir = Path(blog_dir).resolve()
+    target = (blog_dir / f"{slug}.html").resolve()
+    if target.parent != blog_dir:
+        raise ValueError(f"slug {slug!r} escapes the blog dir (#4)")
+    return target
+
+
+def _page(slug, body_html, *, skill, date, css):
+    """Wrap the rendered body in a self-contained neutral HTML page (no tricolor stripe —
+    the neutralized base.css has no .header-stripe). Matches the existing entry shape:
+    `<article class="report">` with `<p class="meta">{date} · {skill}</p>`.
+
+    Codex round-4 [high]: reviewers only see slug/content/cites, so the wrapper's own
+    caller/spec values (date, skill, the slug-derived title) reach the public page as raw
+    HTML if not escaped. `html.escape(quote=True)` ALL wrapper text — no wrapper value may
+    inject markup. `body_html` is render.spec_to_html's already-sanitized output, untouched."""
+    title = html.escape(slug.replace("-", " "), quote=True)
+    return (
+        '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">\n'
+        f"<title>{title}</title>\n"
+        f"<style>\n{css}\n</style></head>\n"
+        '<body><article class="report">\n'
+        f"<h1>{title}</h1>\n"
+        f'<p class="meta">{html.escape(date, quote=True)} · '
+        f'{html.escape(skill, quote=True)}</p>\n\n'
+        f"{body_html}\n"
+        "</article></body></html>\n"
+    )
+
+
+def _signal_cites(slug, body, cites, embed_fn, log):
+    """Emit one `source.signal` per cited snippet (ADR-0009). With an injected embed_fn the
+    signal is the cosine(embed(snippet), embed(body)) score (offline-testable); without one
+    the cite still records, scored 0.0 — the publish never depends on a network call."""
+    for c in cites:
+        if not (isinstance(c, dict) and c.get("snippet")):
+            continue
+        if embed_fn is not None:
+            sim = eventlog.cosine(embed_fn(c["snippet"]), embed_fn(body))
+        else:
+            sim = 0.0
+        eventlog.source_signal(slug, c.get("ref"), c.get("kind"), sim, log=log)
+
+
+def _render_page(slug, spec, *, skill, date):
+    """Render the self-contained neutral HTML page for `slug` from its spec — the SINGLE
+    place the page bytes are produced, so a normal publish and a reprojection (recovery from
+    the logged spec) emit byte-identical pages. Returns (body_html, page_text)."""
+    body_html = render.spec_to_html(spec)
+    css = BASE_CSS.read_text()
+    page = _page(slug, body_html, skill=skill, date=date or _date.today().isoformat(), css=css)
+    return body_html, page
+
+
+def _write_page(out, page):
+    """Write the page to `out` via temp+rename (atomic, no half-written page). A failure here
+    is recoverable AFTER the commit: the logged spec re-renders the page (reproject_missing_pages)."""
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_suffix(".html.tmp")
+    tmp.write_text(page)
+    os.replace(tmp, out)
+
+
+def _is_canonical_log(log):
+    """True iff `log` is the install's CANONICAL event log — compared by NORMALIZED PATH, not object
+    identity (Codex P3): a caller writing the real log via an equivalent `Path(eventlog.LOG)`, a
+    resolved path, or a string path is still canonical and must project/sync. A temp/dry-run log is
+    not. Path-resolution failures fall back to object identity (never raises)."""
+    if log is eventlog.LOG:
+        return True
+    try:
+        return Path(log).resolve() == Path(eventlog.LOG).resolve()
+    except Exception:  # noqa: BLE001 — a non-path log → not canonical
+        return False
+
+
+def _cluster_slug(label):
+    """wiki_render's canonical cluster-slug rule (letters only — drops spaces, &, digits,
+    punctuation). The ONE rule the projection resolves a `distills` ref against (memory.md:
+    the slug↔display trap) — APOC is not installed, so normalize in Python, never cypher."""
+    return re.sub(r"[^a-z]", "", (label or "").lower())
+
+
+def _load_openai_key():
+    """Load OPENAI_API_KEY into the env if absent (Codex P1): the embedding key lives in the install
+    secrets (or the ~/.edge-sandbox-kit dev fallback) and is NOT necessarily exported when a producer
+    invokes the projection. Without this, the embed fails, the projection never completes, and recall
+    filters the Artefato out forever. Mirrors sweep._load_openai_key (the runtime's loader)."""
+    if os.environ.get("OPENAI_API_KEY"):
+        return
+    for f in (REPO / "secrets" / "openai.env", Path.home() / ".edge-sandbox-kit" / "openai.env"):
+        try:
+            if f.exists():
+                for line in f.read_text().splitlines():
+                    if "OPENAI_API_KEY" in line:
+                        os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip().strip('"')
+                        return
+        except Exception:  # noqa: BLE001 — best-effort; embed degrades if the key cannot be loaded
+            pass
+
+
+def _spec_text(spec):
+    """Flatten the published spec to plain text for the content embedding (Codex P2: embed the
+    CONTENT, not just the kernel). Walks the string leaves render reads — executive_summary +
+    every block's string/list-of-string/list-of-dict values — best-effort, bounded for the embed
+    request. Returns '' for a None/empty spec (the embed then falls back to slug+kernel)."""
+    if not isinstance(spec, dict):
+        return ""
+    parts = []
+    # top-level rendered fields render.spec_to_html emits as content: executive_summary, the
+    # metrics grid, and the bibliography (Codex P2) — plus every section/additional_section block.
+    _walk_strings(spec.get("executive_summary") or [], parts)
+    _walk_strings(spec.get("metrics") or [], parts)
+    _walk_strings(spec.get("bibliography") or [], parts)
+    for block in _iter_spec_blocks(spec):
+        _walk_strings(block, parts)
+    return " ".join(parts)[:8000]   # bound the embed input
+
+
+def _walk_strings(node, out):
+    """Collect every string leaf under `node` (dict/list nested to any depth — e.g. a table's
+    rows are list-of-lists), so table cells and nested bullets reach the content embedding."""
+    if isinstance(node, str):
+        out.append(node)
+    elif isinstance(node, dict):
+        for v in node.values():
+            _walk_strings(v, out)
+    elif isinstance(node, list):
+        for it in node:
+            _walk_strings(it, out)
+
+
+def _iter_spec_blocks(spec):
+    for key in ("sections", "additional_sections"):
+        for section in spec.get(key, []):
+            for block in section.get("blocks", []):
+                if isinstance(block, dict):
+                    yield block
+
+
+def _project_backbone(s, g, log):
+    """Project the canonical SPINE BACKBONE on an open session `s`: :Genesis (space-0) -GROUNDS->
+    :Objective + the ANCHORS rebuild (the active steers, DESTRUCTIVE DELETE-then-readd from the
+    canonical fold). Shared by project_artefato (per publish) and reproject_graph (per sweep) so the
+    ANCHORS stay current with the log every canonical sync, regardless of which artefatos exist."""
+    import yaml
+    try:
+        cfg = yaml.safe_load((REPO / "agent.yaml").read_text()) or {}
+    except Exception:  # noqa: BLE001 — agent.yaml read is best-effort
+        cfg = {}
+    s.run("MERGE (gen:Genesis {group_id:$g}) SET gen.space=0, gen.codename=$c, gen.voice=$v, "
+          "gen.method='memory/method.md', gen.personality='memory/personality.md'",
+          g=g, c=cfg.get("codename") or cfg.get("name"), v=cfg.get("voice"))
+    obj = eventlog.objective_at(log=log) or {}
+    if obj.get("body"):
+        s.run("MERGE (o:Objective {group_id:$g}) SET o.body=$b", g=g, b=obj["body"])
+        s.run("MATCH (gen:Genesis {group_id:$g}),(o:Objective {group_id:$g}) "
+              "MERGE (gen)-[:GROUNDS]->(o)", g=g)
+        # ENSURE every Artefato SERVES the objective (Codex P2): an Artefato published BEFORE the
+        # Objective existed had its SERVES no-op at projection time; the backbone (run every canonical
+        # sweep, once an Objective exists) guarantees the hub link so it is reachable from space-0 —
+        # cheap idempotent MERGEs, no embeddings, independent of the per-slug skip-present recovery.
+        s.run("MATCH (a:Artefato {group_id:$g}),(o:Objective {group_id:$g}) "
+              "MERGE (a)-[:SERVES]->(o)", g=g)
+    # ANCHORS = the CURRENTLY active steers — REBUILD each sync (DESTRUCTIVE) so a dropped/superseded
+    # Direction stops being anchored (recall from space-0 must match the log).
+    dirs = eventlog.direction_at(log=log) or {}
+    s.run("MATCH (o:Objective {group_id:$g})-[r:ANCHORS]->(:Direction) DELETE r", g=g)
+    for it in dirs.get("set", []) + dirs.get("proposed", []):
+        s.run("MERGE (d:Direction {group_id:$g, body:$b})", g=g, b=it["body"])
+        s.run("MATCH (o:Objective {group_id:$g}),(d:Direction {group_id:$g, body:$b}) "
+              "MERGE (o)-[:ANCHORS]->(d)", g=g, b=it["body"])
+
+
+def project_backbone(log=eventlog.LOG):
+    """Open a session and project the canonical spine backbone (Codex P2): the ANCHORS rebuild must
+    run EVERY canonical sweep so newly-folded Directions get anchored even when no artefato changed.
+    CANONICAL-LOG ONLY + degrade-safe — a non-canonical log or an unreachable graph is a no-op."""
+    if not _is_canonical_log(log):
+        return
+    try:
+        import _identity
+        from neo4j import GraphDatabase
+        uri, user, pw = _identity.neo4j_conn()
+        g = _identity.require_group()
+        drv = GraphDatabase.driver(uri, auth=(user, pw))
+    except Exception as ex:  # noqa: BLE001 — best-effort
+        print("backbone sync skipped (best-effort, graph unreachable):", ex)
+        return
+    try:
+        with drv.session() as s:
+            _project_backbone(s, g, log)
+    except Exception as ex:  # noqa: BLE001 — best-effort, never fatal
+        print("backbone sync failed (best-effort):", ex)
+    finally:
+        try:
+            drv.close()
+        except Exception:
+            pass
+
+
+def project_artefato(slug, intent, *, skill, distills=None, proposes=None, cites=None,
+                     spec=None, log=eventlog.LOG):
+    """Project a just-published Artefato into the edge's graph — the deterministic spine write
+    that was prose in `skills/_shared/memory.md` (the "Project — AFTER you publish" block) and so
+    got SKIPPED by the producer. Ported here as a GUARANTEED side-effect of every publish so the
+    graph grows model-independently (#30).
+
+    Best-effort / degrade-safe (ADR-0011/0006): the LOG is canonical; this projection is a
+    re-derivable view. ANY failure (no group, no neo4j driver, graph unreachable, no OpenAI key
+    for the embed) PRINTS and returns — it NEVER raises into the publish (`publish` also wraps the
+    call). The next beat reprojects from the log.
+
+    What it writes (idempotent MERGEs), exactly as memory.md specifies:
+      (0) backbone — :Genesis (space-0, codename+voice) -GROUNDS-> :Objective; ANCHORS REBUILT
+          from the canonical fold each sync (drop retired steers; the Artefato->PROPOSES->Direction
+          provenance is left intact);
+      (1) :Artefato MERGE + SERVES the Objective (the hub that keeps it reachable from space-0) +
+          a content `embedding` (text-embedding-3-small, best-effort — skipped if no key);
+      (2) edges — DISTILLS (slug-resolved to existing clusters only, never fabricated), PROPOSES,
+          CITES.
+    `skill` is passed through so the projection records WHICH producer minted the Artefato."""
+    try:
+        import _identity
+        from neo4j import GraphDatabase
+        uri, user, pw = _identity.neo4j_conn()
+        g = _identity.require_group()
+        distills, proposes, cites = distills or [], proposes or [], cites or []
+        drv = GraphDatabase.driver(uri, auth=(user, pw))
+    except Exception as ex:  # noqa: BLE001 — best-effort; the log already holds the truth
+        print("project skipped (best-effort, graph unreachable):", ex)
+        return
+    # The WHOLE spine backbone (Genesis/Objective/Direction) is CANONICAL-LOG ONLY (Codex P2): it
+    # writes the install group's identity + objective + the destructive ANCHORS rebuild, all of which
+    # read the log. A custom/offline log (a test, a dry-run) must NEVER overwrite the install's live
+    # Objective or delete its Directions — it projects ONLY the ADD-only Artefato + its edges below.
+    canonical = _is_canonical_log(log)
+    try:
+        with drv.session() as s:
+            if canonical:
+                # (0) keep the SPINE BACKBONE current and ROOTED at space-0 (idempotent, cheap).
+                # Shared with reproject_graph so the ANCHORS rebuild runs EVERY canonical sweep even
+                # when no artefato is missing (Codex P2 — newly folded Directions must get anchored).
+                _project_backbone(s, g, log)
+            # (1) the Artefato + its content embedding (semantic search; best-effort). `projected_at`
+            # is the recency signal recall-push orders by (#30, Codex P2) — set on every (re)project.
+            # CLEAR `projection_complete` FIRST (Codex P2): a republish with a corrected payload is
+            # NOT complete until THIS run finishes — if it fails partway, the marker stays false so
+            # the next sweep re-projects and the graph cannot keep a stale kernel/edges forever.
+            # `skill` is COALESCED (Codex P2): the published event now carries skill, so a replay
+            # restores the REAL producer identity; a legacy event with no skill folds to None, which
+            # coalesce PRESERVES (never clobbers an already-projected skill to NULL).
+            s.run("MERGE (a:Artefato {group_id:$g, slug:$slug}) "
+                  "SET a.kernel=$k, a.skill=coalesce($skill, a.skill), a.page=$page, "
+                  "a.projected_at=$pat, a.projection_complete=false",
+                  g=g, slug=slug, k=intent, skill=skill, page=f"blog/entries/{slug}.html",
+                  pat=_dt.now(_tz.utc).isoformat())
+            # every Artefato SERVES the objective — the hub keeping it reachable from space-0.
+            s.run("MATCH (a:Artefato {group_id:$g, slug:$slug}),(o:Objective {group_id:$g}) "
+                  "MERGE (a)-[:SERVES]->(o)", g=g, slug=slug)
+            # embed the CONTENT (Codex P2): a concept in the body but not the kernel must still be
+            # semantically recallable over a.embedding. Re-embed only when the EMBED INPUT CHANGED
+            # (Codex P2): store a hash of (slug+intent+spec_text); a republish with changed
+            # intent/spec refreshes the stale embedding, but a pure edge-link revisit (same content,
+            # e.g. an unresolved distill that resolved) skips the costly re-embed (hash unchanged).
+            emb_input = f"{slug}\n{intent}\n{_spec_text(spec)}".strip()
+            emb_hash = hashlib.sha256(emb_input.encode("utf-8")).hexdigest()
+            row = s.run("MATCH (a:Artefato {group_id:$g, slug:$slug}) "
+                        "RETURN a.embedding IS NOT NULL AS e, a.embedding_input_hash AS h",
+                        g=g, slug=slug).single()
+            embed_current = bool(row["e"]) and row["h"] == emb_hash
+            if not embed_current:
+                try:
+                    from openai import OpenAI
+                    _load_openai_key()   # source the install/dev OpenAI key if not exported (Codex P1)
+                    emb = OpenAI().embeddings.create(model="text-embedding-3-small",
+                                                     input=emb_input).data[0].embedding
+                    s.run("MATCH (a:Artefato {group_id:$g, slug:$slug}) "
+                          "SET a.embedding=$e, a.embedding_input_hash=$h",
+                          g=g, slug=slug, e=emb, h=emb_hash)
+                    embed_current = True
+                except Exception as ex:  # noqa: BLE001 — embed is best-effort (no key → skip)
+                    # a FAILED embed (key/service down) must NOT mark the projection complete (Codex
+                    # P2): leave embed_current False so recovery RETRIES the embed once creds recover,
+                    # instead of skipping the slug forever with no/stale embedding.
+                    print("embed skipped (best-effort, will retry on recovery):", ex)
+            # (2) edges — distills (slug-resolved), proposes, cites. REBUILD this slug's edge set
+            # each (re)project (Codex P2): clear the slug's OLD DISTILLS/PROPOSES/CITES first, so a
+            # republish/replay with corrected provenance does not leave stale clusters/directions/
+            # sources behind — recall stays a faithful projection of the log's latest payload. SERVES
+            # is to the single hub (idempotent) and is left intact.
+            s.run("MATCH (a:Artefato {group_id:$g, slug:$slug})-[r:DISTILLS|PROPOSES|CITES]->() "
+                  "DELETE r", g=g, slug=slug)
+            # resolve distills against ACTIVE clusters only (Codex P2): mirror graph_clusters —
+            # archived/merged entities are hidden, so a retired cluster is never linked or pushed.
+            labels = [r["l"] for r in s.run(
+                "MATCH (e:Entity {group_id:$g}) WHERE e.curated_cluster IS NOT NULL "
+                "AND coalesce(e.archived,false)=false AND e.merged_into IS NULL "
+                "RETURN DISTINCT e.curated_cluster AS l", g=g)]
+            by_slug = {_cluster_slug(l): l for l in labels}
+            unresolved_distills = False
+            for ref in distills:                  # link ONLY existing active clusters (never fabricate)
+                label = by_slug.get(_cluster_slug(str(ref).replace("cluster:", "")))
+                if not label:
+                    # cluster not in the graph yet — the grill attaches it later. Mark the projection
+                    # INCOMPLETE so recovery REVISITS this slug once the cluster exists (the embed is
+                    # already set, so the revisit is a cheap edge-only re-link, not a re-embed).
+                    unresolved_distills = True
+                    continue
+                s.run("MATCH (a:Artefato {group_id:$g, slug:$slug}),"
+                      "(e:Entity {group_id:$g, curated_cluster:$label}) "
+                      "MERGE (a)-[:DISTILLS]->(e)", g=g, slug=slug, label=label)
+            for p in proposes:
+                body = p.get("body") if isinstance(p, dict) else None
+                if not body:
+                    continue
+                s.run("MATCH (a:Artefato {group_id:$g, slug:$slug}) "
+                      "MERGE (d:Direction {group_id:$g, body:$b}) MERGE (a)-[:PROPOSES]->(d)",
+                      g=g, slug=slug, b=body)
+            for c in cites:
+                ref = c.get("ref") if isinstance(c, dict) else None
+                if not ref:
+                    continue
+                s.run("MATCH (a:Artefato {group_id:$g, slug:$slug}) "
+                      "MERGE (src:Source {group_id:$g, key:$key}) MERGE (a)-[:CITES]->(src)",
+                      g=g, slug=slug, key=ref)
+            # (3) COMPLETION MARKER — set LAST, complete ONLY when (a) every edge write succeeded,
+            # (b) the embedding is current (a FAILED embed leaves it false → retried on recovery,
+            # Codex P2), AND (c) every distill ref RESOLVED. `_graph_present_slugs` reads THIS: a node
+            # left half-projected (embed/edge outage) OR with an unresolved distill (cluster not in
+            # the graph yet) is NOT present and is re-projected — so a transient embed outage and the
+            # "grill attaches the cluster later" path both self-heal on the next sweep.
+            s.run("MATCH (a:Artefato {group_id:$g, slug:$slug}) SET a.projection_complete=$done",
+                  g=g, slug=slug, done=(embed_current and not unresolved_distills))
+    except Exception as ex:  # noqa: BLE001 — a failed projection is reported, never fatal
+        print("project failed (best-effort, reproject next beat):", ex)
+    finally:
+        try:
+            drv.close()
+        except Exception:
+            pass
+
+
+_DEFAULT_PROJECT = object()  # sentinel: "use module project_artefato" (resolved at CALL time so a
+                             # test can patch publisher.project_artefato to stay offline) vs an
+                             # explicit None ("skip the projection") vs an injected fake.
+
+
+def publish(slug, spec, intent, *, skill, verdict=None, proposes=None, distills=None,
+            cites=None, date=None, log=eventlog.LOG, blog_dir=BLOG_DIR, embed_fn=None,
+            project_fn=_DEFAULT_PROJECT) -> Path:
+    """Publish an Artefato: render → self-contained neutral HTML → atomic state record.
+
+    #2/#3 at the seam: RAISES ValueError unless `verdict` is the UNFORGEABLE, BOUND proof
+    `close.run_close` mints — `close.verify_proof` requires the run_close-only token, a digest
+    that BINDS to THIS exact payload (slug + spec + intent + cites + proposes + distills +
+    skill), both blind reviewers passed, and both CANONICAL reviewer identities are present. A
+    hand-built dict, a proof minted for a different artefato (digest mismatch), an altered
+    distills/skill, a single-reviewer proof, or a proof from fake reviewers raises here, before
+    any HTML or state lands — the publisher is never a back door around the gate. C3 at the seam: RAISES when `intent` is
+    missing/empty — you cannot publish without the kernel (and defensively when the genus
+    contract is violated). #4 at the seam: the slug is validated + contained under blog_dir,
+    the page written via temp+rename.
+
+    Order (#2/#3, ADR-0006): render the page in memory → append the atomic event WITH the spec
+    (the COMMIT POINT; the log is truth) → THEN write the HTML (a projection) → THEN emit source
+    signals. Everything after the commit is a recoverable projection: a page-write or signal
+    failure is no longer unrecoverable — the logged spec re-renders the exact page and the logged
+    cites re-emit the signals via `reproject_missing_pages`. Signal emission is non-fatal to the
+    page (#4). Returns the written page Path. `date` is a param (defaults to today) so tests pin
+    it; `embed_fn` is injectable so the source-signal step runs offline.
+    """
+    # ADR-0016 FIRST — no wake, no publish: the refusal names the real gap (`no-wake`), not a
+    # proof error. The stamp is checked on the SAME log this publish would commit to.
+    if not eventlog.wake_fresh(log=log):
+        raise RuntimeError(
+            f"no-wake: cannot publish {slug!r} — no dispatch.open newer than the last "
+            "artefato.published on this log (ADR-0016: run tools/predispatch.py at dispatch "
+            "entry; one wake per publish)")
+    verify_proof(verdict, slug=slug, spec=spec, intent=intent,
+                 cites=cites or [], proposes=proposes or [],
+                 distills=distills, skill=skill)
+    if not (intent and intent.strip()):
+        raise ValueError(f"cannot publish artefato {slug!r} without an intent kernel (C3)")
+    if skill not in PRODUCER_ROSTER:
+        raise ValueError(
+            f"skill {skill!r} is not in the producer roster {PRODUCER_ROSTER} — "
+            "an out-of-roster skill is refused before anything is written (Codex round-4)")
+
+    out = _safe_target(slug, blog_dir)
+
+    cites = cites or []
+    # The publisher-side genus check must see EVERY field check_genus reads, or it disagrees with
+    # run_close's check (Codex P2): the rich-rite floor reads `distills` (lineage) and content, so
+    # a report whose lineage rides on its published `distills` would pass run_close but raise here.
+    artefato = {"intent": intent, "proposes": proposes or [], "cites": cites,
+                "content": spec, "distills": distills or [], "skill": skill}
+    violations = check_genus(artefato)
+    if violations:
+        raise ValueError(f"artefato {slug!r} violates the genus contract: {violations}")
+
+    body_html, page = _render_page(slug, spec, skill=skill, date=date)
+
+    # COMMIT POINT (#2, ADR-0006: the log is truth). The atomic event carries the proof-bound
+    # spec, so the page is fully regenerable from the log alone. EVERYTHING after this is a
+    # recoverable projection (reproject_missing_pages re-derives it from the logged spec/cites).
+    eventlog.publish_artefato_atomic(slug, intent, proposes=proposes, distills=distills,
+                                     cites=cites, spec=spec, skill=skill, log=log)
+
+    # the page is a PROJECTION written after the commit — a failure here is recoverable.
+    _write_page(out, page)
+
+    # source-signal emission is NON-FATAL to the page (#4): a signal-store failure must not
+    # corrupt the published page; the cites are durably logged, so the signals are recoverable
+    # (reproject_missing_pages re-emits any missing ones).
+    try:
+        _signal_cites(slug, body_html, cites, embed_fn, log)
+    except Exception:
+        pass
+
+    # project-after-publish (#30): a GUARANTEED, best-effort side-effect after the commit — the
+    # spine projection that was prose in memory.md and got skipped, now runs every publish so the
+    # graph grows model-independently. NON-FATAL (ADR-0011/0006): a failed projection is reported,
+    # never breaks the publish — the log is canonical, the next beat reprojects. Injectable so the
+    # seam runs offline. The double-wrap (here + inside project_artefato) is belt-and-suspenders:
+    # even an injected project_fn that raises can never strand the already-committed Artefato.
+    # resolve the default at CALL time (name lookup) so a test can patch project_artefato to stay
+    # offline; an explicit None skips projection entirely. DEFAULT-SKIP for a non-canonical log
+    # (Codex P2): a dry-run/test/recovery publish to a temp log must NOT write into the install
+    # graph — those nodes could not be replayed or cleaned from the canonical log. Only the
+    # canonical-log publish projects by default; a caller wanting to project a custom log must pass
+    # an explicit project_fn.
+    if project_fn is _DEFAULT_PROJECT:
+        project_fn = project_artefato if _is_canonical_log(log) else None
+    if project_fn is not None:
+        try:
+            project_fn(slug, intent, skill=skill, distills=distills, proposes=proposes,
+                       cites=cites, spec=spec, log=log)
+        except Exception as ex:  # noqa: BLE001 — projection is best-effort, never fatal
+            print(f"project skipped for {slug!r} (best-effort, reproject next beat):", ex)
+    return out
+
+
+def reproject_missing_pages(log=eventlog.LOG, blog_dir=BLOG_DIR, date=None, embed_fn=None):
+    """Recovery/reprojection (Codex round-10 [high], ADR-0006: pages are PROJECTIONS of the log).
+    For every committed `artefato.published` that carries a spec, re-render any MISSING
+    blog/entries/<slug>.html from the logged spec (byte-identical to a normal publish) and
+    re-emit any MISSING source signals from the logged cites. Idempotent: a present page is left
+    untouched and an already-emitted signal (per ref) is not re-emitted. This is what makes a
+    page-write or signal failure AFTER the publish commit recoverable rather than unrecoverable.
+
+    The published event now carries `skill` (#30), so the reprojected page uses the REAL producer
+    skill for the meta line (Codex P2) — a map/plan recovered page is byte-identical to the original,
+    not mislabelled 'report'. A legacy event with no skill falls back to the producer-neutral default;
+    the body (the load-bearing content) re-renders exactly either way."""
+    blog_dir = Path(blog_dir)
+    yields = eventlog.source_yield_at(log=log)  # refs that already have a signal
+    redone = []
+    for item in eventlog.corpus_at(log=log):
+        spec = item.get("spec")
+        if spec is None:
+            continue  # legacy/migration published events with no spec are not regenerable
+        slug = item["slug"]
+        try:
+            out = _safe_target(slug, blog_dir)
+        except ValueError:
+            continue
+        body_html, page = _render_page(slug, spec, skill=item.get("skill") or "report", date=date)
+        if not out.exists():
+            _write_page(out, page)
+            redone.append(out)
+        # re-emit only cites whose source signal never landed (idempotent recovery)
+        missing = [c for c in (item.get("cites") or [])
+                   if isinstance(c, dict) and c.get("snippet") and c.get("ref") not in yields]
+        _signal_cites(slug, body_html, missing, embed_fn, log)
+    return redone
+
+
+def _graph_present_slugs():
+    """The slugs FULLY projected into the install graph, mapped to their `projected_at` — read once so
+    recovery replays only the missing/incomplete/STALE ones (Codex P2): never re-embed the whole
+    corpus each sweep, BUT re-project a node left INCOMPLETE (no `projection_complete` marker — set
+    ONLY as project_artefato's last step) OR STALE (its `projected_at` is older than the log's latest
+    published ts for that slug — a republish whose projection never reached the graph). Returns a dict
+    `{slug: projected_at}`, or None on a degrade (no group / no driver / unreachable) — the caller then
+    skips the replay entirely (there is nothing to recover into a graph it cannot read)."""
+    try:
+        import _identity
+        from neo4j import GraphDatabase
+        uri, user, pw = _identity.neo4j_conn()
+        g = _identity.require_group()
+        drv = GraphDatabase.driver(uri, auth=(user, pw))
+    except Exception:  # noqa: BLE001 — degrade: caller skips the replay
+        return None
+    try:
+        with drv.session() as s:
+            return {r["slug"]: r["pat"] for r in s.run(
+                "MATCH (a:Artefato {group_id:$g}) WHERE a.projection_complete = true "
+                "RETURN a.slug AS slug, a.projected_at AS pat", g=g)}
+    except Exception:  # noqa: BLE001
+        return None
+    finally:
+        try:
+            drv.close()
+        except Exception:
+            pass
+
+
+def reproject_graph(log=eventlog.LOG, project_fn=_DEFAULT_PROJECT, present_slugs=_graph_present_slugs,
+                    backbone_fn=project_backbone):
+    """Graph recovery (Codex P2, #30, ADR-0006: the graph is a re-derivable PROJECTION of the log).
+    A transient Neo4j outage at publish time leaves the committed Artefato out of the graph (so
+    `recall_subgraph` misses it) — this is the "reproject next beat" path the publish-time catch
+    promises. Replay `project_artefato` for the MISSING Artefatos only (idempotent MERGEs). The
+    published event carries `skill`, so the replay restores the REAL producer identity; the Artefato
+    + its SERVES/DISTILLS/PROPOSES/CITES + embedding are re-derived from the log.
+
+    REPLAY ONLY THE MISSING/STALE (Codex P2): steady-state must NOT re-embed the whole corpus each
+    sweep. `present_slugs()` reports `{slug: projected_at}` for complete nodes (one cheap read); a slug
+    is skipped ONLY if it is complete AND its `projected_at` is at-or-after the log's latest published
+    ts for that slug. A republished slug (newer log ts) — or one whose republish projection never
+    reached the graph — is STALE and re-projected, so the graph cannot keep a stale kernel/edges
+    forever. If `present_slugs()` degrades to None (graph unreachable), the replay is skipped entirely.
+
+    Best-effort: a still-unreachable graph degrades inside project_artefato (prints, never raises).
+    Call it from the sweep/assemble at beat-open so a missed projection self-heals next beat.
+
+    DEFAULT-SKIP for a non-canonical log (Codex P2): like `publish`, replaying a temp/dry-run log
+    must NOT write into the install graph — those nodes could not be replayed/cleaned from the
+    canonical log. Only a canonical-log (`log is eventlog.LOG`) replay projects by default; a caller
+    wanting to replay a custom log must pass an explicit project_fn."""
+    if project_fn is _DEFAULT_PROJECT:
+        project_fn = project_artefato if _is_canonical_log(log) else None
+    if project_fn is None:
+        return
+    # rebuild the spine backbone FIRST, every canonical sweep (Codex P2): the ANCHORS rebuild reads
+    # the log's active steers, so newly-folded Directions get anchored even when no artefato is
+    # missing — independent of the skip-present optimization below. Cheap (no embeddings), idempotent.
+    if backbone_fn is not None:
+        backbone_fn(log)
+    present = present_slugs() if present_slugs is not None else {}
+    if present is None:
+        return  # graph unreachable — nothing to recover into it; skip (no per-item embed storm)
+    for item in eventlog.corpus_at(log=log):
+        pat = present.get(item["slug"])
+        # skip ONLY if complete AND FRESH: the node's projected_at is at-or-after the log's LATEST
+        # event ts for this slug. `latest_ts` advances to a kernel ADDED LATER (Codex P3), so a
+        # legacy C3-debt repair (kernel appended after publish) makes the slug stale → replay. A
+        # republish (newer ts) or a never-projected republish is likewise STALE → replay.
+        latest = item.get("latest_ts") or item.get("ts")
+        if pat is not None and latest is not None and str(pat) >= str(latest):
+            continue  # already projected and current — skip (no re-embed in steady state)
+        try:
+            # the published event now carries `skill` (Codex P2), so a publish-time-outage replay
+            # restores the REAL producer identity even when the node does not exist yet. A legacy
+            # event with no skill folds to None, which coalesce preserves (never clobbers).
+            project_fn(item["slug"], item.get("intent") or "", skill=item.get("skill"),
+                       distills=item.get("distills"), proposes=item.get("proposes"),
+                       cites=item.get("cites"), spec=item.get("spec"), log=log)
+        except Exception as ex:  # noqa: BLE001 — replay is best-effort, never fatal
+            print(f"graph reproject skipped for {item.get('slug')!r} (best-effort):", ex)


### PR DESCRIPTION
## Contexto

Review de usabilidade do entry `arestas-editor-fluxos-assertia` (2026-06-10) apontou que a camada fraca é o **frame** da página publicada, não o conteúdo: texto full-bleed em telas largas, h1/meta sem estilo (o slug cru como título), referências cruzadas tipo "seção 5" sem seções numeradas, patch em `<pre>` monocromático apesar da paleta de diff existir no CSS, screenshots-evidência pequenos demais para ler, e `lang="en"` em página PT-BR.

Este PR muda **só o frame** (base.css + wrapper do publisher + um novo asset JS). Nenhum byte de conteúdo de entry é alterado; tudo é display-only e degrada para a página atual sem JS.

## Estrutura dos commits (importante para revisar)

O install vivo migrou para a arquitetura Close depois do último push (o `.git` local foi aposentado em 2026-06-09), então o `main` daqui não tem `tools/publisher.py` nem o `base.css` neutralizado.

- **Commit 1** apenas espelha os 4 arquivos do seam de frame exatamente como estão deployados (zero mudança de comportamento).
- **Commit 2** é o diff real a revisar.

## O que muda (commit 2)

- **Coluna de leitura**: `article.report` ganha max-width/margin/padding (o publisher o emite nu sob `<body>`); h1 e `.meta` estilizados; título sentence-cased via `::first-letter` (display-only).
- **`lang="pt-BR"`** no wrapper — seam único (`PAGE_LANG`), nunca sniffado por entry.
- **Seções numeradas** via CSS counter — "seção 5" volta a ser resolvível e bate com o sumário.
- **`assets/page.js`** (novo, inlined ao lado do base.css — página continua self-contained), progressivo e display-only:
  - **Sumário** quando o report tem 3+ seções;
  - **Diff tint** por linha em `<pre>` de texto puro que parece unified diff (verde/vermelho/meta);
  - **Lightbox** clique-para-ampliar nas imagens de `<figure>` (screenshots são evidência; inline ficam pequenos).
- **Defesa em profundidade**: `page.js` é controlado pelo repo, mas `_page` ainda escapa sequência de fechamento de script; `js` vazio não emite elemento script algum.

Fora de escopo (são conteúdo, não frame): bibliografia/links de fontes, glossário, anotações nos screenshots — isso é seam do produtor/render spec.

## Verificação

- Suíte verde em cópia do install vivo: **70 testes** (`test_publisher`, `test_base_css`, `test_render`), incluindo pins novos: `lang`, exatamente 1 elemento script por página, escape do fechamento de script, hooks CSS do frame.
- Entry real re-embrulhado com o frame novo e screenshotado em Edge headless: sumário com as 7 seções, numeração, diff tint e lightbox funcionando; sem JS a página lê igual à atual.
- Reprojeção byte-idêntica preservada (publish e reproject usam o mesmo `_render_page`). Páginas já publicadas não mudam sozinhas; para retrofitar, re-renderizar do log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)