### PR TITLE
fix(rq): o wrapper carregava um caminho de install e assumia home == repo

### DIFF
--- a/rq
+++ b/rq
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
 # rq — probe rápido do cortex deste host (env pré-sourced, driver pronto). Ver tools/_probe.py.
-#   cypher:  ~/edge/rq 'MATCH (c:Community {group_id:$g}) RETURN count(c) AS n'
-#   python:  ~/edge/rq < snip.py     (globais C, d, q(cypher,**p), G já prontos)
-cd ~/edge || exit 1
-set -a; for f in secrets/*.env; do . "$f" 2>/dev/null; done; set +a
+#   cypher:  rq 'MATCH (c:Community {group_id:$g}) RETURN count(c) AS n'   (use $g pro group)
+#   python:  rq < snip.py    (globais C, d, q(cypher,**p), G já prontos)
+#
+# Host-agnóstico (ADR-0015, #21): NENHUM caminho de install aparece aqui. O genótipo é o
+# diretório deste arquivo com symlink resolvido — então funciona tanto chamado no clone quanto
+# pelo link em <home>/rq. A casa vem de _identity.state_root(): EDGE_HOME -> agent.yaml
+# `edge_home` -> genótipo. A versão anterior fazia `cd ~/edge` e `./tools/...`, o que embutia um
+# tenant no genótipo E assumia home == repo — quebrado no layout de árvores separadas.
+set -uo pipefail
+self="$(readlink -f "${BASH_SOURCE[0]}")"
+repo="$(cd "$(dirname "$self")" && pwd)"
+cd "$repo" || exit 1
+
+home="$(./tools/edge-python -c "import sys; sys.path.insert(0, '$repo/tools'); import _identity; print(_identity.state_root())" 2>/dev/null)"
+home="${home:-${EDGE_HOME:-$HOME/edge}}"
+
+set -a; for f in "$home"/secrets/*.env; do [ -r "$f" ] && . "$f"; done; set +a
 exec ./tools/edge-python tools/_probe.py "$@"

--- a/tests/test_phenotype_resolves_at_the_seam.py
+++ b/tests/test_phenotype_resolves_at_the_seam.py
@@ -37,5 +37,35 @@ class PhenotypeResolvesAtTheSeam(unittest.TestCase):
             + "\n  ".join(offenders))
 
 
+class NoInstallLiteralInGenotypeScripts(unittest.TestCase):
+    """Os wrappers de shell do genótipo também não podem carregar caminho de install.
+
+    `test_no_install_literals_in_genotype` varre apenas `tools/*.py` — foi por essa fresta que
+    `rq` viveu com `cd ~/edge` e `./tools/...` embutidos: um tenant dentro do genótipo E a
+    suposição de que a casa é o repo, que é falsa no layout documentado de árvores separadas.
+    """
+
+    SCRIPTS = ("rq",)
+    LITERAL = re.compile(r"(?<!\.)~/(edge|edge-home)\b|/home/[a-z][a-z0-9_-]*/")
+
+    def test_shell_wrappers_carry_no_install_path(self):
+        offenders = []
+        root = pathlib.Path(__file__).resolve().parent.parent
+        for name in self.SCRIPTS:
+            path = root / name
+            if not path.exists():
+                continue
+            for n, line in enumerate(path.read_text().splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("#") or not stripped:
+                    continue          # comentário pode citar o caminho ao explicar
+                if self.LITERAL.search(line):
+                    offenders.append(f"{name}:{n}: {stripped}")
+        self.assertEqual(
+            offenders, [],
+            "wrapper do genótipo com caminho de install embutido — a casa resolve por "
+            "_identity.state_root(), nunca por literal:\n  " + "\n  ".join(offenders))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/edge-apply
+++ b/tools/edge-apply
@@ -175,6 +175,12 @@ def main() -> None:
         (home / d).mkdir(parents=True, exist_ok=True)
 
     _provision.place_file(REPO / "blog" / "server.py", home / "blog" / "server.py")
+    # rq na casa: um symlink para o do genótipo, não uma cópia — o script precisa achar
+    # tools/ ao lado de si mesmo, e resolve o próprio symlink para isso. Sem esta linha
+    # `$EDGE_HOME/rq` simplesmente não existia num install de árvores separadas.
+    rq_link = home / "rq"
+    if (REPO / "rq").exists() and not rq_link.exists() and (REPO / "rq") != rq_link:
+        rq_link.symlink_to(REPO / "rq")
     if (REPO / "blog" / "static").exists():
         _provision.place_tree(REPO / "blog" / "static", home / "blog" / "static")
     if (REPO / "skills").exists():


### PR DESCRIPTION
Closes #597.

A issue dizia *"rq não é provisionado no home"*. O diagnóstico é pior — o `rq` estava **quebrado para o layout documentado**, por dois motivos na mesma linha:

```bash
cd ~/edge || exit 1                       # tenant embutido DENTRO do genótipo (#21)
exec ./tools/edge-python tools/_probe.py  # tools/ sob a casa — só vale se home == repo
```

Em árvores separadas, `~/edge/tools/` não existe. E caminho de install no genótipo é precisamente o que a ADR-0015 proíbe.

### O fix
- `rq` resolve o **genótipo** pelo próprio caminho com symlink resolvido — funciona chamado no clone **e** pelo link na casa — e a **casa** por `_identity.state_root()`. Nenhum literal.
- `edge-apply` cria `<home>/rq` como **symlink**, não cópia: o script precisa achar `tools/` ao lado de si mesmo, e resolve o próprio link para isso. Cópia solta na casa não teria como.

### Por que passou um mês
`test_no_install_literals_in_genotype` varre só `tools/*.py`. `rq` é shell na raiz — a fresta exata. O teste novo fecha a classe para os wrappers do genótipo, ignorando comentários (um comentário **pode** citar o caminho ao explicar).

Verificado: com o `rq` antigo, o guarda acusa `rq:5: cd ~/edge || exit 1`. Com o novo, o `rq` responde dos dois lados e escopa no grupo certo.