### PR TITLE
WIP: Hermes-only hardening checkpoint - known NO-GO blockers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,43 @@
 # edge — leia antes de instalar
 
-(Guarda de clone-fresco para harnesses que leem `AGENTS.md` — Codex, Hermes e afins.
-Conteúdo espelha o `CLAUDE.md` da raiz; em divergência, os dois devem ser editados juntos.)
+## Contrato deste derivado
 
-## Se este é um clone fresco (você ainda não é um install)
+Este repositório é **Hermes-only**. Toda orientação, delegação e revisão acontece em Hermes,
+com subagentes independentes quando o contrato pedir separação de contexto. Não configure
+superfícies de execução ou revisores externos.
 
-Este repositório é **genótipo sem identidade**: não existe `agent.yaml` aqui — cada host
-escreve o seu como SAÍDA do onboarding (o arquivo é untracked/gitignored de propósito).
+## Clone fresco
 
-- **NÃO** fabrique um `agent.yaml` nem rode `edge-apply` — essa é a estrada legada para
-  um fenótipo que JÁ pertence a um host vivo.
-- **SIM**: siga o rito guiado em `skills/onboard/SKILL.md` — entreviste o operador
-  (nome, pasta, CLIs, adversarial, segredos/embeddings, dias de backfill com cheque de
-  custo), conduza a instalação inteira explicando cada passo e emende no primeiro mentor.
-  `agent.yaml` é a SAÍDA do onboarding, nunca a semente.
+Este repositório é **genótipo sem identidade**: `agent.yaml` não deve existir no clone.
+Cada instalação o escreve como SAÍDA do onboarding; não o fabrique e não use o caminho
+legado de apply.
 
-Como saber: se `state/bootstrap.json` não existe e ninguém te disse que este diretório é
-um install vivo, trate como clone fresco e pergunte primeiro.
+Antes de qualquer bootstrap, estabeleça um perfil Hermes dedicado ao install:
 
-## Se este é um install vivo
+```sh
+export HERMES_HOME="$HOME/.hermes/profiles/edge"
+```
 
-Operação normal — `CONTEXT.md` é o mapa, `CONTRACT.md` o contrato, `docs/adr/` as
-decisões.
+O caminho é apenas um exemplo confirmável com o operador. Requisitos obrigatórios:
+
+- `HERMES_HOME` deve estar definido e apontar para um perfil dedicado;
+- nunca use o home global `~/.hermes` como destino de provisionamento;
+- clone, install home e `HERMES_HOME` são árvores distintas;
+- Hermes é o primary;
+- não configure adversarial externo;
+- ingestão de sessões fica dark até existir reader Hermes-native verificado;
+- runtime do grafo fica dark no onboarding;
+- heartbeat fica **off**; operação é manual-only até heartbeat Hermes-native.
+
+Siga `skills/onboard/SKILL.md`. O bootstrap suportado recebe explicitamente
+`--primary hermes --hermes-home "$HERMES_HOME"`. O finish não recebe
+`--enable-heartbeat`.
+
+Como reconhecer: se `state/bootstrap.json` não existe e ninguém declarou este diretório
+como install vivo, trate-o como clone fresco e inicie pelo rito guiado.
+
+## Install vivo
+
+Preserve o perfil dedicado e as fronteiras dark declaradas. Para operação normal,
+`CONTEXT.md` é o mapa, `CONTRACT.md` é o contrato e `docs/adr/` registra as decisões.
+Nenhuma ausência de capacidade autoriza fallback para outra superfície ou store.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,43 @@
 # edge — leia antes de instalar
 
-## Se este é um clone fresco (você ainda não é um install)
+## Contrato deste derivado
 
-Este repositório é **genótipo sem identidade**: não existe `agent.yaml` aqui — cada host
-escreve o seu como SAÍDA do onboarding (o arquivo é untracked/gitignored de propósito).
+Este repositório é **Hermes-only**. Toda orientação, delegação e revisão acontece em Hermes,
+com subagentes independentes quando o contrato pedir separação de contexto. Não configure
+superfícies de execução ou revisores externos.
 
-- **NÃO** fabrique um `agent.yaml` nem rode `edge-apply` — essa é a estrada legada para
-  um fenótipo que JÁ pertence a um host vivo.
-- **SIM**: siga o rito guiado em `skills/onboard/SKILL.md` — entreviste o operador
-  (nome, pasta, CLIs, adversarial, segredos/embeddings, dias de backfill com cheque de
-  custo), conduza a instalação inteira explicando cada passo e emende no primeiro mentor.
-  `agent.yaml` é a SAÍDA do onboarding, nunca a semente.
+## Clone fresco
 
-Como saber: se `state/bootstrap.json` não existe e ninguém te disse que este diretório é
-um install vivo, trate como clone fresco e pergunte primeiro.
+Este repositório é **genótipo sem identidade**: `agent.yaml` não deve existir no clone.
+Cada instalação o escreve como SAÍDA do onboarding; não o fabrique e não use o caminho
+legado de apply.
 
-## Se este é um install vivo
+Antes de qualquer bootstrap, estabeleça um perfil Hermes dedicado ao install:
 
-Operação normal — `CONTEXT.md` é o mapa, `CONTRACT.md` o contrato, `docs/adr/` as
-decisões.
+```sh
+export HERMES_HOME="$HOME/.hermes/profiles/edge"
+```
+
+O caminho é apenas um exemplo confirmável com o operador. Requisitos obrigatórios:
+
+- `HERMES_HOME` deve estar definido e apontar para um perfil dedicado;
+- nunca use o home global `~/.hermes` como destino de provisionamento;
+- clone, install home e `HERMES_HOME` são árvores distintas;
+- Hermes é o primary;
+- não configure adversarial externo;
+- ingestão de sessões fica dark até existir reader Hermes-native verificado;
+- runtime do grafo fica dark no onboarding;
+- heartbeat fica **off**; operação é manual-only até heartbeat Hermes-native.
+
+Siga `skills/onboard/SKILL.md`. O bootstrap suportado recebe explicitamente
+`--primary hermes --hermes-home "$HERMES_HOME"`. O finish não recebe
+`--enable-heartbeat`.
+
+Como reconhecer: se `state/bootstrap.json` não existe e ninguém declarou este diretório
+como install vivo, trate-o como clone fresco e inicie pelo rito guiado.
+
+## Install vivo
+
+Preserve o perfil dedicado e as fronteiras dark declaradas. Para operação normal,
+`CONTEXT.md` é o mapa, `CONTRACT.md` é o contrato e `docs/adr/` registra as decisões.
+Nenhuma ausência de capacidade autoriza fallback para outra superfície ou store.

