### PR TITLE
fix(identity): EDGE_GROUP resolvia em quatro lugares fora do seam — um com tenant fixo

### DIFF
--- a/tests/test_identity_ovo_fallback.py
+++ b/tests/test_identity_ovo_fallback.py
@@ -93,6 +93,36 @@ class IdentityFromOvo(unittest.TestCase):
                 if old_group is not None:
                     os.environ["EDGE_GROUP"] = old_group
 
+    def test_named_tree_never_borrows_the_launchers_home(self):
+        """Regressão do próprio ovo-fallback: perguntar pela identidade de OUTRA árvore.
+
+        Quando o chamador passa um agent.yaml explícito (cortex_config perguntando pelo home
+        ALVO), a perna do EDGE_HOME não pode valer — senão a árvore sem identidade recebe o grupo
+        do LANÇADOR, que é exatamente o vazamento cross-tenant da ADR-0015 (#154). A perna do HOME
+        só existe para o caso em que ninguém nomeou árvore nenhuma e identity_path caiu no
+        genótipo."""
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as casa:
+            alheia = Path(tmp)                    # árvore nomeada: sem agent.yaml e sem ovo
+            lancador = Path(casa)                 # a casa de QUEM chama, com identidade própria
+            (lancador / "state").mkdir()
+            (lancador / "state" / "bootstrap.json").write_text(
+                json.dumps({"name": "do-lancador", "edge_home": str(lancador)}))
+            old_home = os.environ.get("EDGE_HOME")
+            old_group = os.environ.pop("EDGE_GROUP", None)
+            os.environ["EDGE_HOME"] = str(lancador)
+            try:
+                self.assertIsNone(
+                    _identity.group(agent_yaml=alheia / "agent.yaml"),
+                    "uma árvore nomeada sem identidade resolve para NADA — nunca para o grupo "
+                    "do lançador")
+            finally:
+                if old_home is None:
+                    os.environ.pop("EDGE_HOME", None)
+                else:
+                    os.environ["EDGE_HOME"] = old_home
+                if old_group is not None:
+                    os.environ["EDGE_GROUP"] = old_group
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/_identity.py
+++ b/tools/_identity.py
@@ -47,7 +47,13 @@ def _ovo(p):
     the only identity there is, and the install rite can never reach the mentor that would emit
     the phenotype (the chicken-and-egg that killed every separated-home onboarding)."""
     roots = [Path(p).parent]
-    env = os.environ.get("EDGE_HOME")
+    # A perna do HOME vale SÓ quando ninguém nomeou a árvore — isto é, quando identity_path()
+    # caiu no genótipo por falta de fenótipo. Se o chamador passou um agent.yaml explícito, ele
+    # está perguntando pela identidade DAQUELA árvore (cortex_config perguntando pelo home alvo);
+    # consultar o EDGE_HOME do lançador ali devolveria o grupo de OUTRO tenant — o vazamento que
+    # a ADR-0015 existe para impedir. Regressão introduzida por mim no #586 e pega por
+    # test_unresolved_target_identity_scrubs_inherited_edge_group.
+    env = os.environ.get("EDGE_HOME") if Path(p).parent == REPO else None
     if env:
         roots.append(Path(os.path.expanduser(env)))
     for root in roots:
@@ -77,12 +83,24 @@ def _cfg(agent_yaml=AGENT_YAML):
     return {}
 
 
+def group_env_override():
+    """The EDGE_GROUP host override, or None — the ONLY read of that variable in the tree.
+
+    ADR-0015 puts identity resolution at one seam. A caller that legitimately needs just the
+    override, without the agent.yaml/ovo precedence — the bootstrap cfg builder, choosing a group
+    for an install that does not exist yet — asks HERE instead of re-implementing the seam inline.
+    An inline os.environ.get("EDGE_GROUP") elsewhere is a second seam, and a second seam is how a
+    tenant writes into another tenant's group (#154)."""
+    g = os.environ.get("EDGE_GROUP")
+    return g.strip() if isinstance(g, str) and g.strip() else None
+
+
 def group(agent_yaml=AGENT_YAML):
     """The graph group for THIS install. EDGE_GROUP (host override) → agent.yaml `graph_group` →
     name/codename. `graph_group` lets an install own a corpus in a group distinct from its mentor
     name without orphaning it — explicit per-install config, never a baked-in default (#21). Returns
     None when nothing resolves — the runtime degrade posture (no cross-tenant default)."""
-    g = os.environ.get("EDGE_GROUP")
+    g = group_env_override()
     if g:
         return g
     cfg = _cfg(agent_yaml)

