### PR TITLE
feat: Adapter - Integrates Hermes agents with Edge of Chaos's Network 

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,22 @@ tools/edge-python tools/edge-apply --yaml agent.yaml --home ~/edge
 
 ---
 
+## Hermes profiles and `edge_group`
+
+A Hermes profile identifies the session source. It does not create a Graphiti namespace named `profile-*`.
+
+`edge_group` isolates one EoC installation's graph inside a shared Neo4j:
+
+- `edge_group: default` reads and writes group `default`.
+- Profiles without an override inherit the root Hermes `edge_group`.
+- Override it only to join another installation/hive, using its name directly (`research`), never `profile-research` or `profile:research`.
+- Sweep, recall, Cortex, and validation must resolve the same value. Changing it selects another namespace; it does not migrate nodes.
+- Graphiti IDs allow only letters, numbers, hyphens, and underscores.
+
+For one installation, set `edge_group: default` in `~/.hermes/config.yaml`.
+
+---
+
 ## Documentation
 
 | Doc | Role |

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ tools/edge-python tools/edge-apply --yaml agent.yaml --home ~/edge
 
 | Doc | Role |
 |-----|------|
+| [`docs/hermes-installation.md`](docs/hermes-installation.md) | Install, upgrade, and verify EoC in Hermes Agent |
 | [`CLAUDE.md`](CLAUDE.md) / [`AGENTS.md`](AGENTS.md) | Fresh-clone guard for agent harnesses |
 | [`CONTRACT.md`](CONTRACT.md) | Product contract |
 | [`CONTEXT.md`](CONTEXT.md) | Domain map (internal self-model) |

--- a/docs/adr/0025-hermes-profiles-share-through-edge-group.md
+++ b/docs/adr/0025-hermes-profiles-share-through-edge-group.md
@@ -1,0 +1,61 @@
+# ADR-0025 — Hermes profiles share through `edge_group`
+
+**Status:** Accepted
+**Date:** 2026-07-28
+
+## Context
+
+Hermes isolates profiles under separate configuration directories, while Edge already uses
+`edge_group` as the network in which an installation exposes learned knowledge. The Hermes
+adapter must preserve profile isolation without inventing a second ACL or changing the other
+surfaces.
+
+## Decision
+
+Hermes resolves one effective `edge_group` per profile:
+
+1. `~/.hermes/config.yaml` supplies the value for the default profile.
+2. `~/.hermes/profiles/<profile>/config.yaml` supplies the value for that named profile.
+3. An absent `edge_group` disables Edge in that profile.
+4. A present empty value means `origin-only` for that profile.
+5. A non-empty value names an existing Edge exposure network. Every string has identical
+   semantics: `global`, if used, is merely a group whose name happens to be `global`.
+6. Legacy Hermes sessions without `profile_name` belong to `default`.
+
+`origin-only` resolves to a profile-private network. Two profiles with empty `edge_group` do not
+share knowledge.
+
+Physical Edge state and cursors remain shared. At the Hermes ingestion seam, evidence keeps the
+existing Hermes `profile_name` from its source session and the resolved `edge_group`. No new
+configuration variable or parallel profile identity is introduced.
+
+A derived artifact receives the most restrictive classification among its evidence. Global or
+named-group evidence combined with `origin-only` remains `origin-only`. Evidence from two
+different `origin-only` profiles must not be consolidated; the conflict is recorded.
+
+At Hermes gateway startup, reconciliation compares every profile configuration with the installed
+Edge state. A newly configured profile receives the Edge skill wrappers. A changed `edge_group`
+migrates only artifacts linked exclusively to sessions from that `profile_name`; mixed-profile
+artifacts remain in their previous group.
+
+Removing the `edge_group` key disables Edge for that profile. Reconciliation removes that
+profile's Edge skill wrappers and deletes Edge memories and derived artifacts linked exclusively
+to its sessions. Mixed-profile artifacts and the original Hermes sessions remain intact.
+
+## Consequences
+
+- Hermes profiles using the same non-empty group name share the same Edge network.
+- An empty override isolates one profile without adding configuration variables.
+- Provenance cannot be reconstructed only at recall time; it must survive the full
+  `sweep → event log → consolidation → memory` path.
+- Group changes need no daemon or gateway startup hook.
+- Disabling a profile is destructive for its exclusive derived Edge knowledge, but never for its
+  Hermes source sessions.
+- Claude, Codex, and Grok behavior is unchanged.
+
+## Rejected
+
+- One Edge installation per Hermes profile: duplicates state and cursors.
+- New profile or exposure configuration variables: duplicate `edge_group` and `profile_name`.
+- Stamping only final memories: loses provenance during consolidation.
+- Automatic promotion from `origin-only` to a named group: leaks restricted evidence.

--- a/docs/hermes-installation.md
+++ b/docs/hermes-installation.md
@@ -15,7 +15,7 @@ Example paths used below:
 ```bash
 export EDGE_REPO="$HOME/src/edge-of-chaos"
 export EDGE_HOME="$HOME/.edge-of-chaos/steve"
-export EDGE_GROUP="profile:default"
+export EDGE_GROUP="default"
 ```
 
 `EDGE_HOME` isolates identity, state, memory, secrets, runtime, and projections for one phenotype. `EDGE_GROUP` selects the graph/hivemind namespace. Use both variables on every EoC command; never rely on an unrelated working directory.
@@ -25,18 +25,18 @@ export EDGE_GROUP="profile:default"
 Hermes resolves EoC per profile:
 
 - missing effective `edge_group`: EoC is disabled for that profile;
-- blank `edge_group`: use `profile:<profile_name>`;
+- blank `edge_group`: use the profile name directly (`work`, not `profile-work` or `profile:work`);
 - named `edge_group`: profiles with that value share one EoC hivemind.
 
 Set the global default in Hermes `config.yaml`, then override it in a profile config only when that profile needs different behavior. See [ADR-0025](adr/0025-hermes-profiles-share-through-edge-group.md).
 
-For an isolated default profile:
+For a single installation:
 
 ```yaml
-edge_group: ""
+edge_group: default
 ```
 
-This resolves to `profile:default`; it does not create a second storage layer.
+This resolves to `default`; it does not create a second storage layer.
 
 ## 3. Create the phenotype runtime
 
@@ -113,7 +113,7 @@ Predispatch validates the phenotype before a wake. Follow the exact command in `
 
 ```bash
 export EDGE_HOME="$HOME/.edge-of-chaos/steve"
-export EDGE_GROUP="profile:default"
+export EDGE_GROUP="default"
 cd "$EDGE_REPO"
 # Run the predispatch command documented by skills/wake/SKILL.md.
 ```
@@ -170,7 +170,7 @@ git diff --check
 cd "$EDGE_REPO"
 git pull --ff-only
 export EDGE_HOME="$HOME/.edge-of-chaos/steve"
-export EDGE_GROUP="profile:default"
+export EDGE_GROUP="default"
 tools/edge-python tools/_hermes_provision.py
 ```
 

--- a/docs/hermes-installation.md
+++ b/docs/hermes-installation.md
@@ -1,0 +1,203 @@
+# Install and onboard Edge of Chaos in Hermes Agent
+
+This runbook installs one Edge of Chaos (EoC) phenotype for a Hermes profile, completes onboarding, and verifies the first wake. The repository is the **genotype**; the directory under `~/.edge-of-chaos/` is the live **phenotype**. Do not create `agent.yaml` in a fresh clone: it is the output of onboarding.
+
+## 1. Prerequisites
+
+- a working Hermes Agent installation;
+- Python 3 and Git;
+- Docker when Neo4j is provisioned locally;
+- a clone of this repository;
+- the target Hermes profile and its intended EoC group.
+
+Example paths used below:
+
+```bash
+export EDGE_REPO="$HOME/src/edge-of-chaos"
+export EDGE_HOME="$HOME/.edge-of-chaos/steve"
+export EDGE_GROUP="profile:default"
+```
+
+`EDGE_HOME` isolates identity, state, memory, secrets, runtime, and projections for one phenotype. `EDGE_GROUP` selects the graph/hivemind namespace. Use both variables on every EoC command; never rely on an unrelated working directory.
+
+## 2. Choose the Hermes profile policy
+
+Hermes resolves EoC per profile:
+
+- missing effective `edge_group`: EoC is disabled for that profile;
+- blank `edge_group`: use `profile:<profile_name>`;
+- named `edge_group`: profiles with that value share one EoC hivemind.
+
+Set the global default in Hermes `config.yaml`, then override it in a profile config only when that profile needs different behavior. See [ADR-0025](adr/0025-hermes-profiles-share-through-edge-group.md).
+
+For an isolated default profile:
+
+```yaml
+edge_group: ""
+```
+
+This resolves to `profile:default`; it does not create a second storage layer.
+
+## 3. Create the phenotype runtime
+
+Keep the clone and live state separate:
+
+```bash
+mkdir -p "$EDGE_HOME"
+ln -sfn "$EDGE_REPO/tools" "$EDGE_HOME/tools"
+python3 -m venv "$EDGE_HOME/.venv"
+"$EDGE_HOME/.venv/bin/python" -m pip install -r "$EDGE_REPO/requirements.txt"
+```
+
+If the repository does not have a requirements file for the current revision, follow `skills/setup/SKILL.md` instead of inventing another installer. All later Python commands should go through the repository wrapper:
+
+```bash
+cd "$EDGE_REPO"
+tools/edge-python -c 'from tools import _identity; print(_identity.state_root())'
+```
+
+The printed state root must equal `EDGE_HOME`. During first bootstrap, identity resolution honors `EDGE_HOME` even before `agent.yaml` exists.
+
+## 4. Run canonical onboarding
+
+Read and execute the rite in [`skills/onboard/SKILL.md`](../skills/onboard/SKILL.md). Onboarding is a real interview and setup sequence, not a copied template. It must establish:
+
+1. mentor identity, personality, method, and language;
+2. who the mentee is and how confirmed signals enter `memory/leveling/`;
+3. available local surfaces and public sources;
+4. embeddings and graph requirements;
+5. backfill scope, with a cost check before acquisition;
+6. heartbeat policy;
+7. the final `agent.yaml` written under `EDGE_HOME`.
+
+Run setup commands with the explicit environment:
+
+```bash
+cd "$EDGE_REPO"
+EDGE_HOME="$EDGE_HOME" EDGE_GROUP="$EDGE_GROUP" \
+  tools/edge-python tools/edge-apply --yaml "$EDGE_HOME/agent.yaml" --home "$EDGE_HOME"
+```
+
+Do not copy credentials into `agent.yaml`, documentation, eventlog, or Git. Store local secrets under `$EDGE_HOME/secrets/` with restrictive permissions.
+
+## 5. Provision and verify Neo4j
+
+Use the canonical provisioner from `tools/_provision.py`; do not create a parallel graph deployment. A local Docker deployment writes its connection environment under `$EDGE_HOME/secrets/neo4j.env`.
+
+After setup, verify the service and configuration without printing secret values:
+
+```bash
+docker ps --filter name=edge-neo4j --format '{{.Names}} {{.Status}}'
+test -s "$EDGE_HOME/secrets/neo4j.env"
+```
+
+The container must be running and the environment file must exist. Never commit that file.
+
+## 6. Install the Hermes integration
+
+The Hermes startup plugin reconciles profile-local EoC skill wrappers. Apply the canonical provisioner from this repository rather than copying wrappers by hand:
+
+```bash
+cd "$EDGE_REPO"
+EDGE_HOME="$EDGE_HOME" EDGE_GROUP="$EDGE_GROUP" \
+  tools/edge-python tools/_hermes_provision.py
+```
+
+Restart the Hermes gateway/app after plugin installation so startup reconciliation runs. The plugin is the owner of generated wrappers; upgrading EoC should reconcile them instead of layering another copy.
+
+Hermes `web_search` and `web_extract` are shared logical acquisition capabilities. Exa, Firecrawl, Tavily, Parallel, or SearXNG are interchangeable Hermes backends and should appear only as provenance. Do not declare each backend as another EoC source, duplicate credentials, or persist full tool payloads.
+
+## 7. Run predispatch and the first wake
+
+Predispatch validates the phenotype before a wake. Follow the exact command in `skills/wake/SKILL.md` for the installed revision, always exporting the phenotype identity:
+
+```bash
+export EDGE_HOME="$HOME/.edge-of-chaos/steve"
+export EDGE_GROUP="profile:default"
+cd "$EDGE_REPO"
+# Run the predispatch command documented by skills/wake/SKILL.md.
+```
+
+Only continue when predispatch exits `0`.
+
+A complete wake keeps four cognitions separate:
+
+- **assemble** — consolidated state and internal orientation;
+- **delta** — Mundo, Atividade, and Voz since the previous wake;
+- **recall** — salient graph memory and mentee persona, without bookkeeping;
+- **quente** — live threads, without taking action.
+
+Run each leg according to its own skill contract (`skills/assemble`, `skills/delta`, `skills/recall`, and `skills/quente`). Do not concatenate their raw outputs into a fifth mega-brief. The live intersection comes from compact references and provenance across native projections.
+
+The eventlog is the source of truth. It records useful events and references, not full web responses or complete tool transcripts. Graph, wiki, and Direction are derived projections and can be rebuilt.
+
+## 8. Verification checklist
+
+A successful installation satisfies all of these:
+
+```text
+[ ] EDGE_HOME resolves to the phenotype directory
+[ ] EDGE_GROUP resolves to the intended profile or shared hivemind
+[ ] agent.yaml exists only in the phenotype
+[ ] Hermes startup plugin reconciles the EoC wrappers
+[ ] Neo4j is online and its secret environment file is local only
+[ ] public/local source canaries pass
+[ ] predispatch exits 0
+[ ] recall is not DARK and includes the confirmed mentee persona
+[ ] quente exits 0
+[ ] assemble, delta, recall, and quente remain separate
+[ ] eventlog contains references, not duplicated full payloads
+```
+
+Focused repository regression gate:
+
+```bash
+cd "$EDGE_REPO"
+python3 -m unittest \
+  tests.test_hermes_pipeline \
+  tests.test_hermes_provision \
+  tests.test_identity_env_dir \
+  tests.test_mentee_persona_brief \
+  tests.test_recall_brief \
+  tests.test_quente \
+  tests.test_hermes_sessions
+git diff --check
+```
+
+## 9. Upgrade
+
+```bash
+cd "$EDGE_REPO"
+git pull --ff-only
+export EDGE_HOME="$HOME/.edge-of-chaos/steve"
+export EDGE_GROUP="profile:default"
+tools/edge-python tools/_hermes_provision.py
+```
+
+Then rerun predispatch and the focused regression gate. Preserve `agent.yaml`, `memory/`, `state/`, `secrets/`, and the eventlog under `EDGE_HOME`; do not replace the phenotype with the repository clone.
+
+## 10. Troubleshooting
+
+### Identity resolves to the clone
+
+Confirm `EDGE_HOME` is exported on the failing command. Bootstrap must resolve `$EDGE_HOME/agent.yaml` even before that file exists.
+
+### Recall is DARK
+
+Check Neo4j first, then `$EDGE_HOME/secrets/neo4j.env`. Do not regenerate recall repeatedly while the graph is unavailable.
+
+### Mentee persona is empty
+
+The canonical path is `$EDGE_HOME/memory/leveling/perfil.md`. Persona belongs to the phenotype, not the genotype clone. Add only confirmed signals; do not fabricate missing biography.
+
+### Quente includes unrelated Hermes sessions
+
+Check the effective `edge_group` for every Hermes profile. Tests that exercise only a local fixture must pass `hermes_dir=False` when the real Hermes surface is intentionally out of scope.
+
+### Duplicate acquisition or inflated context
+
+Keep `web_search`/`web_extract` as the interfaces and backend names as provenance. Store compact references in the eventlog; do not mirror full responses into briefs, graph, wiki, and Direction.
+
+### Generated wrappers drift after an upgrade
+
+Rerun `tools/_hermes_provision.py` and restart Hermes. Do not edit generated profile wrappers manually.