--- a/blog/server.py
+++ b/blog/server.py
@@ -2616,8 +2616,8 @@ def _llm_route_row(r, probe_result=None):
                          if probe_result.get("status") else "") + "</div>")
     options = "".join(
         f'<option value="{p}"{" selected" if p == r["provider"] else ""}>{p}</option>'
-        for p in llm_routes.KNOWN_PROVIDERS
-        if not (r["embedding_route"] and p in llm_routes._llm.SUBSCRIPTION_PROVIDERS))
+        for p in llm_routes.allowed_providers_for_route(r["route"])
+    )
     return f"""<div class="llm-route" id="route-{_esc(r['route'])}">
   <h3>{_esc(r['route'])}</h3>
   <p class="meta">provider <strong>{_esc(r['provider'])}</strong> · modelo

--- a/docs/reviews/hermes-only-checkpoint-no-go-2026-07-26.md
+++ b/docs/reviews/hermes-only-checkpoint-no-go-2026-07-26.md
@@ -1,0 +1,161 @@
+# Checkpoint Hermes-only — relatório de Gate NO-GO
+
+**Data:** 2026-07-26
+**Destinatário:** Lucas
+**Status:** WIP / revisão técnica reprovada / não autorizado para merge ou operação
+
+## Identidade do checkpoint
+
+- Branch local: `feat/hermes-only`
+- Base da derivação: `88828cbfb6a8eae81e6d2d0fbb70b0c528d3a87c`
+- Commit WIP do código: `e535023fc2edb3df9b8802f4732cb47b0080c338`
+- Manifesto portátil do snapshot de implementação antes deste relatório:
+  `daddbb06c647b232e1b99c8be932d1c623214f1bf638ac08d04b2b9a7fb5ef22`
+- `origin/main` observado durante o fechamento: `991fc7455492564243ce8186359ba4d01591a937`
+
+O checkpoint preserva o hardening parcial sem rebasear ou incorporar silenciosamente o delta posterior do upstream. A análise de `991fc745` deve ocorrer separadamente.
+
+## Objetivo do trabalho
+
+Derivar uma variante estritamente Hermes-only do Edge of Chaos:
+
+- Hermes como único harness público;
+- completion pública exclusivamente via Hermes;
+- seleção de provider/modelo de completion mantida dentro do Hermes;
+- `HERMES_HOME` dedicado, sem uso do profile global;
+- embedding em rota separada, explicitamente configurada;
+- readers sem implementação Hermes-native mantidos dark;
+- heartbeat, dogfood e runtime autônomo mantidos dark;
+- adapters legados somente privados;
+- bloqueio antes de secrets, filesystem, locks, subprocessos ou provisionamento.
+
+## Avanço preservado
+
+O checkpoint adiciona uma política central Hermes-only e endurece caminhos nominais de:
+
+- seleção de harness e surfaces;
+- completion e embedding;
+- provisionamento de profile Hermes;
+- onboarding e apply;
+- readers públicos principais;
+- heartbeat e dogfood;
+- documentação e skills selecionadas;
+- testes de política e de ordem fail-closed.
+
+Também corrige a aceitação de seções malformadas como `surfaces: []`, `routers: []` e `heartbeat: []`.
+
+## Evidências positivas
+
+### Regressão focada Linux
+
+```text
+Bateria principal: 110/110
+Bateria effectful/identidade: 61/61
+Total focado: 171/171
+```
+
+### Smoke e verificações complementares
+
+- Smoke canônico: `65/65`.
+- Probes nominais fail-closed: `5/5`.
+- Efeitos temporários observados nos probes: `[]`.
+- Fuzz de seções malformadas: `17/17` bloqueadas.
+- `git diff --check`: verde antes do commit.
+- Bandit baseline-aware: zero achados novos médios ou altos.
+- Ruff: zero erros fatais e zero regras de segurança novas.
+- Literais de credenciais encontrados no delta: zero.
+
+Esses resultados demonstram que os caminhos cobertos estão protegidos, mas não demonstram conformidade Hermes-only de ponta a ponta.
+
+## Suíte integral
+
+A suíte integral não está verde:
+
+```text
+Base 88828cb: 3368 testes, 254 issues
+Derivado:      3401 testes, 403 issues
+Novos:          152
+Resolvidos:        3
+```
+
+Os novos resultados concentram-se em sessões, sweep, harvest, wake, predispatch e contratos legados multi-harness. Parte representa incompatibilidade intencional com capabilities tornadas dark; parte revelou cobertura incoerente ou caminhos públicos ainda alcançáveis. Portanto, o checkpoint não deve ser apresentado como regressão integral aprovada.
+
+## Revisão independente paralela
+
+Três revisores independentes foram executados em paralelo, com lentes diferentes:
+
+1. superfícies, LLM, profiles e provisionamento;
+2. ordem fail-closed e efeitos colaterais;
+3. sessões, adapters, skills, documentação e coerência dos testes.
+
+Resultado:
+
+```text
+Revisor A: REPROVADO
+Revisor B: REPROVADO
+Revisor C: REPROVADO
+```
+
+A correção de validação de seções malformadas ocorreu durante a janela da rodada. Por isso, a rodada não deve ser usada como aprovação criptográfica uniforme do snapshot final. Contudo, os principais blockers foram reproduzidos novamente no manifesto `daddbb...`, o que é suficiente para o NO-GO.
+
+## Blockers reproduzidos no snapshot atual
+
+Probes finais foram executados apenas com stubs e arquivos sintéticos em diretório temporário, sem rede, Docker, subprocesso real de harness, store real ou credencial real.
+
+Foram confirmados:
+
+1. selector externo arbitrário, como `primary: gemini`, aceito pela policy;
+2. `heartbeat: {enabled: true}` aceito;
+3. configuração Hermes aceita sem `HERMES_HOME` dedicado;
+4. modelo externo propagado até `hermes -m <modelo>`;
+5. subprocesso Hermes sem ambiente explícito fixando o profile dedicado;
+6. traversal sintético de `secret_ref` para fora de `secrets/`;
+7. reader público Codex lendo transcript sintético sem gate dark;
+8. `edge-bootstrap runtime` alcançando o provisionador Neo4j.
+
+Esses achados bastam para reprovar o Gate.
+
+## Achados adicionais da revisão
+
+Também foram apontados, devendo virar testes RED antes de correção:
+
+- completion OpenAI direta em caminhos paralelos;
+- fallbacks e descoberta implícita de embedding;
+- efeitos de sweep/predispatch antes do guard dark;
+- bootstrap com estado parcial antes de todas as validações;
+- `edge-apply --provision-runtime` bloqueando após imports/leitura de YAML;
+- helpers públicos adicionais de sessão/store;
+- skills que ainda acionam capacidades dark;
+- README e specs ainda descrevendo operação multi-harness;
+- problema de coleta em `tests/test_onboarding.py`, com classe declarada após `unittest.main()`.
+
+Alguns detalhes tiveram divergência entre revisores, mas não alteram o veredito porque os blockers reproduzidos acima já são suficientes.
+
+## Veredito
+
+> **NO-GO técnico e operacional.**
+
+Este checkpoint:
+
+- não está autorizado para merge;
+- não está autorizado para instalação;
+- não está autorizado para onboarding;
+- não está autorizado para heartbeat, dogfood ou runtime autônomo;
+- não deve ser rotulado como release ou implementação Hermes-only concluída.
+
+O commit existe para preservar e compartilhar o avanço, permitir revisão e transformar os blockers em trabalho dirigido.
+
+## Sequência recomendada
+
+1. Transformar cada blocker reproduzido em teste RED canônico.
+2. Corrigir primeiro traversal de secrets, runtime effectful, readers públicos e seleção externa de modelo.
+3. Tornar selectors uma allowlist positiva e bloquear heartbeat enquanto dark.
+4. Exigir e propagar `HERMES_HOME` dedicado em todo subprocesso Hermes.
+5. Remover completion/embedding paralelos ou colocá-los atrás das factories autorizadas.
+6. Mover guards antes de imports, arquivos, secrets, locks e mutações.
+7. Corrigir skills, README, specs e coleta dos testes de onboarding.
+8. Reexecutar regressão focada e suíte integral Linux.
+9. Lançar nova revisão paralela contra um único commit congelado.
+10. Avaliar separadamente o delta `88828cb..991fc745`.
+
+Somente uma nova rodada sem blockers pode promover o trabalho de WIP para GO.

--- a/skills/_shared/pipeline.md
+++ b/skills/_shared/pipeline.md
@@ -120,7 +120,7 @@ The bounce-bound (`BOUNCE_MAX`) and the loop-2 brake (`LOOP2_MAX_REOPENS`) live 
 constants, never in the producer's discretion — that is what separates a gate from the
 retry-envelope ADR-0003 killed.
 
-## The improve-gates and cross-model help (codex)
+## The improve-gates and independent Hermes review
 
 The close is not only a gate — it **refines**. When the producer wires an `improve_fn`,
 `run_close` runs `IMPROVE_ROUNDS` (default 2) **review→improve** passes before the gating review:
@@ -141,13 +141,12 @@ wired, the `IMPROVE_ROUNDS` passes REVISE the draft from the named gaps BEFORE t
 shallow report is **re-produced richer** (the missing move added) rather than dead-ending. The floor
 is a depth-forcer because the re-production is wired; the gate alone would only reject.
 
-The review and improve subagents — the **adversarial** blind pass, the **feynman** rigor
-reviewer, the **enrichment** (frame / outward-vector) reviewer, and the **improve** reviser — MAY
-reach for the **`/codex` skill** (the Codex CLI: a second, independent model) to pressure-test
-their analysis, when `agent.yaml`'s `subagents.codex_assist.<role>` is true (all on by default).
-Use it to challenge a claim, derive cross-model, or hunt the outside benchmark a frame-closed
-draft is missing — the score is noise; a cross-model second opinion sharpens the *feedback*, which
-is the signal.
+The review and improve roles — the **adversarial** blind pass, the **feynman** rigor reviewer,
+the **enrichment** (frame / outward-vector) reviewer, and the **improve** reviser — run as fresh,
+independent Hermes subagents. Independence comes from separate contexts and the context-denial
+ladder, not from an external executable. Use them to challenge claims, derive a second reading,
+or hunt the outside benchmark a frame-closed draft is missing. If Hermes delegation is
+unavailable, declare the role dark and fail any gate that requires it; never substitute a CLI.
 
 ## Single file is the ONE hard rule — links, JS and imagem liberados (ticket 05)
 
@@ -203,11 +202,11 @@ carries the floor at 0 and nothing changes until the operator turns it up.
 
 ## The publisher subagent OWNS the close (Facet B, #61)
 
-**The default publish path is delegation to the `publisher` subagent** (`.claude/agents/publisher.md`) —
+**The default publish path is delegation to the provisioned Hermes `publisher` subagent** —
 this is not an optional form-only clerk anymore; the publisher owns the WHOLE `run_close`. Once the
 producer has **SETTLED** the artefato (every claim already made, the rich context still in the MAIN's
 window), it does **not** run `close.run_close` inline. It writes the settled spec + fields to **disk
-pointers** and hands off to the publisher (via the Agent tool) with a **brief + disk POINTERS** — the
+pointers** and hands off to the publisher (via Hermes subagent delegation) with a **brief + disk POINTERS** — the
 `conductor.py` node_briefs idiom, never a context dump: `{dispatch_id, main_session_id, skill,
 intent_kernel, slug, spec_path, cites_path, proposes_path, distills_path, lineage_path}`. The publisher
 runs the **whole close** in a clean process — the genus contract, the two blind reviewers, the
@@ -227,8 +226,8 @@ re-found it. The MAIN re-produces and re-hands the pointers under the **same `di
 the stamp is unconsumed, so re-publish under the same id still passes the identity-held gate).
 
 **The floor keeps its teeth across the split.** The publisher runs as a child
-(`CLAUDE_CODE_CHILD_SESSION` set) with a read-less transcript, so a naive `close_floor()` would go
-always-dark — the very S6 grounding floor would lose its teeth. The brief's `main_session_id` cures it:
+with a read-less child context, so a naive `close_floor()` would go always-dark — the very S6
+grounding floor would lose its teeth. The brief's `main_session_id` cures it:
 the publisher wires `floor_fn=lambda: harvest.close_floor(session_id=main_session_id, child_session="")` —
 pointing the floor at the MAIN's transcript (where the reads live) and **clearing** the child guard.
 Without `child_session=""` the floor re-darkens under the split (pinned in

--- a/skills/_shared/scaffold.md
+++ b/skills/_shared/scaffold.md
@@ -86,10 +86,11 @@ never what a particular report-form *is*:
   **The explorer is a WORLD-reading subject — DENY it the `cortex` self door (N5/R6, ADR-0014).** An
   explorer reads the *world* (a paper, a repo, a source key); the **self** (the edge's own memory) is
   the producer's own job, reached **directly at rung 1** (the recall pass below), never by an explorer.
-  Fan it through the **committed `{prefix}-explorer` subagent** (`.claude/agents/explorer.md`, deployed
-  to `~/.claude/agents/`) — that artifact's frontmatter declares `disallowedTools: mcp__cortex__*`, so
-  the harness **mechanically strips** the self door from the explorer BY CONSTRUCTION (not by prose you
-  must remember). A read-only door does NOT make this safe: ADR-0014's failure is one CONTEXT holding
+  Fan it through the **provisioned `{prefix}-explorer` Hermes subagent**. Its canonical skill
+  frontmatter declares `disallowed-tools: mcp__cortex__*`; Hermes must preserve that deny when
+  delegating, so the runtime mechanically strips the self door from the explorer BY CONSTRUCTION
+  (not by prose you must remember). If the deny cannot be enforced, do not fan the explorer and
+  declare that leg dark. A read-only door does NOT make this safe: ADR-0014's failure is one CONTEXT holding
   world-new evidence beside recalled-self, where one is read as the other — the contamination forms
   before any write, so the **scope deny** is the wall, not read-only-ness. The producer holds the door
   and recalls for itself; its world-reading fan does not. (A graph-reading recall is rung-1 producer

--- a/skills/beat/SKILL.md
+++ b/skills/beat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: beat
-description: The beat — the 3-act production flow (ticket 05). Trunk: grounding inicial → an
+description: Manual-only Hermes beat — the 3-act production flow (ticket 05). Trunk: grounding inicial → an
   explicit PROPOSTA of which artefatos (1..N) and why; branches: one agent per artefato, each
   with its own grounding rounds, funneling through the shared close at its exit.
 ---
@@ -9,18 +9,27 @@ monolith (one grounding → one close): production is **3 acts** — escolher, p
 with **loops localizados**. The trunk chooses; the branches produce; every branch exits through
 the shared close (`skills/_shared/pipeline.md`).
 
+## Hermes-only execution gate — manual until native scheduling exists
+
+Run this skill only inside a live, operator-initiated Hermes session. Heartbeat and scheduled
+dispatch are **declared-dark** until a Hermes-native heartbeat owns launch, identity and completion
+receipts. If origin is autonomous or scheduled, stop before gate zero and report
+`DARK — Hermes-native heartbeat unavailable`. Never emulate scheduling with a shell loop, timer,
+background process or another execution surface.
+
 ## Gate zero — plano autoritativo ANTES de qualquer grounding
 
-Comece lendo `EDGE_DISPATCH_PLAN`. No heartbeat ele foi calculado mecanicamente e injetado no
-prompt + env **antes** deste processo existir — é o plano PRÉ-LANÇAMENTO: `decision.producer`
-vem `null` + `pauta: pendente`, porque a forma nasce na PROPOSTA da Pauta (ADR-0024; a rotação
-morreu). Tools/permissions desse plano são autoritativos desde já. Depois do Ato-1, re-derive o
-plano pelo mesmo seam — **este comando é o dente: sem `pauta.proposta` viva ele FALHA e Ato-2
+Comece lendo `EDGE_DISPATCH_PLAN`. Na invocação manual ele é calculado mecanicamente e
+injetado no prompt + env **antes** do funil: é o plano PRÉ-LANÇAMENTO,
+`decision.producer` vem `null` + `pauta: pendente`, porque a forma nasce na PROPOSTA da Pauta
+(ADR-0024; a rotação morreu). Tools/permissions desse plano são autoritativos desde já. Depois
+do Ato-1, re-derive o plano pelo mesmo seam — **este comando é o dente: sem `pauta.proposta`
+viva ele FALHA e Ato-2
 não abre**:
 
 `tools/edge-python tools/_beat.py dispatch-plan --home "$PWD" --dispatch-id "$EDGE_DISPATCH_PLAN_ID"`
 
-(Invocação interativa sem plano: use `interactive-${CLAUDE_CODE_SESSION_ID:-$$}` como
+(Invocação interativa sem plano: use `interactive-${HERMES_SESSION_ID:-$$}` como
 dispatch-id nos dois atos.) O `{decision, tools, permissions}` re-derivado é autoritativo:
 `decision.producer` = a `forma` da PROPOSTA; grounding posterior escolhe ângulo/quantidade
 **dentro dessa forma**, nunca outro producer e nunca outras permissões. **Mapa descreve, nunca
@@ -34,9 +43,11 @@ A escolha de pauta é o Módulo Pauta (`tools/pauta.py`; contrato assinado
 1. **SORTEIO antes do wake** — `tools/edge-python tools/pauta.py sortear` (Voz trava campos:
    `--lock objeto=mentorado`). A célula `{objeto × abordagem}` sai ANTES de qualquer leitura — a
    leitura já sai mirada. Sem blocklist: célula inviável morre em silêncio logado.
-2. **Grounding INICIAL mirado** — run the mechanical entry-driver
-   (`tools/edge-python tools/predispatch.py`) and read its briefs (briefing + quente + delta +
-   recall) ATRAVÉS do catálogo da célula (`tools/pauta.py catalogo --cell '<json>'`: mundo→
+2. **Grounding INICIAL mirado** — obey the wake's Hermes-native reader gate. Run the mechanical
+   entry-driver (`tools/edge-python tools/predispatch.py`) only when its session rail is confirmed
+   Hermes-native; otherwise stop with that rail declared-dark rather than read a fallback store.
+   When it runs, read its briefs (briefing + quente + delta + recall) ATRAVÉS do catálogo da
+   célula (`tools/pauta.py catalogo --cell '<json>'`: mundo→
    sources · atividade→conversas/obra · mentorado→leveling/fog · ser→livre). READ the latest
    `user_requested` artefatos (the quente's anchors carry them) — first-order sinal de pauta.
 3. **~12 SUGESTÕES** baratas, função do wake que você acabou de ler — NUNCA um pool fixo do
@@ -55,12 +66,10 @@ A escolha de pauta é o Módulo Pauta (`tools/pauta.py`; contrato assinado
 7. **O dente** — re-derive o plano (gate zero acima). Sem `pauta.proposta` viva, Ato-2 não
    abre — uniforme para autônomo e comandado.
 
-**Lei do turno (headless):** o beat roda em `claude -p` — o processo MORRE no fim do turno.
-NUNCA termine o turno esperando notificação de tarefa em background (a espera vira morte
-silenciosa: sem artefato, sem `pauta.silencio`). Todo comando lento do funil (shortlist,
-propose, dente) roda em FOREGROUND, por mais minutos que leve; subagentes (explorers,
-artefato-agents) são chamadas paralelas NO MESMO turno — o paralelismo vem das chamadas
-simultâneas, nunca de background + espera.
+**Lei do turno Hermes:** all work belongs to the current live turn. Never leave a dispatch
+waiting on a background notification. Slow funnel commands (shortlist, propose, dente) run in
+the foreground; Hermes subagents (explorers and artefato agents) are blocking calls in the same
+turn. Parallelism comes from simultaneous subagent delegation, never background + later polling.
 
 **Caminho comandado (Voz fast-path, §1 da tabela):** quando o dispatch nasce de uma ordem do
 operador (wake `--origin user_requested`, um `/ed-report sobre X`, um pedido direto na sessão),
@@ -81,7 +90,7 @@ inexistente ou célula fora da matriz FALHA alto (ordem quebrada), nunca silênc
 **A autoridade DERIVA do log, nunca do JSON:** `propose` só aceita `origem:"voz"` quando o
 log tem o `dispatch.open` comandado (`origin: user_requested`) para o MESMO `--dispatch-id`
 — o que a trilha comandada da predispatch (`--origin user_requested`) pena. `origem:"voz"`
-num dispatch de heartbeat é ordem FORJADA: `propose` levanta e o pós-gate marca gap. Prosa
+num dispatch não comandado é ordem FORJADA: `propose` levanta e o pós-gate marca gap. Prosa
 nunca confere autoridade (o log é a verdade, ADR-0006).
 
    **O gate pendura SÓ na abordagem (§2 da tabela):** o "porquê" da PROPOSTA é o `gate_trace`
@@ -122,7 +131,7 @@ the SAME turn — blocking; the lei do turno above rules here too):
 - Each branch-agent runs exactly `skills/<decision.producer>` on the shared scaffold
   (`skills/_shared/scaffold.md`) and produces **one Artefato** in its form.
 - **O slug do artefato começa com `decision.slug_prefix`** (`{abordagem}-{objeto}--`, §3 da
-  tabela: o nome carrega o setup — não é opção do producer). O post-gate do heartbeat verifica
+  tabela: o nome carrega o setup — não é opção do producer). O post-gate do dispatch verifica
   mecanicamente: slug sem o prefixo da célula é gap.
 - **Grounding is NOT a single trunk phase**: each branch does its **own rounds** of grounding —
   it goes back to the world as many times as ITS artefato asks (rounds localizados; the harvest

--- a/skills/delta/SKILL.md
+++ b/skills/delta/SKILL.md
@@ -15,9 +15,10 @@ cognition's job.) The delta is **over the world, never over the wiki**.
 
 List the configured **source keys**: source-agnostic locators for the mentee's
 Mundo / Atividade / Voz, from the **Source-roadmap** (`state/source-roadmap.md`) plus the declared
-sources in `agent.yaml`. The roadmap names the **native** key (Claude sessions, every instance has it)
-and the declared keys (GitHub, exa, …). A key is just a locator — a folder of transcripts, a gh repo,
-an API.
+sources in `agent.yaml`. A Hermes session key exists only when a Hermes-native reader is declared
+available; otherwise that rail is dark and cannot fall back to another transcript store. The other
+declared keys may include GitHub, exa, and operator-approved APIs. A key is just a locator — a
+Hermes-readable session source, a repository, or an API.
 
 ## Judgment — figure out what's new (agentic)
 

--- a/skills/dig/SKILL.md
+++ b/skills/dig/SKILL.md
@@ -37,14 +37,14 @@ stop early.
    operator's intent priors: exploração→x, científico→arxiv, deep-research→exa), ordered
    by the yield table. Write each query **in that source's declared idiom** — an off-idiom
    query that returns empty is a FALSE dry you manufactured.
-3. **Sweep agentically** (ADR-0001 — the key + the `via` line, no primitive ever). Fan
-   `{prefix}-explorer` subagents for parallel legs; explorers are world-readers, DENIED the
-   cortex door. The **default execution subagent is a GROK agent** (`execution_subagents.default`)
-   — and the **X leg runs on the grok CLI's NATIVE X** (`grok --always-approve -p "<query>"`,
-   subject-blind), not the raw xAI API: one call, no wiring. Every dispatched grok agent carries
-   the standing directives (agent.yaml `execution_subagents`): after the task, return an **X report**
-   of what the field is saying that bears on the dispatch, and it has the **freedom to abort** if X
-   surfaces something that justifies stopping (moot, already done, about to break) — with citations.
+3. **Sweep agentically with Hermes** (ADR-0001 — the key + the `via` line, no primitive ever).
+   Fan fresh `{prefix}-explorer` Hermes subagents for independent parallel legs; explorers are
+   world-readers, DENIED the cortex door. For an X leg, use Hermes's `x_search` tool when it is
+   available in the active profile, with the literal query and a subject-blind brief. If
+   `x_search` is absent, the leg is declared-dark with that exact reason — never replaced by an
+   external CLI, a raw provider call, or an improvised transport. Each subagent returns an **X
+   report** only for evidence actually read and may recommend aborting when cited evidence makes
+   the dispatch moot, already done, or unsafe to continue.
    House rule (harvester blind spot): any script of yours that reads a source **logs the literal
    query to stdout**.
 4. **Paid modalities are first-class legs**: a modality with per-call cost (exa `deep`,

--- a/skills/map/SKILL.md
+++ b/skills/map/SKILL.md
@@ -43,8 +43,8 @@ The scaffold names three role-defined slots; map maps each to its connections-di
 - **`gather-grounding`** (loop1) — **recall first, then DIRECT reads by the main agent** (`scaffold.md`,
   #61): **recall** (`skills/_shared/memory.md`) pulls the connections you already mapped on this theme from
   the edge's own graph, so you extend the web rather than redraw it; then **you** cross **both** the
-  internal context pool (Claude sessions, GitHub, the projects' CONTEXT.md, the Knowledge clusters) **and
-  the world** (exa, the field, adjacent industries) — internal edges AND the **outward bridge**: the named
+  internal context pool (Hermes sessions when the native reader is available, GitHub, the projects'
+  CONTEXT.md, the Knowledge clusters) **and the world** (exa, the field, adjacent industries)
   concept/pattern/practice out there that each entity rhymes with — the **rich context stays in you** to
   see the relations. Explorers are an **optional fan-out for breadth** — fan a subagent per candidate
   relation or per entity's world-connection when the web is wide enough to warrant parallelism, **not the

--- a/skills/mentor/SKILL.md
+++ b/skills/mentor/SKILL.md
@@ -4,7 +4,7 @@ description: Mentor posture first — know the mentee (leveling-state), residual
   Cadence: never stall waiting for «continue»; after an answer, land writeback/steers/synthesis in
   the same breath. Not always a closing question. Output = persona writeback + steers + optional
   inscription. Wayfind/ticket grill is the LEAST occupation. Accepts `motivo` when uninvited.
-  Invoked as /{prefix}-mentor or inside the beat (no claude -p).
+  Invoked as /{prefix}-mentor or inside a live Hermes beat.
 ---
 The mentor skill is where the mentor DEVELOPS the mentee actively — not the wake's passive absorption,
 but the edge ASKING. Feynman-interlocutor in real time: SENTIR (olhar-quente) → JULGAR (abate) →
@@ -129,8 +129,8 @@ timestamp ou leitura do log. Nunca chame `eventlog.open_map` diretamente e nunca
 `{uuid, display}` confiado pelo caller.
 
 **The evidence ladder of the stranger (onboarding):** (1) the **seed yaml** — sources, objetivos:
-an explosion of knowledge, you never start from 0; (2) empty yaml → there are **always the Claude
-sessions**; (3) the extreme case (fresh VPS, no source at all) → **ask for anything, honestly**:
+an explosion of knowledge, you never start from 0; (2) empty yaml + a verified Hermes-native
+session reader → admissible Hermes sessions; (3) reader dark or no source at all → **ask for anything, honestly**:
 "olha, isso foi feito pra funcionar assim — eu preciso de algo." The mentor declares its own
 hunger instead of pretending to know.
 
@@ -143,8 +143,10 @@ After steers + leveling land, **one close**:
 
 ```sh
 tools/edge-python tools/edge-bootstrap finish --home "$EDGE_HOME" \
-  --mission "…" --voice "…"   # optional --enable-heartbeat
+  --mission "…" --voice "…"
 ```
+
+Heartbeat remains off; this Hermes-only derivative is manual until native heartbeat support exists.
 
 (`finish_onboarding` = `grill_gate.assert_grill_complete` + `emit_phenotype`. See
 `docs/specs/onboarding-first-run.md`, README first-run.)
@@ -357,7 +359,7 @@ reason)` — a measurement never becomes an opinion.
 The first authorial draft stays sealed and blind-readable in the run dir; prove the rite ran with `tools/edge-python tools/rito.py verify state/rito/<slug>`. When the evidence yields **no** real insight, the report carries forward unchanged — do **not** manufacture insight or bloat the corpus. This is the ONLY leg of the mentor that changed: the **three-steers close** below (the `grill_gate` on Objective / Direction / Direcionamento) is untouched — it is not the artefato-publication path and it stays exactly as specified.
 
 ## The close gate — steers **and** leveling-state (MANDATORY, stage-(ii) + persona floor)
-The outward half above is conditional in its *wording* — set the objective "only when sharpened", propose Direction "additively", publish an Artefato "only when the insight is real". That wording is the trap the audit catches (`docs/briefing-lifecycle-audit.md`, Codex gate [high]): a mentor could read "only when…" as licence to land **nothing**, leaving the briefing's **Objective / Direction / Direcionamento** empty — and an **empty-post-mentor is a stage-(ii) failure, not acceptable** (empty-on-fresh is correct; empty-after-a-mentor is the bug, issue #26). The three feeders are not optional once a mentor runs; "only when sharpened" means *refine the standing one*, never *skip it*.
+The outward half above is conditional in its *wording* — set the objective "only when sharpened", propose Direction "additively", publish an Artefato "only when the insight is real". That wording is the trap the lifecycle audit catches: a mentor could read "only when…" as licence to land **nothing**, leaving the briefing's **Objective / Direction / Direcionamento** empty — and an **empty-post-mentor is a stage-(ii) failure, not acceptable** (empty-on-fresh is correct; empty-after-a-mentor is the bug, issue #26). The three feeders are not optional once a mentor runs; "only when sharpened" means *refine the standing one*, never *skip it*.
 
 **Persona-only session policy:** refine/confirm standing objective **without inventing** product wayfind/direction stamps. Prefer continuity ("continuidade: conhecer X") over ticket theatre. Objective-carimbo (treating log strings as telos without "does this still move you?") is a **posture failure**.
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,347 +1,167 @@
 ---
 name: onboard
 description: >
-  Agentic first-run — the guided install rite. Interviews the operator (name, home folder,
-  secrets location, backfill days with a cost check), performs the WHOLE installation
-  (bootstrap, Neo4j runtime, first wake) explaining each step in plain language, then flows
-  directly into the first mentor session and closes with the phenotype + heartbeat + local
-  access. Invoked as /{prefix}-onboard on a fresh clone.
+  Agentic first-run for a Hermes-only install. Establishes a dedicated HERMES_HOME,
+  interviews the operator, bootstraps with Hermes as primary, keeps session ingestion,
+  runtime and heartbeat declared-dark, then flows into the first mentor session.
+  Invoked as /{prefix}-onboard on a fresh clone.
 ---
 
-You are the **install guide** — the person who sits next to the operator on day one. Every
-mechanical step already exists as a tool; your job is to DRIVE them in order, EXPLAIN what
-each one is doing in the operator's language (pedagogia Feynman: explain generously —
-mechanism before label; the sin is cryptic, never didactic), and STOP at the two points that belong to the human.
-Internal identifiers — env vars, flags, file paths, function names — belong in the
-commands you RUN, never in the sentences you SPEAK: the operator hears what a thing
-does and why, not what it is called inside.
+You are the **install guide** for a Hermes-only deployment. Drive each supported step,
+explain mechanism before label, and stop whenever a human decision is required. Never
+invent a command, a credential, a successful capability, or a completed stage.
 
-**The onboarding explains ITSELF because that is how the operator learns what the edge
-IS.** Each step names the edge concept it embodies as it runs — the wake that films
-history, the insumo, the phenotype born at the close, the heartbeat as the autonomous
-pulse, the Direction. By the end of the install the operator has met the whole product
-without a single tour or manual.
+## Contract underneath
 
-**The contract underneath (never violate):** `agent.yaml` is the OUTPUT of onboarding, not
-the seed. No autonomous production (heartbeat) before a Direction exists. Secrets are
-delivered by the operator — you never invent, fetch, or print key values. **And the rite
-never self-terminates**: every act of the close happens WITH the operator — the narrated
-discovery runs in front of them, the first artefato is read side by side — and the
-session ends when the OPERATOR ends it. A sign-off note ("está completo", next-steps
-shell block, farewell) is the consultant leaving the room; the edge lives here now, and
-its first day does not end with it walking out.
+- `agent.yaml` is the OUTPUT of onboarding, never a seed to fabricate.
+- Hermes is the only execution surface and the primary provider.
+- `HERMES_HOME` points to a **dedicated profile home** for this install. The global
+  `~/.hermes` home is not an acceptable target.
+- No external review harness is configured. Blind review, when needed, uses fresh,
+  independent Hermes subagents with the context-denial rules of the shared pipeline.
+- Session ingestion is declared-dark until a Hermes-native session reader exists and is
+  explicitly available to this install.
+- The graph runtime and heartbeat are declared-dark during onboarding. Do not start a
+  container, timer, scheduler, daemon, or autonomous beat.
+- Secrets come from the operator. Inventory names only; never print values.
+- The rite stays with the operator through the first mentor handoff. Do not manufacture a
+  ceremonial sign-off while work remains.
 
-## 0-pre. Reconhecimento do host — a vasculhada geral
+## 0. Recognize the host, read-only
 
-Before the first question, survey the terrain — read-only, broad, **everything within
-reach**: the local ground (repos and what they build, live services, tooling, session
-stores of every harness, key candidates — never echoing values) and any remote surface
-the host is already authenticated to (a logged `gh` means their GitHub; the same logic
-for whatever else holds a session). The principle: if evidence about the operator is
-one credentialed call away, it is part of the vasculhada — and anything you later cite
-("vi no teu GitHub...") must trace to something actually read. This sweep is where the
-interview's proposals, the mentee profile, and the mentor's provenance all come from.
-Say in one line what you are doing and that nothing leaves the machine. A guide that
-asks before looking is the lazy consultant; a guide that looked first never needs to
-ask what the terrain already answers.
+Inspect the clone, the intended install home, available Hermes configuration, repositories,
+services and credential-file names without exposing values. Do not inspect or import session
+stores belonging to another execution surface. State in one line that this reconnaissance is
+read-only and local.
 
-## 0. Interview — work first, confirm second
+A clone is fresh when `state/bootstrap.json` is absent and the operator has not identified the
+directory as a live install. On a fresh clone, do not create `agent.yaml` by hand and do not use
+the legacy apply path.
 
-**This is a CONVERSATION — one decision per turn, each explained.** Two failure modes,
-both fatal and both already seen in the field: (a) firing the items as bare questions
-(questionário preguiçoso); (b) rendering all seven at once as a PRE-FILLED form —
-derive-and-confirm in batch is the same questionnaire in new clothes. The discipline,
-per turn: do the work the host allows (inspect, derive), present ONE verified proposal
-("achei um diretório de chaves em <caminho>: openai, xai — uso essas?") with the one
-line of what it feeds and why it matters, then WAIT for the answer before the next
-decision. A true open question is reserved for what no inspection can answer (the name,
-the backfill appetite). **The seven decisions below are the floor, not a cage.** Spontaneous questions are
-welcome — a guide that notices something real and asks about it is the product working.
-But whatever you bring spontaneously obeys the SAME two laws as everything else: (1) it
-arrives worked — derived from what you saw and proposed by name, never a blank category
-for the operator to fill ("quais sources? o que você nomear" is the lazy form of a good
-instinct); (2) it arrives in its moment — sources, em particular, are hunted and
-proposed AFTER Direction exists (§4b), because before knowing the person they are just
-plumbing. The mentee should end the interview understanding the seven
-decisions because each one was a small conversation — never because they reviewed a
-table. The seven decisions, in order:
+## 1. Establish the dedicated Hermes profile first
 
-1. **Name** — the install's identity seed (`--name`). One word, lowercase.
-2. **Home folder** — where the install lives (`--home`, default `~/edge-home`). Genotype
-   (the clone) and install home are different trees; say so.
-3. **Which CLIs, and which is PRIMARY** — the edge is multi-CLI (Claude / Codex / Grok /
-   Hermes, each on its own subscription). Show what is already on the host
-   (`which claude codex grok hermes`) and ask which they want; offer to install the
-   missing ones they choose (e.g. `npm i -g @anthropic-ai/claude-code`,
-   `npm i -g @openai/codex`, `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`).
-   Then ask which one LEADS (`--primary`, default claude) — any installed CLI can be the
-   primary; never assume. Separate decision: the INSTALL SESSION itself is best driven
-   by the most contract-adherent CLI on the host — recommend it for the rite even when
-   the daily primary will be another (executor do rito ≠ primário do dia-a-dia). Detection at bootstrap is by harness home dir — a CLI installed
-   now is a surface filmed forever.
-4. **Adversarial** — who reviews the primary's work. SYMMETRIC: whatever the primary is,
-   the candidates are the OTHER installed CLIs (codex primary → claude/grok adversarial;
-   claude primary → codex/grok; and so on). Three honest shapes; ask which:
-   - **another CLI** (best: real second opinion — `--adversarial <cli>`, repeatable);
-   - **an API key** they will drop in secrets (review route via key, no second CLI);
-   - **self-fallback** (no flags: the primary reviews itself — works, weakest; say so).
-5. **Secrets & embeddings** — where their keys are NOW. You will create `<home>/secrets/`
-   and guide the copy (`openai.env`, `xai.env`, …, one `VAR=value` per line). Then the
-   embedding adapter, explicitly: which provider serves embeddings —
-   - **OpenAI direto** (`OPENAI_API_KEY`, default model `text-embedding-3-small`) — no flags;
-   - **OpenRouter** (`OPENROUTER_API_KEY`) — `--embedding-provider openrouter`;
-   - **Azure** — `--embedding-provider azure --embedding-var AZURE_OPENAI_API_KEY
-     --embedding-base-url https://<recurso>.openai.azure.com/openai/v1`;
-   - **any OpenAI-compatible endpoint** — `--embedding-base-url` + `--embedding-var`;
-   - **none** — declared-dark, FTS covers search; can be added later by re-running bootstrap.
-   Model override: `--embedding-model`. Never echo key values.
-6. **Heartbeat cadence** — how often the autonomous pulse fires once ignited
-   (`--heartbeat-interval`; recommend `8h` as the default cadence). Explain the
-   trade-off in one line: shorter = more presence and more spend; the dial moves later by
-   editing `heartbeat_interval` in `agent.yaml`. Whether it ignites AT ALL is still
-   confirmed at the close (step 5), not here — this question only sets the rhythm.
-7. **Backfill days** — how much session history the first wake reads. Before accepting,
-   run the cost check:
+Before bootstrap, derive and confirm one dedicated profile directory, for example:
 
-```bash
-tools/edge-python tools/edge-bootstrap estimate --days N
+```sh
+export HERMES_HOME="$HOME/.hermes/profiles/edge"
 ```
 
-The table the estimate prints already counts ONLY voice-sessions (the film's own
-gate, #153) — agent-driven noise is not in the numbers and is NEVER mentioned; there is
-nothing to disclaim. Show the numbers (sessions, MB, ~minutes) and move on. This is a WARNING, not a
-negotiation: if it looks long, say so in one line ("30 dias = ~70 min de primeiro wake") —
-and if the operator wants to wait, they wait. Their call, never yours.
+The exact directory is the operator's decision. Verify that it is non-empty, is not
+`$HOME/.hermes`, and is reserved for this install. Keep the export active for every later
+Hermes invocation in this install. If a dedicated profile cannot be established, stop: skill
+provisioning into a global profile is unsafe.
 
-## 1. Bootstrap — the skeleton
+Do not promise a profile subcommand that has not been verified on the installed Hermes version.
+The supported contract here is the explicit `HERMES_HOME` boundary consumed by bootstrap.
 
-```bash
-tools/edge-python tools/edge-bootstrap bootstrap --home <home> --name <name> --backfill-days <N> \
-  [--adversarial codex --adversarial grok] \
+## 2. Interview — one worked decision per turn
+
+This is a conversation, not a pre-filled form. For each item, inspect first, present one verified
+proposal with its consequence, and wait for the operator before moving to the next decision.
+
+1. **Name** — one lowercase word for `--name`.
+2. **Install home** — where the phenotype and state live (`--home`, default `~/edge-home`).
+   Explain that clone, install home and `HERMES_HOME` are three distinct boundaries.
+3. **Secrets and embeddings** — identify credential-file names already available, create no
+   values, and offer FTS as the valid zero-key path. An embedding adapter may be configured only
+   from a provider the operator explicitly chooses; otherwise mark embeddings dark.
+4. **Backfill appetite** — record the operator's future appetite, but do not estimate or ingest yet.
+   Cost and volume estimation are dark with session ingestion until a Hermes-native reader is
+   present. Do not run `estimate`, fabricate counts, or fall back to another transcript layout.
+
+The following decisions are already fixed by this derivative and are not interview questions:
+
+- primary: `hermes`;
+- external adversarial cast: none;
+- session ingestion: dark;
+- graph runtime: dark;
+- heartbeat: off and dark.
+
+## 3. Bootstrap — phenotype skeleton and Hermes skills
+
+Run bootstrap only after `HERMES_HOME` and the install home are confirmed:
+
+```sh
+tools/edge-python tools/edge-bootstrap bootstrap \
+  --home <home> \
+  --name <name> \
+  --backfill-days <N> \
+  --primary hermes \
+  --hermes-home "$HERMES_HOME" \
   [--embedding-provider … --embedding-var … --embedding-model … --embedding-base-url …]
 ```
 
-Explain while it runs: install tree + `state/bootstrap.json` (pre-phenotype knobs), skills
-provisioned into EVERY CLI harness present (`~/.claude`, `~/.codex`, `~/.grok`,
-`~/.hermes` — detection by directory), adversarial cast as interviewed (none → primary self-adversarial), the
-embedding route wired through the adapter chosen in the interview (or declared-dark).
-**Heartbeat stays off** — say why (no Direction yet).
+Do not pass external adversarial flags. Explain and verify:
 
-## 2. Runtime — the graph
+- `state/bootstrap.json` records pre-phenotype choices;
+- canonical skills remain under the install, while Hermes wrappers are provisioned under
+  `$HERMES_HOME/skills/`;
+- the primary route is Hermes;
+- absent embedding credentials remain declared-dark;
+- heartbeat remains off.
 
-```bash
-tools/edge-python tools/edge-bootstrap runtime --home <home>
+If bootstrap rejects the profile boundary, report the exact error and choose another dedicated
+profile; never weaken the guard.
+
+## 4. Runtime and first wake — declared-dark boundaries
+
+Do **not** run the graph runtime command during this onboarding. Record the graph runtime as
+`DARK — not started by the Hermes-only onboarding contract`. FTS remains the zero-key search
+path where supported; it is not evidence that the graph is live.
+
+Do **not** ingest historical sessions. Until a Hermes-native reader is implemented and verified,
+record:
+
+```text
+session-ingest: DARK — Hermes-native reader unavailable
+quente: DARK — no session input
 ```
 
-Neo4j 5.x pinned, docker container `edge-neo4j`, password generated into
-`secrets/neo4j.env` (mode 600), survives reboots (`restart unless-stopped`), idempotent.
-If it prints `DARK — Docker is absent`: stop, offer to help install docker, or continue
-with the graph declared-dark (FTS covers node search zero-key) — operator's call.
+There is no fallback to another store, path convention, environment variable, or transcript
+format. An honest dark brief is preferable to contaminated continuity.
 
-## 3. First wake — the insumo, shown and explained
+Build the mentor input only from admissible material that is actually available: explicit
+operator statements, confirmed repositories, declared source keys, bootstrap inventory names,
+and existing Edge state. Label every absent rail dark. Write `state/onboarding-insumo.md` only
+with those truthful inputs and with **no Direction**; Direction is born in the mentor.
 
-Run predispatch/wake (lookback = the backfill days). It films the operator's history and
-stamps `state/onboarding-insumo.md` — a wake package WITHOUT Direction, because Direction
-does not exist yet.
+## 5. First mentor — human stop
 
-**The film is VOICE-ONLY (issue #153): a session without the mentee's own voice is a
-HARD PASS — silent.** It does not degrade, does not enter "for later", and above all it
-is NEVER offered as an option ("quer indexar as sessões dos agentes?" is offering
-garbage to the operator — the rule exists precisely so they never have to decide this).
-Agent-driven work is obra, not voice; it reaches the mentor by other rails (the fog
-census, the recon), never through the film. An honest empty film beats a full fake one.
+Invoke `/{prefix}-mentor` in the same Hermes session. The mentor reads the truthful onboarding
+input, starts from a real observation or declared hunger, and asks at most one live question per
+turn. It must establish mutual understanding, persist leveling state, and land Objective,
+Direction (set or proposed) and Direcionamento through their normal gates. The operator confirms
+what is attributed to them; unconfirmed interpretations remain proposed.
 
-**AT INSTALL, EVERYTHING STOPS UNTIL THE DATA EXISTS.** The daily wake tolerates a
-not-yet-consolidated graph; the INSTALL does not. The same split governs the ingest
-clock: the daily wake BOUNDS graph ingest (`EDGE_SWEEP_INGEST_BUDGET_S`, default 30s)
-so a morning never hangs on a slow extraction — but at install that default is a
-skipped step in disguise. At install, give the ingest HOURS — export
-`EDGE_SWEEP_INGEST_BUDGET_S=14400` (or more for a big backfill, without hesitation)
-for the first sweep; quality over time is doctrine, and the only wrong number is one
-that truncates extraction. An ingest that "degrades dark" during install means you did
-not wait, not that the data was absent — "communities vazias, esperado no dia 1"
-is skipped work dressed as honesty. Before the walk-through: run the ingestion to
-completion, then the consolidation
-(`tools/edge-python -c "import communities; communities.consolidate()"`), and the
-atividades detection — and WAIT for them. Declared-dark is for a missing key, never for a
-step you did not run. Only two honest states exist here: the material is BUILT and you
-show it, or the filmed history genuinely contains nothing (then say exactly that:
-"filmei N dias e não havia sessões substanciais" — a fact about their history, not about
-the day of the install). Persona is the one legitimate empty: leveling is born in the
-mentor, next step.
+Sources are proposed only after Direction exists. Use `/{prefix}-dig` with Hermes subagents to
+find live sources relevant to the person's growth. The operator accepts or rejects each proposed
+source. Missing interfaces are declared-dark; no source is fabricated from availability alone.
 
-Then SHOW what was just built, because this is the moment the edge demonstrates how it
-works — with the operator's own material:
+## 6. Finish — phenotype written, autonomy still off
 
-- **the wake** — "isto foi um wake: eu li teus últimos N dias e acordei sabendo onde você
-  está. É assim que eu começo TODO dia de trabalho";
-- **the communities** — open what the graph formed and name them ("das tuas sessões
-  nasceram estes agrupamentos: X, Y, Z — é a minha memória se organizando sozinha");
-- **the atividades** — the threads of work it detected ("eu vi estas frentes abertas:
-  ..."), each with where it was seen;
-- and close the frame: "é assim que eu funciono — filmo o que você faz, isso vira
-  memória, a memória vira orientação, e o mentor conversa contigo em cima disso."
+After the mentor gates pass, emit the phenotype without enabling heartbeat:
 
-This walk-through is not decoration: it is the operator meeting the machine that will
-watch their work every day. Real names from their history, never generic examples.
-
-## 4. Emenda — the first mentor is a GRILL
-
-Do NOT end the session and ask them to come back. Invoke the mentor rite
-(`/{prefix}-mentor`) right here — and run it as what it is: **the intensive session**.
-The grill's spirit: **interview incessantly until mutual understanding** — a
-conversation that does not drop the bone, never a deep-looking form.
-
-**Work before the first word.** Before opening, the mentor WORKS everything the recon
-and the film put in reach — sessions, repos, communities, authenticated remotes —
-hunting for something REAL: a contradiction between what they say and what they do, a
-right move they made without naming it, a decision they sign without being able to
-verify. The opening line is that achado, with its provenance spoken naturally ("vi no
-teu GitHub...", "nas tuas sessões de..."). If the substrate is thin, the honest opening
-is hunger — "o que eu consigo ver é X, me conta o resto" — never a performed cut:
-dureza without having followed the work is cheap cruelty, so each cut is EARNED with
-evidence or not made.
-
-**The grill cadence, once open:**
-
-- **One live question per breath, bisected at the wound** — each question aims at the
-  point of highest uncertainty and consequence, born from what you already read, never
-  researchable elsewhere. The BEST question is the one the mentee did not know needed
-  asking (the unknown-unknown about the PERSON): the out-of-the-box probe, the
-  enumeration edge ("o que você não listar — e existe — é o achado"), the decisions
-  they sign without being able to verify.
-- **The climb is always UP** — when they name a goal ("virar um SaaS"), grill the
-  motivação maior ("o que você quer no fim das contas? se der certo, o que muda na TUA
-  vida?"), never sideways into project detail (pra-quem/pricing you derive alone; asking
-  them on day one is the consultant). Ask their mission — never wait for it to be
-  volunteered. Read back the threads the wake detected ("quais estão vivas? qual
-  sangra?") and let them confirm, kill, or add.
-- **Keep the ledger of branches** — never re-ask the resolved, never abandon the open;
-  a branch still open when understanding arrives is SAID OUT LOUD and becomes an
-  inscription, not silently dropped.
-
-**The only stop condition is MUTUAL understanding — and it is PROVEN with the wayfind
-on the table.** Before any close, the mentor lays out its map, out loud: "isto é o que
-eu agora sei de ti; estes são os buracos que eu sei que não sei; este é o que sangra" —
-and the mentee corrects or confirms it. No map shown = no mutual understanding = no
-close; the wayfind is not a report to file, it is the instrument by which the mentee
-verifies being understood. **And the map LANDS as state, not just speech**: the session
-ends with the wayfind MAPPED in the install (the map opened through the bound surface,
-each confirmed hole/open branch already a created internal ticket with its one-line why)
-— the mentee walks away from day one with a live map and a queue, not a promise of one.
-And the map is EARNED by the grill, never dumped at the end: each ticket traces to a
-branch the conversation actually grilled (the ledger's residue — a ticket the session
-never touched is fabrication), each hole was named and probed with the mentee, and the
-grill runs as long as it takes to make the map real. The wayfind is the grill's
-crystallization; without the grill behind it, it is scenery. The session may close only when BOTH directions hold: you
-can say who this person is, what moves them, and where they are going — and THEY
-confirm the map in their own words; and they can say what the edge will do for them —
-and YOU confirm it. Not when the pipeline is satisfied: the pipeline has
-no clock, the remaining steps wait as long as the person is still opening, and
-narrating them to hurry an answer ("with this I close X") is the consultant's rush.
-
-**By the time mutual understanding arrives, the ground covered will include** (fruit of
-the conversation, never a script walked in order): Direction born and STAMPED
-(`direction.proposed`); mission and voice AUTHORED by the mentor and read back. **The read-back binds the STAMPS**: nothing lands as `objective.set` or
-`direction.set` that the mentee did not hear read back and confirm — set is the
-mentee's ratification, not the mentor's authorship; anything authored but unconfirmed
-lands as `.proposed`, honestly (the close gate accepts proposed). Stamping set
-unilaterally to satisfy the gate is the exact fraud the mother-rule forbids.
-
-This is the second human stop; everything before and after is yours.
-
-## 4b. Sources — AFTER the mentor, hunted by a dig
-
-Sources are chosen only NOW, with Direction and driver in hand — **they depend on what
-the person wants from life, and the objective is the person's growth, never executing
-the project**. A source list drawn from the repo alone serves the project; the right
-list serves where the mentor session said this person is going.
-
-Run the dig rite (`/{prefix}-dig` — the grounded-research organ the producers use) with
-the DIRECTION and the driver as the question: *live sources that feed this person's
-growth* (feeds, normative diaries, tag-feeds, communities, APIs) *plus orientation
-material* (the 2-3 field maps worth their reading time). Narrate it as the demo it is:
-"isto é o dig — é assim que eu pesquiso antes de escrever qualquer coisa; cada perna
-varre um ângulo, e fonte sem chave eu declaro escura, nunca finjo". Never ask "quais
-fontes você quer?" — you hunt, they trim; machine-local realities count too (reachable
-ssh peers, local archives), each proposed by NAME with what it would feed and its
-read-only scope, never as a category for the operator to fill in. The dig's findings
-become the proposed set:
-
-- generic strong defaults the dig confirms or kills: **arXiv** (their area), **Hacker News**;
-- **Exa** if `EXA_API_KEY` landed in secrets; **X** if the xai key is there;
-- the **growth-specific** ones the dig surfaced — the part that changes per person, and
-  the proof the list came from the Direction, not from a template or from the repo.
-
-Each with one line of what it would feed — and CLOSE the demo on the lesson it just made
-visible: the generic feeds everyone reads yield what everyone already knows; the
-personalized ones the dig dug from THEIR direction are where the delta will find what no
-generic feed carries. Point at one concrete pair from the run ("HN vai te dar o que todo
-mundo lê; ESTA aqui só existe porque você é você") — that contrast is the argument for
-fontes personalizadas, shown instead of told. **Source ≠ artefato:** a source is a
-CONTINUOUS feed the wake/delta/grounding consume (a normative diary, an API, a changelog,
-a tag-feed); a one-shot investigation ("mine competitor reviews") is an artefato pauta,
-not a source — offer those separately as the install's first candidate themes. The
-operator accepts/rejects; accepted sources seed the phenotype `sources:` block before
-`finish` emits it.
-
-## 5. Close — phenotype, heartbeat, local access
-
-With mission and voice out of the mentor session:
-
-```bash
+```sh
 tools/edge-python tools/edge-bootstrap finish --home <home> \
-  --mission "<from mentor>" --voice "<from mentor>" \
-  --heartbeat-interval <from interview> --enable-heartbeat
+  --mission "<from mentor>" \
+  --voice "<from mentor>"
 ```
 
-`finish` writes `agent.yaml` (the phenotype — now it may exist) and `--enable-heartbeat`
-renders the timer at the interviewed cadence and ignites the autonomous pulse
-(`edge-heartbeat.timer` + linger, so it survives logout). Confirm the ignition with the
-operator before flipping it — an operator who wants to drive by hand first says no, and
-that is a fine close (the interval still lands in the phenotype for later).
+Do not add `--enable-heartbeat`. Verify that `agent.yaml` now exists, primary routing is Hermes,
+`HERMES_HOME` is the dedicated profile used for provisioning, and no autonomous timer was
+created. Surface the final capability ledger:
 
-**Then the final act, in one breath: heartbeat → skills → a real discovery.** After
-`finish`, the mentor closes the day like this:
+- Hermes skills: provisioned and manually invocable;
+- session ingestion: dark pending a Hermes-native reader;
+- graph runtime: dark, not started;
+- heartbeat: off, manual-only operation;
+- embeddings and paid sources: configured only when explicitly supplied, otherwise dark.
 
-1. **Explain the heartbeat** — "a cada <intervalo> eu acordo sozinho, leio teu estado,
-   sorteio um ângulo, e se algo sobreviver ao meu gate, publico no teu blog. Você não
-   precisa me chamar."
-2. **Present the skills** — the doors the operator can open by hand, each in half a
-   line: `/{prefix}-wake` (me orientar de manhã), `/{prefix}-mentor` (conversar),
-   `/{prefix}-report`, `/{prefix}-research`, `/{prefix}-discovery` (me pedir um achado),
-   e a Voz no blog (responder qualquer artefato por escrito).
-3. **EMENDA with a `/{prefix}-discovery` — no argument, narrated IN PARTS.** The first
-   artefato of an install is ALWAYS a discovery — an achado contextualizado é sempre
-   útil, no dia um e em qualquer estado do mentee (forma travada; tema livre). Do not
-   run it as a black box: walk the operator through each stage as it happens —
-   - **the dispatch**: "todo trabalho autônomo meu nasce num envelope destes — id,
-     origem, e um dente: sem pauta aprovada, nada publica";
-   - **the config selection**: run the sorteio and SHOW what fell — "a célula sorteada
-     foi <abordagem × objeto>: é o ângulo e a fonte de evidência desta batida";
-   - **the candidate list**: show the ~suggestions the funnel produced, one line each —
-     "destes candidatos, o funil aterrou estes";
-   - **the verdict**: "**esse foi o escolhido** — passou no gate por <razão do trace>";
-   - then production runs and the artefato lands — **through the full producer rite,
-     pinned renderer included**: the first artefato sounds and LOOKS like every artefato
-     that will follow (the blog's face is part of the product). A hand-rendered or
-     raw-md page is the cargo-cult runway — form skipped, presented as done. Close the frame: "isto que você viu
-     por dentro é exatamente o que acontece sozinho às <intervalo> — só que sem
-     narração."
-
-Then walk them to it:
-
-```bash
-systemctl --user status blog-server   # or: tools/edge-python blog/server.py
-```
-
-The artefato just published is waiting at **http://127.0.0.1:8766** (loopback-only by
-design — the local reader IS the mentee). Open it together; reading their first artefato
-is the last act of the onboarding, and the Voz box under it is the handover: "quando
-quiser me responder, é aqui."
+The next move is operator-directed. A first manual discovery may be offered and narrated, but it
+must not be launched without the operator's command.
 
 ## Failure honesty
 
-Any step that fails is reported with its real error and what it blocks — never skipped
-silently, never retried into mystery. The install is resumable: every tool above is
-idempotent, so "fix and re-run the same command" is always the recovery path.
+Any failed step is reported with its real error and what it blocks. Retry only the documented,
+idempotent command after correcting the cause. Never translate absence into success, darkness
+into emptiness, or an unsupported integration into a fallback.

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -41,7 +41,8 @@ The scaffold names three role-defined slots; report maps each to its prose-synth
 - **`gather-grounding`** (loop1) — **recall first, then DIRECT reads by the main agent** (`scaffold.md`,
   #61): **recall** (`skills/_shared/memory.md`) pulls what you already wrote on this theme from the edge's
   own graph, so you build on prior depth rather than restate it; then **you** read the pool the synthesis
-  stands on (Claude sessions, GitHub, exa, the projects' CONTEXT.md) — the **rich context stays in you**,
+  stands on (Hermes sessions when the native reader is available, GitHub, exa, the projects'
+  CONTEXT.md) — the **rich context stays in you**,
   which is what gives the synthesis its **real cases and depth** (a thin `{source, ref}` handed back loses
   the founding context). Explorers are an **optional fan-out per facet for breadth** — when the theme has
   independent facets worth parallelism — **not the default grounding path**. Depth comes from evidence

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Onboarding + ongoing tooling autonomy. First activation understands how the operator
   works and persists the phenotype (agent.yaml / frontier). Later activations converse
   and dig for tools, skills, sources, keys, and concepts — discovery biased to tooling.
-  Zero-key first-class (FTS nodes + CLI adversarial). Keys optional. Propositions only
-  in v0 (no silent install). Invoked as /{prefix}-setup or /{prefix}-autonomia.
+  Zero-key first-class (FTS nodes + independent Hermes review). Keys optional.
+  Propositions only in v0 (no silent install). Invoked as /{prefix}-setup or /{prefix}-autonomia.
 ---
 
 # Setup (= onboarding = autonomia de tooling)
@@ -27,7 +27,7 @@ The edge must work with **no cloud API keys**:
 | Need | Zero-key path |
 |------|----------------|
 | Graph / nodes | **FTS** (full-text on nodes) — no embeddings required |
-| Adversarial / review | **CLI** already in use (Claude / Codex / Grok CLI signature) — not a paid API gate |
+| Adversarial / review | Fresh, context-denied **Hermes subagent** — not a paid API gate |
 | Memory / assemble | Read what exists; declare hunger when thin |
 
 Keys are **optional multi-mode**:

--- a/skills/wake/SKILL.md
+++ b/skills/wake/SKILL.md
@@ -7,50 +7,42 @@ You are **ed, waking under command** — not a beat. You come online the way the
 four briefs, block on them), render where things stand, and then **stop**. This is the beat's step 1
 without steps 2–4: you orient, you do not act. The operator drives from here.
 
-## 1. Wake — fan the four briefs (blocking; ADR-0004, ADR-0014)
+## 1. Wake — Hermes-only briefs, with session ingestion dark
 
-First, run the **entry-driver** — the wake IS pre-dispatch (ADR-0016), and the driver performs its
-mechanical floor and stamps `dispatch.open` (so a publish the operator later commands in this
-session finds a fresh wake). It also computes the quente window and passes `hot_cutoff` into the
-briefing, so §5 clusters touched inside the hot window defer to the quente brief ("→ coberto no
-quente") — the wake never tells the same story twice:
+**Hard boundary:** session ingestion is `DARK — Hermes-native session reader unavailable` until
+the active Hermes profile exposes a verified native reader. Do not probe another transcript
+store, infer another path convention, read another surface's environment variables, or run a
+fallback converter. Absence of the reader means unknown session history, not an empty history.
+
+Run the mechanical entry-driver only when its configured session rail is confirmed Hermes-native.
+Otherwise leave that rail dark and make no publish claim from this wake; wake itself only orients.
+When the native reader exists, the supported entry remains:
 
     tools/edge-python tools/predispatch.py --origin user_requested
 
-Then build the **quente insumo** (the two-rail input the quente reader consumes — operator prompts
-verbatim + mechanical git anchors, last K=3 substantial sessions). The store resolves
-**host-agnostically** (`_identity.project_dir()`: `EDGE_PROJECT_DIR` → the `~/.claude/projects/`
-convention for this host's `$HOME`); the session in course is excluded by default
-(`CLAUDE_CODE_SESSION_ID`) — never hard-code a host path:
-
-    tools/edge-python tools/quente.py > /tmp/quente-insumo.md
-
-Then get your briefs. Use the **Agent tool** to run the four subagents in parallel and
-**block** on all; do not read these surfaces in your own window (the bookkeeping stays out of it):
+Then get the four logical briefs. Use fresh Hermes subagents in parallel and **block** on all;
+do not move bookkeeping into the lead context:
 - **assemble** (`skills/assemble`) → the **curated self-state** (Memento's tattoo): curated
   Direction, what is open / the next bet, the corpus, source orientation, knowledge clusters.
   Invoke it in its **`/load` aperture** — the full active state, not just "what's active."
-  (Assemble's own entry sweep finds the cursors your driver already advanced — idempotent and
-  flock-serialized, so the second pass is a cheap no-op, not a contradiction.)
-- **delta** (`skills/delta`) → the **world's new**: what is new in the mentee's
-  Mundo / Atividade / Voz. May be empty — it never gates the wake.
-- **recall** (`skills/recall`) → the **memory-salient**: space-0 push + **Persona do mentee** +
-  (on employment wakes) **semantic dual-entry** seeded by standing objective (predispatch appends
-  it; marker names corpus vs embedder if DARK). Rooted at space-0; dark on graph outage — never
-  gates the wake. Never fused with delta (ADR-0014). **Portfolio** is stamped once by the
-  entry-driver on `--origin user_requested` via `compose_portfolio_recall_brief` — sole portfolio
-  owner. Fan recall subagent only for map-blind deepen if needed; do not re-render portfolio
-  (Finding C).
-- **quente** (`skills/quente`) → the **hot threads** (o SENTIR passivo): the live threads of the
-  last K substantial sessions, read from `/tmp/quente-insumo.md` (hand the path in the prompt).
-  **Always a FRESH subagent, never cached** — o quente de 2h atrás já nasceu morto. Dark when the
-  insumo build fails — it never gates the wake (the cold briefs still orient).
+- **delta** (`skills/delta`) → the **world's new** from declared Hermes-readable source keys.
+  It may be empty and never gates wake.
+- **recall** (`skills/recall`) → the **memory-salient**: space-0 push + Persona do mentee +
+  semantic dual-entry when its dependencies are available. A dark graph never gates wake.
+- **quente** (`skills/quente`) → the **hot threads** only when the Hermes-native reader supplied
+  a current, bounded insumo. Until then return exactly the dark marker above. **Always a FRESH
+  Hermes subagent, never cached.** Dark quente never gates the cold briefs and never licenses a
+  claim about recent activity.
 
 You wake holding only these four briefs. Anterograde amnesia: trust nothing not inscribed in them.
 
 ## 2. Surface — render the wake to the operator (the one human-facing act)
 
 ### 2a. Session liveness first — then inacabada vs ongoing
+
+This section is conditional on a non-dark quente produced by the Hermes-native reader. When
+quente is dark, skip every liveness classification below and say plainly that recent-session
+state is unavailable. Never infer ONGOING, INACABADA, settled, or clear status from absence.
 
 The unit is **Atividade** (employment: finalidade + estado), **not** a chat thread / fio.
 Before soft orientation, classify work from **quente** + portfolio against **session liveness**.
@@ -113,7 +105,7 @@ Present a tight orientation, **not a state dump**:
 - **O que está quente** (from quente) — heat narrative with state table (**Atividade · sessão
   aberta|fechada · ongoing|inacabada|settled · clear**). Fios = how heat is told; employment =
   Atividade. Ongoing acknowledged; inacabada already led if any.
-- **What's new** — the world delta (from delta), or "nothing new" stated plainly.
+- **What's new** — the world delta (from delta), or its dark/unavailable state stated plainly.
 - **What you hold** — recall: objective, live bets, open Atividades, salient Artefatos; weave,
   do not dump.
 - **The live intersection** — the one theme ed *would* pursue as autonomous beat: deep domain
@@ -129,34 +121,8 @@ operator overrules). In prose, never a multiple-choice box.
 
 If `state/bootstrap.json` exists and phenotype `agent.yaml` is absent (or onboarding incomplete):
 
-1. Use bootstrap `backfill_days` for assemble/sweep lookback.
-2. Read secrets via onboarding inventory (names only).
-3. After the four briefs, stamp the **mentor insumo** (wake package, **no Direction**):
-
-```sh
-tools/edge-python <<'PY'
-import onboarding, pathlib, os
-home = pathlib.Path(os.environ.get("EDGE_HOME", ".")).expanduser()
-boot = onboarding.load_bootstrap(home)
-inv = onboarding.inventory_secrets(onboarding.secrets_dir(home))
-delta = onboarding.secrets_delta(home, inv)
-# fill assemble/quente/delta/recall texts from the briefs you fanned
-text = onboarding.compose_insumo(
-    home=home, bootstrap=boot, inventory=inv, secrets_delta_=delta,
-    assemble_text="…", quente_text="…", delta_text="…", recall_text="…")
-onboarding.write_insumo(home, text)
-onboarding.stamp_secrets_cursor(home, inv)
-print("insumo →", onboarding.insumo_path(home))
-PY
-```
-
-4. Recommended next move: **`/ed-mentor`** with that insumo — not production beat.
-
-### First-run / onboarding wake (no agent.yaml yet)
-
-If `state/bootstrap.json` exists and phenotype `agent.yaml` is absent (or onboarding incomplete):
-
-1. Use bootstrap `backfill_days` for assemble/sweep lookback.
+1. Use bootstrap `backfill_days` only when the Hermes-native reader is available; otherwise
+   preserve the session and quente rails as dark.
 2. Read secrets via onboarding inventory (names only).
 3. After the four briefs, stamp the **mentor insumo** (wake package, **no Direction**):
 
@@ -185,9 +151,9 @@ This is **not a beat.** Do **not** fan explorers, produce an Artefato, run `skil
 the `intent.kernel` close — those are the beat's autonomous acts (ADR-0009), and wake stops before them.
 
 - **Read-only, fully (CONTRACT C1, hard):** the mentee's world is read-only **and** wake writes no
-  state of its own beyond the mechanical `dispatch.open` wake stamp (ADR-0016 — the entry-driver's
-  bookkeeping, not a judgment write) and the throwaway `/tmp/quente-insumo.md`. Wake reads and
-  renders — nothing else.
+  state of its own beyond the mechanical `dispatch.open` wake stamp when the Hermes-native
+  entry-driver ran (ADR-0016 — bookkeeping, not a judgment write). A Hermes-native reader may
+  insumo; when it does not, the quente rail remains dark. Wake reads and renders — nothing else.
 - **Everything downstream is operator-directed.** The next move is the operator's word. When they
   give it, run the skill it names under command — `/ed-mentor` (legacy `/ed-grill`), `/ed-report`,
   the full beat, a direct question — each within its own contract. Until then, **wait.**

--- a/tests/test_apply_authoritative.py
+++ b/tests/test_apply_authoritative.py
@@ -8,7 +8,8 @@ validation FAILED. The `--validate` path had the same missing agent_yaml arg.
 This guards the fix on the `--validate` path (offline — no venv/docker provisioned):
   • a THIN applied agent.yaml (no declared sources → briefing fail-closed) makes the IDENTITY check
     FAIL, and edge-apply exits NONZERO (today it would read the checkout default and pass);
-  • a COMPLETE applied agent.yaml keeps identity OK and the install HEALTHY → exit 0.
+  • a COMPLETE applied agent.yaml plus target-home doctrine keeps identity OK;
+  • the otherwise empty substrate remains unhealthy and exits nonzero.
 
 Invoked via subprocess (the test_beat_launch.py pattern). `--home` defaults to the real edge_home
 (genuinely healthy substrate); only `--claude-home` is pointed at a tmp dir so the run never touches
@@ -17,6 +18,7 @@ APPLIED config, not the checkout default.
 """
 import subprocess
 import sys
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -41,15 +43,23 @@ sources:
 
 
 def _run_validate(yaml_text):
