### PR TITLE
feat: Cortex employment gate — mining porteiro for Entity/communities

### DIFF
--- a/docs/adr/0025-cortex-entity-intake-is-gated-by-mining-employment-verdict.md
+++ b/docs/adr/0025-cortex-entity-intake-is-gated-by-mining-employment-verdict.md
@@ -1,0 +1,42 @@
+# Cortex Entity intake is gated by the mining employment verdict
+
+## Status
+
+Accepted (2026-07-26). Operator + turing product decision; implemented as `tools/emprego.py`.
+
+## Context
+
+Communities and Graphiti `:Entity` nodes were built from raw session dialogue
+(`sweep.graphiti_ingest` on human+edge `clean_body`). That bypassed Mineração's
+employment judgment (`sessao.racionalizada.stitch.attribution.activity_relevant`).
+
+Live consequence (roberto): mega-clusters mixing real domain work with addresses,
+CNPJs, toy examples, and agent-meta name soup. Glossary already said Atividade /
+employment only; code violated it.
+
+## Decision
+
+1. **Porteiro:** only material accepted as **mentee employment** may enter Cortex
+   Tier-1 (`:Entity` / communities via extraction).
+2. **Verdict source:** `activity_relevant is True` on the current
+   `sessao.racionalizada` (supersedes chain). No second judgment at consolidate.
+3. **Intake body:** deterministic employment digest (FINALIDADE / EXECUCAO /
+   RESULTADO / … / CENAS) — never raw dialogue, never `organizacional.enderecos`.
+4. **`sweep.execute`:** Tier-0 only (episode events + cursors). Raw Graphiti
+   dialogue ingest is deleted.
+5. **Assemble tooth:** residual `session-*` Episodic names block wake
+   (`CODE_EMPLOYMENT`) until `tools/emprego.py --migrate`.
+
+## Consequences
+
+- The session Entity tier becomes **rebuildable from the log**
+  (`reset_bypass` + `project`) — closes the ADR-0006 gap the old ingest admitted.
+- Graphs go **sparse-and-correct** until rationalization backlog drains (accepted).
+- Communities code unchanged: after migration, all Entity = accepted set.
+- Migration preserves curated entities (`parceiro` / `curated_cluster`).
+
+## Rejected alternatives
+
+- **Voz-rail-only cortex** — too narrow for domain maps (emprego is Atividade).
+- **Filter at communities.consolidate** — second judgment; wrong seam.
+- **Pretty cluster names only** — treats symptom, not intake.

--- a/tests/test_assemble_ready.py
+++ b/tests/test_assemble_ready.py
@@ -64,6 +64,31 @@ class ReadyReportIsTheInterface(unittest.TestCase):
         self.assertIn(assemble_ready.CODE_PENDING_DRAIN, msg)
         self.assertIn("pkg-block", msg)
 