--- a/skills/_shared/pipeline.md
+++ b/skills/_shared/pipeline.md
@@ -111,7 +111,7 @@ The prose phases above bottom out in two testable modules in `tools/`:
 ## The close lives at the skill's EXIT
 
 The close is **not** the beat's job. It lives in this shared pipeline, at the **skill's exit**.
-This honors **ADR-0008**: a **standalone** `/ed-report` — invoked directly, with no beat around
+This honors **ADR-0008**: a **standalone** `/{prefix}-report` — invoked directly, with no beat around
 it — exits through the same close, so it observes the same review gates and the same atomic
 publish. The lifecycle is never privileged to the beat; whatever runs the producer, the close
 runs at its exit.
@@ -167,7 +167,7 @@ artefato opens whole by itself. The gate is unchanged: interaction that TEACHES,
 Every artefato carries its **origin** (`user_requested | beat`), resolved from the dispatch that
 woke it (`predispatch.py --origin`; the publisher persists it on `artefato.published`, the corpus
 fold and the graph projection carry it). **A standalone producer the mentee invoked directly
-(`/ed-report`, a pedido) wakes with `--origin user_requested`** — the default is `beat`, so an
+(`/{prefix}-report`, a pedido) wakes with `--origin user_requested`** — the default is `beat`, so an
 undeclared wake never claims the mentee's voice. A
 user-requested artefato is exactly where the mentee's cognition is NOW — first-order signal;
 a beat artefato is exploration, indistinguishable from noise. Everything that learns from

--- a/skills/beat/SKILL.md
+++ b/skills/beat/SKILL.md
@@ -63,7 +63,7 @@ artefato-agents) são chamadas paralelas NO MESMO turno — o paralelismo vem da
 simultâneas, nunca de background + espera.
 
 **Caminho comandado (Voz fast-path, §1 da tabela):** quando o dispatch nasce de uma ordem do
-operador (wake `--origin user_requested`, um `/ed-report sobre X`, um pedido direto na sessão),
+operador (wake `--origin user_requested`, um `/{prefix}-report sobre X`, um pedido direto na sessão),
 a ordem TRAVA os campos que nomeia e o funil roda só nos graus de liberdade restantes:
 
 - `tools/edge-python tools/pauta.py sortear --lock abordagem=... [--lock objeto=...]` para os
@@ -140,7 +140,7 @@ the SAME turn — blocking; the lei do turno above rules here too):
 The close is **not the beat's job**. Every branch funnels through the **one shared pipeline**
 (`skills/_shared/pipeline.md`) at its own exit: the genus contract, the two blind reviewers, the
 improve loop, the atomic publish with its `intent.kernel`, the **consolidação do grafo**, the
-chamada and the Voz cycle. A standalone `/ed-report` observes the same gates (ADR-0008). The
+chamada and the Voz cycle. A standalone `/{prefix}-report` observes the same gates (ADR-0008). The
 bounce-bound lives in the protocol, never in the producer's discretion. Do not run a close in
 the trunk; do not archive or fan by hand (digestion is the pull-at-open sweep every dispatch
 runs at entry).

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -15,7 +15,7 @@ translate the uncertainty into the schema.
 enters the ledger and cortex. That does **not** dissolve experiment. An **Experiment is a subset of
 Atividade** — same employment case, plus a **provenance rite** (chain of prior experiments/claims)
 and a mandatory **eval** product (biased or not; still an eval) that **generates knowledge**. This
-skill (`/ed-experiment`) is what **manages that subset**. Ordinary Atividades (ship, fix, wayfind)
+skill (`/{prefix}-experiment`) is what **manages that subset**. Ordinary Atividades (ship, fix, wayfind)
 stay employment-only unless promoted into this rite. See CONTEXT.md **Experiment** and
 `memory/experiment-is-atividade-with-rite-and-eval.md`.
 

--- a/skills/mentor/SKILL.md
+++ b/skills/mentor/SKILL.md
@@ -136,7 +136,7 @@ hunger instead of pretending to know.
 
 **First-run (no phenotype yet):** do **not** open cold. Require the wake-shaped insumo at
 `state/onboarding-insumo.md` (assemble + secrets + secrets delta + quente + delta + recall;
-**no Direction** — Direction is born in this mentor). If missing: run `/ed-wake` / predispatch
+**no Direction** — Direction is born in this mentor). If missing: run `/{prefix}-wake` / predispatch
 first (it auto-stamps via `onboarding.maybe_stamp_insumo`) or
 `tools/edge-python -c "import onboarding; onboarding.assert_mentor_has_insumo(home)"`.
 After steers + leveling land, **one close**:

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -237,6 +237,10 @@ default interval (`8h`) so a later hand-ignition has its dial.
 
 ## 2. Runtime — the graph
 