-    """Run `edge-apply --yaml <tmp> --validate --claude-home <tmp>` and return the CompletedProcess.
-    --home is left default (the real edge_home, a genuinely healthy substrate); only the applied
-    agent.yaml and --claude-home vary, so the run stays offline and never touches the real ~/.claude."""
+    """Run read-only validation against a synthetic target with minimal doctrine."""
     with tempfile.TemporaryDirectory() as tmp:
-        y = Path(tmp) / "agent.yaml"
+        home = Path(tmp)
+        memory = home / "memory"
+        state = home / "state"
+        memory.mkdir()
+        state.mkdir()
+        (memory / "personality.md").write_text("# Personality — probe" + chr(10) * 2 + "Analytical.")
+        (memory / "method.md").write_text("# Feynman Method" + chr(10) * 2 + "Derive first.")
+        (memory / "canone.md").write_text("# O cânone" + chr(10) * 2 + "Evidence before claims.")
+        (state / "idiom.md").write_text("# Idiom" + chr(10) * 2 + "**beat** — work cycle.")
+        y = home / "agent.yaml"
         y.write_text(yaml_text)
+        env = {k: v for k, v in os.environ.items() if k != "HERMES_HOME"}
         return subprocess.run(
-            [sys.executable, str(APPLY), "--yaml", str(y), "--validate", "--claude-home", tmp],
-            capture_output=True, text=True,
+            [sys.executable, str(APPLY), "--yaml", str(y), "--home", str(home), "--validate"],
+            capture_output=True, text=True, env=env,
         )
 
 