+    def test_employment_pipe_miss_on_bypass_residue(self):
+        miss = assemble_ready.check_employment_pipe(
+            bypass_fn=lambda: ["session-abc"])
+        self.assertIsNotNone(miss)
+        self.assertEqual(miss.code, assemble_ready.CODE_EMPLOYMENT)
+        self.assertIn("migrate", miss.detail)
+
+    def test_employment_pipe_clear_on_empty_or_dark(self):
+        self.assertIsNone(assemble_ready.check_employment_pipe(bypass_fn=lambda: []))
+        self.assertIsNone(assemble_ready.check_employment_pipe(bypass_fn=lambda: None))
+
+    def test_default_checks_include_employment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            log.write_text("")
+            report = assemble_ready.ready(
+                log=log,
+                checks=[
+                    lambda: assemble_ready.check_employment_pipe(
+                        bypass_fn=lambda: ["session-x"]),
+                ],
+            )
+        self.assertFalse(report.ok)
+        self.assertEqual(report.misses[0].code, assemble_ready.CODE_EMPLOYMENT)
+
 
 class PredispatchHonorsAssembleReadyGate(unittest.TestCase):
     """Assemble readiness is a first-class wake gate (not a grounding annotation).

--- a/tests/test_emprego.py
+++ b/tests/test_emprego.py
@@ -1,0 +1,282 @@
+"""emprego — porteiro fold: accepted employment digests from sessao.racionalizada."""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import eventlog  # noqa: E402
+import emprego  # noqa: E402
+
+
+def _rid(ch):
+    return ch * 64
+
+
+def _rationalized(
+    sessao_id="s1",
+    rid=None,
+    activity_relevant=True,
+    human_purpose="ship billing recurrence",
+    edge_execution="added route and tests",
+    shared_outcome="controlled recurrence flow",
+    operacoes=None,
+    supersedes=None,
+    cenas=None,
+    enderecos=None,
+    presuncoes=None,
+    surface="codex",
+):
+    rid = rid or _rid("b")
+    payload = {
+        "sessao_id": sessao_id,
+        "surface": surface,
+        "watermark": 2,
+        "operacoes": operacoes or ["edge"],
+        "source_hash": _rid("a"),
+        "rationalization_id": rid,
+        "racionalizador_version": "test-v1",
+        "stitch": {
+            "goal": human_purpose,
+            "acao": shared_outcome,
+            "entidades": [],
+            "attribution": {
+                "human_purpose": human_purpose,
+                "human_turn_indexes": [0],
+                "edge_execution": edge_execution,
+                "shared_outcome": shared_outcome,
+                "activity_relevant": activity_relevant,
+            },
+        },
+        "epistemico": {"presuncoes": presuncoes or []},
+        "organizacional": {"enderecos": enderecos if enderecos is not None else []},
+    }
+    if cenas is not None:
+        payload["cenas"] = cenas
+    if supersedes:
+        payload["supersedes"] = supersedes
+    return payload
+
+
+class AcceptedEmploymentFilter(unittest.TestCase):
+    def test_activity_relevant_true_only_and_body_labels(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.append(
+                "sessao.racionalizada", "sessao:s1",
+                _rationalized(sessao_id="s1", rid=_rid("1")), log=log)
+            eventlog.append(
+                "sessao.racionalizada", "sessao:s2",
+                _rationalized(
+                    sessao_id="s2", rid=_rid("2"), activity_relevant=False,
+                    human_purpose="chatter only"),
+                log=log)
+            items = emprego.accepted_employment(log=log)
+            self.assertEqual(len(items), 1)
+            item = items[0]
+            self.assertEqual(item["session_id"], "s1")
+            self.assertEqual(item["rationalization_id"], _rid("1"))
+            self.assertEqual(item["surface"], "codex")
+            body = item["body"]
+            self.assertIn("FINALIDADE: ship billing recurrence", body)
+            self.assertIn("EXECUCAO: added route and tests", body)
+            self.assertIn("RESULTADO: controlled recurrence flow", body)
+            self.assertIn("OPERACOES: edge", body)
+            self.assertNotIn("ATIVIDADES:", body)
+            self.assertNotIn("PRESSUPOSTOS:", body)
+            self.assertNotIn("CENAS:", body)
+            self.assertIsInstance(item["ref_time"], str)
+            self.assertTrue(item["ref_time"])
+
+
+class LatestWinsSupersedes(unittest.TestCase):
+    def test_superseded_rid_dropped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            first = _rid("1")
+            second = _rid("2")
+            eventlog.append(
+                "sessao.racionalizada", "sessao:s1",
+                _rationalized(
+                    sessao_id="s1", rid=first,
+                    human_purpose="old purpose"),
+                log=log)
+            eventlog.append(
+                "sessao.racionalizada", "sessao:s1",
+                _rationalized(
+                    sessao_id="s1", rid=second, supersedes=first,
+                    human_purpose="new purpose"),
+                log=log)
+            items = emprego.accepted_employment(log=log)
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]["rationalization_id"], second)
+            self.assertIn("FINALIDADE: new purpose", items[0]["body"])
+            self.assertNotIn("old purpose", items[0]["body"])
+
+
+class CenasInDigest(unittest.TestCase):
+    def test_cenas_section_when_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.append(
+                "sessao.racionalizada", "sessao:s1",
+                _rationalized(
+                    cenas=[
+                        {"summary": "human set recurrence goal",
+                         "human_turn_indexes": [0, 2]},
+                        {"summary": "edge added tests",
+                         "human_turn_indexes": [4]},
+                    ]),
+                log=log)
+            body = emprego.accepted_employment(log=log)[0]["body"]
+            self.assertIn("CENAS:", body)
+            self.assertIn("- human set recurrence goal", body)
+            self.assertIn("- edge added tests", body)
+
+    def test_legacy_without_cenas_omits_section(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            p = _rationalized()
+            # legacy: no cenas key
+            assert "cenas" not in p or p.pop("cenas", None) or True
+            p.pop("cenas", None)
+            eventlog.append("sessao.racionalizada", "sessao:s1", p, log=log)
+            body = emprego.accepted_employment(log=log)[0]["body"]
+            self.assertNotIn("CENAS:", body)
+
+
+class AtividadeJoinAndEnderecosExcluded(unittest.TestCase):
+    def test_atividades_and_no_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            rid = _rid("e")
+            eventlog.append(
+                "sessao.racionalizada", "sessao:s1",
+                _rationalized(
+                    rid=rid,
+                    enderecos=[{
+                        "path": "/tmp/secret/contrato.pdf",
+                        "kind": "file",
+                    }],
+                ),
+                log=log)
+            eventlog.append(
+                "atividade.opened", "atividade:auto",
+                {
+                    "ulid": "01ACTIVITYOPEN000000000000",
+                    "operacao": "edge",
+                    "num": "atv-001",
+                    "finalidade": "controlar cobranças",
+                    "novo": "placeholder",
+                    "tier": "llm_judged",
+                    "author": "racionalizador",
+                    "origem_sessao": "s1",
+                    "rationalization_id": rid,
+                    "source_hash": _rid("a"),
+                },
+                log=log)
+            eventlog.append(
+                "atividade.touched", "atividade:auto",
+                {
+                    "ref": "01ACTIVITYOPEN000000000000",
+                    "novo": "fluxo idempotente",
+                    "origem_sessao": "s1",
+                    "rationalization_id": rid,
+                    "source_hash": _rid("a"),
+                },
+                log=log)
+            body = emprego.accepted_employment(log=log)[0]["body"]
+            self.assertIn("ATIVIDADES:", body)
+            self.assertIn("- controlar cobranças — fluxo idempotente", body)
+            self.assertNotIn("/tmp/secret", body)
+            self.assertNotIn("contrato.pdf", body)
+
+    def test_superseded_atividades_do_not_bleed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            old_rid, new_rid = _rid("1"), _rid("2")
+            eventlog.append(
+                "sessao.racionalizada", "sessao:s1",
+                _rationalized(rid=old_rid, human_purpose="old"), log=log)
+            eventlog.append(
+                "atividade.opened", "atividade:auto",
+                {
+                    "ulid": "01OLD000000000000000000000",
+                    "operacao": "edge", "num": "atv-001",
+                    "finalidade": "old-only activity",
+                    "tier": "llm_judged", "author": "racionalizador",
+                    "origem_sessao": "s1", "rationalization_id": old_rid,
+                    "source_hash": _rid("a"),
+                }, log=log)
+            eventlog.append(
+                "sessao.racionalizada", "sessao:s1",
+                _rationalized(
+                    rid=new_rid, supersedes=old_rid,
+                    human_purpose="new purpose"),
+                log=log)
+            items = emprego.accepted_employment(log=log)
+            self.assertEqual(len(items), 1)
+            self.assertNotIn("old-only activity", items[0]["body"])
+            self.assertNotIn("ATIVIDADES:", items[0]["body"])
+
+
+class ProjectIdempotent(unittest.TestCase):
+    def test_adds_once_then_noop_and_dark(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            rid = _rid("p")
+            eventlog.append(
+                "sessao.racionalizada", "sessao:s1",
+                _rationalized(rid=rid), log=log)
+            recorded = []
+
+            def add_fn(name, body, ref_time):
+                recorded.append((name, body, ref_time))
+
+            first = emprego.project(
+                log=log, existing_names=set(), add_fn=add_fn)
+            self.assertEqual(first, {"added": 1, "total": 1})
+            self.assertEqual(len(recorded), 1)
+            name = emprego.episode_name(rid)
+            self.assertEqual(recorded[0][0], name)
+            self.assertIn("FINALIDADE:", recorded[0][1])
+
+            second = emprego.project(
+                log=log, existing_names={name}, add_fn=add_fn)
+            self.assertEqual(second, {"added": 0, "total": 1})
+            self.assertEqual(len(recorded), 1)
+
+            # force dark without touching live Neo4j (group_fn raises → None)
+            def _boom():
+                raise RuntimeError("dark-test")
+            self.assertIsNone(emprego.project(log=log, group_fn=_boom))
+
+    def test_bypass_query_fn(self):
+        self.assertEqual(
+            emprego.bypass_episodes(query_fn=lambda g: ["session-abc"]),
+            ["session-abc"])
+        self.assertEqual(emprego.bypass_episodes(query_fn=lambda g: []), [])
+
+
+class ImportStaysBare(unittest.TestCase):
+    def test_no_neo4j_at_import(self):
+        import ast
+        src = (REPO / "tools" / "emprego.py").read_text()
+        tree = ast.parse(src)
+        top_imports = set()
+        for node in tree.body:
+            if isinstance(node, ast.Import):
+                top_imports.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                top_imports.add(node.module.split(".")[0])
+        self.assertNotIn("neo4j", top_imports)
+        self.assertNotIn("graphiti_core", top_imports)
+        self.assertNotIn("communities", top_imports)
+        self.assertTrue(callable(emprego.accepted_employment))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emprego.py
+++ b/tests/test_emprego.py
@@ -261,6 +261,39 @@ class ProjectIdempotent(unittest.TestCase):
         self.assertEqual(emprego.bypass_episodes(query_fn=lambda g: []), [])
 
 
+class ResetBypassRecording(unittest.TestCase):
+    def test_reset_bypass_runs_deletes_via_injected_tx(self):
+        recorded = []
+
+        class FakeResult:
+            def __init__(self, n):
+                self._n = n
+
+            def single(self):
+                return {"n": self._n}
+
+        class FakeTx:
+            def run(self, cypher, **params):
+                recorded.append(cypher)
+                if "RETURN count" in cypher:
+                    return FakeResult(2)
+                return FakeResult(0)
+
+        def run_tx(fn):
+            fn(FakeTx())
+
+        out = emprego.reset_bypass(group="g1", run_tx=run_tx)
+        self.assertEqual(out["communities"], 2)
+        self.assertEqual(out["entities"], 2)
+        self.assertEqual(out["episodics"], 2)
+        joined = "\n".join(recorded)
+        self.assertIn("Community", joined)
+        self.assertIn("Entity", joined)
+        self.assertIn("Episodic", joined)
+        self.assertIn("STARTS WITH", joined)
+        self.assertIn("parceiro IS NULL", joined)
+
+
 class ImportStaysBare(unittest.TestCase):
     def test_no_neo4j_at_import(self):
         import ast

--- a/tests/test_racionalizador.py
+++ b/tests/test_racionalizador.py
@@ -87,6 +87,8 @@ class NothingChangedTracerBullet(unittest.TestCase):
             self.assertEqual(len(payload["source_hash"]), 64)
             self.assertEqual(len(payload["rationalization_id"]), 64)
             self.assertNotIn("supersedes", payload)
+            # employment-gate: single-shot path persists empty cenas (no version bump)
+            self.assertEqual(payload["cenas"], [])
             open_payload = written[1]["payload"]
             self.assertEqual(open_payload["finalidade"], "implementar as lentes")
             self.assertEqual(open_payload["tier"], "llm_judged")
@@ -635,6 +637,13 @@ class MarathonMechanicalCoreAndLocalBudget(unittest.TestCase):
                 result["emitted"][0]["payload"]["stitch"]["goal"],
                 "MIDDLE_OBJECTIVE_CHANGE",
             )
+            cenas = result["emitted"][0]["payload"]["cenas"]
+            self.assertEqual(len(cenas), 3)
+            for cena in cenas:
+                self.assertIsInstance(cena.get("summary"), str)
+                self.assertTrue(cena["summary"].strip())
+                self.assertIsInstance(cena.get("human_turn_indexes"), list)
+                self.assertTrue(cena["human_turn_indexes"])
 
     def test_budget_exhaustion_leaves_no_checkpoint_and_next_call_resumes(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -19,6 +19,13 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import sweep      # noqa: E402
 import eventlog   # noqa: E402
+import emprego    # noqa: E402
+
+
+def setUpModule():
+    """Unbounded film window — phenotype backfill_days=0 empties every plan (mtime race)."""
+    sweep._film_window_start = lambda log=None: None
+
 
 BODY = "a substantive design decision about the edge-next architecture and its direction " * 4
 
@@ -161,7 +168,7 @@ class RunIsSerializedByTheCursorLock(unittest.TestCase):
             lock.parent.mkdir(parents=True, exist_ok=True)
             done = []
             def go():
-                sweep.run(proj, ingest_fn=lambda items: set(), cursors_path=cursors_path,
+                sweep.run(proj, cursors_path=cursors_path,
                           reproject_fn=False, log=log, graph_recover_fn=False,
                           group="test-group", cursors_lock_wait_s=2.0)
                 done.append(True)
@@ -194,7 +201,7 @@ class RunIsSerializedByTheCursorLock(unittest.TestCase):
                 t0 = time.monotonic()
                 with redirect_stdout(out):
                     n = sweep.run(
-                        proj, ingest_fn=lambda items: set(), cursors_path=cursors_path,
+                        proj, cursors_path=cursors_path,
                         reproject_fn=False, log=log, graph_recover_fn=False,
                         group="test-group", cursors_lock_wait_s=0.4)
                 elapsed = time.monotonic() - t0
@@ -255,7 +262,7 @@ class RunPreflightsIdentityBeforeAnyWrite(unittest.TestCase):
             log = Path(st) / "log.jsonl"
             with mock.patch.object(_identity, "group", return_value=None):
                 with self.assertRaises(RuntimeError):
-                    sweep.run(proj, ingest_fn=lambda items: set(), cursors_path=cursors_path,
+                    sweep.run(proj, cursors_path=cursors_path,
                               reproject_fn=False, log=log, graph_recover_fn=False)
             self.assertFalse(log.exists(), "no episode may land before identity resolves")
             self.assertEqual(sweep.load_cursors(cursors_path), {},
@@ -265,7 +272,7 @@ class RunPreflightsIdentityBeforeAnyWrite(unittest.TestCase):
         with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as st:
             write_session(proj, "sessA")
             log = Path(st) / "log.jsonl"
-            n = sweep.run(proj, ingest_fn=lambda items: set(),
+            n = sweep.run(proj,
                           cursors_path=Path(st) / "cursors.json",
                           reproject_fn=False, log=log, graph_recover_fn=False,
                           group="test-group")
@@ -280,10 +287,8 @@ class ExecuteIngestsLogsAdvances(unittest.TestCase):
         with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as st:
             write_session(proj, "sessA")
             log = Path(st) / "log.jsonl"
-            seen = []
-            cur, n = sweep.execute(sweep.plan_sweep(proj, {}),
-                                   lambda items: seen.extend(i["id"] for i in items), {}, log=log)
-            self.assertEqual((n, seen), (1, ["sessA"]))
+            cur, n = sweep.execute(sweep.plan_sweep(proj, {}), {}, log=log)
+            self.assertEqual(n, 1)
             self.assertIn("sessA", cur)
             eps = eventlog.read(types=["episode"], log=log)
             self.assertEqual(len(eps), 1)
@@ -299,18 +304,15 @@ class ExecuteIngestsLogsAdvances(unittest.TestCase):
         with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as st:
             write_session(proj, "tiny", n_human=1, text="hi")
             log = Path(st) / "log.jsonl"
-            seen = []
-            cur, n = sweep.execute(sweep.plan_sweep(proj, {}),
-                                   lambda items: seen.extend(i["id"] for i in items), {}, log=log)
-            self.assertEqual((n, seen, cur), (0, [], {}))
+            cur, n = sweep.execute(sweep.plan_sweep(proj, {}), {}, log=log)
+            self.assertEqual((n, cur), (0, {}))
 
     def test_codex_episode_carries_surface_metadata(self):
         with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as codex, \
              tempfile.TemporaryDirectory() as st:
             write_codex_session(codex, "codexA")
             log = Path(st) / "log.jsonl"
-            cur, n = sweep.execute(sweep.plan_sweep(proj, {}, codex_dir=codex),
-                                   lambda items: None, {}, log=log)
+            cur, n = sweep.execute(sweep.plan_sweep(proj, {}, codex_dir=codex), {}, log=log)
             self.assertEqual(n, 1)
             self.assertIn("codex:codexA", cur)
             eps = eventlog.read(types=["episode"], log=log)
@@ -323,9 +325,7 @@ class ExecuteIngestsLogsAdvances(unittest.TestCase):
              tempfile.TemporaryDirectory() as st:
             write_grok_session(grok, "grokA")
             log = Path(st) / "log.jsonl"
-            cur, n = sweep.execute(
-                sweep.plan_sweep(proj, {}, grok_dir=grok, codex_dir=False),
-                lambda items: None, {}, log=log)
+            cur, n = sweep.execute(sweep.plan_sweep(proj, {}, grok_dir=grok, codex_dir=False), {}, log=log)
             self.assertEqual(n, 1)
             self.assertIn("grok:grokA", cur)
             eps = eventlog.read(types=["episode"], log=log)
@@ -342,28 +342,24 @@ class RunIsIdempotent(unittest.TestCase):
         with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as st:
             write_session(proj, "sessA")
             cp, log = Path(st) / "cursors.json", Path(st) / "log.jsonl"
-            calls = []
-            fake = lambda items: calls.append(len(items))
-            n1 = sweep.run(proj, ingest_fn=fake, cursors_path=cp, reproject_fn=False, log=log,
-                          graph_recover_fn=False)
-            n2 = sweep.run(proj, ingest_fn=fake, cursors_path=cp, reproject_fn=False, log=log,
-                          graph_recover_fn=False)
-            self.assertEqual((n1, n2, calls), (1, 0, [1]))
+            n1 = sweep.run(proj, cursors_path=cp, reproject_fn=False, log=log,
+                          graph_recover_fn=False, group="test-group")
+            n2 = sweep.run(proj, cursors_path=cp, reproject_fn=False, log=log,
+                          graph_recover_fn=False, group="test-group")
+            # Tier-0 only: first run logs 1 episode, second is no-op (no graph ingest calls)
+            self.assertEqual((n1, n2), (1, 0))
 
     def test_growing_session_digests_only_new_delta(self):
         with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as st:
             cp, log = Path(st) / "cursors.json", Path(st) / "log.jsonl"
             write_session(proj, "sessA")
-            ingested = []
-            fake = lambda items: ingested.append([i["id"] for i in items])
-            sweep.run(proj, ingest_fn=fake, cursors_path=cp, reproject_fn=False, log=log,
-                          graph_recover_fn=False)
+            sweep.run(proj, cursors_path=cp, reproject_fn=False, log=log,
+                          graph_recover_fn=False, group="test-group")
             # the session grows; a second sweep sees only the new tail
             write_session(proj, "sessA", n_human=6)  # rewrites longer (append-only in spirit)
-            n2 = sweep.run(proj, ingest_fn=fake, cursors_path=cp, reproject_fn=False, log=log,
-                          graph_recover_fn=False)
+            n2 = sweep.run(proj, cursors_path=cp, reproject_fn=False, log=log,
+                          graph_recover_fn=False, group="test-group")
             self.assertEqual(n2, 1)  # the new delta re-qualified
-            self.assertEqual(ingested, [["sessA"], ["sessA"]])
 
     def test_graph_recovery_runs_even_on_a_no_delta_sweep(self):
         # Codex P2: graph recovery is NOT gated by new ingest — a no-delta sweep (n==0) after Neo4j
@@ -373,7 +369,7 @@ class RunIsIdempotent(unittest.TestCase):
             cp, log = Path(st) / "cursors.json", Path(st) / "log.jsonl"
             # no sessions → n == 0 (no delta)
             recovered = []
-            n = sweep.run(proj, ingest_fn=lambda items: None, cursors_path=cp,
+            n = sweep.run(proj, cursors_path=cp,
                           reproject_fn=False, log=log,
                           graph_recover_fn=lambda lg: recovered.append(lg))
             self.assertEqual(n, 0)             # no delta ingested
@@ -385,13 +381,13 @@ class RunIsIdempotent(unittest.TestCase):
         with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as st:
             cp, log = Path(st) / "cursors.json", Path(st) / "log.jsonl"
             called = []
-            original = sweep._maybe_consolidate
+            original = sweep._cortex_refresh
             try:
-                sweep._maybe_consolidate = lambda: called.append(True)
-                n = sweep.run(proj, ingest_fn=lambda items: None, cursors_path=cp,
+                sweep._cortex_refresh = lambda log=None: called.append(True)
+                n = sweep.run(proj, cursors_path=cp,
                               log=log, graph_recover_fn=False, group="test-group")
             finally:
-                sweep._maybe_consolidate = original
+                sweep._cortex_refresh = original
             self.assertEqual(n, 0)
             self.assertEqual(called, [True])
 
@@ -400,48 +396,46 @@ class RunIsIdempotent(unittest.TestCase):
              tempfile.TemporaryDirectory() as st:
             write_codex_session(codex, "codexA")
             cp, log = Path(st) / "cursors.json", Path(st) / "log.jsonl"
-            seen = []
-            n1 = sweep.run(proj, ingest_fn=lambda items: seen.extend(i["id"] for i in items),
+            n1 = sweep.run(proj,
                            cursors_path=cp, reproject_fn=False, log=log,
                            graph_recover_fn=False, group="test-group", codex_dir=codex)
             cursors = sweep.load_cursors(cp)
             self.assertEqual(n1, 0)
-            self.assertEqual(seen, [])
             self.assertTrue(cursors[sweep.CODEX_BASELINE_KEY])
             self.assertGreater(cursors["codex:codexA"], 0)
             self.assertEqual(eventlog.read(types=["episode"], log=log), [])
 
             write_codex_session(codex, "codexA", append=True)
-            n2 = sweep.run(proj, ingest_fn=lambda items: seen.extend(i["id"] for i in items),
+            n2 = sweep.run(proj,
                            cursors_path=cp, reproject_fn=False, log=log,
                            graph_recover_fn=False, group="test-group", codex_dir=codex)
             self.assertEqual(n2, 1)
-            self.assertEqual(seen, ["codex:codexA"])
+            eps = eventlog.read(types=["episode"], log=log)
+            self.assertEqual([e["payload"]["session"] for e in eps], ["codex:codexA"])
 
     def test_first_grok_run_baselines_existing_logs_without_ingesting(self):
         with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as grok, \
              tempfile.TemporaryDirectory() as st:
             write_grok_session(grok, "grokA")
             cp, log = Path(st) / "cursors.json", Path(st) / "log.jsonl"
-            seen = []
-            n1 = sweep.run(proj, ingest_fn=lambda items: seen.extend(i["id"] for i in items),
+            n1 = sweep.run(proj,
                            cursors_path=cp, reproject_fn=False, log=log,
                            graph_recover_fn=False, group="test-group",
                            grok_dir=grok, codex_dir=False)
             cursors = sweep.load_cursors(cp)
             self.assertEqual(n1, 0)
-            self.assertEqual(seen, [])
             self.assertTrue(cursors[sweep.GROK_BASELINE_KEY])
             self.assertGreater(cursors["grok:grokA"], 0)
             self.assertEqual(eventlog.read(types=["episode"], log=log), [])
 
             write_grok_session(grok, "grokA", append=True)
-            n2 = sweep.run(proj, ingest_fn=lambda items: seen.extend(i["id"] for i in items),
+            n2 = sweep.run(proj,
                            cursors_path=cp, reproject_fn=False, log=log,
                            graph_recover_fn=False, group="test-group",
                            grok_dir=grok, codex_dir=False)
             self.assertEqual(n2, 1)
-            self.assertEqual(seen, ["grok:grokA"])
+            eps = eventlog.read(types=["episode"], log=log)
+            self.assertEqual([e["payload"]["session"] for e in eps], ["grok:grokA"])
 
 
 class ReprojectFoldsCorpusAndReadsTheC3Gate(unittest.TestCase):
@@ -527,27 +521,43 @@ class ReprojectFoldsCorpusAndReadsTheC3Gate(unittest.TestCase):
 
 
 class GraphIngestIsBestEffort(unittest.TestCase):
-    """ADR-0006: the Tier-0 log is the source of truth. A graph ingest failure (no graphiti_core /
-    Neo4j down on a fleet host like petertosh) is skipped, not fatal — episodes are still logged and
-    cursors still advance, so digestion is current and the graph stays rebuildable from the log."""
+    """employment-gate: raw graphiti_ingest deleted; execute is Tier-0 only."""
 
-    def test_ingest_failure_still_logs_and_advances(self):
-        with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as st:
-            write_session(proj, "sessA")
-            cp, log = Path(st) / "cursors.json", Path(st) / "log.jsonl"
+    def test_execute_is_tier0_only_no_ingest_arg(self):
+        import inspect
+        sig = inspect.signature(sweep.execute)
+        self.assertNotIn("ingest_fn", sig.parameters)
+        self.assertFalse(hasattr(sweep, "graphiti_ingest"))
 
-            def boom(items):
-                raise ModuleNotFoundError("No module named 'graphiti_core'")
+    def test_cortex_refresh_orders_project_before_consolidate(self):
+        order = []
+        original_p = sweep._maybe_project_emprego
+        original_c = sweep._maybe_consolidate
+        try:
+            sweep._maybe_project_emprego = lambda log=None: order.append("project")
+            sweep._maybe_consolidate = lambda: order.append("consolidate")
+            sweep._cortex_refresh()
+            self.assertEqual(order, ["project", "consolidate"])
+        finally:
+            sweep._maybe_project_emprego = original_p
+            sweep._maybe_consolidate = original_c
 
-            n = sweep.run(proj, ingest_fn=boom, cursors_path=cp, reproject_fn=False, log=log,
-                          graph_recover_fn=False)
-            self.assertEqual(n, 1)                                    # logged despite graph failure
-            self.assertEqual(len(eventlog.read(types=["episode"], log=log)), 1)
-            self.assertIn("sessA", sweep.load_cursors(cp))           # cursor advanced
+    def test_project_then_consolidate_both_invoked(self):
+        original_p = sweep._maybe_project_emprego
+        original_c = sweep._maybe_consolidate
+        called = []
+        try:
+            sweep._maybe_project_emprego = lambda log=None: called.append("project")
+            sweep._maybe_consolidate = lambda: called.append("consolidate")
+            sweep._cortex_refresh()
+            self.assertEqual(called, ["project", "consolidate"])
+        finally:
+            sweep._maybe_project_emprego = original_p
+            sweep._maybe_consolidate = original_c
 
 
 class ChunkEpisodeBodyKeepsLargeSessionsUnderContext(unittest.TestCase):
-    """#53 (ex edge-of-chaos #573) — graphiti_ingest shipped each session's ENTIRE body as one
+    """#53 (ex edge-of-chaos #573) — raw graphiti dialogue ingest shipped each session's ENTIRE body as one
     episode to gpt-4o-mini; an oversized session overflowed the context window, FAILED, and was
     silently dropped from the graph while the cursor advanced (no replay) — silent knowledge loss.
     The fix splits the body into context-sized sub-episodes at TURN ('\\n') boundaries. Tier-0 keeps
@@ -556,25 +566,25 @@ class ChunkEpisodeBodyKeepsLargeSessionsUnderContext(unittest.TestCase):
 
     def test_body_under_budget_is_a_single_chunk_unchanged(self):
         body = "human: hi\nassistant: hello"
-        self.assertEqual(sweep.chunk_episode_body(body, 1000), [body])
+        self.assertEqual(emprego.chunk_episode_body(body, 1000), [body])
 
     def test_large_body_splits_into_chunks_each_under_budget(self):
         body = "\n".join(f"human: turn {i} " + "x" * 200 for i in range(50))
-        chunks = sweep.chunk_episode_body(body, 1000)
+        chunks = emprego.chunk_episode_body(body, 1000)
         self.assertGreater(len(chunks), 1)
         for c in chunks:
             self.assertLessEqual(len(c), 1000)
 
     def test_split_is_lossless_and_at_turn_boundaries(self):
         body = "\n".join(f"human: turn {i} " + "x" * 200 for i in range(50))
-        chunks = sweep.chunk_episode_body(body, 1000)
+        chunks = emprego.chunk_episode_body(body, 1000)
         self.assertEqual("".join(chunks), body, "no character may be lost across the split")
         for c in chunks[:-1]:
             self.assertTrue(c.endswith("\n"), "a chunk boundary must fall between turns, not mid-turn")
 
     def test_a_single_oversized_turn_is_hard_split_never_over_budget(self):
         body = "human: " + "y" * 5000   # one turn far larger than a whole chunk (a giant paste)
-        chunks = sweep.chunk_episode_body(body, 1000)
+        chunks = emprego.chunk_episode_body(body, 1000)
         for c in chunks:
             self.assertLessEqual(len(c), 1000)
         self.assertEqual("".join(chunks), body, "every character of an oversized turn must still land")
@@ -626,56 +636,16 @@ class EmbedAndSignalDegradesWithoutEmbedder(unittest.TestCase):
 
 
 class GraphIngestIsBoundedAndNeverGatesTheSweep(unittest.TestCase):
-    """#62 (second front): Tier-0 (episode + cursor) is durable BEFORE the best-effort graph ingest,
-    and the ingest is time-bounded on a daemon thread — a HANG (add_episode on a network call with
-    no client timeout, the real sweep hang) degrades dark LOUD, never blocks the wake."""
+    """#62 budget now guards emprego.project via _maybe_project_emprego, not raw ingest."""
 
