### PR TITLE
fix(tests): o teste que emite o fenótipo nunca carimbava o wayfind

### DIFF
--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -521,12 +521,45 @@ class FinishOnboarding(unittest.TestCase):
                 "diario", "sem update de persona; residual = x",
                 root=home / "lv", log=log,
             )
+            # o wayfind: direção e MAPA são complementares e ambos têm que ter se movido
+            # (plano do operador 2026-07-13). O gate cobra isso desde então; esta fixture
+            # não acompanhou, e o teste do passo que EMITE o fenótipo ficou vermelho.
+            eventlog.open_map(
+                operacao="onboarding", titulo="mapa do wayfind",
+                rationale="o que o mentor entendeu e os buracos que sabe que não sabe",
+                dispatch_id="d1", author="mentor", log=log,
+            )
             path = onboarding.finish_onboarding(
                 home, log=log, mission="learn", voice="direct", enable_heartbeat=False
             )
             self.assertTrue(path.is_file())
             self.assertTrue(onboarding.is_onboarding_complete(home, log=log))
             onboarding.assert_production_allowed(home, log=log)
+
+    def test_finish_refuses_when_only_the_wayfind_is_missing(self):
+        """A peça que fez este arquivo ficar vermelho merece teste próprio.
+
+        Sem ela, a única cobertura do wayfind era um efeito colateral do caminho feliz — e um
+        caminho feliz que envelhece não acusa a peça que faltou, só fica vermelho por inteiro."""
+        import eventlog
+        import grill_writeback
+
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            log = home / "log.jsonl"
+            (home / "secrets").mkdir()
+            onboarding.run_bootstrap(
+                home=home, name="ed", backfill_days=14, provision_skills=False
+            )
+            eventlog.set_objective("learn", log=log)
+            eventlog.propose("d1", "direction body", log=log)
+            eventlog.report_direction("steer", log=log)
+            grill_writeback.leveling(
+                "diario", "sem update de persona", root=home / "lv", log=log
+            )
+            # tudo menos o mapa
+            with self.assertRaisesRegex(ValueError, "wayfind"):
+                onboarding.finish_onboarding(home, log=log, mission="m", voice="v")
 
     def test_finish_refuses_without_grill(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Closes #592.

O teste carimbava objetivo, direção, direcionamento e leveling — e **nenhum mapa**. O plano de 2026-07-13 tornou direção e mapa complementares; o `grill_gate` cobra os dois desde então. O portão está certo, a fixture é que envelheceu.

### Por que pesa mais que um vermelho comum
`finish_onboarding` é o passo que **emite o `agent.yaml`**. É a única função do repositório cujo defeito impede o agente de existir para reportar o defeito. Ficou sem rede desde julho — e foi nesse intervalo que o caminho de pré-fenótipo acumulou #586, #590, #593 e #594.

### Teste novo
`test_finish_refuses_when_only_the_wayfind_is_missing`: a peça que derrubou o arquivo passa a ter cobertura própria, exigindo que a recusa **nomeie** `wayfind`.

Sem isso, a única cobertura da peça era efeito colateral do caminho feliz — e caminho feliz que envelhece não acusa **qual** peça faltou, só fica vermelho por inteiro. Cada peça do gate merece uma recusa nomeada.

`test_onboarding`: **41/41**.