+Before bootstrap, require `secrets/openai.env` containing `OPENAI_API_KEY`. Graphiti extraction
+currently uses OpenAI directly even when embeddings use OpenRouter/Azure; do not proceed until
+`edge-apply --validate` reports the key present.
+
 ```bash
 tools/edge-python tools/edge-bootstrap runtime --home <home>
 ```

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -247,6 +247,13 @@ Picks the install mode automatically (`ensure_neo4j`): **docker** (Neo4j 5.x pin
 Password generated into `secrets/neo4j.env` (mode 600), idempotent. A host without docker no longer
 stops the install — it installs `local`. `DARK` prints only when no mode can bring the graph up.
 
+### Hermes network boundary
+
+If Hermes is installed and `edge_group` is not already declared in its config, ask whether the
+user wants a named shared EoC network. Blank means origin-only and is the safe default. Pass the
+answer to bootstrap as `--hermes-edge-group "<name>"`. Never replace an existing value, including
+an existing blank value.
+
 ## 3. First wake — the insumo, shown and explained
 
 Run predispatch/wake (lookback = the backfill days). It films the operator's history and

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -160,6 +160,6 @@ Create `state/setup/` if missing:
 - Portuguese if `agent.yaml` language is pt-BR.
 ---
 
-## Relationship to old `ed-autonomia`
+## Relationship to old `/{prefix}-autonomia`
 
 Absorbs the **v1** job (bootstrap inventory, frontier, “what am I missing?”) and the **setup** job (phenotype: sources, voice, keys, routers) into one operator-facing door. Continuous primitive probe/repair stays out of this skill unless explicitly asked.

--- a/skills/wake/SKILL.md
+++ b/skills/wake/SKILL.md
@@ -3,7 +3,7 @@ name: wake
 description: Operator wake — come online holding the four briefs (assemble + delta + recall + quente),
   render the orientation to the human, then halt and work under command. The beat's open without its act.
 ---
-You are **ed, waking under command** — not a beat. You come online the way the beat opens (fan the
+You are **{name}, waking under command** — not a beat. You come online the way the beat opens (fan the
 four briefs, block on them), render where things stand, and then **stop**. This is the beat's step 1
 without steps 2–4: you orient, you do not act. The operator drives from here.
 
@@ -109,14 +109,14 @@ split up** — do not re-soften inacabada or re-harden ongoing.
 ### 2b. Orientation (after §2a)
 
 Present a tight orientation, **not a state dump**:
-- **Where ed left off** — curated Direction + the open bet (from assemble).
+- **Where {name} left off** — curated Direction + the open bet (from assemble).
 - **O que está quente** (from quente) — heat narrative with state table (**Atividade · sessão
   aberta|fechada · ongoing|inacabada|settled · clear**). Fios = how heat is told; employment =
   Atividade. Ongoing acknowledged; inacabada already led if any.
 - **What's new** — the world delta (from delta), or "nothing new" stated plainly.
 - **What you hold** — recall: objective, live bets, open Atividades, salient Artefatos; weave,
   do not dump.
-- **The live intersection** — the one theme ed *would* pursue as autonomous beat: deep domain
+- **The live intersection** — the one theme {name} *would* pursue as autonomous beat: deep domain
   insight × mentee's live work, named as the decision not yet made — **with ongoing employment
   held in mind**.
 - **Awaiting your word (Voz)** — the latest published artefatos the mentee has NOT
@@ -166,7 +166,7 @@ print("insumo →", onboarding.insumo_path(home))
 PY
 ```
 
-4. Recommended next move: **`/ed-mentor`** with that insumo — not production beat.
+4. Recommended next move: **`/{prefix}-mentor`** with that insumo — not production beat.
 
 ### First-run / onboarding wake (no agent.yaml yet)
 
@@ -193,7 +193,7 @@ print("insumo →", onboarding.insumo_path(home))
 PY
 ```
 
-4. Recommended next move: **`/ed-mentor`** with that insumo — not production beat.
+4. Recommended next move: **`/{prefix}-mentor`** with that insumo — not production beat.
 
 ## 3. Halt — do nothing; stand by (the whole point)
 
@@ -205,5 +205,5 @@ the `intent.kernel` close — those are the beat's autonomous acts (ADR-0009), a
   bookkeeping, not a judgment write) and the throwaway `/tmp/quente-insumo.md`. Wake reads and
   renders — nothing else.
 - **Everything downstream is operator-directed.** The next move is the operator's word. When they
-  give it, run the skill it names under command — `/ed-mentor` (legacy `/ed-grill`), `/ed-report`,
+  give it, run the skill it names under command — `/{prefix}-mentor` (legacy `/{prefix}-grill`), `/{prefix}-report`,
   the full beat, a direct question — each within its own contract. Until then, **wait.**

--- a/tests/test_hermes_pipeline.py
+++ b/tests/test_hermes_pipeline.py
@@ -43,13 +43,22 @@ class HermesPipelineTest(HermesSessionsTest):
         self.assertEqual(planned[0]["turns"][:2], [
             sessions.Turn("human", "question"), sessions.Turn("edge", "answer")])
 
-    def test_sweep_does_not_date_cut_hermes_history(self):
+    def test_first_sweep_does_not_date_cut_hermes_history(self):
         (self.home / "config.yaml").write_text("edge_group: hive\n")
         with mock.patch.object(sweep, "_film_window_start", return_value=10**20):
             planned = sweep.plan_sweep(
                 project_dir=self.home, cursors={}, recent=None,
                 codex_dir=False, grok_dir=False, hermes_dir=self.db)
         self.assertEqual([p["profile_name"] for p in planned], ["work", "default"])
+
+    def test_later_sweep_restores_hermes_date_window(self):
+        (self.home / "config.yaml").write_text("edge_group: hive\n")
+        with mock.patch.object(sweep, "_film_window_start", return_value=10**20):
+            planned = sweep.plan_sweep(
+                project_dir=self.home,
+                cursors={sweep.HERMES_BASELINE_KEY: True}, recent=None,
+                codex_dir=False, grok_dir=False, hermes_dir=self.db)
+        self.assertEqual(planned, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_hermes_pipeline.py
+++ b/tests/test_hermes_pipeline.py
@@ -1,0 +1,41 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "tools"))
+import quente
+import sessions
+import sweep
+from tests.test_hermes_sessions import HermesSessionsTest
+
+
+class HermesPipelineTest(HermesSessionsTest):
+    def test_sweep_skips_profiles_without_edge_group(self):
+        planned = sweep.plan_sweep(
+            project_dir=self.home, cursors={}, recent=None,
+            codex_dir=False, grok_dir=False, hermes_dir=self.db)
+        self.assertEqual(planned, [])
+
+    def test_quente_and_sweep_consume_hermes(self):
+        (self.home / "config.yaml").write_text("edge_group: hive\n")
+        with __import__("sqlite3").connect(self.db) as conn:
+            for i in range(6, 12):
+                conn.execute("INSERT INTO messages VALUES (?, 'a', 'user', ?, ?, 1)",
+                             (i, "substantial operator prompt " * 20, f"2026-01-{i:02d}"))
+        selected, _ = quente.select_window(
+            store_dir=self.home, k=2, max_age_days=None,
+            codex_dir=False, grok_dir=False, hermes_dir=self.db)
+        self.assertEqual([m["id"] for m in selected], ["hermes:a"])
+
+        planned = sweep.plan_sweep(
+            project_dir=self.home, cursors={}, recent=None,
+            codex_dir=False, grok_dir=False, hermes_dir=self.db)
+        self.assertEqual([p["surface"] for p in planned], ["hermes", "hermes"])
+        self.assertEqual([p["profile_name"] for p in planned], ["work", "default"])
+        self.assertEqual([p["edge_group"] for p in planned], ["hive", "hive"])
+        self.assertEqual(planned[0]["turns"][:2], [
+            sessions.Turn("human", "question"), sessions.Turn("edge", "answer")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_pipeline.py
+++ b/tests/test_hermes_pipeline.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+from unittest import mock
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -41,6 +42,14 @@ class HermesPipelineTest(HermesSessionsTest):
         self.assertEqual([p["edge_group"] for p in planned], ["hive", "hive"])
         self.assertEqual(planned[0]["turns"][:2], [
             sessions.Turn("human", "question"), sessions.Turn("edge", "answer")])
+
+    def test_sweep_does_not_date_cut_hermes_history(self):
+        (self.home / "config.yaml").write_text("edge_group: hive\n")
+        with mock.patch.object(sweep, "_film_window_start", return_value=10**20):
+            planned = sweep.plan_sweep(
+                project_dir=self.home, cursors={}, recent=None,
+                codex_dir=False, grok_dir=False, hermes_dir=self.db)
+        self.assertEqual([p["profile_name"] for p in planned], ["work", "default"])
 
 
 if __name__ == "__main__":

--- a/tests/test_hermes_pipeline.py
+++ b/tests/test_hermes_pipeline.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parents[1] / "tools"))
@@ -19,14 +20,19 @@ class HermesPipelineTest(HermesSessionsTest):
     def test_quente_and_sweep_consume_hermes(self):
         (self.home / "config.yaml").write_text("edge_group: hive\n")
         with __import__("sqlite3").connect(self.db) as conn:
+            now = datetime.now(timezone.utc).isoformat()
             for i in range(6, 12):
                 conn.execute("INSERT INTO messages VALUES (?, 'a', 'user', ?, ?, 1)",
-                             (i, "substantial operator prompt " * 20, f"2026-01-{i:02d}"))
+                             (i, "substantial operator prompt " * 20, now))
         selected, _ = quente.select_window(
             store_dir=self.home, k=2, max_age_days=None,
             codex_dir=False, grok_dir=False, hermes_dir=self.db)
         self.assertEqual([m["id"] for m in selected], ["hermes:a"])
 
+        with __import__("sqlite3").connect(self.db) as conn:
+            for i in range(12, 18):
+                conn.execute("INSERT INTO messages VALUES (?, 'b', 'user', ?, ?, 1)",
+                             (i, "substantial operator prompt " * 20, now))
         planned = sweep.plan_sweep(
             project_dir=self.home, cursors={}, recent=None,
             codex_dir=False, grok_dir=False, hermes_dir=self.db)

--- a/tests/test_hermes_profiles.py
+++ b/tests/test_hermes_profiles.py
@@ -1,0 +1,24 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "tools"))
+import hermes_profiles
+
+
+class HermesProfilesTest(unittest.TestCase):
+    def test_membership_tri_state_and_override(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertFalse(hermes_profiles.membership(root, "default").enabled)
+            (root / "config.yaml").write_text("edge_group: hive\n")
+            self.assertEqual(hermes_profiles.membership(root, "work").edge_group, "hive")
+            local = root / "profiles" / "work"
+            local.mkdir(parents=True)
+            (local / "config.yaml").write_text("edge_group:\n")
+            self.assertEqual(hermes_profiles.membership(root, "work").edge_group, "profile:work")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_profiles.py
+++ b/tests/test_hermes_profiles.py
@@ -17,7 +17,7 @@ class HermesProfilesTest(unittest.TestCase):
             local = root / "profiles" / "work"
             local.mkdir(parents=True)
             (local / "config.yaml").write_text("edge_group:\n")
-            self.assertEqual(hermes_profiles.membership(root, "work").edge_group, "profile:work")
+            self.assertEqual(hermes_profiles.membership(root, "work").edge_group, "work")
 
 
 if __name__ == "__main__":

--- a/tests/test_hermes_provision.py
+++ b/tests/test_hermes_provision.py
@@ -19,13 +19,47 @@ import surfaces_cfg  # noqa: E402
 class WrapperRender(unittest.TestCase):
     def test_wrapper_points_to_canonical_contract(self):
         out = _hermes_provision.render_hermes_skill(
-            slug="wake", prefix="ed", canonical_skill=Path("/x/skills/wake/SKILL.md"))
+            slug="wake", prefix="ed", canonical_skill=Path("/x/skills/wake/SKILL.md"),
+            edge_group="hive")
         self.assertIn("name: ed-wake", out)
+        self.assertIn("EDGE_GROUP=hive", out)
         self.assertIn("/x/skills/wake/SKILL.md", out)
         self.assertIn("canonical contract", out)
 
 