-    def test_a_hanging_ingest_degrades_dark_within_budget_tier0_intact(self):
-        with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as st:
-            write_session(proj, "sessA")
-            log = Path(st) / "log.jsonl"
+    def test_nonfinite_or_bad_project_budget_fails_loud(self):
+        for bad in ("nan", "inf", "-1", "soon"):
+            with self.subTest(budget=bad), mock.patch.dict(os.environ, {
+                    "EDGE_SWEEP_INGEST_BUDGET_S": bad}):
+                with self.assertRaises(ValueError):
+                    sweep._maybe_project_emprego()
 
-            def hang(items):
-                time.sleep(30)            # a network call with no timeout — the real hang
+    def test_execute_no_longer_takes_ingest_fn(self):
+        import inspect
+        self.assertNotIn("ingest_fn", inspect.signature(sweep.execute).parameters)
 
-            buf = io.StringIO()
-            t0 = time.monotonic()
-            with mock.patch.dict(os.environ, {"EDGE_SWEEP_INGEST_BUDGET_S": "1"}), \
-                 contextlib.redirect_stdout(buf):
-                cur, n = sweep.execute(sweep.plan_sweep(proj, {}), hang, {}, log=log)
-            dt = time.monotonic() - t0
-            self.assertLess(dt, 6.0, "a hung graph ingest must not block the sweep past the budget")
-            self.assertIn("EXCEEDED", buf.getvalue(), "the timeout degrades DARK and LOUD")
-            self.assertEqual(n, 1)
-            self.assertIn("sessA", cur, "Tier-0 cursor advanced despite the hung ingest")
-            self.assertEqual(len(eventlog.read(types=["episode"], log=log)), 1,
-                             "the episode is logged (Tier-0 truth) before the best-effort ingest")
-
-    def test_a_raising_ingest_still_logs_and_advances(self):
-        with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as st:
-            write_session(proj, "sessA")
-            log = Path(st) / "log.jsonl"
-
-            def boom(items):
-                raise RuntimeError("neo4j down")
-
-            buf = io.StringIO()
-            with contextlib.redirect_stdout(buf):
-                cur, n = sweep.execute(sweep.plan_sweep(proj, {}), boom, {}, log=log)
-            self.assertIn("skipped", buf.getvalue())
-            self.assertIn("sessA", cur)
-            self.assertEqual(len(eventlog.read(types=["episode"], log=log)), 1)
-
-    def test_nonfinite_or_bad_ingest_budget_fails_loud(self):
-        with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as st:
-            write_session(proj, "sessA")
-            log = Path(st) / "log.jsonl"
-            for bad in ("nan", "inf", "-1", "soon"):
-                with self.subTest(budget=bad), \
-                     mock.patch.dict(os.environ, {"EDGE_SWEEP_INGEST_BUDGET_S": bad}):
-                    with self.assertRaises(ValueError):
-                        sweep.execute(sweep.plan_sweep(proj, {}), lambda items: None, {}, log=log)
-
-
-if __name__ == "__main__":
-    unittest.main(verbosity=2)

