### PR TITLE
fix: ingest Hermes sessions without Claude store

### DIFF
--- a/tests/test_sessions_hermes.py
+++ b/tests/test_sessions_hermes.py
@@ -1,0 +1,209 @@
+"""Hermes transcript adapter — public session export into the Edge sweep."""
+import json
+import os
+import stat
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import eventlog  # noqa: E402
+import sessions  # noqa: E402
+import sweep  # noqa: E402
+
+BODY = "a substantial decision about the Produto Isis architecture and its operational direction " * 4
+
+
+def export_row(session_id="h1", *, source="whatsapp_cloud", parent=None):
+    messages = []
+    for i in range(3):
+        messages.extend([
+            {"id": i * 2 + 1, "role": "user", "content": f"{BODY} ({i})",
+             "timestamp": 1000 + i * 2, "active": 1, "compacted": 0},
+            {"id": i * 2 + 2, "role": "assistant", "content": f"reply {i}: {BODY}",
+             "timestamp": 1001 + i * 2, "active": 1, "compacted": 0},
+        ])
+    messages.extend([
+        {"id": 90, "role": "tool", "content": "sensitive tool output", "timestamp": 2000,
+         "active": 1, "compacted": 0},
+        {"id": 91, "role": "session_meta", "content": "runtime metadata", "timestamp": 2001,
+         "active": 1, "compacted": 0},
+        {"id": 92, "role": "user", "content": "rewound text", "timestamp": 2002,
+         "active": 0, "compacted": 0},
+    ])
+    return {"id": session_id, "source": source, "parent_session_id": parent,
+            "started_at": 1000.0, "ended_at": 2000.0, "messages": messages}
+
+
+class MaterializeHermesExport(unittest.TestCase):
+    def test_current_session_anchor_uses_hermes_runtime_id(self):
+        self.assertEqual(
+            sessions.current_session_anchor({"HERMES_SESSION_ID": "h-live"}),
+            "hermes:h-live",
+        )
+
+    def test_writes_only_active_user_assistant_dialogue_and_preserves_surface(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            export = root / "export.jsonl"
+            export.write_text(json.dumps(export_row()) + "\n", encoding="utf-8")
+            found = sessions.materialize_hermes_export(export, root / "sessions")
+            self.assertEqual(len(found), 1)
+            self.assertEqual(stat.S_IMODE((root / "sessions").stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(found[0].path.stat().st_mode), 0o600)
+            self.assertEqual(found[0].surface, "hermes")
+            turns = sessions.read_turns(found[0].path, surface="hermes")
+            self.assertEqual([t.role for t in turns], ["human", "edge"] * 3)
+            text = "\n".join(t.text for t in turns)
+            self.assertNotIn("sensitive tool output", text)
+            self.assertNotIn("runtime metadata", text)
+            self.assertNotIn("rewound text", text)
+
+    def test_excludes_subagents_tool_sessions_cron_and_parent_sessions(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            export = root / "export.jsonl"
+            rows = [export_row("operator"), export_row("child", parent="operator"),
+                    export_row("subagent", source="subagent"),
+                    export_row("tool", source="tool"), export_row("cron", source="cron")]
+            export.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+            found = sessions.materialize_hermes_export(export, root / "sessions")
+            self.assertEqual([s.id for s in found], ["operator"])
+
+    def test_refresh_invokes_public_export_with_explicit_hermes_home(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            calls = []
+            def fake_run(command, **kwargs):
+                calls.append((command, kwargs))
+                Path(command[-1]).write_text(json.dumps(export_row()) + "\n", encoding="utf-8")
+                return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            found = sessions.refresh_hermes_sessions(
+                root / "sessions", hermes_home=root / "hermes-home", run=fake_run)
+            self.assertEqual([s.id for s in found], ["h1"])
+            self.assertEqual(calls[0][0][:3], ["hermes", "sessions", "export"])
+            self.assertEqual(calls[0][1]["env"]["HERMES_HOME"], str(root / "hermes-home"))
+            self.assertEqual(calls[0][1]["timeout"], 300)
+            self.assertFalse((root / "sessions.export.tmp").exists())
+
+    def test_refresh_serializes_concurrent_exports_for_one_cache(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            state = {"active": 0, "max_active": 0}
+            guard = threading.Lock()
+            errors = []
+
+            def fake_run(command, **kwargs):
+                with guard:
+                    state["active"] += 1
+                    state["max_active"] = max(state["max_active"], state["active"])
+                time.sleep(0.05)
+                Path(command[-1]).write_text(json.dumps(export_row()) + "\n", encoding="utf-8")
+                with guard:
+                    state["active"] -= 1
+                return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+            def refresh():
+                try:
+                    sessions.refresh_hermes_sessions(root / "sessions", run=fake_run)
+                except Exception as exc:  # captured so both threads always join
+                    errors.append(exc)
+
+            threads = [threading.Thread(target=refresh) for _ in range(2)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=5)
+
+            self.assertEqual(errors, [])
+            self.assertEqual(state["max_active"], 1)
+
+
+class SweepPlansHermesWithoutClaudeStore(unittest.TestCase):
+    def _store(self, root):
+        export = root / "export.jsonl"
+        export.write_text(json.dumps(export_row()) + "\n", encoding="utf-8")
+        store = root / "hermes"
+        sessions.materialize_hermes_export(export, store)
+        return store
+
+    def test_explicit_hermes_store_does_not_require_a_claude_project_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = self._store(Path(td))
+            plan = sweep.plan_sweep(False, {}, codex_dir=False, grok_dir=False, hermes_dir=store)
+            self.assertEqual([item["id"] for item in plan], ["hermes:h1"])
+            self.assertEqual(plan[0]["surface"], "hermes")
+            self.assertFalse(plan[0]["skip"])
+
+    def test_live_plan_refreshes_hermes_and_skips_missing_claude_store(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            export = root / "export.jsonl"
+            export.write_text(json.dumps(export_row()) + "\n", encoding="utf-8")
+            hermes_home = root / "hermes-home"
+            hermes_home.mkdir()
+            edge_home = root / "edge-home"
+
+            def fake_refresh(output_dir, *, hermes_home=None, run=None):
+                self.assertEqual(Path(hermes_home), root / "hermes-home")
+                return sessions.materialize_hermes_export(export, output_dir)
+
+            env = {"HERMES_HOME": str(hermes_home), "EDGE_HOME": str(edge_home)}
+            with mock.patch.dict(os.environ, env, clear=False), \
+                 mock.patch.object(sessions, "refresh_hermes_sessions", side_effect=fake_refresh), \
+                 mock.patch.object(sweep, "_claude_enabled", return_value=False):
+                plan = sweep.plan_sweep(None, {}, codex_dir=False, grok_dir=False)
+
+            self.assertEqual([item["id"] for item in plan], ["hermes:h1"])
+
+    def test_live_run_refreshes_once_and_never_resolves_claude(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            export = root / "export.jsonl"
+            export.write_text(json.dumps(export_row()) + "\n", encoding="utf-8")
+            hermes_home = root / "hermes-home"
+            hermes_home.mkdir()
+            edge_home = root / "edge-home"
+            calls = []
+
+            def fake_refresh(output_dir, *, hermes_home=None, run=None):
+                calls.append(Path(output_dir))
+                return sessions.materialize_hermes_export(export, output_dir)
+
+            env = {"HERMES_HOME": str(hermes_home), "EDGE_HOME": str(edge_home),
+                   "EDGE_TOPIC_DIRECTION": "0"}
+            with mock.patch.dict(os.environ, env, clear=False), \
+                 mock.patch.object(sessions, "refresh_hermes_sessions", side_effect=fake_refresh), \
+                 mock.patch.object(sweep, "_claude_enabled", return_value=False):
+                n = sweep.run(None, ingest_fn=lambda items: None,
+                              cursors_path=root / "cursors.json", reproject_fn=False,
+                              log=root / "log.jsonl", graph_recover_fn=False,
+                              group="limiar-test", codex_dir=False, grok_dir=False)
+
+            self.assertEqual(n, 1)
+            self.assertEqual(len(calls), 1)
+
+    def test_run_threads_hermes_store_into_episode_and_cursor(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            store = self._store(root)
+            log, cursors = root / "log.jsonl", root / "cursors.json"
+            seen = []
+            n = sweep.run(False, ingest_fn=lambda items: seen.extend(i["id"] for i in items),
+                          cursors_path=cursors, reproject_fn=False, log=log,
+                          graph_recover_fn=False, group="limiar-test", codex_dir=False,
+                          grok_dir=False, hermes_dir=store)
+            self.assertEqual((n, seen), (1, ["hermes:h1"]))
+            self.assertIn("hermes:h1", sweep.load_cursors(cursors))
+            episodes = eventlog.read(types=["episode"], log=log)
+            self.assertEqual(episodes[0]["payload"]["surface"], "hermes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sessions.py
+++ b/tools/sessions.py
@@ -1,7 +1,7 @@
 """Session reader + delta — the raw layer of the measure-learn spike (ADR-0004 decision A).
 
-A transcript is the non-lossy raw: one `.jsonl` = one session. **Three operator surfaces** —
-Claude Code, Codex, and Grok — normalize into the same ``Turn(role, text)`` shape.
+A transcript is the non-lossy raw: one `.jsonl` = one session. **Four operator surfaces** —
+Claude Code, Codex, Grok, and Hermes — normalize into the same ``Turn(role, text)`` shape.
 
 **Dialogue filter (rationalizer / quente / employment film):** the operator-visible corpus is
 exactly the Claude Code UI filter “conversation without terminals” — **user + assistant prose
@@ -14,11 +14,14 @@ Locator/offset-based; carries no domain semantics beyond surface normalization (
 import json
 import os
 import re
+import hashlib
+import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-# Operator-facing chat surfaces the edge films. Rationalization plans over all three.
-SURFACES = ("claude", "codex", "grok")
+# Operator-facing chat surfaces the edge films. Rationalization plans over all four.
+SURFACES = ("claude", "codex", "grok", "hermes")
 
 ROLES = {"user": "human", "assistant": "edge"}
 CODEX_ROLES = {"user": "human", "assistant": "edge"}
@@ -82,6 +85,10 @@ def grok_session_anchor(session_id: str) -> str:
     return session_id if session_id.startswith("grok:") else f"grok:{session_id}"
 
 
+def hermes_session_anchor(session_id: str) -> str:
+    return session_id if session_id.startswith("hermes:") else f"hermes:{session_id}"
+
+
 def split_session_anchor(session_id):
     if isinstance(session_id, str) and session_id.startswith("codex:"):
         raw = session_id[len("codex:"):]
@@ -89,11 +96,164 @@ def split_session_anchor(session_id):
     if isinstance(session_id, str) and session_id.startswith("grok:"):
         raw = session_id[len("grok:"):]
         return ("grok", raw) if raw else (None, None)
+    if isinstance(session_id, str) and session_id.startswith("hermes:"):
+        raw = session_id[len("hermes:"):]
+        return ("hermes", raw) if raw else (None, None)
     return ("claude", session_id) if isinstance(session_id, str) and session_id else (None, None)
 
 
+_HERMES_EXCLUDED_SOURCES = frozenset({"subagent", "tool", "cron"})
+
+
+def materialize_hermes_export(export_path, output_dir) -> list:
+    """Convert ``hermes sessions export`` JSONL into one transcript per operator session.
+
+    The public export is one JSON object per session, with nested messages. Edge cursors consume
+    one JSON line per message, so the private cache keeps only active user/assistant prose. Tool
+    output, rewound rows, worker sessions and parent/child sessions never enter the cache.
+    """
+    export_path = Path(export_path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(output_dir, 0o700)
+    for stale in output_dir.glob("*.jsonl"):
+        stale.unlink()
+    found = []
+    for raw in export_path.read_text(errors="replace").splitlines():
+        try:
+            row = json.loads(raw)
+        except ValueError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        session_id = row.get("id")
+        source = str(row.get("source") or "").strip().lower()
+        if (not isinstance(session_id, str) or not session_id.strip()
+                or source in _HERMES_EXCLUDED_SOURCES
+                or row.get("parent_session_id")):
+            continue
+        lines = [{
+            "type": "hermes_session_meta",
+            "id": session_id.strip(),
+            "source": source,
+            "started_at": row.get("started_at"),
+        }]
+        for message in row.get("messages") or []:
+            if not isinstance(message, dict) or message.get("active") in (0, False):
+                continue
+            role = message.get("role")
+            content = message.get("content")
+            if (role not in ("user", "assistant") or not isinstance(content, str)
+                    or not content.strip()):
+                continue
+            lines.append({
+                "type": "hermes_message",
+                "id": message.get("id"),
+                "role": role,
+                "content": content,
+                "timestamp": message.get("timestamp"),
+            })
+        if len(lines) == 1:
+            continue
+        digest = hashlib.sha256(session_id.strip().encode()).hexdigest()
+        path = output_dir / f"{digest}.jsonl"
+        path.write_text("".join(json.dumps(item, ensure_ascii=False) + "\n" for item in lines),
+                        encoding="utf-8")
+        os.chmod(path, 0o600)
+        stamp = row.get("ended_at") or row.get("started_at")
+        if isinstance(stamp, (int, float)) and stamp > 0:
+            os.utime(path, (float(stamp), float(stamp)))
+        found.append(Session(id=session_id.strip(), path=path, surface="hermes"))
+    return found
+
+
+def refresh_hermes_sessions(output_dir, *, hermes_home=None, run=None, timeout=300) -> list:
+    """Refresh one normalized cache at a time through public ``hermes sessions export``."""
+    import fcntl
+    output_dir = Path(output_dir)
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = output_dir.with_name(output_dir.name + ".refresh.lock")
+    with lock_path.open("w") as lock:
+        os.chmod(lock_path, 0o600)
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            return _refresh_hermes_sessions_unlocked(
+                output_dir, hermes_home=hermes_home, run=run, timeout=timeout)
+        finally:
+            fcntl.flock(lock, fcntl.LOCK_UN)
+
+
+def _refresh_hermes_sessions_unlocked(
+        output_dir, *, hermes_home=None, run=None, timeout=300) -> list:
+    """Build beside the live cache and replace it only after a complete successful export.
+
+    A failed or interrupted refresh cannot erase the last readable snapshot. The public wrapper
+    serializes this operation because predispatch and heartbeat may overlap on the same install.
+    """
+    output_dir = Path(output_dir)
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    export_tmp = output_dir.with_name(output_dir.name + ".export.tmp")
+    staging = output_dir.with_name(output_dir.name + ".refresh.tmp")
+    previous = output_dir.with_name(output_dir.name + ".previous.tmp")
+    for path in (staging, previous):
+        if path.exists():
+            shutil.rmtree(path)
+    export_tmp.unlink(missing_ok=True)
+    export_tmp.touch(mode=0o600)
+    env = os.environ.copy()
+    if hermes_home is not None:
+        env["HERMES_HOME"] = str(Path(hermes_home).expanduser())
+    run = subprocess.run if run is None else run
+    try:
+        result = run(
+            ["hermes", "sessions", "export", str(export_tmp)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=timeout,
+        )
+        if result.returncode != 0 or not export_tmp.is_file():
+            raise RuntimeError(f"hermes sessions export failed with exit {result.returncode}")
+        materialize_hermes_export(export_tmp, staging)
+        if output_dir.exists():
+            output_dir.rename(previous)
+        try:
+            staging.rename(output_dir)
+        except Exception:
+            if previous.exists() and not output_dir.exists():
+                previous.rename(output_dir)
+            raise
+        if previous.exists():
+            shutil.rmtree(previous)
+        return list_hermes_sessions(output_dir)
+    finally:
+        export_tmp.unlink(missing_ok=True)
+        if staging.exists():
+            shutil.rmtree(staging)
+
+
+def list_hermes_sessions(root) -> list:
+    """Discover normalized Hermes transcripts created by ``materialize_hermes_export``."""
+    root = Path(root)
+    if not root.is_dir():
+        return []
+    found = []
+    for path in sorted(root.glob("*.jsonl")):
+        session_id = None
+        try:
+            first = json.loads(path.read_text(errors="replace").splitlines()[0])
+            if first.get("type") == "hermes_session_meta":
+                session_id = first.get("id")
+        except (OSError, ValueError, IndexError):
+            pass
+        if isinstance(session_id, str) and session_id.strip():
+            found.append(Session(id=session_id.strip(), path=path, surface="hermes"))
+    return found
+
+
 def current_session_anchor(env=None):
-    """Live session anchor: Claude first, then Codex, then Grok, else None.
+    """Live session anchor: Claude, Codex, Grok, then Hermes, else None.
 
     Grok CLI does not export GROK_SESSION_ID; when unset, resolve from
     active_sessions.json (pid match / parent chain, else sole entry).
@@ -109,6 +269,9 @@ def current_session_anchor(env=None):
     sid = env.get("GROK_SESSION_ID")
     if isinstance(sid, str) and sid.strip():
         return grok_session_anchor(sid.strip())
+    sid = env.get("HERMES_SESSION_ID")
+    if isinstance(sid, str) and sid.strip():
+        return hermes_session_anchor(sid.strip())
     live = resolve_grok_live_session_id(env=env)
     if live:
         return grok_session_anchor(live)
@@ -320,7 +483,15 @@ def _first_human_text(path, surface="claude") -> str:
             obj = json.loads(line)
         except ValueError:
             continue
-        if surface == "codex":
+        if surface == "hermes":
+            if obj.get("type") != "hermes_message" or obj.get("role") != "user":
+                continue
+            text = _text_of(obj.get("content")).strip()
+            if any(text.startswith(prefix) for prefix in AUTOMATED_SESSION_PREFIXES):
+                return text
+            if not any(text.startswith(prefix) for prefix in SCAFFOLDING_PREFIXES):
+                return text
+        elif surface == "codex":
             if obj.get("type") != "response_item":
                 continue
             payload = obj.get("payload") or {}
@@ -536,6 +707,17 @@ def _grok_turn_from_obj(obj):
     return Turn(role=role, text=text)
 
 
+def _hermes_turn_from_obj(obj):
+    """One normalized Hermes-export message → Turn; metadata/tool rows stay dark."""
+    if not isinstance(obj, dict) or obj.get("type") != "hermes_message":
+        return None
+    role = {"user": "human", "assistant": "edge"}.get(obj.get("role"))
+    text = _text_of(obj.get("content")).strip()
+    if not role or not text or _is_scaffolding_turn(role, text):
+        return None
+    return Turn(role=role, text=text)
+
+
 def _normalize_surface(surface) -> str:
     s = (surface or "claude").strip().lower()
     if s not in SURFACES:
@@ -552,7 +734,9 @@ def _turns_from_lines(lines, surface="claude") -> list:
     """
     surface = _normalize_surface(surface)
     turns = []
-    if surface == "codex":
+    if surface == "hermes":
+        turn_from_obj = _hermes_turn_from_obj
+    elif surface == "codex":
         turn_from_obj = _codex_turn_from_obj
     elif surface == "grok":
         turn_from_obj = _grok_turn_from_obj

--- a/tools/surfaces_cfg.py
+++ b/tools/surfaces_cfg.py
@@ -130,13 +130,14 @@ def surface_enabled(name: str, cfg: dict | None = None, agent_yaml=None) -> bool
 
 
 def surface_home(name: str, cfg: dict | None = None, agent_yaml=None, env=None) -> Path | None:
-    """Resolved home dir for an optional surface (codex/grok), or None if unset.
+    """Resolved home dir for an optional surface (codex/grok/hermes), or None if unset.
 
     Precedence for codex: CODEX_HOME env → agent.yaml surfaces.codex.home → ~/.codex
     Precedence for grok:  GROK_HOME env  → agent.yaml surfaces.grok.home  → ~/.grok
+    Precedence for Hermes: HERMES_HOME env → agent.yaml surfaces.hermes.home → ~/.hermes
     """
     env = os.environ if env is None else env
-    env_key = {"codex": "CODEX_HOME", "grok": "GROK_HOME"}.get(name)
+    env_key = {"codex": "CODEX_HOME", "grok": "GROK_HOME", "hermes": "HERMES_HOME"}.get(name)
     if env_key:
         raw = env.get(env_key)
         if isinstance(raw, str) and raw.strip():
@@ -149,6 +150,8 @@ def surface_home(name: str, cfg: dict | None = None, agent_yaml=None, env=None) 
         return Path.home() / ".codex"
     if name == "grok":
         return Path.home() / ".grok"
+    if name == "hermes":
+        return Path.home() / ".hermes"
     return None
 
 

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -108,11 +108,9 @@ def _qualifies(turns, body):
 
 
 def _cursor_id(session):
-    """Claude keeps its historical cursor key; Codex/Grok are namespaced to avoid collisions."""
-    if session.surface == "codex":
-        return f"codex:{session.id}"
-    if session.surface == "grok":
-        return f"grok:{session.id}"
+    """Claude keeps its historical cursor key; other surfaces are namespaced."""
+    if session.surface in ("codex", "grok", "hermes"):
+        return f"{session.surface}:{session.id}"
     return session.id
 
 
@@ -122,6 +120,8 @@ def _source_description(item):
         return "Codex work session (mentee<->edge)"
     if surface == "grok":
         return "Grok work session (mentee<->edge)"
+    if surface == "hermes":
+        return "Hermes work session (mentee<->edge)"
     return "Claude work session (mentee<->edge)"
 
 
@@ -141,6 +141,35 @@ def _grok_enabled(project_dir, grok_dir):
     """Optional Grok surface: explicit dir / False override, else agent.yaml surfaces.grok."""
     import surfaces_cfg
     return surfaces_cfg.include_optional_surface("grok", project_dir, grok_dir)
+
+
+def _hermes_enabled(project_dir, hermes_dir):
+    """Optional Hermes surface: explicit normalized export dir or installed live Hermes."""
+    import surfaces_cfg
+    return surfaces_cfg.include_optional_surface("hermes", project_dir, hermes_dir)
+
+
+def _claude_enabled(project_dir):
+    """Claude is required only when explicit or both configured and installed on the live host."""
+    if project_dir is False:
+        return False
+    if project_dir is not None:
+        return True
+    import surfaces_cfg
+    return surfaces_cfg.include_optional_surface("claude", None, None)
+
+
+def _prepare_hermes_dir(project_dir, hermes_dir):
+    """Return an explicit normalized Hermes cache, refreshing it once for a live-host sweep."""
+    if hermes_dir is False or hermes_dir is not None:
+        return hermes_dir
+    if not _hermes_enabled(project_dir, None):
+        return False
+    import surfaces_cfg
+    home = surfaces_cfg.surface_home("hermes")
+    cache = _identity.state_root() / "state" / "hermes-sessions"
+    sessions.refresh_hermes_sessions(cache, hermes_home=home)
+    return cache
 
 
 def _film_window_start(log=None):
@@ -245,7 +274,7 @@ def _grok_baseline(cursors, grok_dir=None, install_birth=None):
 
 
 def record_session_exclusions(project_dir=None, *, log=eventlog.LOG, codex_dir=None,
-                              grok_dir=None):
+                              grok_dir=None, hermes_dir=None):
     """Append provenance corrections for non-operator sessions, once per session.
 
     This is deliberately mechanical and model-free. The raw transcript remains intact; report
@@ -253,13 +282,17 @@ def record_session_exclusions(project_dir=None, *, log=eventlog.LOG, codex_dir=N
     """
     include_codex = _codex_enabled(project_dir, codex_dir)
     include_grok = _grok_enabled(project_dir, grok_dir)
+    include_hermes = _hermes_enabled(project_dir, hermes_dir)
     if project_dir is None:
         project_dir = _identity.project_dir()
-    discovered = list(sessions.list_sessions(project_dir))
+    discovered = (list(sessions.list_sessions(project_dir))
+                  if project_dir is not False else [])
     if include_codex:
         discovered.extend(sessions.list_codex_sessions(codex_dir))
     if include_grok:
         discovered.extend(sessions.list_grok_sessions(grok_dir))
+    if include_hermes:
+        discovered.extend(sessions.list_hermes_sessions(hermes_dir))
     already = {
         payload["sessao_id"]
         for event in eventlog.read(types=["sessao.excluded"], log=log)
@@ -300,30 +333,33 @@ def _load_install_env():
 
 # --- pure plan: the digestible deltas (reads files, no graph/LLM) ---
 def plan_sweep(project_dir=None, cursors=None, recent=None, codex_dir=None, grok_dir=None,
-               install_birth=None):
+               hermes_dir=None, install_birth=None):
     """For each session, the turns after its cursor + the new watermark, in **chronological order**
     (oldest first — bi-temporal ingest wants it). `skip` marks a delta too thin to ingest (left
     un-advanced to grow). Idempotent: a session at its watermark yields nothing new. `recent=N`
     bounds a run to the N most-recently-modified sessions (the rest backfill on later sweeps —
     the cursor makes the full sweep resumable)."""
+    hermes_dir = _prepare_hermes_dir(project_dir, hermes_dir)
     include_codex = _codex_enabled(project_dir, codex_dir)
     include_grok = _grok_enabled(project_dir, grok_dir)
+    include_hermes = _hermes_enabled(project_dir, hermes_dir)
     if project_dir is None:
-        project_dir = _identity.project_dir()   # fail-loud seam (ADR-0015), never a baked-in path
+        project_dir = (_identity.project_dir() if _claude_enabled(None) else False)
     cursors = cursors or {}
     window = _film_window_start()
     found = []
-    for s in sessions.list_sessions(project_dir):
-        if not _in_window(s.path, window):
-            continue
-        if not sessions.is_user_session(s, install_birth=install_birth):
-            continue
-        sid = _cursor_id(s)
-        seen = cursors.get(sid, 0)
-        turns, watermark = sessions.delta(s.path, seen, surface=s.surface)
-        if watermark <= seen or not turns:
-            continue  # no new raw lines / no new dialogue
-        found.append((Path(s.path).stat().st_mtime, s, turns, watermark, sid))
+    if project_dir is not False:
+        for s in sessions.list_sessions(project_dir):
+            if not _in_window(s.path, window):
+                continue
+            if not sessions.is_user_session(s, install_birth=install_birth):
+                continue
+            sid = _cursor_id(s)
+            seen = cursors.get(sid, 0)
+            turns, watermark = sessions.delta(s.path, seen, surface=s.surface)
+            if watermark <= seen or not turns:
+                continue  # no new raw lines / no new dialogue
+            found.append((Path(s.path).stat().st_mtime, s, turns, watermark, sid))
     if include_codex:
         for s in sessions.list_codex_sessions(codex_dir):
             if not _in_window(s.path, window):
@@ -347,6 +383,18 @@ def plan_sweep(project_dir=None, cursors=None, recent=None, codex_dir=None, grok
             turns, watermark = sessions.delta(s.path, seen, surface=s.surface)
             if watermark <= seen or not turns:
                 continue  # no new raw lines / no new dialogue
+            found.append((Path(s.path).stat().st_mtime, s, turns, watermark, sid))
+    if include_hermes:
+        for s in sessions.list_hermes_sessions(hermes_dir):
+            if not _in_window(s.path, window):
+                continue
+            if not sessions.is_user_session(s, install_birth=install_birth):
+                continue
+            sid = _cursor_id(s)
+            seen = cursors.get(sid, 0)
+            turns, watermark = sessions.delta(s.path, seen, surface=s.surface)
+            if watermark <= seen or not turns:
+                continue
             found.append((Path(s.path).stat().st_mtime, s, turns, watermark, sid))
     found.sort(key=lambda x: x[0])           # chronological
     if recent:
@@ -833,7 +881,7 @@ def execute(plan, ingest_fn, cursors, log=eventlog.LOG):
         # until which the read-door fail-safe (unknown ⇒ context_only) holds the C5 invariant.
         payload = {"session": it["id"], "watermark": it["watermark"], "chars": len(it["body"]),
                    "medium_tier": "low_tier"}
-        if it.get("surface") in ("codex", "grok"):
+        if it.get("surface") in ("codex", "grok", "hermes"):
             payload["surface"] = it["surface"]
         eventlog.append("episode", f"session:{it['id']}", payload, log=log)
         cursors[it["id"]] = it["watermark"]
@@ -1163,7 +1211,7 @@ def _acquire_cursors_lock(lk, wait_s=CURSORS_LOCK_WAIT_S, poll_s=CURSORS_LOCK_PO
 
 def run(project_dir=None, ingest_fn=None, cursors_path=CURSORS, reproject_fn=None,
         log=eventlog.LOG, recent=None, graph_recover_fn=None, group=None, codex_dir=None,
-        grok_dir=None, cursors_lock_wait_s=None):
+        grok_dir=None, hermes_dir=None, cursors_lock_wait_s=None):
     """Full sweep: plan the deltas → ingest + log + advance cursors → re-project (if anything new) →
     graph-recover (ALWAYS). `recent=N` bounds this run to the N newest sessions (the rest backfill on
     later sweeps). Graph recovery runs EVERY sweep, independent of `n` (Codex P2), so a no-delta sweep
@@ -1176,8 +1224,17 @@ def run(project_dir=None, ingest_fn=None, cursors_path=CURSORS, reproject_fn=Non
     # write as anyone — Tier-0 episode appends and cursor advances ARE writes. Identity fails
     # loud HERE, before the delta is consumed, never mid-sweep (where a rerun would see the
     # delta as already eaten by a groupless ghost). Tests pass `group` explicitly (hermetic).
-    if project_dir is None:
+    live_host = project_dir is None
+    if live_host:
         _load_install_env()
+        # Resolve every installed optional surface before replacing the absent Claude store with
+        # the explicit False sentinel. This preserves Codex/Grok parity on multi-harness hosts.
+        if codex_dir is None and _codex_enabled(None, None):
+            codex_dir = sessions.codex_sessions_dir()
+        if grok_dir is None and _grok_enabled(None, None):
+            grok_dir = sessions.grok_sessions_dir()
+        hermes_dir = _prepare_hermes_dir(None, hermes_dir)
+        project_dir = (_identity.project_dir() if _claude_enabled(None) else False)
     if group is None:
         group = _identity.require_group()
     # The whole load→plan→execute→save window is serialized by an exclusive flock on a sibling
@@ -1201,7 +1258,8 @@ def run(project_dir=None, ingest_fn=None, cursors_path=CURSORS, reproject_fn=Non
         try:
             cursors = load_cursors(cursors_path)
             excluded = record_session_exclusions(
-                project_dir, log=log, codex_dir=codex_dir, grok_dir=grok_dir)
+                project_dir, log=log, codex_dir=codex_dir, grok_dir=grok_dir,
+                hermes_dir=hermes_dir)
             corrected = bool(excluded)
             if excluded:
                 print(f"sweep: excluded {len(excluded)} delegated/protocol session(s) "
@@ -1212,7 +1270,8 @@ def run(project_dir=None, ingest_fn=None, cursors_path=CURSORS, reproject_fn=Non
             if _grok_enabled(project_dir, grok_dir):
                 cursors = _grok_baseline(cursors, grok_dir, install_birth=birth)
             plan = plan_sweep(project_dir, cursors, recent=recent, codex_dir=codex_dir,
-                              grok_dir=grok_dir, install_birth=birth)
+                              grok_dir=grok_dir, hermes_dir=hermes_dir,
+                              install_birth=birth)
             cursors, n = execute(plan, ingest_fn or graphiti_ingest, cursors, log=log)
             save_cursors(cursors, cursors_path)
             proposed = _maybe_propose_topic_directions(project_dir=project_dir, codex_dir=codex_dir,


### PR DESCRIPTION
## Summary

- add a narrow adapter from the public `hermes sessions export` JSONL format to Edge's per-session dialogue cache
- let `sweep` ingest Hermes sessions without requiring a Claude transcript store
- namespace Hermes cursors/events and resolve the live session from `HERMES_SESSION_ID`
- filter tool, metadata, inactive, cron, subagent, and parent-session records before they reach the cache
- refresh the normalized cache through a staged replacement so failed exports retain the last readable snapshot

## Scope

This does **not** add a Claude fallback, enable heartbeat/autonomy, author `agent.yaml`, or change the onboarding identity contract. It only closes the mismatch where onboarding already estimated Hermes sessions but the sweep still required Claude.

## Verification

- `EDGE_GROUP=test /opt/data/edge-home/.venv/bin/python -m unittest tests.test_sessions_hermes tests.test_onboarding_hermes tests.test_sweep -q` — 47 tests passed
- Python compilation and `git diff --check` passed
- live read-only plan with `HERMES_HOME=/opt/data`, `EDGE_HOME=/opt/data/edge-home`, and no Claude store succeeded: 5/5 recent Hermes sessions qualified
- normalized cache contained 234 operator-facing session files; no transcript bodies or credentials were printed

## Baseline note

A separate broader run found nine failures in legacy Claude/Codex/Grok session-filter tests. The same nine failures reproduce on an untouched worktree at the base commit, so they are pre-existing and not regressions from this patch.

## Review focus

- public-export compatibility and idempotent cursor behavior
- privacy filtering and tenant-local cache placement
- live-host behavior when Claude is absent
- concurrent refresh/failure semantics