-class ProvisionTree(unittest.TestCase):
+class HermesProvisionTest(unittest.TestCase):
+    def test_configure_group_seeds_once_and_preserves_blank_override(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertTrue(_hermes_provision.configure_hermes_group(root, "hive"))
+            self.assertIn("edge_group: hive", (root / "config.yaml").read_text())
+            (root / "config.yaml").write_text("edge_group:\nother: kept\n")
+            self.assertFalse(_hermes_provision.configure_hermes_group(root, "other-hive"))
+            self.assertEqual((root / "config.yaml").read_text(), "edge_group:\nother: kept\n")
+
+    def test_reconcile_installs_only_enabled_profiles(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            (repo / "skills" / "wake").mkdir(parents=True)
+            (repo / "skills" / "wake" / "SKILL.md").write_text("---\nname: wake\n---\nx")
+            (root / "config.yaml").write_text("edge_group: hive\n")
+            off = root / "profiles" / "off"
+            off.mkdir(parents=True)
+            (off / "config.yaml").write_text("edge_group: null\n")
+            # null is origin-only, therefore still enabled.
+            result = _hermes_provision.reconcile_hermes_profiles(
+                {"skill_prefix": "ed", "tool_prefix": "edge"}, repo, root / "edge", root)
+            self.assertIn("hermes skills", result["default"][0])
+            self.assertIn("hermes skills", result["off"][0])
+
+    def test_startup_plugin_is_installable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = _hermes_provision.install_hermes_plugin({}, root / "repo", root / "edge", root)
+            self.assertTrue((plugin / "plugin.yaml").is_file())
+            compile((plugin / "__init__.py").read_text(), str(plugin / "__init__.py"), "exec")
+
     def test_provisions_prefixed_wrappers_under_hermes_home(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -37,11 +71,19 @@ class ProvisionTree(unittest.TestCase):
             edge_home = root / "home"
             hermes_home = root / ".hermes"
             cfg = {"skill_prefix": "ed", "tool_prefix": "edge"}
+            legacy = hermes_home / "skills" / "edge-wake"
+            legacy.mkdir(parents=True)
+            (legacy / "SKILL.md").write_text(_hermes_provision.render_hermes_skill(
+                "wake", "edge", repo / "skills" / "wake" / "SKILL.md"))
+            foreign = hermes_home / "skills" / "edge-foreign"
+            foreign.mkdir(parents=True)
+            (foreign / "SKILL.md").write_text("third-party skill")
             _hermes_provision.provision_hermes(cfg, repo, edge_home, hermes_home)
+            _hermes_provision.reconcile_hermes_profiles(cfg, repo, edge_home, hermes_home)
             self.assertTrue(
                 (hermes_home / "skills" / "ed-wake" / "SKILL.md").is_file())
-            self.assertTrue(
-                (hermes_home / "skills" / "edge-wake" / "SKILL.md").is_file())
+            self.assertFalse((hermes_home / "skills" / "edge-wake").exists())
+            self.assertTrue(foreign.exists())
             # _shared não vira wrapper
             self.assertFalse((hermes_home / "skills" / "ed-_shared").exists())
 

--- a/tests/test_hermes_provision.py
+++ b/tests/test_hermes_provision.py
@@ -35,6 +35,17 @@ class WrapperRender(unittest.TestCase):
             edge_group="hive")
         self.assertNotIn("WAKE TERMINAL INVARIANT", out)
 
+    def test_mentor_wrapper_preserves_cadence_invariants(self):
+        out = _hermes_provision.render_hermes_skill(
+            slug="mentor", prefix="Steve", canonical_skill=Path("/x/skills/mentor/SKILL.md"),
+            edge_group="hive")
+        self.assertIn("observe leveling-state and the work first", out)
+        self.assertIn("cite one state line", out)
+        self.assertIn("never a menu", out)
+        self.assertIn("process writeback/steers/synthesis in the same turn", out)
+        self.assertIn("do not stop and ask them to say continue", out)
+        self.assertIn("Do not force a closing question", out)
+
 
 class HermesProvisionTest(unittest.TestCase):
     def test_configure_group_seeds_once_and_preserves_blank_override(self):

--- a/tests/test_hermes_provision.py
+++ b/tests/test_hermes_provision.py
@@ -25,6 +25,15 @@ class WrapperRender(unittest.TestCase):
         self.assertIn("EDGE_GROUP=hive", out)
         self.assertIn("/x/skills/wake/SKILL.md", out)
         self.assertIn("canonical contract", out)
+        self.assertIn("human-facing orientation", out)
+        self.assertIn("ask what the operator wants to work on", out)
+        self.assertIn("Do not start work before their reply", out)
+
+    def test_terminal_invariant_is_wake_only(self):
+        out = _hermes_provision.render_hermes_skill(
+            slug="recall", prefix="ed", canonical_skill=Path("/x/skills/recall/SKILL.md"),
+            edge_group="hive")
+        self.assertNotIn("WAKE TERMINAL INVARIANT", out)
 
 
 class HermesProvisionTest(unittest.TestCase):

--- a/tests/test_hermes_provision.py
+++ b/tests/test_hermes_provision.py
@@ -30,10 +30,21 @@ class WrapperRender(unittest.TestCase):
         self.assertIn("Do not start work before their reply", out)
 
     def test_terminal_invariant_is_wake_only(self):
-        out = _hermes_provision.render_hermes_skill(
-            slug="recall", prefix="ed", canonical_skill=Path("/x/skills/recall/SKILL.md"),
-            edge_group="hive")
-        self.assertNotIn("WAKE TERMINAL INVARIANT", out)
+     out = _hermes_provision.render_hermes_skill(
+      slug="recall", prefix="ed", canonical_skill=Path("/x/skills/recall/SKILL.md"),
+      edge_group="hive")
+     self.assertNotIn("WAKE TERMINAL INVARIANT", out)
+
+    def test_every_canonical_skill_gets_a_thin_wrapper(self):
+     skills = Path(__file__).parents[1] / "skills"
+     for canonical in sorted(skills.glob("*/SKILL.md")):
+      slug = canonical.parent.name
+      with self.subTest(slug=slug):
+       out = _hermes_provision.render_hermes_skill(
+        slug, "Steve", canonical, edge_group="hive")
+       self.assertIn(f"name: Steve-{slug}", out)
+       self.assertIn(str(canonical.resolve()), out)
+       self.assertLess(len(out), 5_000)
 
     def test_mentor_wrapper_preserves_cadence_invariants(self):
         out = _hermes_provision.render_hermes_skill(

--- a/tests/test_hermes_provision.py
+++ b/tests/test_hermes_provision.py
@@ -39,12 +39,16 @@ class WrapperRender(unittest.TestCase):
         out = _hermes_provision.render_hermes_skill(
             slug="mentor", prefix="Steve", canonical_skill=Path("/x/skills/mentor/SKILL.md"),
             edge_group="hive")
-        self.assertIn("observe leveling-state and the work first", out)
+        self.assertIn("observe leveling-state and the operator's work first", out)
         self.assertIn("cite one state line", out)
+        self.assertIn("opt-in portfolio orientation", out)
+        self.assertIn("lint agenda as evidence", out)
         self.assertIn("never a menu", out)
-        self.assertIn("process writeback/steers/synthesis in the same turn", out)
-        self.assertIn("do not stop and ask them to say continue", out)
+        self.assertIn("persona writeback, steers, synthesis, and traceable inscription", out)
+        self.assertIn("advice alone is not completion", out)
+        self.assertIn("Do not stop and ask them to say continue", out)
         self.assertIn("Do not force a closing question", out)
+        self.assertIn("never invent a writeback or inscription", out)
 
 
 class HermesProvisionTest(unittest.TestCase):

--- a/tests/test_hermes_provision.py
+++ b/tests/test_hermes_provision.py
@@ -70,22 +70,27 @@ class HermesProvisionTest(unittest.TestCase):
             (repo / "skills" / "_shared" / "pipeline.md").write_text("y")
             edge_home = root / "home"
             hermes_home = root / ".hermes"
-            cfg = {"skill_prefix": "ed", "tool_prefix": "edge"}
+            hermes_home.mkdir()
+            (hermes_home / "config.yaml").write_text("edge_group: ''\n")
+            cfg = {"skill_prefix": "Steve", "tool_prefix": "edge"}
             legacy = hermes_home / "skills" / "edge-wake"
             legacy.mkdir(parents=True)
+            installed_skill = edge_home / "skills" / "wake" / "SKILL.md"
+            installed_skill.parent.mkdir(parents=True)
+            installed_skill.write_text("canonical installed copy")
             (legacy / "SKILL.md").write_text(_hermes_provision.render_hermes_skill(
-                "wake", "edge", repo / "skills" / "wake" / "SKILL.md"))
+                "wake", "edge", installed_skill))
             foreign = hermes_home / "skills" / "edge-foreign"
             foreign.mkdir(parents=True)
             (foreign / "SKILL.md").write_text("third-party skill")
             _hermes_provision.provision_hermes(cfg, repo, edge_home, hermes_home)
             _hermes_provision.reconcile_hermes_profiles(cfg, repo, edge_home, hermes_home)
             self.assertTrue(
-                (hermes_home / "skills" / "ed-wake" / "SKILL.md").is_file())
+                (hermes_home / "skills" / "Steve-wake" / "SKILL.md").is_file())
             self.assertFalse((hermes_home / "skills" / "edge-wake").exists())
             self.assertTrue(foreign.exists())
             # _shared não vira wrapper
-            self.assertFalse((hermes_home / "skills" / "ed-_shared").exists())
+            self.assertFalse((hermes_home / "skills" / "Steve-_shared").exists())
 
 
 class SurfaceDetection(unittest.TestCase):

--- a/tests/test_hermes_sessions.py
+++ b/tests/test_hermes_sessions.py
@@ -1,0 +1,49 @@
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "tools"))
+import sessions
+import surfaces_cfg
+
+
+class HermesSessionsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self.tmp.name)
+        self.db = self.home / "state.db"
+        with sqlite3.connect(self.db) as conn:
+            conn.executescript("""
+                CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT,
+                    parent_session_id TEXT, started_at TEXT, ended_at TEXT, profile_name TEXT);
+                CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT,
+                    role TEXT, content TEXT, timestamp TEXT, active INTEGER);
+                INSERT INTO sessions VALUES ('a', 'cli', NULL, '1', NULL, 'work');
+                INSERT INTO sessions VALUES ('b', 'cli', NULL, '1', NULL, NULL);
+                INSERT INTO messages VALUES (3, 'a', 'assistant', 'answer', '2026-01-02', 1);
+                INSERT INTO messages VALUES (1, 'a', 'user', 'question', '2026-01-01', 1);
+                INSERT INTO messages VALUES (2, 'a', 'system', 'hidden', '2026-01-01', 1);
+                INSERT INTO messages VALUES (4, 'a', 'user', 'inactive', '2026-01-03', 0);
+                INSERT INTO messages VALUES (5, 'b', 'user', 'later', '2026-02-01', 1);
+            """)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_resolution_listing_turns_and_delta(self):
+        self.assertEqual(surfaces_cfg.surface_home("hermes", env={"HERMES_HOME": str(self.home)}), self.home)
+        found = sessions.list_hermes_sessions(env={"HERMES_HOME": str(self.home)})
+        self.assertEqual([(s.id, s.updated_at) for s in found],
+                         [('a', '2026-01-02'), ('b', '2026-02-01')])
+        self.assertEqual([s.profile_name for s in found], ["work", "default"])
+        self.assertEqual(sessions.read_turns(found[0].path, "hermes"),
+                         [sessions.Turn("human", "question"), sessions.Turn("edge", "answer")])
+        turns, watermark = sessions.delta(found[0].path, 1, "hermes")
+        self.assertEqual(turns, [sessions.Turn("edge", "answer")])
+        self.assertEqual(watermark, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_identity_env_dir.py
+++ b/tests/test_identity_env_dir.py
@@ -76,11 +76,11 @@ class IdentityPathHomeFirst(unittest.TestCase):
                 self.assertEqual(_identity.identity_path("agent.yaml"),
                                  Path(tmp) / "agent.yaml")
 
-    def test_missing_in_home_falls_to_repo(self):
+    def test_missing_agent_yaml_in_home_still_uses_home_for_bootstrap(self):
         with tempfile.TemporaryDirectory() as tmp:
             with mock.patch.dict(os.environ, {"EDGE_HOME": tmp}, clear=False):
                 self.assertEqual(_identity.identity_path("agent.yaml"),
-                                 REPO / "agent.yaml")
+                                 Path(tmp) / "agent.yaml")
 
     def test_no_edge_home_uses_repo(self):
         env = {k: v for k, v in os.environ.items() if k != "EDGE_HOME"}

--- a/tests/test_install_validate.py
+++ b/tests/test_install_validate.py
@@ -65,6 +65,14 @@ class PlaceSkipsSelfCopy(unittest.TestCase):
             self.assertTrue(_provision.place_tree(src, dst))
             self.assertTrue((dst / "a.md").exists())
 