--- a/tools/assemble_ready.py
+++ b/tools/assemble_ready.py
@@ -90,10 +90,44 @@ def check_relational_act(*, log=eventlog.LOG) -> Miss | None:
     return None
 
 
+def check_employment_pipe(*, log=eventlog.LOG, bypass_fn=None) -> Miss | None:
+    """EMPLOYMENT: legacy session-* Episodic residue means raw-dialogue bypass still in graph.
+
+    Empty list or dark graph (None) → no miss. Non-empty → fail closed with migrate hint.
+    """
+    if bypass_fn is None:
+        try:
+            import emprego
+            bypass_fn = emprego.bypass_episodes
+        except Exception as exc:  # noqa: BLE001
+            return Miss(
+                code=CODE_EMPLOYMENT,
+                detail=f"could not load emprego porteiro: {type(exc).__name__}: {exc}",
+            )
+    try:
+        names = bypass_fn()
+    except Exception as exc:  # noqa: BLE001
+        return Miss(
+            code=CODE_EMPLOYMENT,
+            detail=f"bypass check raised: {type(exc).__name__}: {exc}",
+        )
+    if names is None or not names:
+        return None
+    n = len(names)
+    return Miss(
+        code=CODE_EMPLOYMENT,
+        detail=(
+            f"{n} bypass episode(s) in graph — run tools/edge-python tools/emprego.py --migrate"
+        ),
+    )
+
+
 def _default_checks(*, log) -> list[Callable[[], Miss | None]]:
     # Pending open set is the bar: per package_id on the log (sole truth). seq is audit only.
+    # Employment pipe: no session-* Graphiti residue (employment-gate ADR-0025).
     return [
         lambda: check_pending_drain(log=log),
+        lambda: check_employment_pipe(log=log),
     ]
 
 

