### PR TITLE
docs: en-US public house language (README, CLAUDE, AGENTS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,27 @@
-# edge — leia antes de instalar
+# edge — read this before you install
 
-(Guarda de clone-fresco para harnesses que leem `AGENTS.md` — Codex, Hermes e afins.
-Conteúdo espelha o `CLAUDE.md` da raiz; em divergência, os dois devem ser editados juntos.)
+(Fresh-clone guard for harnesses that read `AGENTS.md` — Codex, Hermes, and similar.
+Mirrors root `CLAUDE.md`; if they diverge, edit both together.)
 
-## Se este é um clone fresco (você ainda não é um install)
+## If this is a fresh clone (you are not an install yet)
 
-Este repositório é **genótipo sem identidade**: não existe `agent.yaml` aqui — cada host
-escreve o seu como SAÍDA do onboarding (o arquivo é untracked/gitignored de propósito).
+This repository is **genotype without identity**: there is no `agent.yaml` here — each host
+writes its own as the **output** of onboarding (the file is untracked / gitignored on purpose).
 
-- **NÃO** fabrique um `agent.yaml` nem rode `edge-apply` — essa é a estrada legada para
-  um fenótipo que JÁ pertence a um host vivo.
-- **SIM**: siga o rito guiado em `skills/onboard/SKILL.md` — entreviste o operador
-  (nome, pasta, CLIs, adversarial, segredos/embeddings, dias de backfill com cheque de
-  custo), conduza a instalação inteira explicando cada passo e emende no primeiro mentor.
-  `agent.yaml` é a SAÍDA do onboarding, nunca a semente.
+- **Do not** invent an `agent.yaml` or run `edge-apply` — that path is for a phenotype that
+  **already** belongs to a live host.
+- **Do** follow the guided rite in `skills/onboard/SKILL.md` — interview the operator
+  (name, home folder, CLIs, adversarials, secrets/embeddings, backfill days with a **cost
+  check**), run the full install while explaining each step, and hand off into the first mentor.
+  `agent.yaml` is the **output** of onboarding, never the seed.
 
-Como saber: se `state/bootstrap.json` não existe e ninguém te disse que este diretório é
-um install vivo, trate como clone fresco e pergunte primeiro.
+How to tell: if `state/bootstrap.json` does not exist and nobody told you this directory is a
+live install, treat it as a fresh clone and ask first.
 
-## Se este é um install vivo
+**House language:** documentation and install defaults are **en-US**. Operator session language
+can still follow phenotype `agent.yaml` `language:` after install.
 
-Operação normal — `CONTEXT.md` é o mapa, `CONTRACT.md` o contrato, `docs/adr/` as
-decisões.
+## If this is a live install
+
+Normal operation — `CONTEXT.md` is the map, `CONTRACT.md` the contract, `docs/adr/` the
+decisions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,24 @@
-# edge — leia antes de instalar
+# edge — read this before you install
 
-## Se este é um clone fresco (você ainda não é um install)
+## If this is a fresh clone (you are not an install yet)
 
-Este repositório é **genótipo sem identidade**: não existe `agent.yaml` aqui — cada host
-escreve o seu como SAÍDA do onboarding (o arquivo é untracked/gitignored de propósito).
+This repository is **genotype without identity**: there is no `agent.yaml` here — each host
+writes its own as the **output** of onboarding (the file is untracked / gitignored on purpose).
 
-- **NÃO** fabrique um `agent.yaml` nem rode `edge-apply` — essa é a estrada legada para
-  um fenótipo que JÁ pertence a um host vivo.
-- **SIM**: siga o rito guiado em `skills/onboard/SKILL.md` — entreviste o operador
-  (nome, pasta, CLIs, adversarial, segredos/embeddings, dias de backfill com cheque de
-  custo), conduza a instalação inteira explicando cada passo e emende no primeiro mentor.
-  `agent.yaml` é a SAÍDA do onboarding, nunca a semente.
+- **Do not** invent an `agent.yaml` or run `edge-apply` — that path is for a phenotype that
+  **already** belongs to a live host.
+- **Do** follow the guided rite in `skills/onboard/SKILL.md` — interview the operator
+  (name, home folder, CLIs, adversarials, secrets/embeddings, backfill days with a **cost
+  check**), run the full install while explaining each step, and hand off into the first mentor.
+  `agent.yaml` is the **output** of onboarding, never the seed.
 
-Como saber: se `state/bootstrap.json` não existe e ninguém te disse que este diretório é
-um install vivo, trate como clone fresco e pergunte primeiro.
+How to tell: if `state/bootstrap.json` does not exist and nobody told you this directory is a
+live install, treat it as a fresh clone and ask first.
 
-## Se este é um install vivo
+**House language:** documentation and install defaults are **en-US**. Operator session language
+can still follow phenotype `agent.yaml` `language:` after install.
 
-Operação normal — `CONTEXT.md` é o mapa, `CONTRACT.md` o contrato, `docs/adr/` as
-decisões.
+## If this is a live install
+
+Normal operation — `CONTEXT.md` is the map, `CONTRACT.md` the contract, `docs/adr/` the
+decisions.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
-# edge
+# edge of chaos
 
-Genotype for the Edge mentor install (edge-next). Identity and phenotype live per install; this tree is subject-blind code plus optional living install state.
+**A mentor that keeps one state and one direction across every CLI you use.**
+
+Not another chat that forgets. Edge consolidates what you are doing — across Claude, Codex, Grok, Hermes, and the rest — and steers with a single Direction instead of a pile of disconnected threads.
+
+People already run it. The core works. This repo is the **genotype**: subject-blind code you install; identity and secrets stay on your machine.
+
+```text
+one memory  ·  one direction  ·  real mentor, not assistant cosplay
+```
+
+| | |
+|--|--|
+| **Repo** | [github.com/lucasrp/edge-of-chaos](https://github.com/lucasrp/edge-of-chaos) |
+| **Language (docs & defaults)** | **en-US** |
+| **Operator language** | Optional per install (`agent.yaml` `language:`) — phenotype, not genotype |
+
+---
+
+## What you get
+
+- **Multi-CLI continuity** — skills and session film on every harness present on the host (Claude / Codex / Grok / Hermes).
+- **Wake → mentor → produce → close** — a rite, not a single prompt: orient, sharpen, ship artifacts with gates.
+- **Graph + log** — long-term memory when Neo4j is up; zero-key path still works (FTS / declared-dark).
+- **Your install is yours** — `agent.yaml`, secrets, and state are **outputs** of onboarding, never committed as “the” product identity.
+
+---
 
 ## Multi-CLI (Claude + Codex + Grok + Hermes)
 
@@ -11,32 +36,35 @@ Install provisions **every CLI harness present on the host**:
 | Claude | `~/.claude/skills/{ed,edge}-*` | `~/.claude/projects/…` (native) |
 | Codex | `~/.codex/skills/{ed,edge}-*` | `~/.codex/sessions/` |
 | Grok | `~/.grok/skills/{ed,edge}-*` | `~/.grok/sessions/` |
-| Hermes | `~/.hermes/skills/{ed,edge}-*` | `~/.hermes/state.db` (SQLite — estimate hoje; filmagem completa é adaptador futuro) |
+| Hermes | `~/.hermes/skills/{ed,edge}-*` | `~/.hermes/state.db` (SQLite — estimate today; full film adapter later) |
 
-Detection = home directory exists (`detect_installed_surfaces`). Phenotype gets a `surfaces:` block enabling those harnesses. Assemble/quente/sweep **include every installed surface** (not Claude-only). Hermes (Nous Research) roda pela conta do próprio usuário (`hermes setup` define o modelo default — o edge nunca fixa modelo pra ele); adversarial via `--adversarial hermes` (rota `review_hermes`, transporte `hermes -z`).
+Detection = home directory exists (`detect_installed_surfaces`). Phenotype gets a `surfaces:` block for those harnesses. Assemble / quente / sweep **include every installed surface** (not Claude-only). Hermes runs under the user’s own account (`hermes setup` picks the model — edge never pins it); adversarial via `--adversarial hermes` (`review_hermes`, transport `hermes -z`).
 
-On **ed** and **roberto** (all three CLIs present), a normal install fills all three pickers (`/ed-wake`, `@ed-wake`, …).
+On hosts with several CLIs installed, a normal install fills each picker (`/ed-wake`, `@ed-wake`, …).
+
+---
 
 ## First-run (no `agent.yaml` yet)
 
-**Agentic path (recommended):** clone, open your CLI (Claude/Codex/Grok) in the repo and
-ask for the guided install — the `onboard` skill (`skills/onboard/SKILL.md`; `/ed-onboard`
-once provisioned) interviews you (name, home, secrets, backfill days **with a cost check**
-— `edge-bootstrap estimate --days N`), runs every step below explaining as it goes,
-brings up the Neo4j runtime (`edge-bootstrap runtime`), and flows straight into the first
-mentor session before closing with `finish` + heartbeat + the local blog URL.
+**Agentic path (recommended):** clone, open your CLI in the repo, and ask for the guided install — the `onboard` skill (`skills/onboard/SKILL.md`; `/ed-onboard` once provisioned) interviews you (name, home, secrets, backfill days **with a cost check** — `edge-bootstrap estimate --days N`), runs every step below while explaining, brings up Neo4j (`edge-bootstrap runtime`), and flows into the first mentor session before `finish` + optional heartbeat + local blog URL.
 
-The manual road underneath: `agent.yaml` is the **output** of onboarding, not the seed. Order:
+The manual path underneath: `agent.yaml` is the **output** of onboarding, not the seed.
 
 1. **Deliver secrets** into a folder the install will read  
 2. **Bootstrap** (name, lookback days, adversarials, optional embeddings)  
-3. **Assemble + wake** over that history (structures the mentor insumo)  
-4. **Mentor** (Direction / objective born here)  
+3. **Assemble + wake** over that history (builds the mentor package)  
+4. **Mentor** (Direction / objective are born here)  
 5. Phenotype written → heartbeat may be enabled  
 
-### Secrets folder (required)
+### Defaults (en-US)
 
-Create a secrets directory under the install home (default) or point `EDGE_SECRETS_DIR`:
+| Knob | Default |
+|------|---------|
+| Docs & README | English (en-US) |
+| New phenotype `language:` | `en` (see `tools/onboarding.py` emit) |
+| Operator voice in session | Follows install `language` / mentee preference |
+
+### Secrets folder (required)
 
 ```text
 $EDGE_HOME/secrets/
@@ -49,9 +77,9 @@ $EDGE_HOME/secrets/
 ```
 
 - Format: one `VAR=value` per line (optional `export ` prefix).  
-- **Bootstrap, assemble, wake, and onboarding read this folder.** The installer does **not** download or invent keys.  
+- **Bootstrap, assemble, wake, and onboarding read this folder.** The installer does **not** invent keys.  
 - Do not commit secrets (`secrets/` is gitignored).  
-- Logs and insumo packages record **key names only**, never values.
+- Logs record **key names only**, never values.
 
 ### Bootstrap knobs
 
@@ -60,8 +88,8 @@ $EDGE_HOME/secrets/
 | Install home | yes | `--home ~/my-edge` or `EDGE_HOME` |
 | Agent name | yes | `--name ed` or `EDGE_AGENT_NAME` |
 | Assemble lookback (days) | yes | `--backfill-days 30` or `EDGE_ASSEMBLE_BACKFILL_DAYS` |
-| Adversarials | no | `--adversarial codex --adversarial grok` — if none available, **the primary model does the adversarial** |
-| Embeddings key | no | if `OPENAI_API_KEY` (or configured embedding secret) is in `secrets/`, embedding route is wired; otherwise declared-dark |
+| Adversarials | no | `--adversarial codex --adversarial grok` — if none, **the primary model does adversarial** |
+| Embeddings key | no | if embedding secret is present, route is wired; else declared-dark |
 
 ```bash
 # after placing secrets under $EDGE_HOME/secrets/
@@ -77,9 +105,9 @@ Heartbeat stays **off** until onboarding completes.
 
 ### After bootstrap
 
-1. Bring up the local runtime: `tools/edge-python tools/edge-bootstrap runtime --home "$EDGE_HOME"` — pinned Neo4j 5.x in docker (container `edge-neo4j`, generated password → `secrets/neo4j.env`, idempotent). No docker → declared-dark (FTS covers zero-key).  
-2. Run **wake / predispatch** (lookback = install `backfill_days`) — auto-stamps `state/onboarding-insumo.md` (wake package **without** Direction).  
-3. Run **`/ed-mentor`** with that insumo — mentor creates objective/direction/leveling.  
+1. Runtime: `tools/edge-python tools/edge-bootstrap runtime --home "$EDGE_HOME"` — pinned Neo4j 5.x in Docker (`edge-neo4j`, password → `secrets/neo4j.env`). No Docker → declared-dark (FTS covers zero-key).  
+2. **Wake / predispatch** (lookback = install `backfill_days`) — stamps `state/onboarding-insumo.md` (wake package **without** Direction).  
+3. **`/ed-mentor`** with that package — objective / direction / leveling.  
 4. Close install:
 
 ```bash
@@ -88,28 +116,52 @@ tools/edge-python tools/edge-bootstrap finish --home "$EDGE_HOME" \
 # optional: --enable-heartbeat
 ```
 
-5. Only then may autonomous beat/heartbeat be enabled (`--enable-heartbeat` = systemd user timer + linger). Artifacts read at **http://127.0.0.1:8766** (`blog-server`, loopback-only).
+5. Only then enable autonomous beat/heartbeat (`--enable-heartbeat` = systemd user timer + linger). Artifacts: **http://127.0.0.1:8766** (`blog-server`, loopback-only).
 
 Full contract: [`docs/specs/onboarding-first-run.md`](docs/specs/onboarding-first-run.md).
+
+---
 
 ## Legacy install (phenotype already exists)
 
 ```bash
 tools/edge-python tools/edge-apply --yaml agent.yaml --home ~/edge
-# optional runtime: --provision-runtime
+# optional: --provision-runtime
 ```
+
+---
 
 ## Layout (install home)
 
 | Path | Role |
 |------|------|
-| `secrets/` | Operator-delivered keys (read by onboarding) |
+| `secrets/` | Operator-delivered keys |
 | `state/bootstrap.json` | Pre-phenotype install knobs |
-| `state/onboarding-insumo.md` | Mentor insumo after first wake |
+| `state/onboarding-insumo.md` | Mentor package after first wake |
 | `agent.yaml` | Phenotype (written at end of onboarding) |
 | `skills/`, `blog/`, `memory/` | Install tree |
+
+---
+
+## Documentation
+
+| Doc | Role |
+|-----|------|
+| [`CLAUDE.md`](CLAUDE.md) / [`AGENTS.md`](AGENTS.md) | Fresh-clone guard for agent harnesses |
+| [`CONTRACT.md`](CONTRACT.md) | Product contract |
+| [`CONTEXT.md`](CONTEXT.md) | Domain map (internal self-model) |
+| [`docs/`](docs/) | Specs, ADRs, runtime notes — **English is the house default**; older paths may still mix languages while we migrate |
+
+---
 
 ## Contract pointers
 
 - Identity / secrets: CONTRACT C4 — genotype declares where secrets live, not how they arrive.  
-- Issue context: edge-next#136 (first-run); this README implements the stronger “yaml = output” path.
+- Issue context: first-run path where **yaml = output** of onboarding.
+- Public face: ship the core that already works; polish backlog does not block the face.
+
+---
+
+## License / status
+
+Open genotype. Installs carry their own identity. Contributions and issues welcome in **English** on this repo.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Documentation (en-US default)
+
+House language for **public and operator docs** is **English (en-US)**.
+
+| Area | Notes |
+|------|--------|
+| Root `README.md`, `CLAUDE.md`, `AGENTS.md`, `CONTRACT.md` | English entry surface |
+| `docs/adr/` | Architecture Decision Records (prefer English for new ADRs) |
+| `docs/specs/` | Product / install specs |
+| Older paths (`protocolo-*.md`, `contrato-*.md`, mixed PT prose) | **Migration in progress** — do not expand PT surface; new text in en-US |
+
+## Start here
+
+1. [../README.md](../README.md) — product + first-run  
+2. [specs/onboarding-first-run.md](specs/onboarding-first-run.md) — first-run contract  
+3. [../CONTRACT.md](../CONTRACT.md) — product contract  
+4. [adr/](adr/) — decisions  
+
+## Language policy (short)
+
+- **Genotype docs & defaults:** en-US.  
+- **Phenotype `language:`:** per install (onboarding emits `en` unless the operator sets otherwise).  
+- **Code comments / identifiers:** English; domain terms from the glossary may stay (Voz, Atividade, …) when they are product nouns.  
+- **Gradual migration:** translate or replace PT docs when you touch them; no big-bang rewrite required.


### PR DESCRIPTION
## Summary

- Public face of **edge-of-chaos** in **en-US**: product pitch + first-run truth in `README.md` (drops leftover PT and edge-next framing).
- `CLAUDE.md` / `AGENTS.md` fresh-clone guards translated to English; house language called out.
- `docs/README.md` — language policy: en-US default, gradual migration of older PT paths.
- Phenotype default was already `language: "en"` in `tools/onboarding.py` (unchanged).

## Out of scope (later)

- Full translation of mixed PT docs under `docs/` and skill bodies.
- Code string migration.

## Test plan

- [ ] Skim README as a cold GitHub visitor
- [ ] Confirm clone-fresh agents read EN CLAUDE/AGENTS
- [ ] Merge when ready; optionally set GitHub repo description to match pitch