+    def test_place_tree_renders_install_identity(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = Path(d) / "skills"; src.mkdir()
+            (src / "wake.md").write_text("You are {name}. Run /{prefix}-wake.")
+            dst = Path(d) / "home" / "skills"
+            _provision.place_tree(src, dst, {"{name}": "Steve", "{prefix}": "Steve"})
+            self.assertEqual((dst / "wake.md").read_text(), "You are Steve. Run /Steve-wake.")
+
 
 class ValidateNotifies(unittest.TestCase):
     CFG = {"sources": [], "routers": {}}

--- a/tests/test_onboarding_embedding.py
+++ b/tests/test_onboarding_embedding.py
@@ -9,6 +9,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import onboarding  # noqa: E402
+import _validate  # noqa: E402
 
 
 def _inv(**by_file):
@@ -49,6 +50,11 @@ class EmbeddingAdapter(unittest.TestCase):
 
     def test_no_key_is_dark(self):
         self.assertIsNone(onboarding.embedding_from_inventory(_inv()))
+
+    def test_install_requires_openai_key_for_graphiti_even_with_other_embedding_provider(self):
+        refs = _validate._required_refs({"routers": {"embedding": {
+            "provider": "openrouter", "secret_ref": "openrouter.env:OPENROUTER_API_KEY"}}})
+        self.assertIn("openai.env:OPENAI_API_KEY", refs)
 
 
 class RouterCarriesBaseUrl(unittest.TestCase):

--- a/tests/test_onboarding_hermes.py
+++ b/tests/test_onboarding_hermes.py
@@ -15,6 +15,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import onboarding  # noqa: E402
+import _hermes_provision  # noqa: E402
 
 
 def _mk_hermes_db(home, started_days_ago):
@@ -64,6 +65,15 @@ class HermesAdversarialAndRouters(unittest.TestCase):
         cast = onboarding.resolve_adversarial_cast([], primary="hermes")
         routers = onboarding._routers_for_cfg(cast, "hermes", None)
         self.assertEqual(routers["chat"]["provider"], "hermes")
+
+
+class HermesOnboardingGroup(unittest.TestCase):
+    def test_default_is_origin_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertTrue(_hermes_provision.configure_hermes_group(root, ""))
+            cfg = __import__("yaml").safe_load((root / "config.yaml").read_text())
+            self.assertEqual(cfg["edge_group"], "")
 
 
 if __name__ == "__main__":

--- a/tests/test_quente.py
+++ b/tests/test_quente.py
@@ -158,7 +158,8 @@ class TestSelectWindow(unittest.TestCase):
             old = os.environ.get("EDGE_PROJECT_DIR")
             os.environ["EDGE_PROJECT_DIR"] = tmp
             try:
-                sel, window_start = quente.select_window(k=1, exclude=(), codex_dir=False)
+                sel, window_start = quente.select_window(
+                    k=1, exclude=(), codex_dir=False, hermes_dir=False)
             finally:
                 if old is None:
                     del os.environ["EDGE_PROJECT_DIR"]
@@ -174,7 +175,7 @@ class TestSelectWindow(unittest.TestCase):
             old = os.environ.get("CLAUDE_CODE_SESSION_ID")
             os.environ["CLAUDE_CODE_SESSION_ID"] = "s-novo"
             try:
-                sel, _ = quente.select_window(store_dir=tmp, k=2)
+                sel, _ = quente.select_window(store_dir=None, k=2)
                 self.assertNotIn("s-novo", [m["id"] for m in sel])
                 sel_all, _ = quente.select_window(store_dir=tmp, k=2, exclude=())
                 self.assertIn("s-novo", [m["id"] for m in sel_all])

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -558,6 +558,9 @@ class ChunkEpisodeBodyKeepsLargeSessionsUnderContext(unittest.TestCase):
         body = "human: hi\nassistant: hello"
         self.assertEqual(sweep.chunk_episode_body(body, 1000), [body])
 
+    def test_hermes_virtual_path_has_no_file_timestamp(self):
+        self.assertIsNone(sweep._first_ts("/tmp/state.db#session-id"))
+
     def test_large_body_splits_into_chunks_each_under_budget(self):
         body = "\n".join(f"human: turn {i} " + "x" * 200 for i in range(50))
         chunks = sweep.chunk_episode_body(body, 1000)

--- a/tools/_hermes_provision.py
+++ b/tools/_hermes_provision.py
@@ -7,7 +7,9 @@ canônico do install (mesmo shape dos wrappers Grok/Codex). Genérico por constr
 nenhum nome de install hardcoded — qualquer usuário do hermes com o edge provisiona igual.
 """
 from pathlib import Path
+import shutil
 
+import yaml
 
 def _write_if_changed(path: Path, content: str) -> None:
     """Write only when content differs, keeping repeated apply runs idempotent."""
@@ -18,16 +20,9 @@ def _write_if_changed(path: Path, content: str) -> None:
 
 
 def hermes_prefixes(cfg: dict) -> list:
-    """The Hermes skill names exposed for this install.
-
-    tool_prefix keeps the stable family alias (edge-*). skill_prefix is the install's
-    operator-facing alias (ed-* for the edge-of-chaos branch).
-    """
-    raw = [
-        cfg.get("tool_prefix") or "edge",
-        cfg.get("skill_prefix") or cfg.get("codename") or cfg.get("name") or "edge",
-    ]
-    out = []
+    """Expose only the install-specific alias; duplicate families add no capability."""
+    prefix = cfg.get("skill_prefix") or cfg.get("codename") or cfg.get("name") or "edge"
+    return [str(prefix).strip()]
     for item in raw:
         prefix = str(item).strip()
         if prefix and prefix not in out:
@@ -35,7 +30,7 @@ def hermes_prefixes(cfg: dict) -> list:
     return out
 
 
-def render_hermes_skill(*, slug: str, prefix: str, canonical_skill: Path) -> str:
+def render_hermes_skill(slug: str, prefix: str, canonical_skill: Path, edge_group=None) -> str:
     """Render a global Hermes wrapper for one canonical Edge skill."""
     name = f"{prefix}-{slug}"
     canonical = str(Path(canonical_skill).expanduser())
@@ -43,18 +38,20 @@ def render_hermes_skill(*, slug: str, prefix: str, canonical_skill: Path) -> str
         "---\n"
         f"name: {name}\n"
         f"description: \"Edge `{slug}` skill (`/{name}`). Use when the user invokes "
-        f"`/{name}`, `@{name}`, or asks for Edge {slug}. "
+        f"`/{name}`, `@{name}`, or asks for Edge of Chaos {slug}. "
         f"Read the full contract at {canonical} and follow it.\"\n"
         "---\n"
-        f"You are running the Edge skill **{name}**.\n\n"
+        f"You are running the Edge of Chaos skill **{name}**.\n\n"
         f"1. Read `{canonical}` completely (canonical contract).\n"
         f"2. Follow it as the active skill — do not re-interpret this wrapper.\n"
         f"3. Work from the install edge_home that owns that skills/ tree.\n"
+        + (f"4. Set `EDGE_GROUP={edge_group}` for every EoC tool command.\n" if edge_group else "")
     )
 
 
-def provision_hermes(cfg: dict, repo: Path, edge_home: Path, hermes_home: Path) -> list:
-    """Idempotently provision HERMES_HOME/skills with prefixed Edge wrappers."""
+def provision_hermes(cfg: dict, repo: Path, edge_home: Path, hermes_home: Path,
+                     edge_group=None) -> list:
+    """Idempotently provision HERMES_HOME/skills with prefixed EoC wrappers."""
     repo = Path(repo)
     edge_home = Path(edge_home).expanduser()
     hermes_home = Path(hermes_home).expanduser()
@@ -76,8 +73,84 @@ def provision_hermes(cfg: dict, repo: Path, edge_home: Path, hermes_home: Path) 
                 _write_if_changed(
                     dst,
                     render_hermes_skill(
-                        slug=skill_dir.name, prefix=prefix, canonical_skill=canonical),
+                        slug=skill_dir.name, prefix=prefix, canonical_skill=canonical,
+                        edge_group=edge_group),
                 )
                 installed += 1
     rows.append(f"hermes skills: {installed} wrappers em {hermes_home / 'skills'}")
     return rows
+
+
+def _managed_wrapper(path, repo):
+    try:
+        body = (path / "SKILL.md").read_text()
+    except OSError:
+        return False
+    return ("You are running the Edge of Chaos skill" in body
+            and str(Path(repo) / "skills") in body)
+
+
+def reconcile_hermes_profiles(cfg, repo, edge_home, hermes_root):
+    """Make profile-local Edge wrappers match Hermes edge_group configuration."""
+    import hermes_profiles
+
+    root = Path(hermes_root)
+    homes = [("default", root)]
+    profiles = root / "profiles"
+    if profiles.is_dir():
+        homes.extend((p.name, p) for p in profiles.iterdir() if p.is_dir())
+    result = {}
+    for name, home in homes:
+        member = hermes_profiles.membership(root, name)
+        if member.enabled:
+            result[name] = provision_hermes(
+                cfg, repo, edge_home, home, edge_group=member.edge_group)
+            continue
+        removed = []
+        skills = home / "skills"
+        if skills.is_dir():
+            for path in skills.iterdir():
+                if path.is_dir() and _managed_wrapper(path, repo):
+                    shutil.rmtree(path)
+                    removed.append(path.name)
+        result[name] = {"skills_removed": removed}
+    return result
+
+
+def configure_hermes_group(hermes_root, edge_group):
+    """Seed the EoC group unless Hermes already has an explicit policy."""
+    path = Path(hermes_root) / "config.yaml"
+    try:
+        cfg = yaml.safe_load(path.read_text()) or {}
+    except FileNotFoundError:
+        cfg = {}
+    if not isinstance(cfg, dict):
+        raise ValueError(f"Hermes config must be a mapping: {path}")
+    if "edge_group" in cfg:
+        return False
+    cfg["edge_group"] = edge_group
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".yaml.tmp")
+    tmp.write_text(yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True))
+    tmp.replace(path)
+    return True
+
+
+def install_hermes_plugin(cfg, repo, edge_home, hermes_root):
+    """Install the startup reconciler as a normal Hermes user plugin."""
+    plugin = Path(hermes_root) / "plugins" / "edge-of-chaos"
+    plugin.mkdir(parents=True, exist_ok=True)
+    (plugin / "plugin.yaml").write_text(
+        "name: edge-of-chaos\nversion: 1.0.0\ndescription: Reconcile Edge skills across Hermes profiles\n"
+    )
+    (plugin / "__init__.py").write_text(
+        "from pathlib import Path\nimport sys\n\n"
+        f"REPO = Path({str(Path(repo))!r})\n"
+        f"EDGE_HOME = Path({str(Path(edge_home))!r})\n"
+        f"HERMES_ROOT = Path({str(Path(hermes_root))!r})\n"
+        "sys.path.insert(0, str(REPO / 'tools'))\n"
+        "def register(ctx):\n"
+        "    from _hermes_provision import reconcile_hermes_profiles\n"
+        f"    reconcile_hermes_profiles({cfg!r}, REPO, EDGE_HOME, HERMES_ROOT)\n"
+    )
+    return plugin

--- a/tools/_hermes_provision.py
+++ b/tools/_hermes_provision.py
@@ -23,12 +23,6 @@ def hermes_prefixes(cfg: dict) -> list:
     """Expose only the install-specific alias; duplicate families add no capability."""
     prefix = cfg.get("skill_prefix") or cfg.get("codename") or cfg.get("name") or "edge"
     return [str(prefix).strip()]
-    for item in raw:
-        prefix = str(item).strip()
-        if prefix and prefix not in out:
-            out.append(prefix)
-    return out
-
 
 def render_hermes_skill(slug: str, prefix: str, canonical_skill: Path, edge_group=None) -> str:
     """Render a global Hermes wrapper for one canonical Edge skill."""
@@ -61,12 +55,18 @@ def provision_hermes(cfg: dict, repo: Path, edge_home: Path, hermes_home: Path,
 
     skills_src = repo / "skills"
     if skills_src.exists():
-        for skill_dir in sorted(skills_src.iterdir()):
-            if not skill_dir.is_dir() or skill_dir.name.startswith("."):
-                continue
-            skill_file = skill_dir / "SKILL.md"
-            if not skill_file.exists() or skill_dir.name == "_shared":
-                continue
+        skill_dirs = [p for p in sorted(skills_src.iterdir())
+                      if p.is_dir() and not p.name.startswith(".")
+                      and p.name != "_shared" and (p / "SKILL.md").exists()]
+        desired = {f"{prefix}-{skill_dir.name}"
+                   for prefix in prefixes for skill_dir in skill_dirs}
+        installed_skills = hermes_home / "skills"
+        if installed_skills.is_dir():
+            for path in installed_skills.iterdir():
+                if path.name not in desired and path.is_dir() \
+                        and _managed_wrapper(path, repo, edge_home):
+                    shutil.rmtree(path)
+        for skill_dir in skill_dirs:
             canonical = edge_home / "skills" / skill_dir.name / "SKILL.md"
             for prefix in prefixes:
                 dst = hermes_home / "skills" / f"{prefix}-{skill_dir.name}" / "SKILL.md"
@@ -81,14 +81,16 @@ def provision_hermes(cfg: dict, repo: Path, edge_home: Path, hermes_home: Path,
     return rows
 
 
-def _managed_wrapper(path, repo):
+def _managed_wrapper(path, repo, edge_home=None):
     try:
         body = (path / "SKILL.md").read_text()
     except OSError:
         return False
-    return ("You are running the Edge of Chaos skill" in body
-            and str(Path(repo) / "skills") in body)
-
+    roots = [Path(repo).resolve() / "skills"]
+    if edge_home is not None:
+        roots.append(Path(edge_home).resolve() / "skills")
+    marker = "Canonical implementation:" in body or "Read the full contract at" in body
+    return marker and any(str(root) in body for root in roots)
 
 def reconcile_hermes_profiles(cfg, repo, edge_home, hermes_root):
     """Make profile-local Edge wrappers match Hermes edge_group configuration."""
@@ -110,7 +112,7 @@ def reconcile_hermes_profiles(cfg, repo, edge_home, hermes_root):
         skills = home / "skills"
         if skills.is_dir():
             for path in skills.iterdir():
-                if path.is_dir() and _managed_wrapper(path, repo):
+                if path.is_dir() and _managed_wrapper(path, repo, edge_home):
                     shutil.rmtree(path)
                     removed.append(path.name)
         result[name] = {"skills_removed": removed}

--- a/tools/_hermes_provision.py
+++ b/tools/_hermes_provision.py
@@ -34,6 +34,14 @@ def render_hermes_skill(slug: str, prefix: str, canonical_skill: Path, edge_grou
         "ask what the operator wants to work on. Do not start work before their reply.\n"
         if slug == "wake" else ""
     )
+    mentor_invariant = (
+        "5. MENTOR CADENCE INVARIANT: observe leveling-state and the work first; cite one "
+        "state line before any residual question. Ask at most one free-prose residual question, "
+        "never a menu. After the operator answers, process writeback/steers/synthesis in the same "
+        "turn; do not stop and ask them to say continue. Do not force a closing question when the "
+        "path is clear.\n"
+        if slug == "mentor" else ""
+    )
     return (
         "---\n"
         f"name: {name}\n"
@@ -47,6 +55,7 @@ def render_hermes_skill(slug: str, prefix: str, canonical_skill: Path, edge_grou
         f"3. Work from the install edge_home that owns that skills/ tree.\n"
         + (f"4. Set `EDGE_GROUP={edge_group}` for every EoC tool command.\n" if edge_group else "")
         + wake_terminal
+        + mentor_invariant
     )
 
 

--- a/tools/_hermes_provision.py
+++ b/tools/_hermes_provision.py
@@ -35,11 +35,14 @@ def render_hermes_skill(slug: str, prefix: str, canonical_skill: Path, edge_grou
         if slug == "wake" else ""
     )
     mentor_invariant = (
-        "5. MENTOR CADENCE INVARIANT: observe leveling-state and the work first; cite one "
-        "state line before any residual question. Ask at most one free-prose residual question, "
-        "never a menu. After the operator answers, process writeback/steers/synthesis in the same "
-        "turn; do not stop and ask them to say continue. Do not force a closing question when the "
-        "path is clear.\n"
+        "5. MENTOR CONTRACT INVARIANT: observe leveling-state and the operator's work first; cite "
+        "one state line before any residual question. Render the contract's opt-in portfolio "
+        "orientation and use the lint agenda as evidence, not as an opening script. Ask at most one "
+        "free-prose residual question, never a menu. After the operator answers, process all "
+        "applicable persona writeback, steers, synthesis, and traceable inscription in the same "
+        "turn; advice alone is not completion. Do not stop and ask them to say continue. Do not "
+        "force a closing question when the path is clear, and never invent a writeback or "
+        "inscription merely to satisfy this wrapper.\n"
         if slug == "mentor" else ""
     )
     return (

--- a/tools/_hermes_provision.py
+++ b/tools/_hermes_provision.py
@@ -28,6 +28,12 @@ def render_hermes_skill(slug: str, prefix: str, canonical_skill: Path, edge_grou
     """Render a global Hermes wrapper for one canonical Edge skill."""
     name = f"{prefix}-{slug}"
     canonical = str(Path(canonical_skill).expanduser())
+    wake_terminal = (
+        "5. WAKE TERMINAL INVARIANT: after all four briefs complete, render the canonical "
+        "human-facing orientation (do not dump or merely summarize the briefs), then halt and "
+        "ask what the operator wants to work on. Do not start work before their reply.\n"
+        if slug == "wake" else ""
+    )
     return (
         "---\n"
         f"name: {name}\n"
@@ -40,6 +46,7 @@ def render_hermes_skill(slug: str, prefix: str, canonical_skill: Path, edge_grou
         f"2. Follow it as the active skill — do not re-interpret this wrapper.\n"
         f"3. Work from the install edge_home that owns that skills/ tree.\n"
         + (f"4. Set `EDGE_GROUP={edge_group}` for every EoC tool command.\n" if edge_group else "")
+        + wake_terminal
     )
 
 

--- a/tools/_identity.py
+++ b/tools/_identity.py
@@ -25,9 +25,7 @@ def identity_path(name):
     identidade. Sem EDGE_HOME (ou sem o arquivo no home), REPO é o legado home==repo."""
     env = os.environ.get("EDGE_HOME")
     if env:
-        p = Path(os.path.expanduser(env)) / name
-        if p.exists():
-            return p
+        return Path(os.path.expanduser(env)) / name
     return REPO / name
 
 

--- a/tools/_provision.py
+++ b/tools/_provision.py
@@ -70,13 +70,21 @@ def place_file(src, dst):
     return True
 
 
-def place_tree(src, dst):
+def place_tree(src, dst, replacements=None):
     """copytree a genotype dir into the install home, skipping when src == dst (REPO == edge_home).
     Returns True iff copied."""
     src, dst = Path(src), Path(dst)
     if src.resolve() == dst.resolve():
         return False
     shutil.copytree(src, dst, dirs_exist_ok=True)
+    for path in dst.rglob("*") if replacements else ():
+        if path.is_file():
+            text = path.read_text()
+            rendered = text
+            for old, new in replacements.items():
+                rendered = rendered.replace(old, new)
+            if rendered != text:
+                path.write_text(rendered)
     return True
 
 

--- a/tools/_validate.py
+++ b/tools/_validate.py
@@ -63,6 +63,8 @@ def _required_refs(cfg):
     refs = [r["secret_ref"] for r in (cfg.get("routers") or {}).values() if r.get("secret_ref")]
     refs += [s["secret_ref"] for s in (cfg.get("sources") or [])
              if s.get("kind") == "api" and s.get("secret_ref")]
+    # Graphiti extraction is OpenAI-specific even when embeddings use another provider.
+    refs.append("openai.env:OPENAI_API_KEY")
     return refs
 
 

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -178,7 +178,10 @@ def main() -> None:
     if (REPO / "blog" / "static").exists():
         _provision.place_tree(REPO / "blog" / "static", home / "blog" / "static")
     if (REPO / "skills").exists():
-        _provision.place_tree(REPO / "skills", home / "skills")
+        name = str(cfg.get("name") or cfg.get("codename") or "Edge")
+        prefix = str(cfg.get("skill_prefix") or cfg.get("codename") or name)
+        _provision.place_tree(REPO / "skills", home / "skills",
+                              {"{name}": name, "{prefix}": prefix})
     render_caddyfile(home, args.yaml)
 
     mem = home / "memory" / "MEMORY.md"

--- a/tools/edge-bootstrap
+++ b/tools/edge-bootstrap
@@ -32,6 +32,7 @@ def cmd_bootstrap(args) -> int:
             primary=args.primary,
             provision_skills=not args.no_provision_skills,
             embedding_choice=choice or None,
+            hermes_edge_group=args.hermes_edge_group,
         )
     except ValueError as e:
         print(f"edge-bootstrap: {e}", file=sys.stderr)
