### PR TITLE
fix(identity): o ovo é inalcançável antes do fenótipo em install geno/home separado

### DIFF
--- a/tests/test_identity_ovo_fallback.py
+++ b/tests/test_identity_ovo_fallback.py
@@ -42,6 +42,57 @@ class IdentityFromOvo(unittest.TestCase):
                 if old is not None:
                     os.environ["EDGE_GROUP"] = old
 
+    def test_ovo_is_found_through_real_resolution_when_home_is_not_the_repo(self):
+        """The regression: the two tests above inject agent_yaml= and so never exercise
+        identity_path(), which is where the ovo was actually being lost. In the documented
+        geno/home-separated layout, pre-phenotype identity_path() falls back to REPO (it only
+        honours EDGE_HOME when agent.yaml is ALREADY there) while the ovo lives in the HOME —
+        so the fallback was unreachable exactly when it is the only identity there is, and no
+        separated-home install could ever reach the mentor that emits the phenotype."""
+        if (_identity.REPO / "agent.yaml").exists():
+            self.skipTest("this tree is itself a home==repo install; resolution case N/A")
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / "state").mkdir()
+            (home / "state" / "bootstrap.json").write_text(
+                json.dumps({"name": "regressao", "edge_home": str(home)}))
+            old_home = os.environ.get("EDGE_HOME")
+            old_group = os.environ.pop("EDGE_GROUP", None)
+            os.environ["EDGE_HOME"] = str(home)
+            try:
+                resolved = _identity.identity_path("agent.yaml")
+                self.assertEqual(resolved, _identity.REPO / "agent.yaml",
+                                 "pre-phenotype identity_path must fall back to the genotype")
+                self.assertEqual(_identity.group(agent_yaml=resolved), "regressao")
+                self.assertEqual(_identity.edge_home(agent_yaml=resolved), home)
+            finally:
+                if old_home is None:
+                    os.environ.pop("EDGE_HOME", None)
+                else:
+                    os.environ["EDGE_HOME"] = old_home
+                if old_group is not None:
+                    os.environ["EDGE_GROUP"] = old_group
+
+    def test_explicit_path_wins_over_edge_home(self):
+        """The HOME leg must never override a tree a caller named outright."""
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as other:
+            named, home = Path(tmp), Path(other)
+            for root, name in ((named, "nomeado"), (home, "do-home")):
+                (root / "state").mkdir()
+                (root / "state" / "bootstrap.json").write_text(json.dumps({"name": name}))
+            old_home = os.environ.get("EDGE_HOME")
+            old_group = os.environ.pop("EDGE_GROUP", None)
+            os.environ["EDGE_HOME"] = str(home)
+            try:
+                self.assertEqual(_identity.group(agent_yaml=named / "agent.yaml"), "nomeado")
+            finally:
+                if old_home is None:
+                    os.environ.pop("EDGE_HOME", None)
+                else:
+                    os.environ["EDGE_HOME"] = old_home
+                if old_group is not None:
+                    os.environ["EDGE_GROUP"] = old_group
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/_identity.py
+++ b/tools/_identity.py
@@ -34,16 +34,40 @@ def identity_path(name):
 AGENT_YAML = identity_path("agent.yaml")
 
 
+def _ovo(p):
+    """The OVO (state/bootstrap.json) backing a resolved identity path.
+
+    Looks NEXT TO the identity file first (an explicit path always wins — tests and callers that
+    pass agent_yaml= mean that tree), then the declared install HOME.
+
+    The HOME leg is what makes pre-phenotype life actually work: identity_path() only resolves
+    EDGE_HOME when the file is ALREADY there, so before the mentor's finish emits agent.yaml it
+    falls back to REPO — and in the documented geno/home-separated layout the ovo lives in the
+    home, never in the genotype. Without this the ovo fallback is unreachable exactly when it is
+    the only identity there is, and the install rite can never reach the mentor that would emit
+    the phenotype (the chicken-and-egg that killed every separated-home onboarding)."""
+    roots = [Path(p).parent]
+    env = os.environ.get("EDGE_HOME")
+    if env:
+        roots.append(Path(os.path.expanduser(env)))
+    for root in roots:
+        ovo = root / "state" / "bootstrap.json"
+        if ovo.is_file():
+            return ovo
+    return None
+
+
 def _cfg(agent_yaml=AGENT_YAML):
     """agent.yaml when it exists; before the mentor's finish emits it, the OVO
-    (state/bootstrap.json next to it) supplies the mechanical identity facts — so pre-phenotype
-    life runs whole and nobody is pressured into creating agent.yaml before the mentor."""
+    (state/bootstrap.json — next to it, or in the declared EDGE_HOME) supplies the mechanical
+    identity facts, so pre-phenotype life runs whole and nobody is pressured into creating
+    agent.yaml before the mentor."""
     import yaml
     p = Path(agent_yaml)
     if p.exists():
         return yaml.safe_load(p.read_text()) or {}
-    ovo = p.parent / "state" / "bootstrap.json"
-    if ovo.is_file():
+    ovo = _ovo(p)
+    if ovo is not None:
         import json
         try:
             boot = json.loads(ovo.read_text()) or {}


### PR DESCRIPTION
Closes #586.

`_ovo()` procura `state/bootstrap.json` ao lado do arquivo de identidade primeiro (um caminho explícito sempre vence — preserva os testes existentes e chamadas com `agent_yaml=`) e então no `EDGE_HOME` declarado. A resolução continua dentro de `_identity`: o seam único da ADR-0015 é preservado.

### Efeito neste host
Home `/home/edge/edge`, genótipo `/home/edge/edge-of-chaos`, sem `agent.yaml`:

| | antes | depois |
|---|---|---|
| `group()` | `None` | `ed` |
| `edge_home()` | RuntimeError | `/home/edge/edge` |

### Testes
Dois novos que passam pela **resolução real**, não pelo caminho injetado:
- `test_ovo_is_found_through_real_resolution_when_home_is_not_the_repo` — o de regressão; sem o fix falha com `None != 'regressao'`
- `test_explicit_path_wins_over_edge_home` — garante que a perna do HOME nunca atropela uma árvore nomeada pelo chamador

Suíte de identidade/onboarding/install: as **mesmas 5 falhas pré-existentes** antes e depois (`test_identity_blinding` x2, `test_install_guards_154` x2, `test_onboarding` x1). 87 → 89 testes.

### Fora de escopo, anotado
As falhas pré-existentes do `test_identity_blinding` são reais: `EDGE_GROUP` lido fora do seam em `cortex_config.py:116` e `onboarding.py:550` (ADR-0015).