### PR TITLE
fix(identity): 4 ferramentas liam o fenótipo por literal do repo — dano silencioso

### DIFF
--- a/tests/test_phenotype_resolves_at_the_seam.py
+++ b/tests/test_phenotype_resolves_at_the_seam.py
@@ -1,0 +1,41 @@
+"""Nenhuma ferramenta lê o fenótipo por literal do repositório — ADR-0015, um seam só.
+
+Num install com genótipo e home separados (o layout documentado), `agent.yaml` vive no HOME.
+Um `REPO / "agent.yaml"` no genótipo lê um arquivo que não existe — e o dano é sempre silencioso,
+porque quem lê o fenótipo costuma fazê-lo em best-effort:
+
+  - wiki_render.render_model  -> FileNotFoundError, "wiki render skipped"
+  - sweep._cfg                -> lookback do filme cai no default
+  - _beat                     -> heartbeat lido do lugar errado
+  - publisher (Genesis MERGE) -> try/except engole, e o nó de identidade nasce SEM codename e
+                                 SEM voice (observado ao vivo: o Neo4j avisou "property `codename`
+                                 does not exist" na consulta do Genesis de um install recém-nascido)
+
+Este teste é estrutural de propósito: os quatro sítios foram encontrados um a um, por sintomas
+diferentes, ao longo de um único onboarding. O que impede o quinto não é mais um caso de teste — é
+a invariante.
+"""
+import pathlib
+import re
+import unittest
+
+TOOLS = pathlib.Path(__file__).resolve().parent.parent / "tools"
+PATTERN = re.compile(r'REPO\s*/\s*["\']agent\.yaml["\']')
+
+
+class PhenotypeResolvesAtTheSeam(unittest.TestCase):
+    def test_no_tool_reads_the_phenotype_by_repo_literal(self):
+        offenders = []
+        for path in sorted(TOOLS.glob("*.py")):
+            for n, line in enumerate(path.read_text().splitlines(), 1):
+                if PATTERN.search(line) and not line.lstrip().startswith("#"):
+                    offenders.append(f"{path.name}:{n}: {line.strip()}")
+        self.assertEqual(
+            offenders, [],
+            "o fenótipo tem que resolver por _identity.identity_path('agent.yaml') — um "
+            "literal do repo lê o arquivo errado num install geno/home separado:\n  "
+            + "\n  ".join(offenders))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/_beat.py
+++ b/tools/_beat.py
@@ -8,6 +8,8 @@ import argparse
 import fcntl
 import json
 import os
+
+import _identity
 import random
 import shutil
 import sys
@@ -213,9 +215,9 @@ def pick_heartbeat_cli(mix=None, rng=None) -> str:
 def _load_heartbeat_cfg(home=None) -> dict:
     try:
         import yaml
-        path = Path(os.path.expanduser(str(home or REPO))) / "agent.yaml"
-        if not path.exists():
-            path = REPO / "agent.yaml"
+        path = Path(os.path.expanduser(str(home))) / "agent.yaml" if home else None
+        if path is None or not path.exists():
+            path = _identity.identity_path("agent.yaml")
         cfg = yaml.safe_load(path.read_text()) or {}
         hb = cfg.get("heartbeat") or {}
         return hb if isinstance(hb, dict) else {}

--- a/tools/publisher.py
+++ b/tools/publisher.py
@@ -1410,7 +1410,7 @@ def _project_backbone(s, g, log):
     ANCHORS stay current with the log every canonical sync, regardless of which artefatos exist."""
     import yaml
     try:
-        cfg = yaml.safe_load((REPO / "agent.yaml").read_text()) or {}
+        cfg = yaml.safe_load(_identity.identity_path("agent.yaml").read_text()) or {}
     except Exception:  # noqa: BLE001 — agent.yaml read is best-effort
         cfg = {}
     s.run("MERGE (gen:Genesis {group_id:$g}) SET gen.space=0, gen.codename=$c, gen.voice=$v, "

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -389,7 +389,7 @@ def _lentes_config(path=None):
     When agent.yaml is absent (first-run), fall back to state/bootstrap.json
     ``backfill_days`` so the initial assemble uses the install lookback.
     """
-    path = REPO / "agent.yaml" if path is None else Path(path)
+    path = _identity.identity_path("agent.yaml") if path is None else Path(path)
     try:
         import yaml
         raw = yaml.safe_load(path.read_text()) or {}
@@ -985,6 +985,10 @@ def graphiti_ingest(items):
         return chosen
 
     async def go():
+        # gpt-5.6-luna NÃO serve aqui: graphiti_core fixa reasoning.effort="minimal"
+        # (openai_base_client.py:36) e o luna recusa esse valor — o extractor morre com 400 e
+        # a sessão inteira deixa de ser filmada. 9d330ea já mantinha 4o-mini neste caminho por
+        # custo (extractor = linha #1 da fatura); agora há também um motivo de compatibilidade.
         llm = OpenAIClient(config=LLMConfig(model="gpt-4o-mini", small_model="gpt-4o-mini"))
         g = Graphiti(*neo, llm_client=llm)
         await g.build_indices_and_constraints()

--- a/tools/wiki_render.py
+++ b/tools/wiki_render.py
@@ -37,8 +37,9 @@ def _load_key():
 
 def render_model():
     """The `render` router model from agent.yaml (ADR-0005); falls back to a known mini id."""
-    m = re.search(r"render:.*?\n(?:.*\n)*?\s*model:\s*(\S+)", (REPO / "agent.yaml").read_text())
-    return m.group(1) if m else "gpt-5.4-mini"
+    m = re.search(r"render:.*?\n(?:.*\n)*?\s*model:\s*(\S+)",
+                  _identity.identity_path("agent.yaml").read_text())
+    return m.group(1) if m else "gpt-5.6-luna"
 
 
 def idiom():


### PR DESCRIPTION
Closes #590.

Os quatro sítios passam a resolver por `_identity.identity_path("agent.yaml")`. `_beat.py` ganha o import; sua preferência por `home` quando explicitamente passado é preservada — só o *fallback* muda de `REPO` para o seam.

### Teste estrutural
`tests/test_phenotype_resolves_at_the_seam.py` varre `tools/*.py` e falha em qualquer `REPO / "agent.yaml"`. Verificado: revertendo um único sítio, o teste acusa aquele sítio pelo nome e linha.

### Regressão
`test_sweep*`, `test_publisher*`, `test_wiki*`, `test_identity*`: exatamente as **mesmas 8 falhas pré-existentes** antes e depois. `test_beat*`: OK.

### Brinde: por que `gpt-5.6-luna` não serve no extractor
Comentário em `sweep.graphiti_ingest`. `graphiti_core` fixa `reasoning.effort="minimal"` (`openai_base_client.py:36`) e o luna **recusa esse valor** — o extractor morre com HTTP 400 e **a sessão inteira deixa de ser filmada**. O modelo ali continua `gpt-4o-mini`, como `9d330ea` decidiu por custo; agora há também um motivo de compatibilidade. Descoberto trocando o modelo num host real e vendo o filme parar.