@@ -62,11 +72,11 @@ class ValidateIsAuthoritativeOverAppliedConfig(unittest.TestCase):
         # AUTHORITATIVE: an unhealthy report exits NONZERO.
         self.assertNotEqual(res.returncode, 0, res.stdout + res.stderr)
 
-    def test_complete_applied_yaml_is_healthy_and_exits_zero(self):
+    def test_complete_applied_yaml_passes_identity_on_target_home(self):
         res = _run_validate(COMPLETE_YAML)
         self.assertIn("[OK] identity:", res.stdout, res.stdout + res.stderr)
-        self.assertIn("INSTALL HEALTHY", res.stdout)
-        self.assertEqual(res.returncode, 0, res.stdout + res.stderr)
+        self.assertIn("INSTALL INCOMPLETE", res.stdout)
+        self.assertNotEqual(res.returncode, 0, res.stdout + res.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_apply_keyless_source.py
+++ b/tests/test_apply_keyless_source.py
@@ -9,6 +9,7 @@ import importlib.util
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -31,6 +32,21 @@ class KeylessSource(unittest.TestCase):
 
     def tearDown(self):
         self._tmp.cleanup()
+
+    def test_hermes_router_is_keyless_and_probed_without_secret(self):
+        router = {"provider": "hermes", "model": "default"}
+        cfg = {"routers": {"chat": router}}
+        client = object()
+        with mock.patch.object(edge_apply._llm, "make_client", return_value=client) as make_client,              mock.patch.object(
+                 edge_apply._llm, "probe",
+                 return_value={"ok": True, "status": 200, "detail": "synthetic ok"},
+             ) as probe:
+            rows = edge_apply.verify_credentials(self.home, cfg)
+        row = next(r for r in rows if "router:chat" in r[0])
+        self.assertTrue(row[2], row)
+        self.assertNotIn("FALTA", row[1])
+        make_client.assert_called_once_with(router, None)
+        probe.assert_called_once_with(client, "default", "chat")
 
     def test_keyless_api_source_does_not_crash(self):
         cfg = {"sources": [{"name": "hn", "kind": "api", "via": "GET ..."}]}

--- a/tests/test_beat_launch.py
+++ b/tests/test_beat_launch.py
@@ -133,23 +133,20 @@ class BeatPromptLoadsSkillBody(unittest.TestCase):
             self.assertIn("one Artefato", prompt)
 
 
-class HeartbeatDryRunShowsTheLaunch(unittest.TestCase):
-    """`edge-heartbeat --dry-run` shows the exact single-shot command and the piped prompt
-    without invoking claude — so the autonomous launch is inspectable and tests never bill."""
+class HeartbeatPublicLauncherIsDark(unittest.TestCase):
+    """The public launcher must fail before reading a skill or constructing a command."""
 
-    def test_dry_run_prints_command_and_prompt(self):
+    def test_dry_run_is_still_blocked_before_home_access(self):
         with tempfile.TemporaryDirectory() as tmp:
-            home = _skill_home(tmp, "RUN-THE-BEAT-MARKER")
-            # Pin claude: without agent.yaml home falls through to the repo phenotype (often grok).
+            home = Path(tmp) / "not-created"
             res = subprocess.run(
-                [sys.executable, str(HEARTBEAT), "--home", str(home),
-                 "--cli", "claude", "--dry-run"],
+                [sys.executable, str(HEARTBEAT), "--home", str(home), "--dry-run"],
                 capture_output=True, text=True,
             )
-            self.assertEqual(res.returncode, 0, res.stderr)
-            self.assertIn("-p", res.stdout)
-            self.assertIn("--dangerously-skip-permissions", res.stdout)
-            self.assertIn("RUN-THE-BEAT-MARKER", res.stdout)
+            self.assertEqual(res.returncode, 2, res.stdout + res.stderr)
+            self.assertEqual(res.stdout, "")
+            self.assertIn("blocked until Hermes-native parity", res.stderr)
+            self.assertFalse(home.exists())
 
 
 class BeatEnvCarriesInstallSecrets(unittest.TestCase):

--- a/tests/test_hermes_provision.py
+++ b/tests/test_hermes_provision.py
@@ -9,11 +9,13 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import _hermes_provision  # noqa: E402
 import surfaces_cfg  # noqa: E402
+import runtime_policy  # noqa: E402
 
 
 class WrapperRender(unittest.TestCase):
@@ -26,6 +28,34 @@ class WrapperRender(unittest.TestCase):
 
 
 class ProvisionTree(unittest.TestCase):
+    def test_global_hermes_home_is_rejected_before_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            (repo / "skills" / "wake").mkdir(parents=True)
+            (repo / "skills" / "wake" / "SKILL.md").write_text("---\nname: wake\n---\nx")
+            global_home = root / ".hermes"
+            with mock.patch.object(runtime_policy.Path, "home", return_value=root):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    _hermes_provision.provision_hermes(
+                        {}, repo, root / "edge-home", global_home
+                    )
+            self.assertFalse((global_home / "skills").exists())
+
+    def test_external_harness_instruction_is_rejected_before_wrapper_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            skill = repo / "skills" / "dig" / "SKILL.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text("run grok --always-approve for every query")
+            hermes_home = root / "profiles" / "edge"
+            with self.assertRaises(runtime_policy.RuntimePolicyError):
+                _hermes_provision.provision_hermes(
+                    {}, repo, root / "edge-home", hermes_home
+                )
+            self.assertFalse((hermes_home / "skills").exists())
+
     def test_provisions_prefixed_wrappers_under_hermes_home(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -63,12 +93,28 @@ class SurfaceDetection(unittest.TestCase):
                 env={"HERMES_HOME": str(alt)}, home=Path(tmp))
             self.assertTrue(out["hermes"])
 
-    def test_installed_hermes_enters_the_surfaces_block(self):
+    def test_global_hermes_inventory_does_not_authorize_surface(self):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             (home / ".hermes").mkdir()
-            block = surfaces_cfg.surfaces_block_for_installed(env={}, home=home)
-            self.assertEqual(block["hermes"], {"enabled": True, "home": "~/.hermes"})
+            self.assertEqual(
+                surfaces_cfg.surfaces_block_for_installed(env={}, home=home),
+                {},
+            )
+
+    def test_dedicated_hermes_env_enters_the_surfaces_block(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            dedicated = home / ".hermes" / "profiles" / "edge"
+            dedicated.mkdir(parents=True)
+            with mock.patch.object(runtime_policy.Path, "home", return_value=home):
+                block = surfaces_cfg.surfaces_block_for_installed(
+                    env={"HERMES_HOME": str(dedicated)}, home=home
+                )
+            self.assertEqual(
+                block["hermes"],
+                {"enabled": True, "home": str(dedicated.resolve())},
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_panel.py
+++ b/tests/test_llm_panel.py
@@ -17,13 +17,11 @@ AGENT_YAML = """\
 name: tester
 routers:
   chat:
-    provider: openai
-    secret_ref: openai.env:OPENAI_API_KEY
-    model: gpt-5.4
+    provider: hermes
+    model: default
   review:
-    provider: xai
-    secret_ref: xai.env:XAI_API_KEY
-    model: grok-4.3
+    provider: hermes
+    model: default
   embedding:
     provider: openai
     secret_ref: openai.env:OPENAI_API_KEY
@@ -67,8 +65,11 @@ class TestLLMPanel(unittest.TestCase):
         r = self.client.get("/llm")
         self.assertEqual(r.status_code, 200)
         body = r.data.decode()
-        for needle in ("chat", "review", "embedding", "gpt-5.4", "grok-4.3", "openai", "xai"):
+        for needle in ("chat", "review", "embedding", "default", "hermes", "openai"):
             self.assertIn(needle, body)
+        self.assertNotIn('<option value="codex"', body)
+        self.assertNotIn('<option value="grok"', body)
+        self.assertNotIn('<option value="claude"', body)
 
     def test_embedding_route_is_separated_with_subscription_warning(self):
         body = self.client.get("/llm").data.decode()
@@ -79,13 +80,14 @@ class TestLLMPanel(unittest.TestCase):
         self.assertIn("insufficient_quota", body)
         self.assertIn("429", body)
 
-    def test_switch_provider_rewrites_agent_yaml(self):
+    def test_external_completion_provider_is_refused_without_write(self):
+        before = (self.root / "agent.yaml").read_bytes()
         r = self.client.post("/llm/provider", data={"route": "review", "provider": "codex"})
-        self.assertIn(r.status_code, (302, 303))
-        self.assertIn("provider: codex", (self.root / "agent.yaml").read_text())
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual((self.root / "agent.yaml").read_bytes(), before)
 
-    def test_codex_on_embedding_is_refused_with_400(self):
-        r = self.client.post("/llm/provider", data={"route": "embedding", "provider": "codex"})
+    def test_external_embedding_provider_is_refused_with_400(self):
+        r = self.client.post("/llm/provider", data={"route": "embedding", "provider": "xai"})
         self.assertEqual(r.status_code, 400)
         self.assertIn("provider: openai", (self.root / "agent.yaml").read_text())
 
@@ -99,7 +101,7 @@ class TestLLMPanel(unittest.TestCase):
     def test_writes_require_authorization(self):
         os.environ["EDGE_DASH_AUTH"] = "on"
         try:
-            r = self.client.post("/llm/provider", data={"route": "review", "provider": "codex"},
+            r = self.client.post("/llm/provider", data={"route": "review", "provider": "hermes"},
                                  environ_base={"REMOTE_ADDR": "10.9.9.9"})
             self.assertin_403_family(r.status_code)
         finally:

--- a/tests/test_llm_routes.py
+++ b/tests/test_llm_routes.py
@@ -1,174 +1,160 @@
-"""llm_routes — o registry por-rota que o dashboard consome (issue #55).
-
-Pinam a metade PURA: leitura das rotas do agent.yaml + saúde da credencial, a troca de
-provider por cirurgia de linha (comentários do yaml preservados), as recusas (rota/provider
-desconhecidos, codex na rota embedding) e o completer_for resolvido do yaml — com um repo
-temporário, sem tocar API nem CLI. O probe live é exercitado no deploy/verify, não aqui.
-"""
-import os
+"""Public LLM routing surfaces are Hermes-only for completion."""
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
-import _llm        # noqa: E402
+import _llm  # noqa: E402
 import llm_routes  # noqa: E402
+import runtime_policy  # noqa: E402
 
-AGENT_YAML = """\
-name: tester
-# --- Routers (LLM) — comentário de bloco que a cirurgia de linha DEVE preservar.
+
+AGENT = """\
 routers:
-  chat:                                  # contextualization
+  chat:
+    provider: hermes
+    model: default
+  review:
+    provider: hermes
+    model: default
+  embedding:
     provider: openai
-    secret_ref: openai.env:OPENAI_API_KEY
-    model: gpt-5.4
-  review:                                # judge + adversarial
-    provider: xai
-    secret_ref: xai.env:XAI_API_KEY
-    model: grok-4.3
-  embedding:                             # RAG
-    provider: openai
-    secret_ref: openai.env:OPENAI_API_KEY
     model: text-embedding-3-small
-sources: []
+    secret_ref: openai.env:OPENAI_API_KEY
 """
 
 
-def temp_repo(openai_key="sk-live", xai_env=False):
+def temp_repo(openai_key="sk-test"):
     root = Path(tempfile.mkdtemp())
-    (root / "agent.yaml").write_text(AGENT_YAML)
-    secrets = root / "secrets"
-    secrets.mkdir()
+    (root / "agent.yaml").write_text(AGENT)
     if openai_key is not None:
-        (secrets / "openai.env").write_text(f"OPENAI_API_KEY={openai_key}\n")
-    if xai_env:
-        (secrets / "xai.env").write_text("XAI_API_KEY=xk\n")
+        (root / "secrets").mkdir()
+        (root / "secrets" / "openai.env").write_text("OPENAI_API_KEY=" + str(openai_key))
     return root
 
 
 class Routes(unittest.TestCase):
-    def test_lists_every_route_with_provider_and_model(self):
-        rs = {r["route"]: r for r in llm_routes.routes(repo=temp_repo())}
-        self.assertEqual(set(rs), {"chat", "review", "embedding"})
-        self.assertEqual(rs["chat"]["provider"], "openai")
-        self.assertEqual(rs["review"]["model"], "grok-4.3")
-
-    def test_credential_present_vs_absent(self):
-        # hermético: um XAI_API_KEY no env do host venceria o secrets/ (override explícito
-        # vence, como _secrets.load_env) — aqui interessa o caminho do arquivo ausente.
-        from unittest import mock
-        env = {k: v for k, v in os.environ.items() if k != "XAI_API_KEY"}
-        with mock.patch.dict(os.environ, env, clear=True):
-            rs = {r["route"]: r for r in llm_routes.routes(repo=temp_repo(xai_env=False))}
-        self.assertEqual(rs["chat"]["credential"], "ok")
-        self.assertEqual(rs["review"]["credential"], "ausente")
-
-    def test_embedding_route_is_flagged_not_subscription_capable(self):
-        rs = {r["route"]: r for r in llm_routes.routes(repo=temp_repo())}
-        self.assertTrue(rs["embedding"]["embedding_route"])
-        self.assertFalse(rs["chat"]["embedding_route"])
-
-    def test_codex_route_reports_subscription_not_secret(self):
+    def test_lists_routes_without_exposing_secret_values(self):
         repo = temp_repo()
-        llm_routes.set_provider("review", "codex", repo=repo)
-        rs = {r["route"]: r for r in llm_routes.routes(repo=repo)}
-        self.assertTrue(rs["review"]["subscription"])
-        self.assertIn(rs["review"]["credential"], ("assinatura", "codex CLI ausente"))
+        rows = {row["route"]: row for row in llm_routes.routes(repo=repo)}
+        self.assertEqual(rows["chat"]["provider"], "hermes")
+        self.assertTrue(rows["chat"]["subscription"])
+        self.assertEqual(rows["embedding"]["credential"], "ok")
+        self.assertNotIn("sk-test", repr(rows))
 
-
-    def test_claude_route_reports_subscription_not_secret(self):
-        repo = temp_repo()
-        llm_routes.set_provider("chat", "claude", repo=repo, model="opus")
-        rs = {r["route"]: r for r in llm_routes.routes(repo=repo)}
-        self.assertTrue(rs["chat"]["subscription"])
-        self.assertIn(rs["chat"]["credential"], ("assinatura", "claude CLI ausente"))
-
-    def test_grok_route_reports_subscription_not_secret(self):
-        repo = temp_repo()
-        llm_routes.set_provider("review", "grok", repo=repo, model="grok-4.5")
-        rs = {r["route"]: r for r in llm_routes.routes(repo=repo)}
-        self.assertTrue(rs["review"]["subscription"])
-        self.assertIn(rs["review"]["credential"], ("assinatura", "grok CLI ausente"))
+    def test_missing_embedding_secret_is_reported_without_value(self):
+        repo = temp_repo(openai_key=None)
+        rows = {row["route"]: row for row in llm_routes.routes(repo=repo)}
+        self.assertEqual(rows["embedding"]["credential"], "ausente")
 
 
 class SetProvider(unittest.TestCase):
-    def test_switch_review_to_codex_rewrites_only_that_line(self):
-        repo = temp_repo()
-        llm_routes.set_provider("review", "codex", repo=repo)
-        text = (repo / "agent.yaml").read_text()
-        self.assertIn("provider: codex", text)
-        self.assertIn("provider: openai", text)          # chat/embedding intactos
-        self.assertIn("comentário de bloco que a cirurgia", text)  # comentários preservados
-        self.assertIn("# judge + adversarial", text)
-        rs = {r["route"]: r for r in llm_routes.routes(repo=repo)}
-        self.assertEqual(rs["review"]["provider"], "codex")
-        self.assertEqual(rs["chat"]["provider"], "openai")
+    def test_allowed_provider_options_are_route_specific(self):
+        self.assertEqual(llm_routes.allowed_providers_for_route("chat"), ("hermes",))
+        self.assertEqual(
+            set(llm_routes.allowed_providers_for_route("embedding")),
+            set(runtime_policy.ALLOWED_EMBEDDING_PROVIDERS),
+        )
 
-    def test_switch_with_model_rewrites_model_too(self):
-        repo = temp_repo()
-        llm_routes.set_provider("chat", "codex", repo=repo, model="gpt-5.2-codex")
-        rs = {r["route"]: r for r in llm_routes.routes(repo=repo)}
-        self.assertEqual(rs["chat"]["model"], "gpt-5.2-codex")
+    def test_completion_rejects_every_external_provider_before_write(self):
+        for provider in ("claude", "codex", "grok", "xai", "openrouter", "openai"):
+            with self.subTest(provider=provider):
+                repo = temp_repo()
+                before = (repo / "agent.yaml").read_bytes()
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    llm_routes.set_provider("chat", provider, repo=repo)
+                self.assertEqual((repo / "agent.yaml").read_bytes(), before)
 
-    def test_codex_on_embedding_route_is_refused(self):
+    def test_hermes_completion_model_can_be_updated_without_touching_other_routes(self):
         repo = temp_repo()
-        with self.assertRaises(ValueError):
-            llm_routes.set_provider("embedding", "codex", repo=repo)
+        llm_routes.set_provider("review", "hermes", repo=repo, model="provider/model")
+        rows = {row["route"]: row for row in llm_routes.routes(repo=repo)}
+        self.assertEqual(rows["review"]["provider"], "hermes")
+        self.assertEqual(rows["review"]["model"], "provider/model")
+        self.assertEqual(rows["chat"]["provider"], "hermes")
+        self.assertEqual(rows["embedding"]["provider"], "openai")
 
-    def test_unknown_provider_and_route_are_refused(self):
+    def test_embedding_uses_closed_provider_policy(self):
         repo = temp_repo()
+        llm_routes.set_provider(
+            "embedding", "openrouter", repo=repo, model="text-embedding-safe"
+        )
+        rows = {row["route"]: row for row in llm_routes.routes(repo=repo)}
+        self.assertEqual(rows["embedding"]["provider"], "openrouter")
+        before = (repo / "agent.yaml").read_bytes()
+        for provider in ("claude", "codex", "grok", "xai"):
+            with self.subTest(provider=provider):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    llm_routes.set_provider("embedding", provider, repo=repo)
+                self.assertEqual((repo / "agent.yaml").read_bytes(), before)
+
+    def test_unknown_route_is_rejected_before_write(self):
+        repo = temp_repo()
+        before = (repo / "agent.yaml").read_bytes()
         with self.assertRaises(ValueError):
-            llm_routes.set_provider("review", "nope", repo=repo)
-        with self.assertRaises(ValueError):
-            llm_routes.set_provider("nope", "openai", repo=repo)
+            llm_routes.set_provider("unknown", "hermes", repo=repo)
+        self.assertEqual((repo / "agent.yaml").read_bytes(), before)
 
 
 class CompleterFor(unittest.TestCase):
-    def test_codex_route_yields_codex_backed_completer(self):
-        repo = temp_repo(openai_key=None)   # SEM chave de API nenhuma
-        llm_routes.set_provider("review", "codex", repo=repo)
-        seen = {}
-
-        def fake_exec(prompt, model, max_tokens):
-            seen.update(prompt=prompt, model=model)
-            return '{"pass": true}'
-
-        fn = llm_routes.completer_for("review", repo=repo, exec_fn=fake_exec)
-        self.assertEqual(fn("judge"), '{"pass": true}')
-        self.assertEqual(seen["prompt"], "judge")
-
-    def test_claude_route_yields_claude_backed_completer(self):
-        repo = temp_repo(openai_key=None)   # SEM chave de API nenhuma
-        llm_routes.set_provider("chat", "claude", repo=repo, model="opus")
-        seen = {}
-
-        def fake_exec(prompt, model, max_tokens):
-            seen.update(prompt=prompt, model=model)
-            return "the completion"
-
-        fn = llm_routes.completer_for("chat", repo=repo, exec_fn=fake_exec)
-        self.assertEqual(fn("write"), "the completion")
-        self.assertEqual(seen["prompt"], "write")
-
-    def test_grok_route_yields_grok_backed_completer(self):
-        repo = temp_repo(openai_key=None)   # SEM chave de API nenhuma — assinatura pura
-        llm_routes.set_provider("review", "grok", repo=repo, model="grok-4.5")
-        seen = {}
-
-        def fake_exec(prompt, model, max_tokens):
-            seen.update(prompt=prompt, model=model)
-            return '{"verdict": "refuted", "x": ["@handle"]}'
-
-        fn = llm_routes.completer_for("review", repo=repo, exec_fn=fake_exec)
-        self.assertEqual(fn("judge this"), '{"verdict": "refuted", "x": ["@handle"]}')
-        self.assertEqual(seen["model"], "grok-4.5")
-
-    def test_api_route_without_key_raises_transport_error(self):
+    def test_hermes_route_uses_guarded_factory_and_exec_seam(self):
         repo = temp_repo(openai_key=None)
-        with self.assertRaises(_llm.LLMTransportError):
-            llm_routes.completer_for("chat", repo=repo)
+        seen = {}
+
+        def fake_exec(prompt, model, max_tokens):
+            seen.update(prompt=prompt, model=model, max_tokens=max_tokens)
+            return "ok"
+
+        fn = llm_routes.completer_for("review", repo=repo, exec_fn=fake_exec)
+        self.assertEqual(fn("judge"), "ok")
+        self.assertEqual(seen["prompt"], "judge")
+        self.assertEqual(seen["model"], "default")
+
+    def test_preexisting_external_route_is_rejected_before_exec_or_secret(self):
+        for provider in ("claude", "codex", "grok", "xai", "openrouter", "openai"):
+            with self.subTest(provider=provider):
+                repo = temp_repo(openai_key=None)
+                text = (repo / "agent.yaml").read_text()
+                text = text.replace("provider: hermes", f"provider: {provider}", 1)
+                (repo / "agent.yaml").write_text(text)
+                called = []
+
+                def forbidden_exec(*args, **kwargs):
+                    called.append((args, kwargs))
+                    return "BYPASS"
+
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    llm_routes.completer_for("chat", repo=repo, exec_fn=forbidden_exec)
+                self.assertEqual(called, [])
+
+    def test_unknown_route_is_rejected(self):
+        repo = temp_repo()
+        with self.assertRaises(ValueError):
+            llm_routes.completer_for("missing", repo=repo)
+
+
+class Probe(unittest.TestCase):
+    def test_external_completion_route_reports_policy_error_without_constructor(self):
+        repo = temp_repo(openai_key=None)
+        text = (repo / "agent.yaml").read_text().replace(
+            "provider: hermes", "provider: xai", 1
+        )
+        (repo / "agent.yaml").write_text(text)
+        out = llm_routes.probe_route("chat", repo=repo)
+        self.assertFalse(out["ok"])
+        self.assertIn("forbidden", out["detail"])
+
+    def test_embedding_probe_uses_embedding_factory(self):
+        repo = temp_repo()
+        fake_client = mock.Mock()
+        fake_client.embeddings.create.return_value.data = [mock.Mock(embedding=[0.1, 0.2])]
+        with mock.patch.object(_llm, "make_embedding_client", return_value=fake_client) as make:
+            out = llm_routes.probe_route("embedding", repo=repo)
+        self.assertTrue(out["ok"])
+        make.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_routes_embed.py
+++ b/tests/test_llm_routes_embed.py
@@ -1,5 +1,5 @@
 """llm_routes.embed_fn — o adapter de embeddings em RUNTIME: routers.embedding do
-agent.yaml → callable text→vector via _llm.make_client (base_url explícito vence o
+agent.yaml → callable text→vector via _llm.make_embedding_client (base_url explícito vence o
 registry — azure/custom entram por aí). Rota ausente ou sem chave = None (caller escurece).
 """
 import sys
@@ -57,7 +57,7 @@ class EmbedFn(unittest.TestCase):
                 "    model: text-embedding-3-large\n"),
                 secret=("azure.env", "AZURE_OPENAI_API_KEY=k1\n"))
             fake = _FakeClient()
-            with mock.patch.object(llm_routes._llm_mod(), "make_client",
+            with mock.patch.object(llm_routes._llm_mod(), "make_embedding_client",
                                    return_value=fake) as mk:
                 fn = llm_routes.embed_fn(repo=root)
                 vec = fn("hello")

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -91,15 +91,14 @@ class RequireKnobs(unittest.TestCase):
 
 class AdversarialCast(unittest.TestCase):
     def test_empty_cast_falls_back_to_self(self):
-        cast = onboarding.resolve_adversarial_cast([], primary="claude")
+        cast = onboarding.resolve_adversarial_cast([], primary="hermes")
         self.assertEqual(cast["mode"], "self")
         self.assertEqual(cast["members"], ["self"])
-        self.assertEqual(cast["primary"], "claude")
+        self.assertEqual(cast["primary"], "hermes")
 
-    def test_declared_members_kept(self):
-        cast = onboarding.resolve_adversarial_cast(["codex", "grok"], primary="claude")
-        self.assertEqual(cast["mode"], "declared")
-        self.assertEqual(cast["members"], ["codex", "grok"])
+    def test_external_members_are_rejected(self):
+        with self.assertRaises(ValueError):
+            onboarding.resolve_adversarial_cast(["codex", "grok"], primary="hermes")
 
 
 class EmbeddingOptional(unittest.TestCase):
@@ -127,7 +126,7 @@ class BootstrapPersist(unittest.TestCase):
             payload = {
                 "name": "ed",
                 "backfill_days": 14,
-                "adversarials": {"mode": "self", "members": ["self"], "primary": "claude"},
+                "adversarials": {"mode": "self", "members": ["self"], "primary": "hermes"},
                 "embedding": None,
             }
             path = onboarding.persist_bootstrap(home, **payload)
@@ -142,7 +141,7 @@ class BootstrapPersist(unittest.TestCase):
 class BootstrapCfg(unittest.TestCase):
     def test_cfg_carries_lentes_and_name(self):
         inv = {"files": [], "vars": [], "by_file": {}}
-        cast = onboarding.resolve_adversarial_cast([], primary="claude")
+        cast = onboarding.resolve_adversarial_cast([], primary="hermes")
         cfg = onboarding.bootstrap_cfg(
             home=Path("/tmp/h"),
             name="ed",
@@ -164,7 +163,7 @@ class BootstrapCfg(unittest.TestCase):
             "by_file": {"openai.env": ["OPENAI_API_KEY"]},
         }
         emb = onboarding.embedding_from_inventory(inv)
-        cast = onboarding.resolve_adversarial_cast(["codex"], primary="claude")
+        cast = onboarding.resolve_adversarial_cast([], primary="hermes")
         cfg = onboarding.bootstrap_cfg(
             home=Path("~/edge"),
             name="ed",
@@ -579,8 +578,8 @@ class PredispatchStampsInsumo(unittest.TestCase):
             self.assertTrue(stamped.get("ok"))
 
 
-class MultiCliInstall(unittest.TestCase):
-    """Install provisions Claude+Codex+Grok; phenotype lists installed surfaces."""
+class HarnessInventoryAndPolicy(unittest.TestCase):
+    """Detection inventories every CLI, while enablement remains Hermes-only."""
 
     def test_detect_installed_surfaces_sees_existing_homes(self):
         import surfaces_cfg
@@ -602,14 +601,16 @@ class MultiCliInstall(unittest.TestCase):
             (host / ".claude").mkdir()
             (host / ".codex").mkdir()
             (host / ".grok").mkdir()
+            (host / ".hermes").mkdir()
             block = surfaces_cfg.surfaces_block_for_installed(home=host)
-            self.assertTrue(block["claude"]["enabled"])
-            self.assertTrue(block["codex"]["enabled"])
-            self.assertTrue(block["grok"]["enabled"])
+            self.assertEqual(
+                block,
+                {"hermes": {"enabled": True, "home": "~/.hermes"}},
+            )
 
     def test_bootstrap_cfg_includes_surfaces_block(self):
         inv = {"files": [], "vars": [], "by_file": {}}
-        cast = onboarding.resolve_adversarial_cast([], primary="claude")
+        cast = onboarding.resolve_adversarial_cast([], primary="hermes")
         cfg = onboarding.bootstrap_cfg(
             home=Path("/tmp/h"),
             name="ed",
@@ -633,8 +634,8 @@ class MultiCliInstall(unittest.TestCase):
                 "claude": False, "codex": True, "grok": False
             }
             try:
-                # real host path: project_dir None, explicit None, surface enabled by default
-                self.assertTrue(
+                # Detection is inventory only; forbidden surfaces remain disabled.
+                self.assertFalse(
                     surfaces_cfg.include_optional_surface(
                         "codex", None, None, cfg={}
                     )
@@ -654,9 +655,9 @@ class MultiCliInstall(unittest.TestCase):
             "claude": True, "codex": True, "grok": True
         }
         try:
-            # cfg with surfaces block that disables nothing listed — empty surfaces means
-            # absent-block defaults when load_agent_cfg; pass cfg without surfaces:
-            self.assertTrue(surfaces_cfg.provision_surface("codex", cfg={}))
-            self.assertTrue(surfaces_cfg.provision_surface("grok", cfg={}))
+            import runtime_policy
+            for forbidden in ("codex", "grok"):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    surfaces_cfg.provision_surface(forbidden, cfg={})
         finally:
             surfaces_cfg.detect_installed_surfaces = real

--- a/tests/test_onboarding_heartbeat_interval.py
+++ b/tests/test_onboarding_heartbeat_interval.py
@@ -5,16 +5,19 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import onboarding  # noqa: E402
+import runtime_policy  # noqa: E402
 
 
 def _cfg(**kw):
     return onboarding.bootstrap_cfg(
         home=kw.pop("home"), name="t", backfill_days=3,
-        adversarials={"mode": "self", "members": ["self"], "primary": "claude"},
+        adversarials={"mode": "self", "members": ["self"], "primary": "hermes"},
         embedding=None, **kw)
 
 
@@ -26,6 +29,26 @@ class HeartbeatInterval(unittest.TestCase):
     def test_interviewed_interval_reaches_cfg(self):
         with tempfile.TemporaryDirectory() as tmp:
             self.assertEqual(_cfg(home=tmp, heartbeat_interval="3h")["heartbeat_interval"], "3h")
+
+    def test_finish_rejects_heartbeat_before_emit_or_systemd(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            calls = []
+            phenotype = Path(tmp) / "agent.yaml"
+            phenotype.write_text("{}")
+            fake_grill = SimpleNamespace(assert_grill_complete=lambda **kw: calls.append("grill"))
+            fake_eventlog = SimpleNamespace(LOG=Path(tmp) / "events.jsonl")
+            fake_provision = SimpleNamespace(
+                install_heartbeat=lambda *a, **kw: calls.append("systemd")
+            )
+            with mock.patch.dict(
+                sys.modules,
+                {"grill_gate": fake_grill, "eventlog": fake_eventlog, "_provision": fake_provision},
+            ), mock.patch.object(
+                onboarding, "emit_phenotype", side_effect=lambda *a, **kw: calls.append("emit") or phenotype
+            ):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    onboarding.finish_onboarding(tmp, enable_heartbeat=True)
+            self.assertEqual(calls, [])
 
     def test_emit_carries_the_interval_into_agent_yaml(self):
         import yaml

--- a/tests/test_onboarding_hermes.py
+++ b/tests/test_onboarding_hermes.py
@@ -51,12 +51,12 @@ class HermesEstimate(unittest.TestCase):
 
 class HermesAdversarialAndRouters(unittest.TestCase):
     def test_hermes_member_maps_to_review_hermes_route_without_model(self):
-        cast = onboarding.resolve_adversarial_cast(["hermes"], primary="claude")
-        adv = onboarding._adversarials_for_cfg(cast, "claude")
+        cast = onboarding.resolve_adversarial_cast(["hermes"], primary="hermes")
+        adv = onboarding._adversarials_for_cfg(cast, "hermes")
         self.assertEqual(adv["hermes"]["route"], "review_hermes")
         self.assertEqual(adv["hermes"]["auth"], "subscription")
         self.assertNotIn("model", {k: v for k, v in adv["hermes"].items() if v})
-        routers = onboarding._routers_for_cfg(cast, "claude", None)
+        routers = onboarding._routers_for_cfg(cast, "hermes", None)
         self.assertEqual(routers["review_hermes"]["provider"], "hermes")
         self.assertIsNone(routers["review_hermes"].get("model"))
 

--- a/tests/test_runtime_policy.py
+++ b/tests/test_runtime_policy.py
@@ -1,0 +1,561 @@
+"""Fail-closed runtime policy for the Hermes-only derivative."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import onboarding  # noqa: E402
+import runtime_policy  # noqa: E402
+import surfaces_cfg  # noqa: E402
+import _claude_provision  # noqa: E402
+import _codex_provision  # noqa: E402
+import _grok_provision  # noqa: E402
+import _llm  # noqa: E402
+import _identity  # noqa: E402
+import sessions  # noqa: E402
+
+
+class HarnessGate(unittest.TestCase):
+    def test_forbidden_harness_is_rejected_before_side_effect(self):
+        for harness in (
+            "claude",
+            "anthropic",
+            "codex",
+            "grok",
+            "",
+            None,
+            "unknown",
+            "Hermes",
+            " hermes ",
+        ):
+            with self.subTest(harness=harness):
+                calls: list[str] = []
+
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    runtime_policy.run_for_harness(
+                        harness,
+                        lambda: calls.append("called"),
+                    )
+
+                self.assertEqual(calls, [])
+
+    def test_missing_dedicated_home_is_rejected(self):
+        with self.assertRaises(runtime_policy.RuntimePolicyError):
+            runtime_policy.require_dedicated_hermes_home(None)
+
+    def test_default_global_home_is_rejected(self):
+        with self.assertRaises(runtime_policy.RuntimePolicyError):
+            runtime_policy.require_dedicated_hermes_home(
+                Path("/profiles/default"),
+                default_home=Path("/profiles/default"),
+            )
+
+    def test_explicit_forbidden_surface_is_rejected_even_when_disabled(self):
+        cfg = {
+            "surfaces": {
+                "hermes": {"enabled": True},
+                "claude": {"enabled": False},
+            }
+        }
+
+        with self.assertRaises(runtime_policy.RuntimePolicyError):
+            runtime_policy.require_hermes_only_surfaces(cfg)
+
+    def test_explicit_config_cannot_reenable_forbidden_surface(self):
+        for forbidden in ("claude", "codex", "grok"):
+            cfg = {"surfaces": {forbidden: {"enabled": True}}}
+            with self.subTest(harness=forbidden):
+                self.assertFalse(surfaces_cfg.surface_enabled(forbidden, cfg=cfg))
+
+    def test_runtime_config_rejects_external_activation_selectors(self):
+        cases = (
+            {"primary": "claude"},
+            {"adversarials": {"members": ["codex"]}},
+            {"heartbeat": {"cli_mix": {"hermes": 1, "grok": 1}}},
+            {"execution_subagents": {"default": "grok"}},
+            {"subagents": {"codex_assist": {"review": True}}},
+        )
+        for cfg in cases:
+            with self.subTest(cfg=cfg):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    runtime_policy.require_hermes_only_runtime_config(cfg)
+
+    def test_runtime_config_rejects_malformed_mapping_sections(self):
+        for section in ("surfaces", "routers", "heartbeat"):
+            with self.subTest(section=section):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    runtime_policy.require_hermes_only_runtime_config({section: []})
+
+    def test_runtime_config_rejects_external_router_and_heartbeat(self):
+        configs = (
+            {"routers": {"chat": {"provider": "claude"}}},
+            {"routers": {"review": {"provider": "codex"}}},
+            {"heartbeat": {"cli": "grok"}},
+        )
+        for cfg in configs:
+            with self.subTest(cfg=cfg):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    runtime_policy.require_hermes_only_runtime_config(cfg)
+
+    def test_make_client_rejects_external_cli_before_constructor(self):
+        constructor = mock.Mock(side_effect=AssertionError("external client constructed"))
+        with mock.patch.dict(_llm._SUBSCRIPTION_CLIENTS, {"claude": constructor}):
+            with self.assertRaises(runtime_policy.RuntimePolicyError):
+                _llm.make_client({"provider": "claude"}, api_key="")
+        constructor.assert_not_called()
+
+    def test_embedding_router_uses_closed_provider_and_model_policy(self):
+        for provider in ("claude", "codex", "grok", "xai", "deepseek", "together"):
+            with self.subTest(provider=provider):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    runtime_policy.require_allowed_embedding_router(
+                        {"provider": provider, "model": "embedding-model"}
+                    )
+        for model in ("claude-embedding", "grok-vector", "codex-embed"):
+            with self.subTest(model=model):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    runtime_policy.require_allowed_embedding_router(
+                        {"provider": "openai", "model": model}
+                    )
+        with self.assertRaises(runtime_policy.RuntimePolicyError):
+            runtime_policy.require_allowed_embedding_router(
+                {"provider": "azure", "model": "text-embedding-3-small"}
+            )
+        accepted = runtime_policy.require_allowed_embedding_router(
+            {
+                "provider": "azure",
+                "base_url": "https://example.openai.azure.com/openai/v1",
+                "model": "text-embedding-3-small",
+            }
+        )
+        self.assertEqual(accepted["provider"], "azure")
+
+    def test_make_client_rejects_external_api_completion_provider(self):
+        for provider in ("xai", "openrouter", "openai"):
+            with self.subTest(provider=provider):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    _llm.make_client({"provider": provider}, "synthetic-key")
+
+    def test_public_session_ingestion_is_dark_before_path_access(self):
+        calls = (
+            lambda: sessions.list_sessions(Path("/must-not-read")),
+            lambda: sessions.list_codex_sessions(Path("/must-not-read")),
+            lambda: sessions.list_grok_sessions(Path("/must-not-read")),
+            lambda: sessions.dialogue_turns(Path("/must-not-read"), surface="claude"),
+            lambda: sessions.read_turns(Path("/must-not-read"), surface="claude"),
+            lambda: sessions.current_session_anchor({"CLAUDE_CODE_SESSION_ID": "synthetic"}),
+            _identity.project_dir,
+        )
+        for call in calls:
+            with self.subTest(call=call):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    call()
+
+    def test_edge_dogfood_shadow_is_blocked_before_home_access(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "dogfood-home"
+            proc = subprocess.run(
+                [sys.executable, str(REPO / "tools" / "edge-dogfood-shadow"),
+                 "--home", str(home), "seed"],
+                text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(proc.returncode, 2, proc.stdout + proc.stderr)
+            self.assertIn("blocked", proc.stderr.lower())
+            self.assertFalse(home.exists())
+
+    def test_edge_heartbeat_is_blocked_before_home_access(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "install"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO / "tools" / "edge-heartbeat"),
+                    "--home",
+                    str(home),
+                    "--cli",
+                    "claude",
+                    "--dry-run",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("forbidden", result.stderr)
+            self.assertFalse(home.exists())
+
+    def test_direct_adversarial_resolver_rejects_forbidden_member(self):
+        with self.assertRaises(runtime_policy.RuntimePolicyError):
+            onboarding.resolve_adversarial_cast(["codex"], primary="hermes")
+
+    def test_direct_bootstrap_cfg_rejects_forbidden_primary(self):
+        with self.assertRaises(runtime_policy.RuntimePolicyError):
+            onboarding.bootstrap_cfg(
+                home=Path("/unused/install"),
+                name="probe",
+                backfill_days=0,
+                adversarials={"mode": "self", "primary": "claude", "members": ["self"]},
+                embedding=None,
+                primary="claude",
+            )
+
+    def test_bootstrap_cfg_declares_hermes_without_host_detection(self):
+        installed = {"claude": False, "codex": False, "grok": False, "hermes": False}
+        with mock.patch.object(
+            surfaces_cfg,
+            "detect_installed_surfaces",
+            return_value=installed,
+        ):
+            cfg = onboarding.bootstrap_cfg(
+                home=Path("/unused/install"),
+                name="probe",
+                backfill_days=0,
+                adversarials={"mode": "self", "primary": "hermes", "members": ["self"]},
+                embedding=None,
+                primary="hermes",
+            )
+
+        self.assertEqual(cfg["surfaces"], {"hermes": {"enabled": True}})
+
+    def test_surface_path_resolvers_do_not_expose_forbidden_homes(self):
+        for forbidden in ("claude", "codex", "grok"):
+            with self.subTest(harness=forbidden):
+                cfg = {
+                    "surfaces": {
+                        forbidden: {
+                            "enabled": True,
+                            "home": f"/synthetic/{forbidden}",
+                            "sessions": f"/synthetic/{forbidden}/sessions",
+                            "active_sessions": f"/synthetic/{forbidden}/active.json",
+                        }
+                    }
+                }
+                env = {
+                    "CODEX_HOME": "/override/codex",
+                    "GROK_HOME": "/override/grok",
+                    "EDGE_CODEX_SESSIONS_DIR": "/override/codex/sessions",
+                    "EDGE_GROK_SESSIONS_DIR": "/override/grok/sessions",
+                }
+                self.assertIsNone(surfaces_cfg.surface_home(forbidden, cfg=cfg, env=env))
+                self.assertIsNone(surfaces_cfg.surface_sessions_dir(forbidden, cfg=cfg, env=env))
+                self.assertIsNone(
+                    surfaces_cfg.surface_active_sessions_path(forbidden, cfg=cfg, env=env)
+                )
+
+    def test_hermes_surface_path_requires_dedicated_home(self):
+        self.assertIsNone(surfaces_cfg.surface_home("hermes", cfg={}, env={}))
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cfg = {"surfaces": {"hermes": {"enabled": True, "home": str(root / ".hermes")}}}
+            with mock.patch.object(runtime_policy.Path, "home", return_value=root):
+                with self.assertRaises(runtime_policy.RuntimePolicyError):
+                    surfaces_cfg.surface_home("hermes", cfg=cfg, env={})
+            dedicated = root / ".hermes" / "profiles" / "edge"
+            cfg["surfaces"]["hermes"]["home"] = str(dedicated)
+            with mock.patch.object(runtime_policy.Path, "home", return_value=root):
+                self.assertEqual(
+                    surfaces_cfg.surface_home("hermes", cfg=cfg, env={}),
+                    dedicated.resolve(),
+                )
+
+    def test_autodetection_authorizes_only_explicit_dedicated_hermes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            for dirname in (".claude", ".codex", ".grok", ".hermes"):
+                (home / dirname).mkdir()
+            self.assertEqual(
+                surfaces_cfg.surfaces_block_for_installed(env={}, home=home),
+                {},
+            )
+            dedicated = home / ".hermes" / "profiles" / "edge"
+            dedicated.mkdir(parents=True)
+            with mock.patch.object(runtime_policy.Path, "home", return_value=home):
+                block = surfaces_cfg.surfaces_block_for_installed(
+                    env={"HERMES_HOME": str(dedicated)}, home=home
+                )
+            self.assertEqual(
+                block,
+                {"hermes": {"enabled": True, "home": str(dedicated.resolve())}},
+            )
+
+    def test_absent_surface_block_defaults_only_to_hermes(self):
+        self.assertTrue(surfaces_cfg.surface_enabled("hermes", cfg={}))
+        for forbidden in ("claude", "codex", "grok"):
+            with self.subTest(harness=forbidden):
+                self.assertFalse(surfaces_cfg.surface_enabled(forbidden, cfg={}))
+
+    def test_provision_surface_rejects_forbidden_harness_before_detection(self):
+        with mock.patch.object(
+            surfaces_cfg,
+            "detect_installed_surfaces",
+            side_effect=AssertionError("host detection reached"),
+        ):
+            with self.assertRaises(runtime_policy.RuntimePolicyError):
+                surfaces_cfg.provision_surface("claude", cfg={})
+
+    def test_bootstrap_rejects_forbidden_primary_before_writing_home(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            install_home = Path(tmp) / "new-install"
+
+            with self.assertRaises(runtime_policy.RuntimePolicyError):
+                onboarding.run_bootstrap(
+                    home=install_home,
+                    name="probe",
+                    backfill_days=0,
+                    primary="claude",
+                    provision_skills=False,
+                )
+
+            self.assertFalse(install_home.exists())
+
+    def test_bootstrap_rejects_forbidden_adversarial_before_writing_home(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            install_home = Path(tmp) / "new-install"
+
+            with self.assertRaises(runtime_policy.RuntimePolicyError):
+                onboarding.run_bootstrap(
+                    home=install_home,
+                    name="probe",
+                    backfill_days=0,
+                    primary="hermes",
+                    adversarials=["codex"],
+                    provision_skills=False,
+                )
+
+            self.assertFalse(install_home.exists())
+
+    def test_bootstrap_requires_dedicated_hermes_home_before_processing(self):
+        with mock.patch.object(
+            onboarding,
+            "require_name",
+            side_effect=AssertionError("bootstrap crossed the policy barrier"),
+        ):
+            with self.assertRaises(runtime_policy.RuntimePolicyError):
+                onboarding.run_bootstrap(
+                    home=Path("/unused/install"),
+                    name="probe",
+                    backfill_days=0,
+                    primary="hermes",
+                    hermes_home=None,
+                    provision_skills=True,
+                )
+
+    def test_bootstrap_provisions_only_dedicated_hermes_home(self):
+        import tempfile
+
+        installed = {"claude": True, "codex": True, "grok": True, "hermes": True}
+        forbidden = AssertionError("forbidden provisioner reached")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            install_home = root / "install"
+            hermes_home = root / "profiles" / "edge"
+            with (
+                mock.patch.object(
+                    surfaces_cfg,
+                    "detect_installed_surfaces",
+                    return_value=installed,
+                ),
+                mock.patch.object(
+                    _claude_provision,
+                    "provision_claude",
+                    side_effect=forbidden,
+                ),
+                mock.patch.object(
+                    _codex_provision,
+                    "provision_codex",
+                    side_effect=forbidden,
+                ),
+                mock.patch.object(
+                    _grok_provision,
+                    "provision_grok",
+                    side_effect=forbidden,
+                ),
+            ):
+                result = onboarding.run_bootstrap(
+                    home=install_home,
+                    name="probe",
+                    backfill_days=0,
+                    primary="hermes",
+                    hermes_home=hermes_home,
+                    provision_skills=True,
+                )
+
+            self.assertNotIn("provision_warning", result)
+            self.assertTrue(result["provisioned_surfaces"])
+            self.assertTrue(
+                all(row.startswith("hermes: ") for row in result["provisioned_surfaces"])
+            )
+            self.assertTrue(
+                (hermes_home / "skills" / "probe-wake" / "SKILL.md").is_file()
+            )
+
+    def test_cli_defaults_primary_to_hermes(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            install_home = Path(tmp) / "install"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO / "tools" / "edge-bootstrap"),
+                    "bootstrap",
+                    "--home",
+                    str(install_home),
+                    "--name",
+                    "probe",
+                    "--backfill-days",
+                    "0",
+                    "--no-provision-skills",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn('"ok": true', result.stdout)
+
+    def test_edge_apply_rejects_forbidden_surface_before_install(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            phenotype = root / "agent.yaml"
+            phenotype.write_text(
+                "name: probe\n"
+                "surfaces:\n"
+                "  hermes:\n"
+                "    enabled: true\n"
+                "  claude:\n"
+                "    enabled: false\n",
+                encoding="utf-8",
+            )
+            install_home = root / "install"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO / "tools" / "edge-apply"),
+                    "--yaml",
+                    str(phenotype),
+                    "--home",
+                    str(install_home),
+                    "--hermes-home",
+                    str(root / "profiles" / "edge"),
+                    "--validate",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("forbidden surfaces declared", result.stderr)
+            self.assertFalse(install_home.exists())
+
+    def test_edge_apply_writes_only_dedicated_hermes_home(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            phenotype = root / "agent.yaml"
+            phenotype.write_text(
+                "name: probe\n"
+                "codename: probe\n"
+                "mission: test gate\n"
+                "voice: direct\n"
+                "skill_prefix: probe\n"
+                "tool_prefix: probe\n"
+                "blog_public_url: https://probe.invalid\n"
+                "surfaces:\n"
+                "  hermes:\n"
+                "    enabled: true\n"
+                "sources:\n"
+                "  - name: hn\n"
+                "    kind: api\n",
+                encoding="utf-8",
+            )
+            install_home = root / "install"
+            hermes_home = root / "profiles" / "edge"
+            external_homes = {
+                "claude": root / "profiles" / "claude",
+                "codex": root / "profiles" / "codex",
+                "grok": root / "profiles" / "grok",
+            }
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO / "tools" / "edge-apply"),
+                    "--yaml",
+                    str(phenotype),
+                    "--home",
+                    str(install_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                ],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "HOME": str(root), "USERPROFILE": str(root)},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            for name, path in external_homes.items():
+                with self.subTest(harness=name):
+                    self.assertFalse(path.exists())
+            self.assertTrue(list((hermes_home / "skills").glob("*/SKILL.md")))
+
+    def test_edge_apply_blocks_runtime_provisioning_before_install(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            phenotype = root / "agent.yaml"
+            phenotype.write_text(
+                "name: probe\n"
+                "surfaces:\n"
+                "  hermes:\n"
+                "    enabled: true\n"
+                "routers:\n"
+                "  chat:\n"
+                "    provider: hermes\n"
+                "    model: test\n"
+                "    secret_ref: missing.env:MISSING_KEY\n",
+                encoding="utf-8",
+            )
+            install_home = root / "install"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO / "tools" / "edge-apply"),
+                    "--yaml",
+                    str(phenotype),
+                    "--home",
+                    str(install_home),
+                    "--hermes-home",
+                    str(root / "profiles" / "edge"),
+                    "--provision-runtime",
+                ],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "HOME": str(root), "USERPROFILE": str(root)},
+            )
+
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("runtime provisioning is blocked", result.stderr)
+            self.assertFalse(install_home.exists())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_surfaces_cfg.py
+++ b/tests/test_surfaces_cfg.py
@@ -7,29 +7,28 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import surfaces_cfg  # noqa: E402
-import sweep  # noqa: E402
 
 
 class SurfacesCfg(unittest.TestCase):
-    def test_absent_block_defaults_enable_optional_surfaces(self):
+    def test_absent_block_defaults_enable_only_hermes(self):
         cfg = {"name": "ed"}  # no surfaces key
-        self.assertTrue(surfaces_cfg.surface_enabled("claude", cfg=cfg))
-        self.assertTrue(surfaces_cfg.surface_enabled("codex", cfg=cfg))
-        self.assertTrue(surfaces_cfg.surface_enabled("grok", cfg=cfg))
-
-    def test_present_block_requires_explicit_enabled(self):
-        cfg = {"surfaces": {"claude": {"enabled": True}, "codex": {"enabled": False}}}
-        self.assertTrue(surfaces_cfg.surface_enabled("claude", cfg=cfg))
+        self.assertTrue(surfaces_cfg.surface_enabled("hermes", cfg=cfg))
+        self.assertFalse(surfaces_cfg.surface_enabled("claude", cfg=cfg))
         self.assertFalse(surfaces_cfg.surface_enabled("codex", cfg=cfg))
-        self.assertFalse(surfaces_cfg.surface_enabled("grok", cfg=cfg))  # not listed
+        self.assertFalse(surfaces_cfg.surface_enabled("grok", cfg=cfg))
 
-    def test_home_from_yaml(self):
+    def test_present_block_cannot_enable_external_surfaces(self):
+        cfg = {"surfaces": {"claude": {"enabled": True}, "codex": {"enabled": True}}}
+        self.assertFalse(surfaces_cfg.surface_enabled("claude", cfg=cfg))
+        self.assertFalse(surfaces_cfg.surface_enabled("codex", cfg=cfg))
+        self.assertFalse(surfaces_cfg.surface_enabled("grok", cfg=cfg))
+
+    def test_external_home_from_yaml_remains_unreachable(self):
         with tempfile.TemporaryDirectory() as tmp:
-            home = Path(tmp) / "my-grok"
+            home = Path(tmp) / "external-home"
             cfg = {"surfaces": {"grok": {"enabled": True, "home": str(home)}}}
-            self.assertEqual(
-                surfaces_cfg.surface_sessions_dir("grok", cfg=cfg, env={}),
-                home / "sessions",
+            self.assertIsNone(
+                surfaces_cfg.surface_sessions_dir("grok", cfg=cfg, env={})
             )
 
     def test_include_hermetic_requires_explicit_dir(self):
@@ -37,7 +36,7 @@ class SurfacesCfg(unittest.TestCase):
         self.assertFalse(
             surfaces_cfg.include_optional_surface("grok", "/tmp/proj", None, cfg=cfg)
         )
-        self.assertTrue(
+        self.assertFalse(
             surfaces_cfg.include_optional_surface("grok", "/tmp/proj", "/tmp/grok", cfg=cfg)
         )
         self.assertFalse(
@@ -68,9 +67,10 @@ class SurfacesCfgYamlRoundTrip(unittest.TestCase):
                 "    enabled: true\n"
                 "    home: ~/custom-grok\n"
             )
-            self.assertTrue(surfaces_cfg.surface_enabled("grok", agent_yaml=y))
-            home = surfaces_cfg.surface_home("grok", agent_yaml=y, env={})
-            self.assertTrue(str(home).endswith("custom-grok"))
+            self.assertFalse(surfaces_cfg.surface_enabled("grok", agent_yaml=y))
+            self.assertIsNone(
+                surfaces_cfg.surface_home("grok", agent_yaml=y, env={})
+            )
 
 
 if __name__ == "__main__":

--- a/tools/_hermes_provision.py
+++ b/tools/_hermes_provision.py
@@ -8,6 +8,8 @@ nenhum nome de install hardcoded — qualquer usuário do hermes com o edge prov
 """
 from pathlib import Path
 
+import runtime_policy
+
 
 def _write_if_changed(path: Path, content: str) -> None:
     """Write only when content differs, keeping repeated apply runs idempotent."""
@@ -38,7 +40,7 @@ def hermes_prefixes(cfg: dict) -> list:
 def render_hermes_skill(*, slug: str, prefix: str, canonical_skill: Path) -> str:
     """Render a global Hermes wrapper for one canonical Edge skill."""
     name = f"{prefix}-{slug}"
-    canonical = str(Path(canonical_skill).expanduser())
+    canonical = Path(canonical_skill).expanduser().as_posix()
     return (
         "---\n"
         f"name: {name}\n"
@@ -55,14 +57,14 @@ def render_hermes_skill(*, slug: str, prefix: str, canonical_skill: Path) -> str
 
 def provision_hermes(cfg: dict, repo: Path, edge_home: Path, hermes_home: Path) -> list:
     """Idempotently provision HERMES_HOME/skills with prefixed Edge wrappers."""
+    hermes_home = runtime_policy.require_dedicated_hermes_home(hermes_home)
     repo = Path(repo)
     edge_home = Path(edge_home).expanduser()
-    hermes_home = Path(hermes_home).expanduser()
     prefixes = hermes_prefixes(cfg)
     rows = []
     installed = 0
 
-    skills_src = repo / "skills"
+    skills_src = runtime_policy.require_hermes_safe_skill_tree(repo / "skills")
     if skills_src.exists():
         for skill_dir in sorted(skills_src.iterdir()):
             if not skill_dir.is_dir() or skill_dir.name.startswith("."):

--- a/tools/_identity.py
+++ b/tools/_identity.py
@@ -16,6 +16,8 @@ secret; no literal default (CONTRACT C4)."""
 import os
 from pathlib import Path
 
+import runtime_policy
+
 REPO = Path(__file__).resolve().parent.parent
 
 
@@ -78,7 +80,8 @@ def require_group(agent_yaml=AGENT_YAML):
 
 
 def project_dir():
-    """The mentee's Claude transcript store for THIS install (ADR-0015). EDGE_PROJECT_DIR env →
+    runtime_policy.require_session_ingestion_ready()
+    """Legacy transcript locator, unreachable until a Hermes-native reader exists. EDGE_PROJECT_DIR →
     derived from the running $HOME per the Claude store convention (/home/x →
     ~/.claude/projects/-home-x). FAIL-LOUD: a store directory that does not exist raises —
     "nothing new" is reserved for a real store with nothing new, never for scanning a foreign or

--- a/tools/_llm.py
+++ b/tools/_llm.py
@@ -11,6 +11,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+import runtime_policy
+
 PROVIDER_BASE_URLS = {
     "openai": "https://api.openai.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
@@ -218,14 +220,25 @@ _SUBSCRIPTION_CLIENTS = {"codex": CodexClient, "claude": ClaudeClient, "grok": G
                          "hermes": HermesClient}
 
 
-def make_client(router: dict, api_key: str):
-    provider = router.get("provider")
+def make_client(router: dict, api_key: str = None, *, exec_fn=None):
+    """Build a completion client. Hermes is the only public completion harness."""
+    provider = runtime_policy.require_allowed_harness(router.get("provider"))
     if provider in SUBSCRIPTION_PROVIDERS:
-        return _SUBSCRIPTION_CLIENTS[provider]()
+        return _SUBSCRIPTION_CLIENTS[provider](exec_fn=exec_fn)
     from openai import OpenAI
     base = resolve_base_url(router)
     if not base:
         raise ValueError(f"provider sem base_url no registry: {router.get('provider')!r}")
+    return OpenAI(base_url=base, api_key=api_key)
+
+
+def make_embedding_client(router: dict, api_key: str):
+    """Build the API-only embedding client after closed-policy validation."""
+    runtime_policy.require_allowed_embedding_router(router)
+    from openai import OpenAI
+    base = resolve_base_url(router)
+    if not base:
+        raise ValueError(f"embedding provider sem base_url: {router.get('provider')!r}")
     return OpenAI(base_url=base, api_key=api_key)
 
 

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -16,12 +16,11 @@ import yaml
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))  # tools/ para importar _llm
 import _llm
-import _claude_provision
-import _codex_provision
-import _grok_provision
 import _hermes_provision
 import _provision
 import _validate
+import runtime_policy
+
 
 
 def render_caddyfile(home: Path, yaml_path: str) -> None:
@@ -94,14 +93,20 @@ def verify_credentials(home: Path, cfg: dict, env_dir: Path = None) -> list:
     contra env_dir (agent.yaml → <home>/secrets/, C4)."""
     rows = []
     for name, r in (cfg.get("routers") or {}).items():
-        key = _read_secret(home, r.get("secret_ref", ""), env_dir) if r.get("secret_ref") else None
-        if not key:
-            rows.append((f"router:{name} ({r.get('provider')})", "FALTA (sem key)", False))
-            continue
         try:
             model = r.get("model", "")
             kind = "embedding" if ("embed" in name.lower() or "embed" in model.lower()) else "chat"
-            res = _llm.probe(_llm.make_client(r, key), model, kind)
+            if kind == "embedding":
+                runtime_policy.require_allowed_embedding_router(r)
+                key = _read_secret(home, r.get("secret_ref", ""), env_dir) if r.get("secret_ref") else None
+                if not key:
+                    rows.append((f"router:{name} ({r.get('provider')})", "FALTA (sem key)", False))
+                    continue
+                client = _llm.make_embedding_client(r, key)
+            else:
+                runtime_policy.require_allowed_harness(r.get("provider"))
+                client = _llm.make_client(r, None)
+            res = _llm.probe(client, model, kind)
             tag = f"router:{name} ({r.get('provider')}/{r.get('model')})"
             rows.append((tag, f"OK — {res['detail']}", True) if res["ok"]
                         else (tag, f"FALHA {res['status']} — {res['detail']}", False))
@@ -124,52 +129,48 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--yaml", required=True)
     ap.add_argument("--home")
-    ap.add_argument("--claude-home",
-                    help="target ~/.claude dir (default: real ~/.claude). "
-                         "Tests/smoke-runs MUST point this at a tmp dir.")
-    ap.add_argument("--codex-home",
-                    help="target Codex home dir (default: CODEX_HOME or real ~/.codex). "
-                         "Tests/smoke-runs MUST point this at a tmp dir.")
-    ap.add_argument("--grok-home",
-                    help="target Grok home dir (default: GROK_HOME or real ~/.grok). "
-                         "Tests/smoke-runs MUST point this at a tmp dir.")
-    ap.add_argument("--hermes-home",
-                    help="target Hermes home dir (default: HERMES_HOME or real ~/.hermes). "
-                         "Tests/smoke-runs MUST point this at a tmp dir.")
-    ap.add_argument("--provision-runtime", action="store_true",
-                    help="provision the mandatory graph runtime: venv (#20), per-host Neo4j via "
-                         "Docker (#18), and the systemd heartbeat timer (#19). Fails loud on a "
-                         "missing prerequisite (ADR-0011). Off by default (files-only apply).")
+    ap.add_argument(
+        "--hermes-home",
+        default=os.environ.get("HERMES_HOME"),
+        help="dedicated Hermes profile home; must not be the global ~/.hermes",
+    )
+    ap.add_argument(
+        "--provision-runtime",
+        action="store_true",
+        help="reserved; currently rejected until Hermes heartbeat parity is implemented",
+    )
     ap.add_argument("--validate", action="store_true",
                     help="validate the install only: report each substrate check and exit nonzero "
                          "if broken (no provisioning, no file placement).")
     args = ap.parse_args()
 
     cfg = yaml.safe_load(Path(args.yaml).read_text()) or {}
+    try:
+        runtime_policy.require_hermes_only_runtime_config(cfg)
+        if args.provision_runtime:
+            raise runtime_policy.RuntimePolicyError(
+                "runtime provisioning is blocked until Hermes heartbeat parity is implemented"
+            )
+    except runtime_policy.RuntimePolicyError as exc:
+        print(f"edge-apply: {exc}", file=sys.stderr)
+        sys.exit(2)
     home = Path(os.path.expanduser(args.home or cfg.get("edge_home") or "~/edge/"))
     env_dir = resolve_env_dir(home, cfg)               # agent.yaml env_dir → <home>/secrets/ (C4)
     import surfaces_cfg
-    claude_home = Path(os.path.expanduser(args.claude_home)) if args.claude_home \
-        else Path.home() / ".claude"
-    if args.codex_home:
-        codex_home = Path(os.path.expanduser(args.codex_home))
-    else:
-        codex_home = surfaces_cfg.surface_home("codex", cfg=cfg) or Path.home() / ".codex"
-    if args.grok_home:
-        grok_home = Path(os.path.expanduser(args.grok_home))
-    else:
-        grok_home = surfaces_cfg.surface_home("grok", cfg=cfg) or Path.home() / ".grok"
-    if args.hermes_home:
-        hermes_home = Path(os.path.expanduser(args.hermes_home))
-    else:
-        hermes_home = surfaces_cfg.surface_home("hermes", cfg=cfg) or Path.home() / ".hermes"
 
     if args.validate:
         report, healthy = _validate.format_report(_validate.validate_install(
             home, cfg, env_dir, provisioned=True, repo_tools=REPO / "tools",
-            agent_yaml=Path(args.yaml)))      # identity validates the APPLIED config, not the default
+            agent_yaml=Path(args.yaml), memory=home / "memory",
+            log=home / "state" / "events.jsonl"))
         print(report)
         sys.exit(0 if healthy else 1)
+
+    try:
+        hermes_home = runtime_policy.require_dedicated_hermes_home(args.hermes_home)
+    except runtime_policy.RuntimePolicyError as exc:
+        print(f"edge-apply: {exc}", file=sys.stderr)
+        sys.exit(2)
 
     for d in ("blog/entries", "state", "memory", "threads", "secrets"):
         (home / d).mkdir(parents=True, exist_ok=True)
@@ -186,50 +187,16 @@ def main() -> None:
         mem.write_text("# MEMORY\n")
 
     print(f"apply: instalado em {home}")
-    # Multi-CLI: provision every harness installed on this host (claude + codex + grok).
-    # Assemble later films every surface that is installed + enabled (see surfaces_cfg).
     installed = surfaces_cfg.detect_installed_surfaces()
-    print(f"apply: surfaces installed on host → {installed}")
-    # Ensure phenotype carries surfaces for everything installed (first-run / thin yaml)
+    print(f"apply: surfaces detected for audit → {installed}")
     if not (cfg.get("surfaces") or {}):
-        cfg["surfaces"] = surfaces_cfg.surfaces_block_for_installed()
-        print(f"apply: surfaces block defaulted to installed harnesses → {list(cfg['surfaces'])}")
+        cfg["surfaces"] = {"hermes": {"enabled": True, "home": str(hermes_home)}}
+        print("apply: surfaces block defaulted to Hermes-only")
 
-    print(f"apply: provisionando Claude skills em {claude_home}")
-    for row in _claude_provision.provision_claude(cfg, REPO, claude_home):
+    print(f"apply: provisionando Hermes skills em {hermes_home}")
+    for row in _hermes_provision.provision_hermes(cfg, REPO, home, hermes_home):
         print(f"  - {row}")
-    if surfaces_cfg.provision_surface("codex", cfg=cfg) or installed.get("codex"):
-        print(f"apply: provisionando Codex skills em {codex_home}")
-        for row in _codex_provision.provision_codex(cfg, REPO, home, codex_home):
-            print(f"  - {row}")
-    else:
-        print("apply: Codex not installed / disabled — skip provision")
-    if surfaces_cfg.provision_surface("grok", cfg=cfg) or installed.get("grok"):
-        print(f"apply: provisionando Grok skills em {grok_home}")
-        for row in _grok_provision.provision_grok(cfg, REPO, home, grok_home):
-            print(f"  - {row}")
-    else:
-        print("apply: Grok not installed / disabled — skip provision")
-    if surfaces_cfg.provision_surface("hermes", cfg=cfg) or installed.get("hermes"):
-        print(f"apply: provisionando Hermes skills em {hermes_home}")
-        for row in _hermes_provision.provision_hermes(cfg, REPO, home, hermes_home):
-            print(f"  - {row}")
-    else:
-        print("apply: Hermes not installed / disabled — skip provision")
 
-    if args.provision_runtime:
-        print("apply: provisionando o runtime (graph obrigatório — ADR-0011)")
-        verify_required_secrets(home, cfg, env_dir)    # C4: fail loud per missing required key
-        print(f"  - secrets verificados em {env_dir}")
-        _provision.build_venv(home, REPO / "requirements.txt")
-        print(f"  - venv → {home / '.venv'} (deps de requirements.txt)")
-        secret = _provision.provision_neo4j(home, env_dir)
-        print(f"  - neo4j (docker, {_provision.NEO4J_IMAGE}) → senha em {secret}")
-        _provision.install_heartbeat(cfg, home)
-        print(f"  - heartbeat timer (systemd --user, OnUnitActiveSec="
-              f"{cfg.get('heartbeat_interval', '3h')}) instalado + enable --now")
-        _provision.check_headless_auth()
-        print("  - headless-auth: claude -p autentica sem TTY")
 
     print("credenciais (adapter testado no apply):")
     missing = False
@@ -238,25 +205,13 @@ def main() -> None:
         if ok is False:
             missing = True
     if missing:
-        print("aviso: há credenciais ausentes/com falha — corrija antes do heartbeat real")
+        print("aviso: há credenciais ausentes/com falha — corrija antes do runtime real")
 
-    report, healthy = _validate.format_report(_validate.validate_install(
-        home, cfg, env_dir, provisioned=args.provision_runtime, repo_tools=REPO / "tools",
-        agent_yaml=Path(args.yaml)))           # identity validates the APPLIED config, not the default
+    report, _healthy = _validate.format_report(_validate.validate_install(
+        home, cfg, env_dir, provisioned=False, repo_tools=REPO / "tools",
+        agent_yaml=Path(args.yaml), memory=home / "memory",
+        log=home / "state" / "events.jsonl"))
     print(report)
-    if args.provision_runtime and not healthy:
-        # AUTHORITATIVE: a PROVISIONED install that comes up unhealthy must NOT finish claiming
-        # success (today it exits 0 regardless). Best-effort: don't leave the heartbeat timer enabled
-        # on a broken install (it would dispatch a lobotomized beat); at minimum exit nonzero so the
-        # operator/automation sees the failure. (Files-only apply keeps its "report, don't block"
-        # contract — it legitimately runs before secrets are delivered.)
-        try:
-            subprocess.run(["systemctl", "--user", "disable", "--now", "edge-heartbeat.timer"],
-                           check=False)
-        except Exception:
-            pass
-        print("apply: install UNHEALTHY — heartbeat timer disabled (best-effort), see [XX] above")
-        sys.exit(1)
     sys.exit(0)
 
 

--- a/tools/edge-bootstrap
+++ b/tools/edge-bootstrap
@@ -31,6 +31,7 @@ def cmd_bootstrap(args) -> int:
             adversarials=args.adversarials or None,
             primary=args.primary,
             provision_skills=not args.no_provision_skills,
+            hermes_home=args.hermes_home,
             embedding_choice=choice or None,
         )
     except ValueError as e:
@@ -133,9 +134,11 @@ def main(argv=None) -> int:
     b.add_argument("--name", default=None)
     b.add_argument("--backfill-days", type=int, default=None)
     b.add_argument("--adversarial", action="append", default=[], dest="adversarials")
-    b.add_argument("--primary", default="claude")
+    b.add_argument("--primary", choices=("hermes",), default="hermes")
+    b.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME"),
+                   help="dedicated Hermes profile home; must not be the global ~/.hermes")
     b.add_argument("--no-provision-skills", action="store_true")
-    # o adapter de embeddings (entrevista): openai direto, openrouter, azure/base_url custom
+
     b.add_argument("--embedding-provider", default=None)
     b.add_argument("--embedding-var", default=None)
     b.add_argument("--embedding-model", default=None)

--- a/tools/edge-dogfood-shadow
+++ b/tools/edge-dogfood-shadow
@@ -1,208 +1,40 @@
 #!/usr/bin/env python3
-"""edge-dogfood-shadow — harvest natural production into the gate-policy dogfood exp.
+"""Fail-closed dogfood launcher for the Hermes-only derivative.
 
-Subcommands:
-  sweep              Harvest new artefatos → production B + gate arms + model queue + Downloads
-  harvest-slug       Backfill one slug + mirror to Downloads
-  export-downloads   Mirror all runs → ~/Downloads/exp003-gate-dogfood-shadow (lado a lado)
-  next-blind         Issue ONE blind model slot (model under test = producer CLI)
-  mark-blind         Mark blind model evaluated + re-export Downloads
-  live               Refresh live board path
-  seed               Ensure experiment workspace + projeto.md
+The upstream experiment emits executable assignments for unsupported model runners. The
+private data adapters remain for migration analysis, but the public launcher is disabled
+until a Hermes-native producer path is implemented and reviewed.
 """
 from __future__ import annotations
 
 import argparse
-import json
-import os
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import dogfood_shadow
+import runtime_policy
 
 
-def _home(args) -> Path:
-    return Path(os.path.expanduser(args.home or os.environ.get("EDGE_HOME") or "~/edge")).resolve()
-
-
-def _cfg_and_exp(home: Path, args):
-    cfg = dogfood_shadow.load_cfg(home)
-    if args.experiment_id:
-        cfg = {**cfg, "experiment_id": args.experiment_id}
-    if not cfg.get("experiment_id"):
-        cfg["experiment_id"] = "exp003"
-    cfg.setdefault("enabled", True)
-    cfg.setdefault("slug", "gate-dogfood-shadow")
-    exp_dir = dogfood_shadow.resolve_exp_dir(home, cfg)
-    return cfg, exp_dir
-
-
-def _rebuild_index(exp_dir: Path) -> None:
-    """Ensure runs/index.json lists every run dir (after consolidations / pulls)."""
-    runs_dir = exp_dir / "runs"
-    if not runs_dir.is_dir():
-        return
-    index = dogfood_shadow.load_index(exp_dir)
-    for run in runs_dir.iterdir():
-        if not run.is_dir() or not (run / "meta.json").is_file():
-            continue
-        meta = json.loads((run / "meta.json").read_text(encoding="utf-8"))
-        slug = meta.get("slug")
-        if slug:
-            index["by_slug"][slug] = run.name
-    dogfood_shadow.save_index(exp_dir, index)
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="edge-dogfood-shadow")
+    parser.add_argument("--home", default=None)
+    parser.add_argument("--experiment-id", default=None)
+    parser.add_argument("--downloads", default=None)
+    parser.add_argument("cmd", nargs="?", help="legacy command; currently disabled")
+    parser.add_argument("rest", nargs=argparse.REMAINDER)
+    return parser
 
 
 def main(argv=None) -> int:
-    ap = argparse.ArgumentParser(prog="edge-dogfood-shadow")
-    ap.add_argument("--home", default=None)
-    ap.add_argument("--experiment-id", default=None)
-    ap.add_argument(
-        "--downloads", default=None,
-        help="Override Downloads root (default ~/Downloads/exp003-gate-dogfood-shadow)",
-    )
-    sub = ap.add_subparsers(dest="cmd", required=True)
-
-    sub.add_parser("sweep", help="Harvest new artefatos into the experiment")
-    p_nb = sub.add_parser("next-blind", help="Issue one blind model slot")
-    p_nb.add_argument("--run-id", default=None)
-    p_mb = sub.add_parser("mark-blind", help="Mark blind model evaluated")
-    p_mb.add_argument("--run-id", required=True)
-    p_mb.add_argument("--model", required=True)
-    sub.add_parser("live", help="Refresh and show live board path")
-    p_seed = sub.add_parser("seed", help="Seed experiment workspace")
-    p_seed.add_argument("--title", default="Gate-policy dogfood on live production seeds")
-    p_seed.add_argument(
-        "--hypothesis",
-        default=(
-            "On the same frozen production seed, gate-policy re-runs (visual-coverage, rich-rite, "
-            "R0, visual-grounding) and three.js operational arm change operator utility vs "
-            "baseline B; model under test produces the report via its own CLI (blind 1×1)."
-        ),
-    )
-    p_h = sub.add_parser("harvest-slug", help="Harvest one slug (sanity / backfill)")
-    p_h.add_argument("slug")
-    p_ex = sub.add_parser(
-        "export-downloads",
-        help="Mirror originais + versões lado a lado em Downloads",
-    )
-
-    args = ap.parse_args(argv)
-    home = _home(args)
-    cfg, exp_dir = _cfg_and_exp(home, args)
-    downloads = (
-        Path(os.path.expanduser(args.downloads)).resolve()
-        if args.downloads
-        else dogfood_shadow.default_downloads_dir()
-    )
-
-    if args.cmd == "seed":
-        dogfood_shadow.seed_experiment_workspace(
-            exp_dir,
-            experiment_id=cfg["experiment_id"],
-            title=args.title,
-            hypothesis=args.hypothesis,
+    _parser().parse_args(argv)
+    try:
+        raise runtime_policy.RuntimePolicyError(
+            "edge-dogfood-shadow is blocked until Hermes-native producer parity is implemented"
         )
-        print(exp_dir)
-        return 0
-
-    if args.cmd == "sweep":
-        if not exp_dir.is_dir():
-            dogfood_shadow.seed_experiment_workspace(
-                exp_dir,
-                experiment_id=cfg["experiment_id"],
-                title="Gate-policy dogfood on live production seeds",
-                hypothesis=cfg.get("hypothesis") or "see projeto.md",
-            )
-        result = dogfood_shadow.sweep(home, exp_dir, cfg)
-        result["downloads"] = str(downloads)
-        # re-export with optional override
-        dogfood_shadow.export_all_to_downloads(exp_dir, downloads)
-        print(json.dumps(result, ensure_ascii=False, indent=2))
-        return 0
-
-    if args.cmd == "harvest-slug":
-        import eventlog
-        log = home / "state" / "events" / "log.jsonl"
-        corpus = eventlog.corpus_at(log=log)
-        item = next((c for c in corpus if c.get("slug") == args.slug), None)
-        if item is None:
-            print(f"slug not in corpus: {args.slug}", file=sys.stderr)
-            return 1
-        dogfood_shadow.seed_experiment_workspace(
-            exp_dir,
-            experiment_id=cfg["experiment_id"],
-            title="Gate-policy dogfood on live production seeds",
-            hypothesis="see projeto.md",
-        )
-        run = dogfood_shadow.harvest_production(
-            home, item, exp_dir, experiment_id=cfg["experiment_id"])
-        var = dogfood_shadow.assign_one_variation(run, exp_dir)
-        dogfood_shadow.enqueue_prototype(run, exp_dir=exp_dir)
-        dest = dogfood_shadow.mirror_run_to_downloads(run, downloads)
-        dogfood_shadow.refresh_live_index(exp_dir)
-        dogfood_shadow.export_all_to_downloads(exp_dir, downloads)
-        print(json.dumps({
-            "run_id": run.name,
-            "path": str(run),
-            "baseline": "production",
-            "variation": var,
-            "rule": "one_variation_per_artefato",
-            "downloads": str(dest),
-            "model_is_producer": var.get("kind") == "model",
-            "recovered": json.loads((run / "meta.json").read_text())["recovered"],
-        }, ensure_ascii=False, indent=2))
-        return 0
-
-    if args.cmd == "export-downloads":
-        _rebuild_index(exp_dir)
-        runs_dir = exp_dir / "runs"
-        if runs_dir.is_dir():
-            for run in runs_dir.iterdir():
-                if run.is_dir() and (run / "meta.json").is_file():
-                    # ensure exactly one variation (idempotent if already set)
-                    dogfood_shadow.assign_one_variation(run, exp_dir)
-        result = dogfood_shadow.export_all_to_downloads(exp_dir, downloads)
-        print(json.dumps(result, ensure_ascii=False, indent=2))
-        return 0
-
-    if args.cmd == "next-blind":
-        slot = dogfood_shadow.next_blind_slot(exp_dir, run_id=args.run_id)
-        if slot is None:
-            print("no pending blind slot", file=sys.stderr)
-            return 1
-        safe = {
-            "run_id": slot["run_id"],
-            "blind_letter": slot["blind_letter"],
-            "status": slot["status"],
-            "reading": slot.get("reading") or slot.get("output"),
-            "arm_path": slot["path"],
-            "model_is_producer": True,
-            "rule": "model under test writes the report via its CLI",
-        }
-        print(json.dumps(safe, ensure_ascii=False, indent=2))
-        print(
-            f"edge-dogfood-shadow: issued model={slot['model']} "
-            f"(producer CLI; do not show operator)",
-            file=sys.stderr,
-        )
-        return 0
-
-    if args.cmd == "mark-blind":
-        st = dogfood_shadow.mark_blind_done(
-            exp_dir, run_id=args.run_id, model=args.model)
-        dogfood_shadow.export_all_to_downloads(exp_dir, downloads)
-        print(json.dumps(st, ensure_ascii=False, indent=2))
-        return 0
-
-    if args.cmd == "live":
-        path = dogfood_shadow.refresh_live_index(exp_dir)
-        print(path)
-        return 0
-
-    return 2
+    except runtime_policy.RuntimePolicyError as exc:
+        print(f"edge-dogfood-shadow: {exc}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/tools/edge-heartbeat
+++ b/tools/edge-heartbeat
@@ -1,174 +1,38 @@
 #!/usr/bin/env python3
-"""edge-heartbeat — autonomous beat launcher (ADR-0003).
+"""Fail-closed autonomous launcher for the Hermes-only derivative.
 
-Runs the beat as a single-shot headless CLI fed the /ed-beat skill body.
-
-Runtimes (``agent.yaml`` ``heartbeat.cli`` or ``EDGE_BEAT_CLI`` / ``--cli``):
-  - ``claude`` — ``claude -p -`` (default genotype)
-  - ``opus`` / ``fable`` — same claude CLI with ``--model opus|fable``
-  - ``grok`` — ``grok --always-approve --prompt-file …``
-  - ``codex`` — ``codex exec … -`` (prompt on stdin)
-  - ``random`` — weighted draw: 33% grok · 33% codex · 16.5% opus · 16.5% fable
-
-No cognition here, no envelope, no retry — cognition lives in the skill.
-Interactive dispatch does not use this: the live session runs /ed-beat in-place.
+The upstream heartbeat implementations target Claude, Codex, or Grok. They remain in
+history/adapters for the later parity phase, but no autonomous process may launch until a
+Hermes-native heartbeat has been implemented and verified.
 """
+from __future__ import annotations
+
 import argparse
-import json
-import os
-import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import _beat
-
-
-# CLI tokens that run on the Anthropic claude binary (optional --model).
-_CLAUDE_FAMILY = frozenset({"claude", "opus", "fable"})
-_ALL_CLIS = tuple(sorted(_beat.FIXED_HEARTBEAT_CLIS | {"random"}))
+import runtime_policy
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--home", required=True)
-    ap.add_argument("--group", default=None,
-                    help="Override the graph group for the cortex door (else identity resolves it)")
-    ap.add_argument("--dispatch-id", default=None,
-                    help="Stable plan id for an idempotent retry (default: mint one invocation id)")
-    ap.add_argument("--cli", default=None, choices=_ALL_CLIS,
-                    help="Headless runtime override (default: agent.yaml heartbeat.cli or claude)")
-    ap.add_argument("--dry-run", action="store_true", help="Print the command and prompt; do not invoke")
-    args = ap.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--home", required=True)
+    parser.add_argument("--group", default=None)
+    parser.add_argument("--dispatch-id", default=None)
+    parser.add_argument("--cli", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
 
-    home = Path(os.path.expanduser(args.home)).resolve()
-    # Onboarding gate (bootstrap path only): refuse until phenotype + grill complete.
-    # Legacy installs (agent.yaml, no state/bootstrap.json) are unchanged.
     try:
-        import onboarding
-        boot = home / "state" / "bootstrap.json"
-        if boot.is_file() and not onboarding.is_onboarding_complete(home):
-            onboarding.assert_production_allowed(home)
-    except RuntimeError as e:
-        print(f"edge-heartbeat: {e}", file=sys.stderr)
-        sys.exit(2)
-    except ImportError:
-        pass
-    prompt = _beat.load_beat_prompt(home)
-
-    if args.cli == "random":
-        cli = _beat.pick_heartbeat_cli()
-    elif args.cli:
-        cli = args.cli.strip().lower()
-    else:
-        cli = _beat.heartbeat_cli(home)
-    if cli not in _beat.FIXED_HEARTBEAT_CLIS:
-        cli = "claude"
-
-    print(f"edge-heartbeat: cli={cli}", file=sys.stderr)
-
-    mcp_config_path = None
-    use_stdin = True
-    prompt_file = None
-    cmd = None
-
-    if cli in _CLAUDE_FAMILY:
-        try:
-            claude_bin = _beat.resolve_claude_bin()
-        except FileNotFoundError:
-            if not args.dry_run:
-                raise
-            claude_bin = "claude"
-        # Slice 6 (F1) — cortex door on lead beat (claude MCP only).
-        try:
-            mcp_config_path = _beat.ensure_cortex_config(home, group=args.group)
-        except Exception as e:  # noqa: BLE001
-            print(f"edge-heartbeat: cortex door not registered ({type(e).__name__}: {e}) — "
-                  f"the beat runs without mid-turn recall; recall still seeds at wake",
-                  file=sys.stderr)
-            mcp_config_path = None
-        model = cli if cli in ("opus", "fable") else None
-        cmd = _beat.build_beat_command(
-            claude_bin, mcp_config_path=mcp_config_path, model=model)
-        use_stdin = True
-    elif cli == "codex":
-        try:
-            codex_bin = _beat.resolve_codex_bin()
-        except FileNotFoundError:
-            if not args.dry_run:
-                raise
-            codex_bin = "codex"
-        cmd = _beat.build_codex_beat_command(codex_bin, home)
-        use_stdin = True
-    else:
-        # grok
-        try:
-            grok_bin = _beat.resolve_grok_bin()
-        except FileNotFoundError:
-            if not args.dry_run:
-                raise
-            grok_bin = "grok"
-        prompt_dir = home / "state" / "beat"
-        prompt_dir.mkdir(parents=True, exist_ok=True)
-        prompt_file = prompt_dir / "last-heartbeat-prompt.md"
-        use_stdin = False
-        cmd = _beat.build_grok_beat_command(grok_bin, prompt_file, home)
-
-    if args.dry_run and use_stdin:
-        print(" ".join(cmd))
-        print("--- prompt ---")
-        print(prompt)
-        return
-
-    dispatch_id = args.dispatch_id or _beat.mint_plan_dispatch_id()
-    # PRE-LAUNCH plan (ADR-0024): no proposta exists before the agent runs the Pauta
-    # funnel — producer is explicitly pendente; the trunk re-derives the plan through
-    # the same seam (dispatch-plan CLI, require_pauta) before opening Ato-2.
-    plan = _beat.dispatch_plan(
-        "lead", dispatch_id,
-        runtime_command=cmd,
-        log=home / "state" / "events" / "log.jsonl",
-        require_pauta=False,
-    )
-    prompt = _beat.bind_dispatch_plan(prompt, plan)
-    child_env = _beat.build_beat_env(home)
-    child_env["EDGE_DISPATCH_PLAN"] = json.dumps(plan, ensure_ascii=False, sort_keys=True)
-    child_env["EDGE_DISPATCH_PLAN_ID"] = dispatch_id
-    child_env["EDGE_BEAT_CLI"] = cli
-
-    if cli == "grok":
-        # Rebuild command after plan is bound; write full prompt to disk for --prompt-file.
-        prompt_file.write_text(prompt, encoding="utf-8")
-        cmd = _beat.build_grok_beat_command(
-            cmd[0] if cmd else _beat.resolve_grok_bin(), prompt_file, home)
-        plan = {**plan, "runtime_command": cmd}
-        if args.dry_run:
-            print(" ".join(cmd))
-            print("--- prompt-file ---", prompt_file)
-            print(prompt[:2000])
-            return
-
-    import eventlog
-    log = home / "state" / "events" / "log.jsonl"
-    with _beat.heartbeat_lock(home):
-        before_count = len(eventlog.corpus_at(log=log))
-
-        if use_stdin:
-            rc = subprocess.run(cmd, cwd=str(home), input=prompt, text=True,
-                                env=child_env).returncode
-        else:
-            rc = subprocess.run(cmd, cwd=str(home), text=True, env=child_env).returncode
-        if rc != 0:
-            sys.exit(rc)
-
-        # Post-gate carries the dente: artefatos require a live pauta.proposta whose
-        # forma matches; a logged pauta.silencio is the honest no-produce (never punished).
-        gaps = _beat.assert_beat_produced(log, before_count, dispatch_id=dispatch_id)
-    if gaps:
-        for gap in gaps:
-            print(f"edge-heartbeat: beat exited 0 but produced no corpus progress: {gap}",
-                  file=sys.stderr)
-        sys.exit(1)
+        if args.cli is not None:
+            runtime_policy.require_allowed_harness(args.cli)
+        raise runtime_policy.RuntimePolicyError(
+            "autonomous heartbeat is blocked until Hermes-native parity is implemented"
+        )
+    except runtime_policy.RuntimePolicyError as exc:
+        print(f"edge-heartbeat: {exc}", file=sys.stderr)
+        raise SystemExit(2) from None
 
 
 if __name__ == "__main__":

--- a/tools/harvest.py
+++ b/tools/harvest.py
@@ -77,8 +77,9 @@ import _envconf                     # noqa: E402  # EDGE_GROUNDING_FLOOR knob (S
 # never rewritten, the interpretation is versioned.
 RECOGNIZER_REV = 1
 
-STORE_ROOT = Path.home() / ".claude" / "projects"
+STORE_ROOT = None
 import _identity as _id_state
+import runtime_policy
 CURSORS = _id_state.state_root() / "state" / "harvest-cursors.json"
 
 # Opaque-script recognition (B2) is a CATEGORY, not a source registry: a script is opaque
@@ -1670,6 +1671,7 @@ def harvest(log=eventlog.LOG, cursors_path=CURSORS, project_dirs=None, store_roo
     whose per-file VALUE is corrupt (non-int, bool, negative) clamps THAT entry to 0 — either
     way flagged + printed, and the ranked/brute dedup makes the re-read a no-op. Everything
     else is fail-dark per row, counted and printed."""
+    runtime_policy.require_session_ingestion_ready()
     if project_dirs is not None:
         dirs = [Path(p) for p in project_dirs]
         if not any(d.is_dir() for d in dirs):
@@ -1819,6 +1821,7 @@ def session_floor(session_id, recognizers=None, store_root=None):
     read). Returns {"reads", "recognized", "dark", "reason"} and NEVER raises: a floor that
     cannot see is a counted `grounding.floor_dark` (S6), not a crash in the close."""
     try:
+        runtime_policy.require_session_ingestion_ready()
         surface, _raw_id = sessions_mod.split_session_anchor(session_id)
         if surface == "codex":
             session = sessions_mod.find_codex_session(session_id)

--- a/tools/llm_routes.py
+++ b/tools/llm_routes.py
@@ -15,6 +15,7 @@ import shutil
 from pathlib import Path
 
 import _llm
+import runtime_policy
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -22,6 +23,13 @@ REPO = Path(__file__).resolve().parent.parent
 EMBEDDING_ROUTE = "embedding"
 
 KNOWN_PROVIDERS = tuple(_llm.PROVIDER_BASE_URLS) + _llm.SUBSCRIPTION_PROVIDERS
+
+
+def allowed_providers_for_route(route: str) -> tuple[str, ...]:
+    """Options exposed by public route mutation surfaces."""
+    if route == EMBEDDING_ROUTE:
+        return tuple(sorted(runtime_policy.ALLOWED_EMBEDDING_PROVIDERS))
+    return ("hermes",)
 
 
 def _load_routers(repo):
@@ -92,7 +100,7 @@ def embed_fn(repo=REPO):
     key = _secret_value(repo, r.get("secret_ref"))
     if not key:
         return None
-    client = _llm_mod().make_client(r, key)
+    client = _llm_mod().make_embedding_client(r, key)
     model = r.get("model") or "text-embedding-3-small"
     return lambda text: client.embeddings.create(
         model=model, input=text).data[0].embedding
@@ -105,7 +113,10 @@ def probe_route(route, repo=REPO):
         return {"ok": False, "status": None, "detail": f"rota desconhecida: {route!r}"}
     r = routers[route]
     try:
-        client = _llm.make_client(r, _secret_value(repo, r.get("secret_ref")))
+        if route == EMBEDDING_ROUTE:
+            client = _llm.make_embedding_client(r, _secret_value(repo, r.get("secret_ref")))
+        else:
+            client = _llm.make_client(r, _secret_value(repo, r.get("secret_ref")))
     except Exception as e:  # noqa: BLE001 — provider fora do registry etc.
         return {"ok": False, "status": None, "detail": str(e)[:140]}
     kind = "embedding" if route == EMBEDDING_ROUTE else "chat"
@@ -116,14 +127,17 @@ def set_provider(route, provider, repo=REPO, model=None):
     """Troca o provider (e opcionalmente o modelo) de UMA rota no agent.yaml do host,
     por cirurgia de linha — todo o resto do arquivo (comentários inclusos) intacto.
     Recusa rota/provider desconhecidos e provider de assinatura na rota embedding."""
-    if provider not in KNOWN_PROVIDERS:
-        raise ValueError(f"provider desconhecido: {provider!r} (conheço {KNOWN_PROVIDERS})")
     routers = _load_routers(repo)
     if route not in routers:
         raise ValueError(f"rota desconhecida: {route!r} (agent.yaml tem {tuple(routers)})")
-    if route == EMBEDDING_ROUTE and provider in _llm.SUBSCRIPTION_PROVIDERS:
-        raise ValueError("a rota embedding não roteia via assinatura (sem endpoint de "
-                         "embedding) — precisa de chave de API ou modelo local")
+    if route == EMBEDDING_ROUTE:
+        candidate = dict(routers[route])
+        candidate["provider"] = provider
+        if model is not None:
+            candidate["model"] = model
+        runtime_policy.require_allowed_embedding_router(candidate)
+    else:
+        runtime_policy.require_allowed_harness(provider)
 
     path = Path(repo) / "agent.yaml"
     lines = path.read_text().splitlines(keepends=True)
@@ -157,14 +171,7 @@ def completer_for(route, repo=REPO, max_tokens=4000, exec_fn=None):
     if route not in routers:
         raise ValueError(f"rota desconhecida: {route!r}")
     r = routers[route]
-    if r.get("provider") in _llm.SUBSCRIPTION_PROVIDERS:
-        client = _llm._SUBSCRIPTION_CLIENTS[r["provider"]](exec_fn=exec_fn)
-    else:
-        key = _secret_value(repo, r.get("secret_ref"))
-        if not key:
-            raise _llm.LLMTransportError(
-                f"rota {route!r} ({r.get('provider')}): credencial ausente "
-                f"({r.get('secret_ref')})")
-        client = _llm.make_client(r, key)
+    runtime_policy.require_allowed_harness(r.get("provider"))
+    client = _llm.make_client(r, exec_fn=exec_fn)
     model = r.get("model")
     return lambda prompt: _llm.complete(client, model, prompt, max_tokens=max_tokens)

--- a/tools/onboarding.py
+++ b/tools/onboarding.py
@@ -201,11 +201,14 @@ def require_backfill_days(cli_value: Optional[int | str], env: Optional[dict] = 
 def resolve_adversarial_cast(
     members: Optional[list[str]],
     *,
-    primary: str = "claude",
+    primary: str = "hermes",
     available: Optional[list[str]] = None,
 ) -> dict[str, Any]:
-    """Who runs blind review. Empty/unavailable → self (primary model)."""
-    primary = (primary or "claude").strip() or "claude"
+    """Who runs blind review. Empty/unavailable → self (primary Hermes model)."""
+    import runtime_policy
+
+    runtime_policy.require_allowed_harness(primary)
+    runtime_policy.require_allowed_adversarials(members)
     requested = [m.strip().lower() for m in (members or []) if m and str(m).strip()]
     # de-dupe preserve order
     seen = set()
@@ -436,14 +439,24 @@ def bootstrap_cfg(
     adversarials: dict,
     embedding: Optional[dict],
     inventory: Optional[dict] = None,
-    primary: str = "claude",
+    primary: str = "hermes",
     heartbeat_interval: str = "8h",
+    hermes_home: Optional[Path | str] = None,
 ) -> dict:
     """Minimal phenotype-shaped cfg for bootstrap (pre–agent.yaml).
 
     Always declares ``env_dir`` as the install secrets folder (CONTRACT C4): the operator
     delivers keys there; apply/onboarding only read. Values never enter this cfg.
     """
+    import runtime_policy
+
+    runtime_policy.require_allowed_harness(primary)
+    runtime_policy.require_allowed_adversarials(adversarials.get("members") if adversarials else None)
+    if adversarials and adversarials.get("primary"):
+        runtime_policy.require_allowed_harness(adversarials["primary"])
+    dedicated_hermes_home = None
+    if hermes_home is not None:
+        dedicated_hermes_home = runtime_policy.require_dedicated_hermes_home(hermes_home)
     home_p = Path(home).expanduser()
     home_s = str(home_p)
     if home_s.startswith(str(Path.home())):
@@ -464,16 +477,11 @@ def bootstrap_cfg(
     routers = _routers_for_cfg(cast, cast.get("primary") or primary, embedding)
     # neo4j is not a router — graph password lives in secrets/neo4j.env (EDGE_NEO4J_PASSWORD)
     sources = _sources_from_inventory(inventory)
-    # Multi-CLI: declare every surface installed on this host (claude + codex + grok)
-    try:
-        import surfaces_cfg as _surfaces
-        surfaces_block = _surfaces.surfaces_block_for_installed()
-    except Exception:
-        surfaces_block = {
-            "claude": {"enabled": True},
-            "codex": {"enabled": True, "home": "~/.codex"},
-            "grok": {"enabled": True, "home": "~/.grok"},
-        }
+    # Authorization is deterministic and never depends on host autodetection.
+    hermes_surface: dict[str, Any] = {"enabled": True}
+    if dedicated_hermes_home is not None:
+        hermes_surface["home"] = str(dedicated_hermes_home)
+    surfaces_block = {"hermes": hermes_surface}
     cfg: dict[str, Any] = {
         "name": name,
         "codename": name,
@@ -723,7 +731,7 @@ def emit_phenotype(
     emb = boot.get("embedding")
     if emb is None:
         emb = embedding_from_inventory(inv)
-    cast = boot.get("adversarials") or resolve_adversarial_cast([], primary="claude")
+    cast = boot.get("adversarials") or resolve_adversarial_cast([], primary="hermes")
     cfg = bootstrap_cfg(
         home=home,
         name=boot["name"],
@@ -732,7 +740,8 @@ def emit_phenotype(
         embedding=emb,
         heartbeat_interval=heartbeat_interval or boot.get("heartbeat_interval") or "8h",
         inventory=inv,
-        primary=cast.get("primary") or "claude",
+        primary=cast.get("primary") or "hermes",
+        hermes_home=boot.get("hermes_home"),
     )
     if mission:
         cfg["mission"] = mission
@@ -831,10 +840,15 @@ def finish_onboarding(
     heartbeat_interval: Optional[str] = None,
     run=None,
 ) -> Path:
-    """Mentor close seam: grill_gate must pass, then emit phenotype; optional heartbeat enable.
+    """Mentor close seam: grill_gate must pass, then emit phenotype.
 
-    O intervalo vem da ENTREVISTA do onboarding (operador 2026-07-25) — entra no fenótipo e
-    no render do .timer (install_heartbeat), nunca só no systemctl enable."""
+    Autonomous heartbeat is intentionally fail-closed until Hermes-native parity exists.
+    """
+    if enable_heartbeat:
+        import runtime_policy
+        raise runtime_policy.RuntimePolicyError(
+            "heartbeat enablement is blocked until Hermes-native parity is implemented"
+        )
     home = Path(home).expanduser()
     import grill_gate
     import eventlog as _eventlog
@@ -845,14 +859,6 @@ def finish_onboarding(
         home, mission=mission, voice=voice, mentee=mentee,
         heartbeat_interval=heartbeat_interval,
     )
-    if enable_heartbeat:
-        import yaml
-        import _provision
-        kwargs = {}
-        if run is not None:
-            kwargs["run"] = run
-        cfg = yaml.safe_load(path.read_text()) or {}
-        _provision.install_heartbeat(cfg, home, **kwargs)   # renderiza timer com o intervalo + enable
     return path
 
 
@@ -862,11 +868,18 @@ def run_bootstrap(
     name: str,
     backfill_days: int,
     adversarials: Optional[list[str]] = None,
-    primary: str = "claude",
+    primary: str = "hermes",
     provision_skills: bool = True,
+    hermes_home: Optional[Path | str] = None,
     embedding_choice: Optional[dict] = None,
 ) -> dict:
     """Layout + secrets inventory + bootstrap.json. Never enables heartbeat."""
+    import runtime_policy
+
+    runtime_policy.require_allowed_harness(primary)
+    runtime_policy.require_allowed_adversarials(adversarials)
+    if provision_skills:
+        hermes_home = runtime_policy.require_dedicated_hermes_home(hermes_home)
     home = Path(home).expanduser()
     name = require_name(name)
     # #154: home que já pertence a OUTRO install = recusa (instalar por cima clobbera —
@@ -902,6 +915,8 @@ def run_bootstrap(
         "embedding": emb,
         "edge_home": str(home),
     }
+    if hermes_home is not None:
+        payload["hermes_home"] = str(hermes_home)
     persist_bootstrap(home, **payload)
     stamp_secrets_cursor(home, inv)
     cfg = bootstrap_cfg(
@@ -912,6 +927,7 @@ def run_bootstrap(
         embedding=emb,
         inventory=inv,
         primary=primary,
+        hermes_home=hermes_home,
     )
     # Doctrine seeds → install memory (o purge 2026-07-25 tirou memory/ do genótipo e
     # levou a doutrina junto — method/personality/canone são CORE, o wake exige space-0).
@@ -952,36 +968,23 @@ def run_bootstrap(
     if provision_skills:
         try:
             import surfaces_cfg
-            import _claude_provision
-            import _grok_provision
-            import _codex_provision
             import _hermes_provision
 
             repo = Path(__file__).resolve().parent.parent
             installed = surfaces_cfg.detect_installed_surfaces()
             provisioned = []
-            # Always try all installed harnesses (operator: install on claude + codex + grok)
-            if installed.get("claude", True):
-                claude_home = Path.home() / ".claude"
-                for row in _claude_provision.provision_claude(cfg, repo, claude_home):
-                    provisioned.append(f"claude: {row}")
-            if installed.get("codex", False) or surfaces_cfg.provision_surface("codex", cfg=cfg):
-                codex_home = Path.home() / ".codex"
-                for row in _codex_provision.provision_codex(cfg, repo, home, codex_home):
-                    provisioned.append(f"codex: {row}")
-            if installed.get("grok", False) or surfaces_cfg.provision_surface("grok", cfg=cfg):
-                grok_home = Path.home() / ".grok"
-                for row in _grok_provision.provision_grok(cfg, repo, home, grok_home):
-                    provisioned.append(f"grok: {row}")
-            if installed.get("hermes", False) or surfaces_cfg.provision_surface("hermes", cfg=cfg):
-                hermes_home = Path.home() / ".hermes"
-                for row in _hermes_provision.provision_hermes(cfg, repo, home, hermes_home):
-                    provisioned.append(f"hermes: {row}")
+            for row in _hermes_provision.provision_hermes(
+                cfg,
+                repo,
+                home,
+                Path(hermes_home),
+            ):
+                provisioned.append(f"hermes: {row}")
             payload["provisioned_surfaces"] = provisioned
             payload["installed_surfaces"] = installed
         except Exception as e:  # noqa: BLE001 — bootstrap still succeeds; report
             payload["provision_warning"] = f"{type(e).__name__}: {e}"
-    # never call install_heartbeat here
+
     payload["secrets_inventory"] = {"files": inv["files"], "vars": inv["vars"]}
     payload["heartbeat"] = "off"
     return payload

--- a/tools/runtime_policy.py
+++ b/tools/runtime_policy.py
@@ -1,0 +1,189 @@
+"""Central fail-closed harness policy for the Hermes-only derivative."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+import re
+from typing import Any
+
+ALLOWED_HARNESSES = frozenset({"hermes"})
+ALLOWED_EMBEDDING_PROVIDERS = frozenset({"openai", "openrouter", "azure", "custom"})
+_FORBIDDEN_MODEL_MARKERS = ("claude", "codex", "grok")
+
+
+class RuntimePolicyError(ValueError):
+    """A requested runtime capability violates the derivative policy."""
+
+
+def require_allowed_harness(harness: object) -> str:
+    """Return the canonical harness or fail before any caller side effect."""
+    if not isinstance(harness, str) or harness not in ALLOWED_HARNESSES:
+        raise RuntimePolicyError(
+            f"harness {harness!r} is forbidden; allowed harnesses: hermes"
+        )
+    return harness
+
+
+def require_allowed_adversarials(values: object) -> tuple[str, ...]:
+    """Allow only Hermes sessions or the explicit same-model ``self`` fallback."""
+    if values is None:
+        return ()
+    if not isinstance(values, (list, tuple)):
+        raise RuntimePolicyError("adversarials must be a list")
+    allowed = []
+    for value in values:
+        if value == "self":
+            allowed.append(value)
+            continue
+        allowed.append(require_allowed_harness(value))
+    return tuple(allowed)
+
+
+def require_dedicated_hermes_home(
+    home: object,
+    *,
+    default_home: object | None = None,
+) -> Path:
+    """Require an explicit Hermes home that is not the active/global profile."""
+    if not isinstance(home, (str, Path)) or not str(home).strip():
+        raise RuntimePolicyError("an explicit dedicated Hermes home is required")
+    resolved = Path(home).expanduser().resolve(strict=False)
+    global_home = (
+        Path.home() / ".hermes"
+        if default_home is None
+        else Path(default_home).expanduser()
+    ).resolve(strict=False)
+    if resolved == global_home:
+        raise RuntimePolicyError(
+            f"Hermes home {resolved} is the global/default profile; use a dedicated profile"
+        )
+    return resolved
+
+
+def require_session_ingestion_ready() -> None:
+    """Session ingestion stays dark until a reviewed Hermes-native reader exists."""
+    raise RuntimePolicyError(
+        "session ingestion is dark until a Hermes-native session reader is implemented"
+    )
+
+
+def require_hermes_safe_skill_tree(skills_root: Path | str) -> Path:
+    """Reject provisioned instructions that mention an external harness."""
+    root = Path(skills_root)
+    forbidden = re.compile(r"\b(?:claude|codex|grok)\b", re.IGNORECASE)
+    for path in sorted(root.rglob("*.md")) if root.exists() else ():
+        if forbidden.search(path.read_text(encoding="utf-8")):
+            raise RuntimePolicyError(
+                f"skill {path.relative_to(root)} references a forbidden external harness"
+            )
+    return root
+
+
+def require_allowed_embedding_router(router: object) -> dict:
+    """Validate the narrow API-only exception used exclusively for embeddings."""
+    if not isinstance(router, dict):
+        raise RuntimePolicyError("embedding router must be a mapping")
+    provider = router.get("provider")
+    if not isinstance(provider, str) or provider not in ALLOWED_EMBEDDING_PROVIDERS:
+        raise RuntimePolicyError(
+            f"embedding provider {provider!r} is forbidden; allowed providers: "
+            + ", ".join(sorted(ALLOWED_EMBEDDING_PROVIDERS))
+        )
+    model = router.get("model")
+    if model is not None:
+        if not isinstance(model, str) or not model.strip():
+            raise RuntimePolicyError("embedding model must be a non-empty string")
+        lowered = model.lower()
+        if any(marker in lowered for marker in _FORBIDDEN_MODEL_MARKERS):
+            raise RuntimePolicyError(f"embedding model {model!r} selects a forbidden model family")
+    if provider in {"azure", "custom"}:
+        base_url = router.get("base_url")
+        if not isinstance(base_url, str) or not base_url.strip():
+            raise RuntimePolicyError(f"embedding provider {provider!r} requires explicit base_url")
+    return router
+
+
+def require_hermes_only_surfaces(cfg: object) -> dict:
+    """Reject any explicitly declared surface outside the Hermes allowlist."""
+    if not isinstance(cfg, dict):
+        raise RuntimePolicyError("runtime config must be a mapping")
+    surfaces = cfg.get("surfaces")
+    if surfaces is None:
+        surfaces = {}
+    if not isinstance(surfaces, dict):
+        raise RuntimePolicyError("surfaces must be a mapping")
+    forbidden = sorted(set(surfaces) - ALLOWED_HARNESSES)
+    if forbidden:
+        raise RuntimePolicyError(
+            "forbidden surfaces declared: " + ", ".join(forbidden)
+        )
+    return surfaces
+
+
+def _require_no_forbidden_selector_markers(value: object, path: str) -> None:
+    if isinstance(value, str):
+        lowered = value.lower()
+        if any(marker in lowered for marker in _FORBIDDEN_MODEL_MARKERS):
+            raise RuntimePolicyError(f"{path} references a forbidden external harness")
+        return
+    if isinstance(value, dict):
+        inert_text_fields = {"directive", "prompt", "description", "instruction", "instructions"}
+        for key, item in value.items():
+            child = f"{path}.{key}"
+            if isinstance(key, str):
+                lowered = key.lower()
+                if any(marker in lowered for marker in _FORBIDDEN_MODEL_MARKERS):
+                    raise RuntimePolicyError(f"{child} references a forbidden external harness")
+                if lowered in inert_text_fields:
+                    continue
+            _require_no_forbidden_selector_markers(item, child)
+        return
+    if isinstance(value, (list, tuple, set)):
+        for index, item in enumerate(value):
+            _require_no_forbidden_selector_markers(item, f"{path}[{index}]")
+
+
+def require_hermes_only_runtime_config(cfg: object) -> dict:
+    """Validate every public harness selector in an agent configuration."""
+    require_hermes_only_surfaces(cfg)
+    assert isinstance(cfg, dict)  # narrowed by require_hermes_only_surfaces
+    for selector in ("primary", "adversarials", "heartbeat", "execution_subagents", "subagents"):
+        if selector in cfg:
+            _require_no_forbidden_selector_markers(cfg[selector], selector)
+
+    routers = cfg.get("routers")
+    if routers is None:
+        routers = {}
+    if not isinstance(routers, dict):
+        raise RuntimePolicyError("routers must be a mapping")
+    for route, router in routers.items():
+        if route == "embedding":
+            require_allowed_embedding_router(router)
+            continue
+        if not isinstance(router, dict):
+            raise RuntimePolicyError(f"router {route!r} must be a mapping")
+        provider = router.get("provider")
+        if provider is None:
+            raise RuntimePolicyError(f"router {route!r} must declare provider=hermes")
+        require_allowed_harness(provider)
+
+    heartbeat = cfg.get("heartbeat")
+    if heartbeat is None:
+        heartbeat = {}
+    if not isinstance(heartbeat, dict):
+        raise RuntimePolicyError("heartbeat must be a mapping")
+    heartbeat_cli = heartbeat.get("cli")
+    if heartbeat_cli is not None:
+        require_allowed_harness(heartbeat_cli)
+    return cfg
+
+
+def run_for_harness(
+    harness: object,
+    operation: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Validate the harness, then and only then invoke ``operation``."""
+    require_allowed_harness(harness)
+    return operation(*args, **kwargs)

--- a/tools/sessions.py
+++ b/tools/sessions.py
@@ -16,6 +16,9 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from functools import wraps
+
+import runtime_policy
 
 # Operator-facing chat surfaces the edge films. Rationalization plans over all three.
 SURFACES = ("claude", "codex", "grok")
@@ -732,3 +735,27 @@ def delta(path, since_line: int, surface="claude"):
             watermark -= 1          # leave the half-flushed tail for the next sweep
             new = new[:-1]
     return _turns_from_lines(new, surface=surface), watermark
+
+# Public ingestion choke point. Legacy parsers remain private for migration/unit evidence,
+# but every operational name fails before resolving paths or opening transcript files.
+def _dark_session_reader(fn):
+    @wraps(fn)
+    def blocked(*args, **kwargs):
+        runtime_policy.require_session_ingestion_ready()
+        return fn(*args, **kwargs)
+    return blocked
+
+
+_legacy_list_sessions = list_sessions
+_legacy_list_codex_sessions = list_codex_sessions
+_legacy_list_grok_sessions = list_grok_sessions
+_legacy_dialogue_turns = dialogue_turns
+_legacy_read_turns = read_turns
+_legacy_current_session_anchor = current_session_anchor
+
+list_sessions = _dark_session_reader(_legacy_list_sessions)
+list_codex_sessions = _dark_session_reader(_legacy_list_codex_sessions)
+list_grok_sessions = _dark_session_reader(_legacy_list_grok_sessions)
+dialogue_turns = _dark_session_reader(_legacy_dialogue_turns)
+read_turns = _dark_session_reader(_legacy_read_turns)
+current_session_anchor = _dark_session_reader(_legacy_current_session_anchor)

--- a/tools/surfaces_cfg.py
+++ b/tools/surfaces_cfg.py
@@ -4,35 +4,26 @@ The edge digests operator sessions from one or more harness stores. Which stores
 phenotype config (agent.yaml `surfaces`), not a code fork. Env overrides still win for hermetic
 tests and host paths (EDGE_*_SESSIONS_DIR, CODEX_HOME, GROK_HOME).
 
-Shape (all keys optional; missing `surfaces` block preserves historical defaults):
+Hermes-only policy:
 
   surfaces:
-    claude:
+    hermes:
       enabled: true
-    codex:
-      enabled: true
-      home: "~/.codex"          # sessions under <home>/sessions
-    grok:
-      enabled: true
-      home: "~/.grok"
-      # active_sessions: optional path; default <home>/active_sessions.json
+      home: "~/.hermes"
 
-Defaults when `surfaces` is absent:
-  claude enabled, codex enabled, grok enabled (parity after the third surface landed).
-When `surfaces` IS present, each surface defaults to enabled=false unless listed with
-enabled:true — so installs opt in by declaration.
+Detection may inventory legacy CLI homes, but configuration cannot authorize them.
+When `surfaces` is absent, only Hermes is enabled.
 """
 from __future__ import annotations
 
 import os
 from pathlib import Path
 
-# Historical defaults when agent.yaml has no `surfaces` block at all.
+import runtime_policy
+
+# Hermes-only defaults when agent.yaml has no `surfaces` block.
 _ABSENT_BLOCK_DEFAULTS = {
-    "claude": {"enabled": True},
-    "codex": {"enabled": True, "home": "~/.codex"},
-    "grok": {"enabled": True, "home": "~/.grok"},
-    "hermes": {"enabled": True, "home": "~/.hermes"},
+    "hermes": {"enabled": True},
 }
 
 # CLI harness homes (relative to $HOME). Presence of the home dir = surface is installed.
@@ -68,21 +59,16 @@ def detect_installed_surfaces(env=None, home=None) -> dict[str, bool]:
 
 
 def surfaces_block_for_installed(env=None, home=None) -> dict:
-    """Phenotype `surfaces:` block enabling every installed harness."""
+    """Declare Hermes only when a dedicated HERMES_HOME is explicitly installed."""
+    env = os.environ if env is None else env
     installed = detect_installed_surfaces(env=env, home=home)
-    block = {}
-    for name, ok in installed.items():
-        if not ok:
-            continue
-        if name == "claude":
-            block[name] = {"enabled": True}
-        elif name == "codex":
-            block[name] = {"enabled": True, "home": "~/.codex"}
-        elif name == "grok":
-            block[name] = {"enabled": True, "home": "~/.grok"}
-        elif name == "hermes":
-            block[name] = {"enabled": True, "home": "~/.hermes"}
-    return block
+    if not installed.get("hermes"):
+        return {}
+    raw = env.get("HERMES_HOME")
+    if not isinstance(raw, str) or not raw.strip():
+        return {}
+    dedicated = runtime_policy.require_dedicated_hermes_home(raw.strip())
+    return {"hermes": {"enabled": True, "home": str(dedicated)}}
 
 
 def load_agent_cfg(agent_yaml=None) -> dict:
@@ -123,69 +109,41 @@ def surface_entry(name: str, cfg: dict | None = None, agent_yaml=None) -> dict:
 
 
 def surface_enabled(name: str, cfg: dict | None = None, agent_yaml=None) -> bool:
-    """Whether agent.yaml enables this surface for real (non-hermetic) sweeps."""
+    """Whether Hermes-only policy enables this surface for real sweeps."""
+    if name not in runtime_policy.ALLOWED_HARNESSES:
+        return False
     entry = surface_entry(name, cfg=cfg, agent_yaml=agent_yaml)
     val = entry.get("enabled", False)
     return bool(val)
 
 
 def surface_home(name: str, cfg: dict | None = None, agent_yaml=None, env=None) -> Path | None:
-    """Resolved home dir for an optional surface (codex/grok), or None if unset.
-
-    Precedence for codex: CODEX_HOME env → agent.yaml surfaces.codex.home → ~/.codex
-    Precedence for grok:  GROK_HOME env  → agent.yaml surfaces.grok.home  → ~/.grok
-    """
+    """Resolve only an explicitly dedicated Hermes home; external surfaces stay opaque."""
+    if name not in runtime_policy.ALLOWED_HARNESSES:
+        return None
     env = os.environ if env is None else env
-    env_key = {"codex": "CODEX_HOME", "grok": "GROK_HOME"}.get(name)
-    if env_key:
-        raw = env.get(env_key)
-        if isinstance(raw, str) and raw.strip():
-            return Path(os.path.expanduser(raw.strip()))
-    entry = surface_entry(name, cfg=cfg, agent_yaml=agent_yaml)
-    home = entry.get("home")
-    if isinstance(home, str) and home.strip():
-        return Path(os.path.expanduser(home.strip()))
-    if name == "codex":
-        return Path.home() / ".codex"
-    if name == "grok":
-        return Path.home() / ".grok"
-    return None
+    raw = env.get("HERMES_HOME")
+    if not isinstance(raw, str) or not raw.strip():
+        raw = surface_entry(name, cfg=cfg, agent_yaml=agent_yaml).get("home")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return runtime_policy.require_dedicated_hermes_home(raw.strip())
 
 
 def surface_sessions_dir(name: str, cfg: dict | None = None, agent_yaml=None, env=None) -> Path | None:
-    """Sessions root for codex/grok. Env EDGE_*_SESSIONS_DIR wins when set."""
-    env = os.environ if env is None else env
-    env_key = {"codex": "EDGE_CODEX_SESSIONS_DIR", "grok": "EDGE_GROK_SESSIONS_DIR"}.get(name)
-    if env_key:
-        raw = env.get(env_key)
-        if isinstance(raw, str) and raw.strip():
-            return Path(os.path.expanduser(raw.strip()))
-    entry = surface_entry(name, cfg=cfg, agent_yaml=agent_yaml)
-    sessions = entry.get("sessions")
-    if isinstance(sessions, str) and sessions.strip():
-        return Path(os.path.expanduser(sessions.strip()))
-    home = surface_home(name, cfg=cfg, agent_yaml=agent_yaml, env=env)
-    if home is None:
+    """Return the dedicated Hermes sessions directory, with no external overrides."""
+    if name not in runtime_policy.ALLOWED_HARNESSES:
         return None
-    return home / "sessions"
+    home = surface_home(name, cfg=cfg, agent_yaml=agent_yaml, env=env)
+    return None if home is None else home / "sessions"
 
 
 def surface_active_sessions_path(name: str, cfg: dict | None = None, agent_yaml=None, env=None) -> Path | None:
-    """Grok (and future) live-session index path."""
-    env = os.environ if env is None else env
-    if name == "grok":
-        raw = env.get("EDGE_GROK_ACTIVE_SESSIONS")
-        if isinstance(raw, str) and raw.strip():
-            return Path(os.path.expanduser(raw.strip()))
-    entry = surface_entry(name, cfg=cfg, agent_yaml=agent_yaml)
-    raw = entry.get("active_sessions")
-    if isinstance(raw, str) and raw.strip():
-        return Path(os.path.expanduser(raw.strip()))
-    home = surface_home(name, cfg=cfg, agent_yaml=agent_yaml, env=env)
-    if home is None:
+    """Return the dedicated Hermes active-session index path, if configured."""
+    if name not in runtime_policy.ALLOWED_HARNESSES:
         return None
-    return home / "active_sessions.json"
-
+    home = surface_home(name, cfg=cfg, agent_yaml=agent_yaml, env=env)
+    return None if home is None else home / "active_sessions.json"
 
 def include_optional_surface(name: str, project_or_store_dir, explicit_dir,
                              cfg: dict | None = None, agent_yaml=None) -> bool:
@@ -199,9 +157,11 @@ def include_optional_surface(name: str, project_or_store_dir, explicit_dir,
       - explicit_dir is None and project_or_store_dir is set → hermetic Claude-only unless
         tests pass explicit_dir
 
-    Assemble rule (operator): pick up **everything installed** — if the harness home exists
-    and agent.yaml enables the surface (or no surfaces block → all enabled by default), include it.
+    Hermes-only rule: external surfaces stay off even when an explicit directory is supplied.
+    Hermes itself may still use the generic override semantics below.
     """
+    if name not in runtime_policy.ALLOWED_HARNESSES:
+        return False
     if explicit_dir is False:
         return False
     if explicit_dir is not None:
@@ -216,14 +176,8 @@ def include_optional_surface(name: str, project_or_store_dir, explicit_dir,
 
 
 def provision_surface(name: str, cfg: dict | None = None, agent_yaml=None) -> bool:
-    """Whether edge-apply / bootstrap should provision skills into this surface's home.
-
-    Claude is always provisioned when its home will be written. Codex/Grok: enabled in yaml
-    **or** installed on the host (first-run / multi-CLI default — provision everything installed).
-    """
-    if name == "claude":
-        return True
-    if surface_enabled(name, cfg=cfg, agent_yaml=agent_yaml):
-        return True
-    # No yaml / first-run: still provision every installed CLI
-    return bool(detect_installed_surfaces().get(name, False))
+    """Whether the Hermes-only derivative may provision this surface."""
+    runtime_policy.require_allowed_harness(name)
+    effective_cfg = load_agent_cfg(agent_yaml) if cfg is None else cfg
+    runtime_policy.require_hermes_only_surfaces(effective_cfg)
+    return surface_enabled(name, cfg=effective_cfg)

--- a/tools/topic_threads.py
+++ b/tools/topic_threads.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import eventlog
 import sessions
+import runtime_policy
 
 
 WINDOW_DAYS = 7
@@ -189,6 +190,7 @@ def _iter_session_files(
     claude_root: str | Path | None = None,
     all_stores: bool | None = None,
 ) -> list[tuple[str, Path]]:
+    runtime_policy.require_session_ingestion_ready()
     if all_stores is None:
         all_stores = project_dir is None and os.environ.get("EDGE_TOPIC_DIRECTION_ALL_STORES", "1") != "0"
     found: list[tuple[str, Path]] = []


### PR DESCRIPTION
## Status

> **Draft / WIP / NO-GO.** This checkpoint is shared for technical review and collaboration. It is **not** approved for merge, installation, onboarding, heartbeat, dogfood, autonomous runtime, or release.

## Summary

This branch preserves a partial Hermes-only hardening derived from `88828cb`:

- adds a central fail-closed runtime policy;
- restricts nominal public completion paths to Hermes;
- separates completion and embedding policy;
- adds dedicated Hermes profile checks;
- darkens selected session, heartbeat, and dogfood entrypoints;
- adds focused policy, provisioning, routing, and side-effect tests;
- records the independent review and reproduced blockers in `docs/reviews/hermes-only-checkpoint-no-go-2026-07-26.md`.

## Verification evidence

### Focused Linux battery

```text
Main:      110/110
Effectful:  61/61
Total:     171/171
```

### Additional checks

- Canonical smoke: `65/65`
- Nominal fail-closed probes: `5/5`, temporary effects `[]`
- Malformed-section fuzz: `17/17` blocked
- Bandit baseline-aware: `0` new medium/high findings
- Ruff: `0` fatal and `0` new security-rule findings
- Literal credentials in the delta: `0`
- Three independent parallel reviewers: **3/3 REJECTED**

## Full-suite status

The full suite is intentionally **not presented as green**:

```text
Base 88828cb: 3368 tests, 254 issues
Derivative:   3401 tests, 403 issues
New:           152
Resolved:        3
```

The delta is concentrated in legacy session/store, sweep, harvest, wake, predispatch, and multi-harness contracts. Some failures are intentional incompatibilities with dark capabilities; others exposed real public bypasses or incoherent coverage.

## Confirmed NO-GO blockers

Safe probes using only stubs and temporary synthetic files reproduced:

1. arbitrary external selectors such as `primary: gemini` are accepted;
2. `heartbeat: {enabled: true}` is accepted;
3. Hermes runtime config can be accepted without a dedicated `HERMES_HOME`;
4. an externally configured model reaches `hermes -m <model>`;
5. the Hermes subprocess does not receive an explicit dedicated-profile environment;
6. `secret_ref` can traverse outside `secrets/`;
7. a public Codex reader can read a synthetic transcript without the dark gate;
8. `edge-bootstrap runtime` reaches the Neo4j provisioner.

Additional review findings include direct completion/embedding paths, effects before dark guards, partial bootstrap state, local commands in provisioned skills that reactivate dark capabilities, and stale multi-harness operational documentation.

## Upstream delta

This checkpoint deliberately remains based on:

```text
88828cbfb6a8eae81e6d2d0fbb70b0c528d3a87c
```

`main` was observed at:

```text
991fc7455492564243ce8186359ba4d01591a937
```

The `88828cb..991fc745` delta should be reviewed separately. This branch was not rebased before preserving the checkpoint.

## Review intent

This Draft PR is intended to:

- preserve the work and evidence;
- let Lucas review the architecture and diff;
- turn reproduced blockers into canonical RED tests;
- decide whether to rebase, cherry-pick selected hardening, or rebuild parts on current `main`.

Please do not merge until a new frozen-snapshot review closes all blockers and the Gate moves from NO-GO to GO.