--- a/tools/emprego.py
+++ b/tools/emprego.py
@@ -1,0 +1,269 @@
+"""emprego — porteiro de Mineração: accepted mentee employment → Cortex intake.
+
+Contract (operator + turing 2026-07-26, PLAN-cortex-employment-gate):
+  Nothing enters Cortex that mining did not accept as mentee employment material.
+  The mining verdict is sessao.racionalizada.stitch.attribution.activity_relevant.
+
+Slice 1 ships the pure fold + injectable project/bypass (callers arrive in later slices).
+No session JSONL reopen. Module imports bare (no neo4j/graphiti at import time).
+"""
+from __future__ import annotations
+
+import eventlog
+
+# Episode name prefix for employment projections (bypass residue is session-*).
+EMPREGO_EPISODE_PREFIX = "emprego-"
+BYPASS_EPISODE_PREFIX = "session-"
+
+
+def _attribution(payload):
+    stitch = payload.get("stitch") if isinstance(payload.get("stitch"), dict) else {}
+    attr = stitch.get("attribution") if isinstance(stitch.get("attribution"), dict) else {}
+    return attr
+
+
+def _activity_relevant(payload):
+    return _attribution(payload).get("activity_relevant") is True
+
+
+def _usable_accepted_payload(payload):
+    """Fail-dark: skip corrupt rows rather than raising from the fold."""
+    if not isinstance(payload, dict):
+        return False
+    if not isinstance(payload.get("rationalization_id"), str) or not payload["rationalization_id"]:
+        return False
+    if not isinstance(payload.get("sessao_id"), str) or not payload["sessao_id"]:
+        return False
+    attr = _attribution(payload)
+    for key in ("human_purpose", "edge_execution", "shared_outcome"):
+        val = attr.get(key)
+        if not isinstance(val, str) or not val.strip():
+            return False
+    ops = payload.get("operacoes")
+    if not isinstance(ops, list) or not ops or not all(
+            isinstance(o, str) and o.strip() for o in ops):
+        return False
+    return _activity_relevant(payload)
+
+
+def _atividades_for_rid(events, rid):
+    """Join atividade.opened/touched by rationalization_id for digest lines."""
+    opens = []
+    touches_by_ref = {}
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        p = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+        if p.get("rationalization_id") != rid:
+            continue
+        et = event.get("type")
+        if et == "atividade.opened":
+            opens.append(p)
+        elif et == "atividade.touched":
+            ref = p.get("ref")
+            if isinstance(ref, str) and ref:
+                touches_by_ref[ref] = p
+    lines = []
+    for op in opens:
+        finalidade = op.get("finalidade")
+        if not isinstance(finalidade, str) or not finalidade.strip():
+            continue
+        ulid = op.get("ulid")
+        novo = None
+        if isinstance(ulid, str) and ulid in touches_by_ref:
+            n = touches_by_ref[ulid].get("novo")
+            if isinstance(n, str) and n.strip():
+                novo = n.strip()
+        if novo is None:
+            n = op.get("novo")
+            if isinstance(n, str) and n.strip():
+                novo = n.strip()
+        if novo is None:
+            novo = finalidade.strip()
+        lines.append(f"- {finalidade.strip()} — {novo}")
+    return lines
+
+
+def _digest_body(payload, atividade_lines=None):
+    """Deterministic employment digest — extractor input contract (omit empty sections)."""
+    attr = _attribution(payload)
+    ops = payload.get("operacoes") or []
+    lines = [
+        f"FINALIDADE: {attr['human_purpose'].strip()}",
+        f"EXECUCAO: {attr['edge_execution'].strip()}",
+        f"RESULTADO: {attr['shared_outcome'].strip()}",
+        f"OPERACOES: {', '.join(o.strip() for o in ops)}",
+    ]
+    if atividade_lines:
+        lines.append("ATIVIDADES:")
+        lines.extend(atividade_lines)
+    pres = []
+    epi = payload.get("epistemico") if isinstance(payload.get("epistemico"), dict) else {}
+    for item in epi.get("presuncoes") or []:
+        if isinstance(item, dict):
+            t = item.get("texto")
+            if isinstance(t, str) and t.strip():
+                pres.append(f"- {t.strip()}")
+    if pres:
+        lines.append("PRESSUPOSTOS:")
+        lines.extend(pres)
+    cenas = payload.get("cenas")
+    cena_lines = []
+    if isinstance(cenas, list):
+        for c in cenas:
+            if isinstance(c, dict):
+                s = c.get("summary")
+                if isinstance(s, str) and s.strip():
+                    cena_lines.append(f"- {s.strip()}")
+    if cena_lines:
+        lines.append("CENAS:")
+        lines.extend(cena_lines)
+    return "\n".join(lines)
+
+
+def accepted_employment(log=eventlog.LOG):
+    """Pure fold: latest accepted sessao.racionalizada per session → employment digests.
+
+    activity_relevant is True only. No graph, no LLM, no session JSONL.
+    [] on empty/unusable log. Fail-dark skip on corrupt rows.
+    """
+    events = eventlog.read(
+        types=["sessao.racionalizada", "atividade.opened", "atividade.touched"],
+        log=log,
+    )
+    rationalized = [e for e in events if e.get("type") == "sessao.racionalizada"]
+    superseded = {
+        p["supersedes"]
+        for e in rationalized
+        for p in [e.get("payload") if isinstance(e.get("payload"), dict) else {}]
+        if isinstance(p.get("supersedes"), str) and p["supersedes"]
+    }
+    out = []
+    for event in rationalized:
+        payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+        rid = payload.get("rationalization_id")
+        if not isinstance(rid, str) or rid in superseded:
+            continue
+        if not _usable_accepted_payload(payload):
+            continue
+        atv_lines = _atividades_for_rid(events, rid)
+        out.append({
+            "session_id": payload["sessao_id"],
+            "rationalization_id": rid,
+            "surface": payload.get("surface") if isinstance(payload.get("surface"), str) else "",
+            "ref_time": event.get("ts") if isinstance(event.get("ts"), str) else "",
+            "body": _digest_body(payload, atv_lines),
+        })
+    return out
+
+
+def episode_name(rationalization_id):
+    """Deterministic Episodic name for an accepted rationalization.
+
+    ponytail: rid truncated to 16 hex (~64 bits). Collision → second item
+    skipped as already-projected until --migrate wipe-rebuild. Fine at O(100).
+    """
+    return f"{EMPREGO_EPISODE_PREFIX}{rationalization_id[:16]}"
+
+
+def project(log=eventlog.LOG, group=None, *, existing_names=None, add_fn=None, group_fn=None):
+    """Idempotent graph write of accepted employment digests.
+
+    Production: lazy Graphiti adapters (slice 2 wires real add). Dark → None.
+    Tests inject existing_names (set of episode names) + add_fn(name, body, ref_time).
+    Returns {"added": n, "total": m} or None when graph dark.
+    """
+    items = accepted_employment(log=log)
+    if existing_names is None and add_fn is None:
+        # Production path: not fully wired until slice 2; degrade dark.
+        try:
+            if group_fn is not None:
+                group = group_fn()
+            elif group is None:
+                import _identity
+                group = _identity.require_group()
+        except Exception:
+            return None
+        try:
+            existing = _existing_emprego_names(group)
+            if existing is None:
+                return None
+            add = _make_graphiti_add(group)
+            if add is None:
+                return None
+        except Exception:
+            return None
+        existing_names = existing
+        add_fn = add
+    if existing_names is None or add_fn is None:
+        return None
+    existing_names = set(existing_names)
+    added = 0
+    for item in items:
+        name = episode_name(item["rationalization_id"])
+        if name in existing_names:
+            continue
+        try:
+            add_fn(name, item["body"], item["ref_time"])
+            existing_names.add(name)
+            added += 1
+        except Exception:
+            # best-effort per item; continue others
+            continue
+    return {"added": added, "total": len(items)}
+
+
+def bypass_episodes(group=None, *, query_fn=None):
+    """Read-only: legacy session-* Episodic names in the group. None = dark."""
+    if query_fn is not None:
+        try:
+            return list(query_fn(group))
+        except Exception:
+            return None
+    try:
+        if group is None:
+            import _identity
+            group = _identity.require_group()
+        names = _query_bypass_names(group)
+        return names
+    except Exception:
+        return None
+
+
+def _existing_emprego_names(group):
+    """MATCH Episodic names with emprego- prefix. None = dark."""
+    try:
+        import communities
+        drv = communities._driver()
+        if drv is None:
+            return None
+        with drv.session() as s:
+            rows = s.run(
+                "MATCH (ep:Episodic {group_id:$g}) "
+                "WHERE ep.name STARTS WITH $p "
+                "RETURN ep.name AS name",
+                g=group, p=EMPREGO_EPISODE_PREFIX,
+            ).data()
+        return {r["name"] for r in rows if r.get("name")}
+    except Exception:
+        return None
+
+
+def _query_bypass_names(group):
+    import communities
+    drv = communities._driver()
+    if drv is None:
+        return None
+    with drv.session() as s:
+        rows = s.run(
+            "MATCH (ep:Episodic {group_id:$g}) "
+            "WHERE ep.name STARTS WITH $p "
+            "RETURN ep.name AS name ORDER BY name",
+            g=group, p=BYPASS_EPISODE_PREFIX,
+        ).data()
+    return [r["name"] for r in rows if r.get("name")]
+
+
+def _make_graphiti_add(group):
+    """Real Graphiti add lands in slice 2; until then production project stays dark."""
+    return None

--- a/tools/emprego.py
+++ b/tools/emprego.py
@@ -386,3 +386,128 @@ def _query_bypass_names(group):
     return [r["name"] for r in rows if r.get("name")]
 
 
+def reset_bypass(group=None, keep_curated=True, *, run_tx=None):
+    """Migration: wipe rebuildable bypass projections (Community, non-curated Entity,
+    session-* Episodic). Curated parceiro/curated_cluster entities preserved when
+    keep_curated=True. Returns counts or None if dark.
+
+    Tests inject run_tx(fn) that receives a recording session-like object.
+    """
+    try:
+        if group is None:
+            import _identity
+            group = _identity.require_group()
+    except Exception:
+        return None
+
+    counts = {"communities": 0, "entities": 0, "episodics": 0}
+
+    def _tx(tx):
+        n_c = tx.run(
+            "MATCH (c:Community {group_id:$g}) RETURN count(c) AS n", g=group
+        ).single()["n"]
+        tx.run("MATCH (c:Community {group_id:$g}) DETACH DELETE c", g=group)
+        if keep_curated:
+            n_e = tx.run(
+                "MATCH (e:Entity {group_id:$g}) "
+                "WHERE e.parceiro IS NULL AND e.curated_cluster IS NULL "
+                "RETURN count(e) AS n", g=group
+            ).single()["n"]
+            tx.run(
+                "MATCH (e:Entity {group_id:$g}) "
+                "WHERE e.parceiro IS NULL AND e.curated_cluster IS NULL "
+                "DETACH DELETE e", g=group)
+        else:
+            n_e = tx.run(
+                "MATCH (e:Entity {group_id:$g}) RETURN count(e) AS n", g=group
+            ).single()["n"]
+            tx.run("MATCH (e:Entity {group_id:$g}) DETACH DELETE e", g=group)
+        n_ep = tx.run(
+            "MATCH (ep:Episodic {group_id:$g}) "
+            "WHERE ep.name STARTS WITH $p RETURN count(ep) AS n",
+            g=group, p=BYPASS_EPISODE_PREFIX,
+        ).single()["n"]
+        tx.run(
+            "MATCH (ep:Episodic {group_id:$g}) "
+            "WHERE ep.name STARTS WITH $p DETACH DELETE ep",
+            g=group, p=BYPASS_EPISODE_PREFIX,
+        )
+        counts["communities"] = int(n_c or 0)
+        counts["entities"] = int(n_e or 0)
+        counts["episodics"] = int(n_ep or 0)
+
+    if run_tx is not None:
+        try:
+            run_tx(_tx)
+            return counts
+        except Exception:
+            return None
+    try:
+        import communities
+        drv = communities._driver()
+        if drv is None:
+            return None
+        with drv.session() as s:
+            s.execute_write(_tx)
+        return counts
+    except Exception as e:
+        print(f"emprego: reset_bypass dark ({type(e).__name__}: {e})")
+        return None
+
+
+def main(argv=None):
+    """CLI: --check (read-only) | --migrate (reset_bypass + project)."""
+    import argparse
+    import sys
+    p = argparse.ArgumentParser(description="emprego porteiro — check/migrate Cortex intake")
+    p.add_argument("--check", action="store_true", help="list bypass episodes + unprojected count")
+    p.add_argument("--migrate", action="store_true", help="wipe bypass projections + project digests")
+    p.add_argument("--group", default=None, help="graph group_id (default: install identity)")
+    args = p.parse_args(argv)
+    if not args.check and not args.migrate:
+        p.print_help()
+        return 2
+    log = eventlog.LOG
+    items = accepted_employment(log=log)
+    bypass = bypass_episodes(group=args.group)
+    if args.check:
+        print(f"accepted_employment: {len(items)}")
+        if bypass is None:
+            print("bypass_episodes: DARK (graph unreachable)")
+        else:
+            print(f"bypass_episodes: {len(bypass)}")
+            for name in bypass[:50]:
+                print(f"  - {name}")
+            if len(bypass) > 50:
+                print(f"  … +{len(bypass) - 50} more")
+        # unprojected: need graph existing names
+        try:
+            import _identity
+            g = args.group or _identity.require_group()
+            existing = _existing_emprego_names(g) or set()
+        except Exception:
+            existing = set()
+            print("existing emprego episodes: DARK")
+        missing = [it for it in items
+                   if episode_name(it["rationalization_id"]) not in existing]
+        print(f"unprojected accepted: {len(missing)}")
+        return 0
+    if args.migrate:
+        wiped = reset_bypass(group=args.group)
+        print(f"reset_bypass: {wiped}")
+        out = project(log=log, group=args.group)
+        print(f"project: {out}")
+        try:
+            import communities
+            if __import__("os").environ.get("EDGE_COMMUNITIES") == "1":
+                written = communities.consolidate(group=args.group)
+                print(f"communities: {len(written or [])} clusters")
+        except Exception as e:
+            print(f"communities skipped ({type(e).__name__}: {e})")
+        return 0 if wiped is not None else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/tools/emprego.py
+++ b/tools/emprego.py
@@ -4,16 +4,22 @@ Contract (operator + turing 2026-07-26, PLAN-cortex-employment-gate):
   Nothing enters Cortex that mining did not accept as mentee employment material.
   The mining verdict is sessao.racionalizada.stitch.attribution.activity_relevant.
 
