### PR TITLE
fix(identity): leveling-store pousava no genótipo, não na casa do install

### DIFF
--- a/tests/test_leveling_store_lives_in_the_home.py
+++ b/tests/test_leveling_store_lives_in_the_home.py
@@ -1,0 +1,58 @@
+"""O leveling-store (persona do mentorado) mora na casa do install, não no genótipo.
+
+`_identity` define o contrato: num install com genótipo e home separados, identidade vive no
+HOME e "o repo é genótipo puro, sem identidade". A persona do mentorado é o arquivo mais
+identitário que existe — e escritor e leitor a resolviam por literal do repositório.
+
+Escritor e leitor CONCORDAVAM entre si, então um install isolado funcionava e nada acusava. O
+dano aparece quando dois installs partilham um clone do genótipo: a persona de um mentorado
+sobrescreve a do outro. É a família do #154 (colonização), e por isso o teste cobre as duas
+pontas juntas — verificar só uma delas reproduz exatamente a cegueira original.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import grill_writeback  # noqa: E402
+import recall  # noqa: E402
+
+
+class LevelingStoreResolvesAtTheSeam(unittest.TestCase):
+    def test_writer_lands_in_the_home_and_reader_finds_it_there(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / "memory").mkdir()
+            log = home / "log.jsonl"
+            old = os.environ.get("EDGE_HOME")
+            os.environ["EDGE_HOME"] = str(home)
+            try:
+                written = grill_writeback.leveling(
+                    "perfil", "# Perfil\n\nquem o mentorado é", log=log)
+                self.assertEqual(written.parent, home / "memory" / "leveling",
+                                 "a persona tem que pousar na casa do install")
+                self.assertFalse((REPO / "memory" / "leveling" / "perfil.md").exists()
+                                 and written.parent == REPO / "memory" / "leveling",
+                                 "a persona não pode pousar no genótipo")
+                brief = recall.compose_mentee_persona_brief()
+                self.assertIn("quem o mentorado é", brief,
+                              "o leitor tem que resolver pela mesma raiz que o escritor")
+            finally:
+                if old is None:
+                    os.environ.pop("EDGE_HOME", None)
+                else:
+                    os.environ["EDGE_HOME"] = old
+
+    def test_explicit_root_still_wins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "escolhida"
+            log = Path(tmp) / "log.jsonl"
+            written = grill_writeback.leveling("perfil", "# Perfil\n\nx", root=root, log=log)
+            self.assertEqual(written.parent, root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/grill_writeback.py
+++ b/tools/grill_writeback.py
@@ -80,7 +80,10 @@ def leveling(kind, content, root=None, log=eventlog.LOG):
         raise ValueError(f"leveling kind must be one of {LEVELING_KINDS}, got {kind!r}")
     if not (isinstance(content, str) and content.strip()):
         raise ValueError(f"refusing a blank leveling {kind} — a hollow persona file is worse than none")
-    root = Path(root) if root else REPO / "memory" / "leveling"
+    # O leveling-store é IDENTIDADE do mentorado: mora na casa do install, não no clone do
+    # genótipo (ADR-0015; _identity: "o repo é genótipo puro, sem identidade"). Um literal do
+    # repo faz dois installs que partilham um clone sobrescreverem a persona um do outro.
+    root = Path(root) if root else _identity.identity_path("memory") / "leveling"
     root.mkdir(parents=True, exist_ok=True)
     path = root / f"{kind}.md"
     stripped = content.strip()

--- a/tools/recall.py
+++ b/tools/recall.py
@@ -573,7 +573,9 @@ def compose_mentee_persona_brief(root=None, *, max_perfil_chars=3500):
 
     Safe for wake/mentor recall: missing/blank perfil is declared empty, never silent.
     """
-    root = Path(root) if root is not None else Path(__file__).resolve().parent.parent / "memory" / "leveling"
+    # Mesma raiz que o ESCRITOR (grill_writeback.leveling): o leveling-store é identidade do
+    # mentorado e mora na casa do install. Leitor e escritor têm que resolver pelo mesmo seam.
+    root = Path(root) if root is not None else _identity.identity_path("memory") / "leveling"
     parts = [
         "## Persona do mentee",
         "",


### PR DESCRIPTION
Closes #594.

Os dois sítios passam a resolver por `_identity.identity_path("memory") / "leveling"`.

### Por que era sutil
Escritor e leitor **concordavam entre si** — um install isolado funciona e nada acusa. O dano só aparece quando dois installs partilham um clone do genótipo: a persona de um mentorado sobrescreve a do outro. Família do #154.

Por isso o teste cobre as **duas pontas juntas**: escreve pelo escritor, lê pelo leitor, e exige que a persona esteja na casa. Verificar só uma ponta reproduz exatamente a cegueira original.

### Verificação
- sem o fix: falha nomeando o caminho errado (`.../edge-of-chaos/memory/leveling != .../tmp/.../memory/leveling`)
- raiz explícita do chamador continua vencendo
- `test_recall*` + `test_grill*`: 154 testes verdes antes e depois