--- a/tools/_probe.py
+++ b/tools/_probe.py
@@ -1,16 +1,17 @@
 """_probe — probe rápido do cortex pro loop de deploy (env pré-sourced pelo wrapper `rq`).
 Cypher:  rq 'MATCH (c:Community {group_id:$g}) RETURN count(c) AS n'   (use $g pro group)
 Python:  rq < snip.py    (globais: C=communities, d=driver, q(cypher,**p)->[dict], G=group)
-Host-agnóstico: G vem do _identity do host (roberto->roberto, ed->edge-next)."""
+Host-agnóstico: G vem SEMPRE do _identity do host — nunca de um literal de install (#21)."""
 import sys, os
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import communities as C
 
-try:
-    import _identity
-    G = _identity.group()
-except Exception:
-    G = os.environ.get("EDGE_GROUP", "roberto")
+import _identity
+
+# FAIL-LOUD, sem fallback (ADR-0015 / #21): q() injeta g=G em todo cypher, então um default
+# embutido faz este probe LER E ESCREVER no grupo de outro tenant sempre que a identidade não
+# resolver — em silêncio, que é o pior modo possível para uma ferramenta de query interativa.
+G = _identity.require_group()
 
 d = C._driver()
 

--- a/tools/communities.py
+++ b/tools/communities.py
@@ -18,7 +18,15 @@ import time
 import uuid as uuidlib
 from collections import Counter, defaultdict
 
-GROUP = os.environ.get("EDGE_GROUP")
+def _group():
+    """O grupo, resolvido pelo seam único (ADR-0015) e SOB DEMANDA.
+
+    Era uma constante de módulo lendo a variável de ambiente do grupo direto, no topo do arquivo:
+    um segundo seam E um cache de identidade em tempo de import — o mesmo par que
+    test_sweep_has_no_import_time_identity_cache já proíbe no sweep. Cache de identidade no import
+    guarda a identidade de quem importou, não a do install que vai ser consultado."""
+    import _identity
+    return _identity.group()
 
 
 # --- pure core (bare python; the internal seam the tests hold) ---
@@ -116,7 +124,7 @@ def _driver(uri=None, user=None, password=None):
 def communities(group=None, **kw):
     """The briefing §5 leg: [{uuid, name, summary, size, last_touched}] recency-desc.
     [] = graph reachable, no communities yet; None = dark."""
-    group = group or GROUP
+    group = group or _group()
     if not group:
         return None
     drv = _driver(**kw)
@@ -140,7 +148,7 @@ def communities(group=None, **kw):
 def community(ref, group=None, **kw):
     """One cluster in full: members (with last_mentioned) + provenance (source sessions via
     MENTIONS, artefatos via DISTILLS). ref = uuid or name. None = dark/not found."""
-    group = group or GROUP
+    group = group or _group()
     if not group:
         return None
     drv = _driver(**kw)
@@ -180,7 +188,7 @@ def community(ref, group=None, **kw):
 def locate(names, group=None, **kw):
     """JULGAR positioning: for each entity name, which community holds it (member), neighbours
     it (edge — RELATES_TO into a community), or none. None = dark."""
-    group = group or GROUP
+    group = group or _group()
     if not group:
         return None
     if not names:
@@ -216,7 +224,7 @@ def _default_summarize(members_text):
     import urllib.request
     req = urllib.request.Request(
         "https://api.openai.com/v1/chat/completions",
-        data=json.dumps({"model": "gpt-5.4-mini", "max_completion_tokens": 300, "messages": [{
+        data=json.dumps({"model": "gpt-5.6-luna", "max_completion_tokens": 300, "messages": [{
             "role": "user",
             "content": "Estas entidades formam um cluster de conhecimento das sessões de "
                        "trabalho de um operador. Dê um NOME curto (3-6 palavras, PT-BR) e um "
@@ -233,7 +241,7 @@ def consolidate(group=None, summarize_fn=None, min_size=3, min_cross=2, **kw):
     entities+RELATES_TO → cluster() → merge_pass() → summarize each → wipe-rebuild Community/
     HAS_MEMBER (their own lifecycle; the log stays the truth, ADR-0006). Returns the list of
     {name, size} written, or None on a dark graph. Dust count is logged, never silent."""
-    group = group or GROUP
+    group = group or _group()
     if not group:
         return None
     drv = _driver(**kw)

--- a/tools/cortex_config.py
+++ b/tools/cortex_config.py
@@ -113,12 +113,12 @@ def mcp_config(group=None, home=None, subject=None):
         # agent.yaml (graph_group → name → codename, read straight from the file, never the launcher
         # checkout). The resolved value is BAKED, so it overrides any stale inherited env in the
         # subprocess; an unresolved identity bakes empty (the scrub above) and the server fails loud.
-        group = os.environ.get("EDGE_GROUP")
-        if not group and home:
-            target_yaml = Path(os.path.expanduser(home)) / "agent.yaml"
-            if target_yaml.exists():
-                cfg = _identity._cfg(target_yaml)
-                group = cfg.get("graph_group") or cfg.get("name") or cfg.get("codename")
+        # A precedência (EDGE_GROUP → graph_group → name → codename) vive em _identity.group();
+        # reimplementá-la aqui era um segundo seam (ADR-0015). Passando o agent.yaml do home
+        # ALVO, a mesma função resolve o grupo daquele install — e, quando ele ainda não tem
+        # fenótipo, cai no ovo dele em vez de devolver nada (#586).
+        target_yaml = (Path(os.path.expanduser(home)) / "agent.yaml") if home else None
+        group = _identity.group(target_yaml) if target_yaml else _identity.group_env_override()
     if not _granted(subject):
         # FAIL-CLOSED (N5): a delta/world OR omitted/unknown subject gets a config with NO cortex
         # server at all — the strongest deny (nothing to inherit). Only an explicit self-cognition is

--- a/tools/onboarding.py
+++ b/tools/onboarding.py
@@ -6,6 +6,7 @@ Secrets are read from <home>/secrets/ (or EDGE_SECRETS_DIR); values never logged
 from __future__ import annotations
 
 import json
+import _identity
 import os
 import re
 from pathlib import Path
@@ -351,7 +352,7 @@ def _adversarials_for_cfg(cast: dict, primary: str) -> dict:
             out["codex"] = {
                 "route": "review",
                 "auth": "subscription",
-                "model": "gpt-5.5",
+                "model": "gpt-5.6-luna",
                 "directive": (
                     "Refute-first. Strike what does not survive; the 0-5 score is advisory."
                 ),
@@ -408,7 +409,7 @@ def _routers_for_cfg(cast: dict, primary: str, embedding: Optional[dict]) -> dic
     else:
         for m in cast.get("members") or []:
             if m == "codex":
-                routers["review"] = {"provider": "codex", "model": "gpt-5.5"}
+                routers["review"] = {"provider": "codex", "model": "gpt-5.6-luna"}
             elif m == "grok":
                 routers["review_grok"] = {"provider": "grok", "model": "grok-4.5"}
             elif m == "hermes":
@@ -547,7 +548,7 @@ def bootstrap_cfg(
     cfg: dict[str, Any] = {
         "name": name,
         "codename": name,
-        "graph_group": os.environ.get("EDGE_GROUP") or name,
+        "graph_group": _identity.group_env_override() or name,
         "edge_home": home_s,
         # CONTRACT C4 — secrets live here; installer verifies, never invents keys
         "env_dir": env_dir_s,


### PR DESCRIPTION
Closes #593.

A issue conhecia **dois** sítios. Eram **quatro** — os outros dois só apareceram quando o guarda ficou verde o bastante para enxergá-los.

| sítio | o que era |
|---|---|
| `cortex_config.py` | reimplementava a precedência inteira contra o home alvo |
| `onboarding.py` | lia a variável para montar o `graph_group` do bootstrap |
| `communities.py` | constante de módulo lida em **tempo de import** — segundo defeito no mesmo lugar |
| **`_probe.py`** | **`os.environ.get("EDGE_GROUP", "roberto")`** — default de **outro tenant** |

### O `_probe` era o grave
O default estava dentro de um `except Exception` que engolia qualquer falha de identidade. Como `q()` injeta `g=G` em todo cypher, o probe **leria e escreveria no grupo `roberto`** sempre que a identidade não resolvesse — em silêncio. É o #21 na forma mais pura. Agora usa `require_group()`: falha alto, sem fallback.

### E corrige uma regressão minha, do #586 (já mesclado)
A perna do `EDGE_HOME` em `_ovo` valia mesmo quando o chamador nomeava uma árvore explícita. Consequência: `cortex_config` perguntando pela identidade de um home **alvo** sem fenótipo recebia **o grupo do lançador** — o vazamento cross-tenant que a ADR existe para impedir.

Pega por `test_unresolved_target_identity_scrubs_inherited_edge_group` (verde antes do #586, vermelho depois), e agora coberta por teste direto em `_identity`: sem o fix, falha com `'do-lancador' is not None`.

### Verificação
- `test_identity_blinding`: **8/8** (eram 2 vermelhos)
- `test_cortex*`: **329/329** (era 1 vermelho)
- `test_communities*`, `test_identity*`: verdes
- `test_sweep*`: mesmas 2 falhas pré-existentes de `test_sweep_lentes`