-Slice 1 ships the pure fold + injectable project/bypass (callers arrive in later slices).
 No session JSONL reopen. Module imports bare (no neo4j/graphiti at import time).
+Graph writes project accepted digests only — never raw dialogue.
 """
 from __future__ import annotations
+
+from datetime import datetime, timezone
 
 import eventlog
 
 # Episode name prefix for employment projections (bypass residue is session-*).
 EMPREGO_EPISODE_PREFIX = "emprego-"
 BYPASS_EPISODE_PREFIX = "session-"
+
+# Tier-1 ONLY: body chunking for the Graphiti extractor window (moved from sweep).
+MAX_EPISODE_CHARS = 48_000
+PREV_CONTEXT_MAX_CHARS = 120_000
 
 
 def _attribution(payload):
@@ -166,16 +172,44 @@ def episode_name(rationalization_id):
     return f"{EMPREGO_EPISODE_PREFIX}{rationalization_id[:16]}"
 
 
+def parse_ts(ts):
+    if not ts:
+        return datetime.now(timezone.utc)
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def chunk_episode_body(body, max_chars=MAX_EPISODE_CHARS):
+    """Split a body into <= max_chars chunks at newline boundaries (lossless)."""
+    if len(body) <= max_chars:
+        return [body]
+    chunks, cur = [], ""
+    for line in body.splitlines(keepends=True):
+        while len(line) > max_chars:
+            if cur:
+                chunks.append(cur)
+                cur = ""
+            chunks.append(line[:max_chars])
+            line = line[max_chars:]
+        if cur and len(cur) + len(line) > max_chars:
+            chunks.append(cur)
+            cur = line
+        else:
+            cur += line
+    if cur:
+        chunks.append(cur)
+    return chunks
+
+
 def project(log=eventlog.LOG, group=None, *, existing_names=None, add_fn=None, group_fn=None):
     """Idempotent graph write of accepted employment digests.
 
-    Production: lazy Graphiti adapters (slice 2 wires real add). Dark → None.
-    Tests inject existing_names (set of episode names) + add_fn(name, body, ref_time).
+    Production: Graphiti add_episode on digests only. Dark → None.
+    Tests inject existing_names + add_fn(name, body, ref_time).
     Returns {"added": n, "total": m} or None when graph dark.
     """
     items = accepted_employment(log=log)
     if existing_names is None and add_fn is None:
-        # Production path: not fully wired until slice 2; degrade dark.
         try:
             if group_fn is not None:
                 group = group_fn()
@@ -185,16 +219,10 @@ def project(log=eventlog.LOG, group=None, *, existing_names=None, add_fn=None, g
         except Exception:
             return None
         try:
-            existing = _existing_emprego_names(group)
-            if existing is None:
-                return None
-            add = _make_graphiti_add(group)
-            if add is None:
-                return None
-        except Exception:
+            return _project_graphiti(items, group)
+        except Exception as e:
+            print(f"emprego: project dark ({type(e).__name__}: {e})")
             return None
-        existing_names = existing
-        add_fn = add
     if existing_names is None or add_fn is None:
         return None
     existing_names = set(existing_names)
@@ -208,9 +236,103 @@ def project(log=eventlog.LOG, group=None, *, existing_names=None, add_fn=None, g
             existing_names.add(name)
             added += 1
         except Exception:
-            # best-effort per item; continue others
             continue
     return {"added": added, "total": len(items)}
+
+
+def _project_graphiti(items, group):
+    """Real Graphiti write path — employment digests only."""
+    import asyncio
+    from graphiti_core import Graphiti
+    from graphiti_core.nodes import EpisodeType
+    from graphiti_core.llm_client import LLMConfig, OpenAIClient
+    import _identity
+
+    _load_openai_key()
+    neo = _identity.neo4j_conn()
+    existing = _existing_emprego_names(group)
+    if existing is None:
+        return None
+    to_add = [it for it in items
+              if episode_name(it["rationalization_id"]) not in existing]
+    if not to_add:
+        return {"added": 0, "total": len(items)}
+
+    async def bounded_previous_uuids(g, ref):
+        eps = await g.retrieve_episodes(
+            ref, last_n=10, group_ids=[group], source=EpisodeType.message)
+        chosen, total = [], 0
+        for ep in reversed(eps):
+            size = len(ep.content)
+            if size > MAX_EPISODE_CHARS:
+                continue
+            if total + size > PREV_CONTEXT_MAX_CHARS:
+                break
+            chosen.append(ep.uuid)
+            total += size
+        return chosen
+
+    async def go():
+        llm = OpenAIClient(config=LLMConfig(model="gpt-4o-mini", small_model="gpt-4o-mini"))
+        g = Graphiti(*neo, llm_client=llm)
+        await g.build_indices_and_constraints()
+        added = 0
+        try:
+            for it in to_add:
+                name = episode_name(it["rationalization_id"])
+                ref = parse_ts(it.get("ref_time"))
+                chunks = chunk_episode_body(it["body"])
+                failed = False
+                for k, chunk in enumerate(chunks):
+                    ep_name = name if len(chunks) == 1 else f"{name}-{k}"
+                    try:
+                        prev = await bounded_previous_uuids(g, ref)
+                        await g.add_episode(
+                            name=ep_name,
+                            episode_body=chunk,
+                            source=EpisodeType.message,
+                            source_description="emprego digest (mentee employment)",
+                            reference_time=ref,
+                            group_id=group,
+                            previous_episode_uuids=prev,
+                        )
+                        print(f"  + emprego {ep_name} ({len(chunk)} chars)")
+                    except Exception as e:
+                        failed = True
+                        print(f"  ! emprego FAILED {ep_name}: {type(e).__name__}: {e}")
+                if not failed:
+                    added += 1
+        finally:
+            await g.close()
+        return added
+
+    added = asyncio.run(go())
+    return {"added": added, "total": len(items)}
+
+
+def _load_openai_key():
+    import os
+    from pathlib import Path
+    if os.environ.get("OPENAI_API_KEY"):
+        return
+    home = Path.home()
+    for root in filter(None, [
+        os.environ.get("EDGE_HOME"),
+        str(Path(__file__).resolve().parent.parent),
+        str(home / "edge"),
+    ]):
+        f = Path(root) / "secrets" / "openai.env"
+        if f.exists():
+            for line in f.read_text().splitlines():
+                if "OPENAI_API_KEY" in line:
+                    os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip().strip('"')
+                    return
+    kit = home / ".edge-sandbox-kit" / "openai.env"
+    if kit.exists():
+        for line in kit.read_text().splitlines():
+            if "OPENAI_API_KEY" in line:
+                os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip().strip('"')
+                return
 
 
 def bypass_episodes(group=None, *, query_fn=None):
@@ -264,6 +386,3 @@ def _query_bypass_names(group):
     return [r["name"] for r in rows if r.get("name")]
 
 
-def _make_graphiti_add(group):
-    """Real Graphiti add lands in slice 2; until then production project stays dark."""
-    return None

--- a/tools/emprego.py
+++ b/tools/emprego.py
@@ -240,8 +240,47 @@ def project(log=eventlog.LOG, group=None, *, existing_names=None, add_fn=None, g
     return {"added": added, "total": len(items)}
 
 
+def _load_openai_key():
+    import os
+    from pathlib import Path
+    if os.environ.get("OPENAI_API_KEY"):
+        return
+
+    def _from_file(f):
+        if not f.exists():
+            return False
+        for line in f.read_text().splitlines():
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            if "OPENAI_API_KEY" in line and "=" in line:
+                os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip().strip('"')
+                return True
+        return False
+
+    home = Path.home()
+    for root in filter(None, [
+        os.environ.get("EDGE_HOME"),
+        str(Path(__file__).resolve().parent.parent),
+        str(home / "edge"),
+    ]):
+        if _from_file(Path(root) / "secrets" / "openai.env"):
+            return
+    _from_file(home / ".edge-sandbox-kit" / "openai.env")
+
+
 def _project_graphiti(items, group):
-    """Real Graphiti write path — employment digests only."""
+    """Real Graphiti write path — employment digests only. Early-exit without Graphiti import."""
+    existing = _existing_emprego_names(group)
+    if existing is None:
+        return None
+    to_add = [it for it in items
+              if episode_name(it["rationalization_id"]) not in existing]
+    if not to_add:
+        return {"added": 0, "total": len(items)}
+    return _project_graphiti_add(to_add, items, group)
+
+
+def _project_graphiti_add(to_add, items, group):
     import asyncio
     from graphiti_core import Graphiti
     from graphiti_core.nodes import EpisodeType
@@ -250,13 +289,6 @@ def _project_graphiti(items, group):
 
     _load_openai_key()
     neo = _identity.neo4j_conn()
-    existing = _existing_emprego_names(group)
-    if existing is None:
-        return None
-    to_add = [it for it in items
-              if episode_name(it["rationalization_id"]) not in existing]
-    if not to_add:
-        return {"added": 0, "total": len(items)}
 
     async def bounded_previous_uuids(g, ref):
         eps = await g.retrieve_episodes(
@@ -308,31 +340,6 @@ def _project_graphiti(items, group):
 
     added = asyncio.run(go())
     return {"added": added, "total": len(items)}
-
-
-def _load_openai_key():
-    import os
-    from pathlib import Path
-    if os.environ.get("OPENAI_API_KEY"):
-        return
-    home = Path.home()
-    for root in filter(None, [
-        os.environ.get("EDGE_HOME"),
-        str(Path(__file__).resolve().parent.parent),
-        str(home / "edge"),
-    ]):
-        f = Path(root) / "secrets" / "openai.env"
-        if f.exists():
-            for line in f.read_text().splitlines():
-                if "OPENAI_API_KEY" in line:
-                    os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip().strip('"')
-                    return
-    kit = home / ".edge-sandbox-kit" / "openai.env"
-    if kit.exists():
-        for line in kit.read_text().splitlines():
-            if "OPENAI_API_KEY" in line:
-                os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip().strip('"')
-                return
 
 
 def bypass_episodes(group=None, *, query_fn=None):

--- a/tools/racionalizador.py
+++ b/tools/racionalizador.py
@@ -770,10 +770,12 @@ def rationalize(
             raise _BudgetExhausted
         return raw
 
+    # Scene summaries for long sessions (free density for employment digests).
+    # Single-shot path leaves []. Additive field — does not enter rationalization_id.
+    summaries = []
     try:
         if scene_turn_limit is not None and len(normalized_turns) > scene_turn_limit:
             scenes = _uniform_scenes(normalized_turns, scene_turn_limit, max_scenes)
-            summaries = []
             for index, scene in enumerate(scenes):
                 raw_scene = _complete({
                     "stage": "scene",
@@ -857,6 +859,7 @@ def rationalize(
         "stitch": output["stitch"],
         "epistemico": output["epistemico"],
         "organizacional": output["organizacional"],
+        "cenas": summaries,
     }
     try:
         derived_batch, pending_activity_opens = _build_derived_batch(

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -7,8 +7,8 @@ delta only, never the whole store. **Keyed on the store, not on any skill** — 
 no ed skill is still digested at the next sweep. Re-running is a no-op (the cursor guards it).
 After ingest, the wiki and Direction **re-project** (sweep → extract → re-project → digest).
 
-The pure planning (`plan_sweep`, cursors) carries no graph/LLM; `execute` takes an injected
-`ingest_fn`, so the cursor/idempotency logic is testable without Neo4j or OpenAI.
+The pure planning (`plan_sweep`, cursors) carries no graph/LLM; `execute` is Tier-0 only
+(episode events + cursors). Cortex Tier-1 is emprego.project() on accepted employment digests.
 
 Run:  tools/edge-python tools/sweep.py          (sweep + re-project)
       python3 tools/sweep.py --plan             (re-execs into .venv when present)
@@ -38,19 +38,7 @@ GROK_BASELINE_KEY = "_grok_baselined"
 # default sent roberto scanning a nonexistent dir — "nothing new" over a 294-session backlog).
 DISPATCH_MARKER = "Dispatch runtime context"   # strip the edge's own framing (exp-001)
 MIN_CHARS = 200                                 # a substantive delta, not a stray turn
-# Tier-1 ONLY: the body fed to ONE Graphiti episode. The extractor (gpt-4o-mini, 128k-token
-# context) also carries its system prompt + retrieved prior episodes + reserved output, so a whole
-# oversized session shipped as one episode overflowed and was dropped (#53). ~48k chars (~12k
-# tokens) leaves deep headroom and keeps the common case (deltas under budget) a single episode —
-# Tier-0 keeps the FULL body uncapped; only the add_episode boundary chunks.
-MAX_EPISODE_CHARS = 48_000
-# Tier-1 ONLY: the OTHER side of the same window. add_episode internally retrieves the last 10
-# previous episodes (RELEVANT_SCHEMA_LIMIT) as prompt context — 10 x 48k already flirts with the
-# 128k window, and legacy pre-#53 episodes (up to ~200k chars) made EVERY new ingest overflow
-# regardless of the new delta's size, wedging the group (nothing lands, so the window never rolls
-# past the giants). We pass previous_episode_uuids explicitly, greedy most-recent-first under this
-# deterministic char budget (~30k tokens), skipping any single episode over MAX_EPISODE_CHARS.
-PREV_CONTEXT_MAX_CHARS = 120_000
+# Tier-1 Graphiti intake moved to emprego (employment digests only).
 DEFAULT_MAX_SESSIONS_PER_SWEEP = 5
 DEFAULT_SWEEP_TOKEN_BUDGET = 20_000
 DEFAULT_SCENE_TURN_LIMIT = 40
@@ -116,19 +104,6 @@ def _cursor_id(session):
     return session.id
 
 
-def _source_description(item):
-    surface = item.get("surface")
-    if surface == "codex":
-        return "Codex work session (mentee<->edge)"
-    if surface == "grok":
-        return "Grok work session (mentee<->edge)"
-    return "Claude work session (mentee<->edge)"
-
-
-def _episode_name(item, chunk_index=None):
-    sid = item["id"].replace(":", "-")[:24]
-    base = f"session-{sid}"
-    return base if chunk_index is None else f"{base}-p{chunk_index + 1}"
 
 
 def _codex_enabled(project_dir, codex_dir):
@@ -819,11 +794,11 @@ def rationalize_pending_sessions(
 
 
 # --- effectful execute: log + ingest + advance cursor ---
-def execute(plan, ingest_fn, cursors, log=eventlog.LOG):
+def execute(plan, cursors, log=eventlog.LOG):
     """**Tier-0 is truth** (ADR-0006): write each qualifying delta as an `episode` event and advance