@@ -145,6 +146,10 @@ def main(argv=None) -> int:
     b.add_argument("--adversarial", action="append", default=[], dest="adversarials")
     b.add_argument("--primary", default="claude")
     b.add_argument("--no-provision-skills", action="store_true")
+    b.add_argument(
+        "--hermes-edge-group", default="",
+        help="shared EoC network for Hermes; empty keeps each profile origin-only",
+    )
     # o adapter de embeddings (entrevista): openai direto, openrouter, azure/base_url custom
     b.add_argument("--embedding-provider", default=None)
     b.add_argument("--embedding-var", default=None)

--- a/tools/hermes_profiles.py
+++ b/tools/hermes_profiles.py
@@ -1,0 +1,37 @@
+"""Resolve Edge membership for Hermes profiles without changing other surfaces."""
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+
+@dataclass(frozen=True)
+class Membership:
+    profile_name: str
+    enabled: bool
+    edge_group: str | None
+
+
+def _yaml(path):
+    try:
+        value = yaml.safe_load(Path(path).read_text())
+        return value if isinstance(value, dict) else {}
+    except (OSError, yaml.YAMLError):
+        return {}
+
+
+def membership(hermes_home, profile_name):
+    """Resolve global default + profile override; blank means profile-local."""
+    root = Path(hermes_home)
+    global_cfg = _yaml(root / "config.yaml")
+    local_path = root / "profiles" / profile_name / "config.yaml"
+    local_cfg = _yaml(local_path) if profile_name != "default" else {}
+    source = local_cfg if "edge_group" in local_cfg else global_cfg
+    if "edge_group" not in source:
+        return Membership(profile_name, False, None)
+    value = source["edge_group"]
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return Membership(profile_name, True, f"profile:{profile_name}")
+    if not isinstance(value, str):
+        raise ValueError(f"edge_group for Hermes profile {profile_name!r} must be a string or blank")
+    return Membership(profile_name, True, value.strip())

--- a/tools/hermes_profiles.py
+++ b/tools/hermes_profiles.py
@@ -31,7 +31,7 @@ def membership(hermes_home, profile_name):
         return Membership(profile_name, False, None)
     value = source["edge_group"]
     if value is None or (isinstance(value, str) and not value.strip()):
-        return Membership(profile_name, True, f"profile:{profile_name}")
+        return Membership(profile_name, True, profile_name)
     if not isinstance(value, str):
         raise ValueError(f"edge_group for Hermes profile {profile_name!r} must be a string or blank")
     return Membership(profile_name, True, value.strip())

--- a/tools/onboarding.py
+++ b/tools/onboarding.py
@@ -967,6 +967,7 @@ def run_bootstrap(
     primary: str = "claude",
     provision_skills: bool = True,
     embedding_choice: Optional[dict] = None,
+    hermes_edge_group: str = "",
 ) -> dict:
     """Layout + secrets inventory + bootstrap.json. Never enables heartbeat."""
     home = Path(home).expanduser()