-    its cursor — **always, even with no graph**. The graph ingest (`ingest_fn`) is **best-effort**:
-    a missing runtime or a down Neo4j (e.g. a graph-less fleet host) is logged and skipped, never
-    fatal — the graph is a projection rebuildable from the log. Returns (cursors, n_logged)."""
+    its cursor — **always, even with no graph**. Cortex Tier-1 (Entity extraction) is NOT driven
+    from raw dialogue here — see emprego.project() on accepted employment digests.
+    Returns (cursors, n_logged)."""
     qualifying = [it for it in plan if not it.get("skip") and it.get("body", "").strip()]
     for it in qualifying:                              # Tier-0: the log + cursor, unconditionally
         # R8c part 1 (F9-dep, C5): STAMP the source Medium's tier on the episode at ingest. The native
@@ -837,40 +812,6 @@ def execute(plan, ingest_fn, cursors, log=eventlog.LOG):
             payload["surface"] = it["surface"]
         eventlog.append("episode", f"session:{it['id']}", payload, log=log)
         cursors[it["id"]] = it["watermark"]
-    if qualifying and ingest_fn is not None:           # Tier-1: graph projection, best-effort
-        # BOUNDED + degrade-dark (#62): Tier-0 (episode + cursor) is ALREADY durable above, so the
-        # graph ingest must never gate the wake. It runs on a daemon thread with a hard deadline —
-        # a HANG (add_episode on a network call with no client timeout) degrades dark LOUD exactly
-        # like a raise; the graph re-projects from the log. Fail loud on a bad budget, never un-cap.
-        # Default 600s (qualidade>latência, operador 2026-07-25): extração LLM honesta
-        # passa fácil de 30s e o grafo vivia truncando em silêncio; o cap segue existindo
-        # só para HANG de rede — nunca para apressar trabalho real.
-        budget_raw = os.environ.get("EDGE_SWEEP_INGEST_BUDGET_S", "600")
-        try:
-            budget = float(budget_raw)
-        except (TypeError, ValueError):
-            raise ValueError(f"EDGE_SWEEP_INGEST_BUDGET_S={budget_raw!r} is not a number — fail loud (#62)")
-        if not math.isfinite(budget) or budget < 0:
-            raise ValueError(f"EDGE_SWEEP_INGEST_BUDGET_S={budget_raw!r} is not a finite non-negative "
-                             "number — nan/inf/negative would un-bound the graph ingest (#62); fail loud")
-        err = []
-        done = threading.Event()
-
-        def _ingest():
-            try:
-                ingest_fn(qualifying)
-            except Exception as e:  # noqa: BLE001 — captured, surfaced on the caller thread
-                err.append(e)
-            finally:
-                done.set()
-
-        threading.Thread(target=_ingest, daemon=True).start()
-        if not done.wait(timeout=budget):
-            print(f"sweep: graph ingest EXCEEDED {budget:g}s budget — degraded DARK (Tier-0 log is "
-                  f"current; the graph is rebuildable from the log)")
-        elif err:
-            print(f"sweep: graph ingest skipped ({type(err[0]).__name__}: {err[0]}) — "
-                  f"Tier-0 log is current; the graph is rebuildable from the log")
     return cursors, len(qualifying)
 
 
@@ -887,112 +828,8 @@ def _load_openai_key():
                     return
 
 
-def _first_ts(path):
-    for line in open(path):
-        try:
-            ts = json.loads(line).get("timestamp")
-            if ts:
-                return ts
-        except Exception:
-            pass
-    return None
-
-
-def _parse_ts(ts):
-    if not ts:
-        return datetime.now(timezone.utc)
-    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
-
-
-def chunk_episode_body(body, max_chars=MAX_EPISODE_CHARS):
-    """Split an episode body into <= max_chars chunks at TURN ('\\n') boundaries, so a large
-    session-delta lands as several sub-episodes that each fit the extractor's context window
-    instead of overflowing as one episode and being dropped whole (#53, ex edge-of-chaos #573).
-    Lossless: ''.join(chunks) == body. A body already under budget is returned as one chunk
-    (the common case — name/behaviour unchanged). A single turn longer than max_chars is
-    hard-split, so a giant paste still lands rather than blocking its session."""
-    if len(body) <= max_chars:
-        return [body]
-    chunks, cur = [], ""
-    for line in body.splitlines(keepends=True):          # keepends → ''.join reconstructs body
-        while len(line) > max_chars:                     # one turn bigger than a whole chunk
-            if cur:
-                chunks.append(cur)
-                cur = ""
-            chunks.append(line[:max_chars])
-            line = line[max_chars:]
-        if cur and len(cur) + len(line) > max_chars:
-            chunks.append(cur)
-            cur = line
-        else:
-            cur += line
-    if cur:
-        chunks.append(cur)
-    return chunks
-
-
-def graphiti_ingest(items):
-    """Incremental Graphiti extraction (C2): one episode per session-delta, into THIS install's
-    own group (agent.yaml identity, #21). Robust: a per-episode failure is logged and skipped (the
-    others still land). Returns the set of session ids that ingested — INFORMATIONAL: `execute`
-    advances cursors unconditionally (Tier-0 is truth; the episode event is already logged), so a
-    failed graph ingest does NOT retry via the cursor — its episode lives in the log awaiting an
-    episode-replay recovery (a known gap, mirror of publisher.reproject_graph for artefatos)."""
-    import asyncio
-    from graphiti_core import Graphiti
-    from graphiti_core.nodes import EpisodeType
-    from graphiti_core.llm_client import LLMConfig, OpenAIClient
-    _load_openai_key()
-    neo = _identity.neo4j_conn()
-    group = _identity.require_group()   # resolved ONCE, before any episode (codex gate)
-    ok = set()
-
-    async def bounded_previous_uuids(g, ref):
-        """The previous-episode context add_episode would retrieve, bounded: most-recent-first
-        under PREV_CONTEXT_MAX_CHARS, never an episode over MAX_EPISODE_CHARS (a legacy pre-#53
-        giant — one alone can blow the window). Deterministic seam: the tool disposes what the
-        extractor may see, instead of trusting the internal unbounded last-10 retrieval."""
-        eps = await g.retrieve_episodes(ref, last_n=10, group_ids=[group],
-                                        source=EpisodeType.message)
-        chosen, total = [], 0
-        for ep in reversed(eps):                     # chronological → most-recent-first
-            size = len(ep.content)
-            if size > MAX_EPISODE_CHARS:
-                continue
-            if total + size > PREV_CONTEXT_MAX_CHARS:
-                break
-            chosen.append(ep.uuid)
-            total += size
-        return chosen
-
-    async def go():
-        llm = OpenAIClient(config=LLMConfig(model="gpt-4o-mini", small_model="gpt-4o-mini"))
-        g = Graphiti(*neo, llm_client=llm)
-        await g.build_indices_and_constraints()
-        for it in items:
-            ref = _parse_ts(_first_ts(it["path"]))   # all sub-episodes share the session's ref-time
-            chunks = chunk_episode_body(it["body"])   # one big session → several context-fit episodes (#53)
-            failed = False
-            for k, chunk in enumerate(chunks):
-                name = _episode_name(it) if len(chunks) == 1 else _episode_name(it, k)
-                try:
-                    prev = await bounded_previous_uuids(g, ref)
-                    await g.add_episode(name=name, episode_body=chunk,
-                                        source=EpisodeType.message,
-                                        source_description=_source_description(it),
-                                        reference_time=ref, group_id=group,
-                                        previous_episode_uuids=prev)
-                    print(f"  + ingested {name} ({len(chunk)} chars)")
-                except Exception as e:
-                    failed = True
-                    print(f"  ! FAILED {name}: {type(e).__name__}: {e}")
-            if not failed:           # a session counts as ingested only if every sub-episode landed
-                ok.add(it["id"])
-        await g.close()
-
-    asyncio.run(go())
-    return ok
+# Graphiti raw-dialogue ingest (graphiti_ingest) DELETED — employment-gate.
+# Chunking + employment projection live in tools/emprego.py.
 
 
 def _openai_embed(text):
@@ -1037,10 +874,45 @@ def embed_and_signal(slug, body, cites, embed_fn=None, log=eventlog.LOG):
     return n
 
 
+def _maybe_project_emprego(log=eventlog.LOG):
+    """Project accepted employment digests into the graph (porteiro). Best-effort + budget-bounded
+    (#62 pattern relocated from raw graphiti_ingest). Never gates the wake."""
+    budget_raw = os.environ.get("EDGE_SWEEP_INGEST_BUDGET_S", "600")
+    try:
+        budget = float(budget_raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"EDGE_SWEEP_INGEST_BUDGET_S={budget_raw!r} is not a number — fail loud (#62)")
+    if not math.isfinite(budget) or budget < 0:
+        raise ValueError(f"EDGE_SWEEP_INGEST_BUDGET_S={budget_raw!r} is not a finite non-negative "
+                         "number — nan/inf/negative would un-bound the graph project (#62); fail loud")
+    err = []
+    done = threading.Event()
+
+    def _run():
+        try:
+            import emprego
+            out = emprego.project(log=log)
+            if out is not None:
+                print(f"sweep: emprego project — added {out.get('added', 0)}/"
+                      f"{out.get('total', 0)} accepted digests")
+        except Exception as e:  # noqa: BLE001
+            err.append(e)
+        finally:
+            done.set()
+
+    threading.Thread(target=_run, daemon=True).start()
+    if not done.wait(timeout=budget):
+        print(f"sweep: emprego project EXCEEDED {budget:g}s budget — degraded DARK "
+              f"(Tier-0 log is current; graph rebuildable via emprego.project)")
+    elif err:
+        print(f"sweep: emprego project skipped ({type(err[0]).__name__}: {err[0]}) — "
+              f"Tier-0 log is current")
+
+
 def _maybe_consolidate():
     """Communities consolidation behind EDGE_COMMUNITIES=1 (dark by default, padrão EDGE_CONDUCTOR).
     Vazão×confiança: a vazão é automática atrás do knob; a confiança fica no harm-bearing. Best-effort
-    como o graph-ingest — NUNCA derruba um sweep (grafo/LLM fora → skip logado)."""
+    — NUNCA derruba um sweep (grafo/LLM fora → skip logado)."""
     if os.environ.get("EDGE_COMMUNITIES") != "1":
         return
     try:
@@ -1049,6 +921,12 @@ def _maybe_consolidate():
         print(f"sweep: communities consolidadas — {len(written or [])} clusters")
     except Exception as e:
         print(f"sweep: communities skipped ({type(e).__name__}: {e}) — graph/LLM leg dark")
+
+
+def _cortex_refresh(log=eventlog.LOG):
+    """Employment projection THEN communities — order is load-bearing (plan slice 2)."""
+    _maybe_project_emprego(log=log)
+    _maybe_consolidate()
 
 
 def _topic_direction_window_days():
@@ -1099,7 +977,7 @@ def reproject():
     eventlog.consolidate_artefato_proposals()
     eventlog.project_direction()                       # pure fold — always
     eventlog.project_corpus()                          # pure fold — always (Tier-0, no graph)
-    _maybe_consolidate()                               # communities: vazão automática, knob-gated
+    _cortex_refresh()                                  # emprego project then communities
     missing = cortex.artefatos_without_kernel()        # the C3 gate finally gets a reader (ADR-0009)
     if missing:
         print(f"sweep: C3 — {len(missing)} published Artefato(s) without an intent.kernel: "
@@ -1161,7 +1039,7 @@ def _acquire_cursors_lock(lk, wait_s=CURSORS_LOCK_WAIT_S, poll_s=CURSORS_LOCK_PO
             time.sleep(poll_s)
 
 
-def run(project_dir=None, ingest_fn=None, cursors_path=CURSORS, reproject_fn=None,
+def run(project_dir=None, cursors_path=CURSORS, reproject_fn=None,
         log=eventlog.LOG, recent=None, graph_recover_fn=None, group=None, codex_dir=None,
         grok_dir=None, cursors_lock_wait_s=None):
     """Full sweep: plan the deltas → ingest + log + advance cursors → re-project (if anything new) →
@@ -1213,7 +1091,7 @@ def run(project_dir=None, ingest_fn=None, cursors_path=CURSORS, reproject_fn=Non
                 cursors = _grok_baseline(cursors, grok_dir, install_birth=birth)
             plan = plan_sweep(project_dir, cursors, recent=recent, codex_dir=codex_dir,
                               grok_dir=grok_dir, install_birth=birth)
-            cursors, n = execute(plan, ingest_fn or graphiti_ingest, cursors, log=log)
+            cursors, n = execute(plan, cursors, log=log)
             save_cursors(cursors, cursors_path)
             proposed = _maybe_propose_topic_directions(project_dir=project_dir, codex_dir=codex_dir,
                                                        grok_dir=grok_dir, log=log)
@@ -1223,9 +1101,8 @@ def run(project_dir=None, ingest_fn=None, cursors_path=CURSORS, reproject_fn=Non
     if (n or proposed or corrected) and reproject_fn is not False:
         (reproject_fn or reproject)()
     elif reproject_fn is None:
-        # Communities are the automatic consolidation leg of the wake. They must still refresh on a
-        # no-delta dispatch so the briefing can read the current graph before any skill reasoning.
-        _maybe_consolidate()
+        # Cortex refresh (emprego project + communities) on no-delta so briefing stays current.
+        _cortex_refresh(log=log)
     # graph recovery runs ALWAYS (not under `if n`) — a no-delta sweep still self-heals the graph.
     # The run's `log` is threaded through (Codex P2): a custom-log dry-run never projects the real
     # corpus (publisher.reproject_graph default-skips a non-canonical log).
@@ -1325,6 +1202,7 @@ def run_rationalization_backlog(project_dir=None, *, log=eventlog.LOG, codex_dir
             render_fn = portfolio.render
         return render_fn(log)
 
+    _best_effort("emprego", lambda: __import__("emprego").project(log=log))
     _best_effort("reconcile", _reconcile)
     _best_effort("project", _project)
     _best_effort("render", _render)


### PR DESCRIPTION
## Summary

Implements the settled contract: **nothing enters Cortex Tier-1 that mining did not accept as mentee employment** (`activity_relevant`).

- **`tools/emprego.py`** — porteiro: `accepted_employment` fold, digest body, Graphiti `project`, `bypass_episodes`, `reset_bypass`, CLI `--check`/`--migrate`
- **`sweep`**: raw `graphiti_ingest` deleted; execute is Tier-0 only; `_cortex_refresh` = project → consolidate
- **`racionalizador`**: persists `cenas` (no identity bump)
- **`assemble_ready`**: `CODE_EMPLOYMENT` tooth when `session-*` Episodic residue remains
- **ADR-0025**

## Slices

1. Fold + cenas (inert)
2. Kill bypass + wire project
3. Migration CLI + ADR
4. Assemble tooth

## Test plan

- [x] `unittest` green: test_emprego, test_assemble_ready, test_sweep, test_communities, test_racionalizador
- [ ] Roberto: `--check` → `--migrate` → project → consolidate; compare communities before/after (operator review)
- [ ] Deploy tooth only in same window as migrate (else wake blocks)

## Operator note

Sparse-and-correct until rationalization backlog drains is the accepted trade. Do **not** merge to fleet and leave unmigrated installs with `session-*` residue + tooth on.