@@ -1077,8 +1078,13 @@ def run_bootstrap(
                     provisioned.append(f"grok: {row}")
             if installed.get("hermes", False) or surfaces_cfg.provision_surface("hermes", cfg=cfg):
                 hermes_home = Path.home() / ".hermes"
-                for row in _hermes_provision.provision_hermes(cfg, repo, home, hermes_home):
-                    provisioned.append(f"hermes: {row}")
+                _hermes_provision.configure_hermes_group(
+                    hermes_home, hermes_edge_group)
+                _hermes_provision.install_hermes_plugin(cfg, repo, home, hermes_home)
+                for rows in _hermes_provision.reconcile_hermes_profiles(
+                        cfg, repo, home, hermes_home).values():
+                    for row in rows if isinstance(rows, list) else []:
+                        provisioned.append(f"hermes: {row}")
             payload["provisioned_surfaces"] = provisioned
             payload["installed_surfaces"] = installed
         except Exception as e:  # noqa: BLE001 — bootstrap still succeeds; report

--- a/tools/onboarding.py
+++ b/tools/onboarding.py
@@ -1037,10 +1037,10 @@ def run_bootstrap(
         if src_skills.is_dir():
             dst_skills = home / "skills"
             if not dst_skills.exists():
-                shutil.copytree(
-                    src_skills, dst_skills,
-                    ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
-                )
+                prefix = str(cfg.get("skill_prefix") or cfg.get("codename") or name)
+                _provision.place_tree(src_skills, dst_skills,
+                                      {"{name}": name, "{prefix}": prefix})
+                payload["skills_seeded"] = True
             else:
                 # merge: copy any missing skill dirs
                 for child in src_skills.iterdir():

--- a/tools/quente.py
+++ b/tools/quente.py
@@ -135,6 +135,12 @@ def _grok_meta_and_turns(path):
 
 
 def _meta_and_turns(path, surface="claude"):
+    if surface == "hermes":
+        turns = [("user" if t.role == "human" else "assistant", t.text)
+                 for t in sessions.read_turns(path, surface="hermes")]
+        prompts = [text for role, text in turns
+                   if role == "user" and not any(m in text[:200] for m in SCAFFOLDING)]
+        return {"op_turns": len(prompts), "op_chars": sum(map(len, prompts)), "last": ""}, turns
     if surface == "codex":
         return _codex_meta_and_turns(path)
     if surface == "grok":
@@ -170,7 +176,13 @@ def _include_grok(store_dir, grok_dir):
     return surfaces_cfg.include_optional_surface("grok", store_dir, grok_dir)
 
 
-def select_window(store_dir=None, k=3, max_age_days=7, exclude=None, codex_dir=None, grok_dir=None):
+def _include_hermes(store_dir, hermes_dir):
+    import surfaces_cfg
+    return surfaces_cfg.include_optional_surface("hermes", store_dir, hermes_dir)
+
+
+def select_window(store_dir=None, k=3, max_age_days=7, exclude=None, codex_dir=None, grok_dir=None,
+                  hermes_dir=None):
     """O scan barato de metadata: seleciona as K substanciais do store (ordinal, teto wall-clock)
     e devolve (metas selecionadas, window_start_ts). COMPARTILHADO por build_bundle e pelo
     hot_cutoff do predispatch — uma seleção só, ou o §5 defere pra um quente que não cobre o
@@ -181,6 +193,7 @@ def select_window(store_dir=None, k=3, max_age_days=7, exclude=None, codex_dir=N
     from datetime import datetime, timezone
     include_codex = _include_codex(store_dir, codex_dir)
     include_grok = _include_grok(store_dir, grok_dir)
+    include_hermes = _include_hermes(store_dir, hermes_dir)
     if store_dir is None:
         import _identity
         store_dir = _identity.project_dir()
@@ -229,6 +242,24 @@ def select_window(store_dir=None, k=3, max_age_days=7, exclude=None, codex_dir=N
             meta["raw_id"] = s.id
             meta["path"] = s.path
             meta["surface"] = "grok"
+            metas.append(meta)
+    if include_hermes:
+        import hermes_profiles
+        hermes_path = sessions.hermes_state_db() if hermes_dir is None else Path(hermes_dir)
+        hermes_home = hermes_path.parent if hermes_path.is_file() else hermes_path
+        for s in sessions.list_hermes_sessions(hermes_dir):
+            member = hermes_profiles.membership(hermes_home, s.profile_name)
+            if not member.enabled:
+                continue
+            sid = f"hermes:{s.id}"
+            if sid in exclude or s.id in exclude or not s.updated_at:
+                continue
+            if floor_mtime is not None and sessions.updated_epoch(s) < floor_mtime:
+                continue
+            meta, _ = _meta_and_turns(s.path, "hermes")
+            meta.update(id=sid, raw_id=s.id, path=s.path, surface="hermes",
+                        profile_name=s.profile_name, edge_group=member.edge_group,
+                        last=datetime.fromtimestamp(sessions.updated_epoch(s), timezone.utc).isoformat())
             metas.append(meta)
     sel = select_sessions(metas, k=k, max_age_days=max_age_days, now=now_dt.isoformat())
     return sel, min((m.get("last", "") for m in sel), default="")

--- a/tools/recall.py
+++ b/tools/recall.py
@@ -573,7 +573,7 @@ def compose_mentee_persona_brief(root=None, *, max_perfil_chars=3500):
 
     Safe for wake/mentor recall: missing/blank perfil is declared empty, never silent.
     """
-    root = Path(root) if root is not None else Path(__file__).resolve().parent.parent / "memory" / "leveling"
+    root = Path(root) if root is not None else _identity.state_root() / "memory" / "leveling"
     parts = [
         "## Persona do mentee",
         "",

--- a/tools/sessions.py
+++ b/tools/sessions.py
@@ -14,6 +14,7 @@ Locator/offset-based; carries no domain semantics beyond surface normalization (
 import json
 import os
 import re
+import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -54,6 +55,8 @@ class Session:
     id: str
     path: Path
     surface: str = "claude"
+    updated_at: str | None = None
+    profile_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -582,8 +585,57 @@ def dialogue_turns(path, surface="claude") -> list:
     )
 
 
+def hermes_state_db(cfg=None, agent_yaml=None, env=None) -> Path:
+    import surfaces_cfg
+    return surfaces_cfg.surface_home("hermes", cfg=cfg, agent_yaml=agent_yaml, env=env) / "state.db"
+
+
+def _hermes_target(path):
+    db, session_id = str(path).rsplit("#", 1)
+    return Path(db), session_id
+
+
+def _hermes_connect(path):
+    return sqlite3.connect(f"file:{Path(path).resolve()}?mode=ro", uri=True)
+
+
+def list_hermes_sessions(root=None, cfg=None, agent_yaml=None, env=None) -> list:
+    db = hermes_state_db(cfg, agent_yaml, env) if root is None else Path(root)
+    if db.is_dir():
+        db /= "state.db"
+    if not db.is_file():
+        return []
+    with _hermes_connect(db) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(sessions)")}
+        profile = "s.profile_name" if "profile_name" in columns else "NULL"
+        rows = conn.execute(f"""SELECT s.id, MAX(m.timestamp), {profile} FROM sessions s
+            LEFT JOIN messages m ON m.session_id = s.id AND m.active = 1
+                AND m.role IN ('user', 'assistant')
+            GROUP BY s.id, {profile} ORDER BY MAX(m.timestamp), s.id""")
+        return [Session(id, Path(f"{db}#{id}"), "hermes", updated_at,
+                        profile_name or "default")
+                for id, updated_at, profile_name in rows]
+
+
+def updated_epoch(session) -> float:
+    """Normalize Hermes REAL timestamps and older ISO-text stores."""
+    try:
+        return float(session.updated_at)
+    except (TypeError, ValueError):
+        from datetime import datetime
+        return datetime.fromisoformat(str(session.updated_at).replace("Z", "+00:00")).timestamp()
+
+
 def read_turns(path, surface="claude") -> list:
     """Parse a transcript into ordered human/edge dialogue turns (alias of dialogue_turns)."""
+    if surface == "hermes":
+        db, session_id = _hermes_target(path)
+        with _hermes_connect(db) as conn:
+            rows = conn.execute("""SELECT role, content FROM messages
+                WHERE session_id = ? AND active = 1 AND role IN ('user', 'assistant')
+                ORDER BY timestamp, id""", (session_id,))
+            return [Turn("human" if role == "user" else "edge", content)
+                    for role, content in rows]
     return dialogue_turns(path, surface=surface)
 
 
@@ -722,6 +774,14 @@ def delta(path, since_line: int, surface="claude"):
     A truncated FINAL line (a writer flushing mid-sweep) is NOT consumed by the watermark —
     when the writer completes it, the next sweep re-reads it (non-lossy raw). A corrupt
     interior line is a crashed writer: dropped and consumed (`_turns_from_lines`)."""
+    if surface == "hermes":
+        db, session_id = _hermes_target(path)
+        with _hermes_connect(db) as conn:
+            rows = list(conn.execute("""SELECT id, role, content FROM messages
+                WHERE session_id = ? AND active = 1 AND role IN ('user', 'assistant') AND id > ?
+                ORDER BY timestamp, id""", (session_id, since_line)))
+        return ([Turn("human" if role == "user" else "edge", content)
+                 for _, role, content in rows], max((id for id, _, _ in rows), default=since_line))
     lines = Path(path).read_text(errors="replace").splitlines()
     watermark = len(lines)
     new = lines[since_line:]

--- a/tools/surfaces_cfg.py
+++ b/tools/surfaces_cfg.py
@@ -136,7 +136,7 @@ def surface_home(name: str, cfg: dict | None = None, agent_yaml=None, env=None) 
     Precedence for grok:  GROK_HOME env  → agent.yaml surfaces.grok.home  → ~/.grok
     """
     env = os.environ if env is None else env
-    env_key = {"codex": "CODEX_HOME", "grok": "GROK_HOME"}.get(name)
+    env_key = {"codex": "CODEX_HOME", "grok": "GROK_HOME", "hermes": "HERMES_HOME"}.get(name)
     if env_key:
         raw = env.get(env_key)
         if isinstance(raw, str) and raw.strip():
@@ -149,6 +149,8 @@ def surface_home(name: str, cfg: dict | None = None, agent_yaml=None, env=None) 
         return Path.home() / ".codex"
     if name == "grok":
         return Path.home() / ".grok"
+    if name == "hermes":
+        return Path.home() / ".hermes"
     return None
 
 

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -365,8 +365,8 @@ def plan_sweep(project_dir=None, cursors=None, recent=None, codex_dir=None, grok
         hermes_path = sessions.hermes_state_db() if hermes_dir is None else Path(hermes_dir)
         hermes_home = hermes_path.parent if hermes_path.is_file() else hermes_path
         for s in sessions.list_hermes_sessions(hermes_dir):
-            if not _session_in_window(s, window):
-                continue
+            # Hermes is the operator's durable conversation store: cursors make the
+            # full scan incremental, while backfill remains an onboarding import knob.
             sid = _cursor_id(s)
             seen = cursors.get(sid, 0)
             turns, watermark = sessions.delta(s.path, seen, surface="hermes")

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -923,6 +923,9 @@ def _load_openai_key():
 
 
 def _first_ts(path):
+    # Hermes sessions are SQLite virtual paths (`state.db#session_id`), not files.
+    if "#" in str(path):
+        return None
     for line in open(path):
         try:
             ts = json.loads(line).get("timestamp")

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -143,6 +143,17 @@ def _grok_enabled(project_dir, grok_dir):
     return surfaces_cfg.include_optional_surface("grok", project_dir, grok_dir)
 
 
+def _hermes_enabled(project_dir, hermes_dir):
+    import surfaces_cfg
+    return surfaces_cfg.include_optional_surface("hermes", project_dir, hermes_dir)
+
+
+def _session_in_window(session, window_start):
+    return window_start is None or (
+        sessions.updated_epoch(session) >= window_start if session.updated_at
+        else _in_window(session.path, window_start))
+
+
 def _film_window_start(log=None):
     """Início da janela do filme (epoch) a partir do backfill_days declarado — agent.yaml
     lentes.backfill_days, senão state/bootstrap.json. None = sem limite (legado).
@@ -300,7 +311,7 @@ def _load_install_env():
 
 # --- pure plan: the digestible deltas (reads files, no graph/LLM) ---
 def plan_sweep(project_dir=None, cursors=None, recent=None, codex_dir=None, grok_dir=None,
-               install_birth=None):
+               install_birth=None, hermes_dir=None):
     """For each session, the turns after its cursor + the new watermark, in **chronological order**
     (oldest first — bi-temporal ingest wants it). `skip` marks a delta too thin to ingest (left
     un-advanced to grow). Idempotent: a session at its watermark yields nothing new. `recent=N`
@@ -308,6 +319,7 @@ def plan_sweep(project_dir=None, cursors=None, recent=None, codex_dir=None, grok
     the cursor makes the full sweep resumable)."""
     include_codex = _codex_enabled(project_dir, codex_dir)
     include_grok = _grok_enabled(project_dir, grok_dir)
+    include_hermes = _hermes_enabled(project_dir, hermes_dir)
     if project_dir is None:
         project_dir = _identity.project_dir()   # fail-loud seam (ADR-0015), never a baked-in path
     cursors = cursors or {}
@@ -323,7 +335,7 @@ def plan_sweep(project_dir=None, cursors=None, recent=None, codex_dir=None, grok
         turns, watermark = sessions.delta(s.path, seen, surface=s.surface)
         if watermark <= seen or not turns:
             continue  # no new raw lines / no new dialogue
-        found.append((Path(s.path).stat().st_mtime, s, turns, watermark, sid))
+        found.append((Path(s.path).stat().st_mtime, s, turns, watermark, sid, None))
     if include_codex:
         for s in sessions.list_codex_sessions(codex_dir):
             if not _in_window(s.path, window):
@@ -335,7 +347,7 @@ def plan_sweep(project_dir=None, cursors=None, recent=None, codex_dir=None, grok
             turns, watermark = sessions.delta(s.path, seen, surface=s.surface)
             if watermark <= seen or not turns:
                 continue  # no new raw lines / no new dialogue
-            found.append((Path(s.path).stat().st_mtime, s, turns, watermark, sid))
+            found.append((Path(s.path).stat().st_mtime, s, turns, watermark, sid, None))
     if include_grok:
         for s in sessions.list_grok_sessions(grok_dir):
             if not _in_window(s.path, window):
@@ -347,14 +359,31 @@ def plan_sweep(project_dir=None, cursors=None, recent=None, codex_dir=None, grok
             turns, watermark = sessions.delta(s.path, seen, surface=s.surface)
             if watermark <= seen or not turns:
                 continue  # no new raw lines / no new dialogue
-            found.append((Path(s.path).stat().st_mtime, s, turns, watermark, sid))
+            found.append((Path(s.path).stat().st_mtime, s, turns, watermark, sid, None))
+    if include_hermes:
+        import hermes_profiles
+        hermes_path = sessions.hermes_state_db() if hermes_dir is None else Path(hermes_dir)
+        hermes_home = hermes_path.parent if hermes_path.is_file() else hermes_path
+        for s in sessions.list_hermes_sessions(hermes_dir):
+            if not _session_in_window(s, window):
+                continue
+            sid = _cursor_id(s)
+            seen = cursors.get(sid, 0)
+            turns, watermark = sessions.delta(s.path, seen, surface="hermes")
+            if watermark <= seen or not turns:
+                continue
+            member = hermes_profiles.membership(hermes_home, s.profile_name)
+            if member.enabled:
+                found.append((sessions.updated_epoch(s), s, turns, watermark, sid, member.edge_group))
     found.sort(key=lambda x: x[0])           # chronological
     if recent:
         found = found[-recent:]              # the N newest, still chronological
     return [{"id": sid, "raw_id": s.id, "surface": s.surface, "path": str(s.path),
+             **({"profile_name": s.profile_name} if s.profile_name else {}),
+             **({"edge_group": group} if group else {}),
              "turns": turns, "watermark": watermark,
              "body": (body := clean_body(turns)), "skip": not _qualifies(turns, body)}
-            for _, s, turns, watermark, sid in found]
+            for _, s, turns, watermark, sid, group in found]
 
 
 # --- bounded a-posteriori rationalization (log-checkpointed; no cursor) ---
@@ -835,6 +864,9 @@ def execute(plan, ingest_fn, cursors, log=eventlog.LOG):
                    "medium_tier": "low_tier"}
         if it.get("surface") in ("codex", "grok"):
             payload["surface"] = it["surface"]
+        if it.get("surface") == "hermes":
+            payload.update(surface="hermes", profile_name=it["profile_name"],
+                           edge_group=it["edge_group"])
         eventlog.append("episode", f"session:{it['id']}", payload, log=log)
         cursors[it["id"]] = it["watermark"]
     if qualifying and ingest_fn is not None:           # Tier-1: graph projection, best-effort
@@ -945,10 +977,10 @@ def graphiti_ingest(items):
     from graphiti_core.llm_client import LLMConfig, OpenAIClient
     _load_openai_key()
     neo = _identity.neo4j_conn()
-    group = _identity.require_group()   # resolved ONCE, before any episode (codex gate)
+    install_group = _identity.require_group()   # unchanged fallback for Claude/Codex/Grok
     ok = set()
 
-    async def bounded_previous_uuids(g, ref):
+    async def bounded_previous_uuids(g, ref, group):
         """The previous-episode context add_episode would retrieve, bounded: most-recent-first
         under PREV_CONTEXT_MAX_CHARS, never an episode over MAX_EPISODE_CHARS (a legacy pre-#53
         giant — one alone can blow the window). Deterministic seam: the tool disposes what the
@@ -971,13 +1003,14 @@ def graphiti_ingest(items):
         g = Graphiti(*neo, llm_client=llm)
         await g.build_indices_and_constraints()
         for it in items:
+            group = it.get("edge_group") or install_group
             ref = _parse_ts(_first_ts(it["path"]))   # all sub-episodes share the session's ref-time
             chunks = chunk_episode_body(it["body"])   # one big session → several context-fit episodes (#53)
             failed = False
             for k, chunk in enumerate(chunks):
                 name = _episode_name(it) if len(chunks) == 1 else _episode_name(it, k)
                 try:
-                    prev = await bounded_previous_uuids(g, ref)
+                    prev = await bounded_previous_uuids(g, ref, group)
                     await g.add_episode(name=name, episode_body=chunk,
                                         source=EpisodeType.message,
                                         source_description=_source_description(it),

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -33,6 +33,7 @@ import _identity
 CURSORS = _identity.state_root() / "state" / "cursors.json"
 CODEX_BASELINE_KEY = "_codex_baselined"
 GROK_BASELINE_KEY = "_grok_baselined"
+HERMES_BASELINE_KEY = "_hermes_baselined"
 # Identity (group + store) resolves LAZILY through _identity at call time (ADR-0015): no
 # import-time cache (stale-copy risk), no baked-in host path (the dev's -home-<user> store
 # default sent roberto scanning a nonexistent dir — "nothing new" over a 294-session backlog).
@@ -365,8 +366,10 @@ def plan_sweep(project_dir=None, cursors=None, recent=None, codex_dir=None, grok
         hermes_path = sessions.hermes_state_db() if hermes_dir is None else Path(hermes_dir)
         hermes_home = hermes_path.parent if hermes_path.is_file() else hermes_path
         for s in sessions.list_hermes_sessions(hermes_dir):
-            # Hermes is the operator's durable conversation store: cursors make the
-            # full scan incremental, while backfill remains an onboarding import knob.
+            # First Hermes sweep imports all available history; later sweeps keep the
+            # configured rolling window and rely on cursors for deltas.
+            if cursors.get(HERMES_BASELINE_KEY) and not _session_in_window(s, window):
+                continue
             sid = _cursor_id(s)
             seen = cursors.get(sid, 0)
             turns, watermark = sessions.delta(s.path, seen, surface="hermes")
@@ -1247,6 +1250,8 @@ def run(project_dir=None, ingest_fn=None, cursors_path=CURSORS, reproject_fn=Non
             plan = plan_sweep(project_dir, cursors, recent=recent, codex_dir=codex_dir,
                               grok_dir=grok_dir, install_birth=birth)
             cursors, n = execute(plan, ingest_fn or graphiti_ingest, cursors, log=log)
+            if _hermes_enabled(project_dir, None):
+                cursors[HERMES_BASELINE_KEY] = True
             save_cursors(cursors, cursors_path)
             proposed = _maybe_propose_topic_directions(project_dir=project_dir, codex_dir=codex_dir,
                                                        grok_dir=grok_dir, log=log)


### PR DESCRIPTION
## Summary

- ingest Hermes sessions directly from `state.db` using stdlib `sqlite3` in read-only mode
- include Hermes sessions in EoC `quente` and `sweep` pipelines with message-ID watermarks
- preserve Hermes `profile_name` and resolve each profile's existing `edge_group`
- route Graphiti episodes and EoC skill commands to the resolved hivemind group
- install a standalone Hermes startup plugin that reconciles profile-local EoC skill wrappers

## Hermes profile policy

- missing effective `edge_group`: EoC disabled for that profile
- blank `edge_group`: profile-local group (`profile:<profile_name>`)
- named `edge_group`: shared EoC hivemind with profiles using the same name
- global Hermes config supplies the default; profile config can override it

The design is recorded in `docs/adr/0025-hermes-profiles-share-through-edge-group.md`.

## Validation

- focused adapter, policy, pipeline, provisioning, and regression gate: 14 tests passed
- standalone plugin `register()` smoke test installed an EoC wrapper in a temporary Hermes home
- real Hermes `state.db` smoke tests discovered and consumed sessions using per-message watermarks
- `git diff --check` passed

## Full-suite baseline

`python3 -m unittest discover -s tests -q` has hundreds of pre-existing environment-dependent failures on clean `HEAD` (3396 tests: 142 failures, 456 errors, 28 skipped). The feature branch initially exposed one additional failure; its root cause was inconsistent profile filtering between `quente` and `sweep`, which was fixed. The focused regression gate passes.

## Installation and onboarding runbook

`docs/hermes-installation.md` now documents the reproducible Hermes/EoC lifecycle end to end:

- genotype vs. profile-local phenotype and mandatory `EDGE_HOME`/`EDGE_GROUP` identity
- Hermes `edge_group` policy for disabled, isolated, and shared profiles
- canonical onboarding, runtime setup, Neo4j provisioning, plugin reconciliation, predispatch, and first wake
- strict separation of `assemble`, `delta`, `recall`, and `quente`, with eventlog as source of truth
- shared `web_search`/`web_extract` acquisition without backend, credential, payload, or context duplication
- verification, upgrade, and root-cause troubleshooting steps

## Wake hardening added

- bootstrap identity now honors `EDGE_HOME` before `agent.yaml` exists
- mentee leveling/persona resolves from the phenotype state root
- Hermes plugin provisioning preserves the real profile policy and startup integration
- Quente fixtures explicitly isolate the optional real Hermes surface

## Latest validation

- `python3 -m unittest tests.test_hermes_pipeline tests.test_hermes_provision tests.test_identity_env_dir tests.test_mentee_persona_brief tests.test_recall_brief tests.test_quente tests.test_hermes_sessions`: **63 passed**
- documentation contract check: **passed**
- `python3 -m py_compile ...`: **passed**
- `git diff --check`: **passed**
- live wake verification: Neo4j online, persona present, recall non-DARK, Quente `rc=0`
