### PR TITLE
fix(onboarding): o roster declarava fonte pela PRESENÇA do secret, sem testar a chave

### DIFF
--- a/tests/test_sources_are_probed_before_declared.py
+++ b/tests/test_sources_are_probed_before_declared.py
@@ -1,0 +1,76 @@
+"""O fenótipo só carrega fonte que já SENTIU — presença de chave não é chave viva.
+
+`_sources_from_inventory` montava o roster a partir dos arquivos presentes em `secrets/`, sem
+uma única chamada de verificação. Observado no nascimento de um install real: `x` (xai) entrou
+no agent.yaml automaticamente com uma chave que responde HTTP 403 — fonte morta declarada viva —
+enquanto `exa` entrou pelo mesmo caminho e, por acaso, respondia.
+
+O dano é assimétrico: uma fonte morta declarada viva transforma um delta silenciosamente vazio
+em "nada novo no mundo", que é o pior modo de falha para um órgão cuja função é notar o que
+mudou. Por isso "não sei perguntar" (None -> unverified) é um estado DISTINTO de "perguntei e
+não respondeu" (False -> dark).
+"""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import onboarding  # noqa: E402
+
+INV = {"files": ["exa.env", "xai.env", "github.env"],
+       "vars": ["EXA_API_KEY", "XAI_API_KEY", "GITHUB_TOKEN"]}
+
+
+class SourcesCarryTheirProbedStatus(unittest.TestCase):
+    def test_status_distinguishes_alive_dead_and_unknown(self):
+        answers = {"exa": True, "x": False, "github": None}
+        rows = onboarding._sources_from_inventory(INV, probe=answers.get)
+        got = {r["name"]: r["status"] for r in rows}
+        self.assertEqual(got, {"exa": "on", "x": "dark", "github": "unverified"})
+
+    def test_without_a_probe_the_historical_behaviour_is_kept(self):
+        rows = onboarding._sources_from_inventory(INV)
+        self.assertTrue(rows)
+        self.assertFalse(any("status" in r for r in rows),
+                         "sem probe nenhum status é AFIRMADO — declarar 'on' sem perguntar é "
+                         "exatamente o defeito")
+
+    def test_probe_reports_dead_key_as_dark_not_as_unknown(self):
+        """Chave presente que não responde é `dark`; sem chave nenhuma, também."""
+        with tempfile.TemporaryDirectory() as tmp:
+            secrets = Path(tmp)
+            (secrets / "exa.env").write_text('EXA_API_KEY="k"\n')
+
+            class _HTTPError(Exception):
+                pass
+            import urllib.error
+            def opener(req, timeout=None):
+                raise urllib.error.HTTPError(req.full_url, 403, "Forbidden", {}, None)
+            self.assertIs(onboarding.probe_source("exa", secrets, opener=opener), False)
+            self.assertIs(onboarding.probe_source("x", secrets, opener=opener), False,
+                          "sem chave no arquivo, a fonte não está viva")
+
+    def test_network_outage_is_unknown_never_dead(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            secrets = Path(tmp)
+            (secrets / "exa.env").write_text('EXA_API_KEY="k"\n')
+            def opener(req, timeout=None):
+                raise OSError("rede fora")
+            self.assertIsNone(onboarding.probe_source("exa", secrets, opener=opener),
+                              "rede indisponível não é chave morta — marcar dark aqui seria "
+                              "condenar uma fonte viva por um problema do host")
+
+    def test_secret_value_is_read_but_never_returned_by_the_roster(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            secrets = Path(tmp)
+            (secrets / "exa.env").write_text('export EXA_API_KEY="segredo-real"\n')
+            self.assertEqual(onboarding._secret_value(secrets, "exa.env", "EXA_API_KEY"),
+                             "segredo-real")
+            rows = onboarding._sources_from_inventory(INV, probe=lambda n: True)
+            self.assertNotIn("segredo-real", repr(rows), "o roster nunca carrega o valor da chave")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/onboarding.py
+++ b/tools/onboarding.py
@@ -437,8 +437,77 @@ _KNOWN_SECRET_SOURCES = (
 )
 
 
-def _sources_from_inventory(inventory: Optional[dict]) -> list[dict]:
-    """Declare sources only when the matching secret file/var is present in secrets/."""
+# Como PERGUNTAR a cada fonte se ela responde. Presença de chave não é chave viva: uma fonte
+# declarada sem teste transforma um delta silenciosamente vazio em "nada novo no mundo" — o pior
+# modo de falha possível para um órgão cuja função é notar o que mudou.
+_SOURCE_PROBES = {
+    "exa": ("POST", "https://api.exa.ai/search", lambda k: {"x-api-key": k},
+            b'{"query":"probe","numResults":1}'),
+    "x": ("GET", "https://api.x.ai/v1/models", lambda k: {"Authorization": f"Bearer {k}"}, None),
+    "github": ("GET", "https://api.github.com/user",
+               lambda k: {"Authorization": f"Bearer {k}", "Accept": "application/vnd.github+json"},
+               None),
+}
+
+
+def _secret_value(secrets: Path | str, filename: str, var: str) -> Optional[str]:
+    """O valor de um secret, lido do arquivo. NUNCA é logado, impresso ou devolvido ao operador —
+    só entregue ao probe. (CONTRACT C4: o instalador verifica, jamais inventa ou exibe chave.)"""
+    path = Path(secrets) / filename
+    if not path.is_file():
+        return None
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("export "):
+            line = line[len("export "):].strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        name, _, value = line.partition("=")
+        if name.strip() == var:
+            return value.strip().strip('"').strip("'") or None
+    return None
+
+
+def probe_source(name: str, secrets: Path | str, *, timeout: float = 6.0,
+                 opener=None) -> Optional[bool]:
+    """A fonte RESPONDE? True/False, ou None quando não há como perguntar.
+
+    None é honesto e DISTINTO de False: "não sei perguntar" / "a rede caiu" não é "está morta".
+    Condenar uma fonte viva por um problema do host seria trocar um erro por outro."""
+    spec = _SOURCE_PROBES.get(name)
+    if spec is None:
+        return None
+    method, url, headers_fn, body = spec
+    entry = next((e for e in _KNOWN_SECRET_SOURCES if e[2] == name), None)
+    if entry is None:
+        return None
+    key = _secret_value(secrets, entry[0], entry[1])
+    if not key:
+        return False
+    import urllib.error
+    import urllib.request
+    req = urllib.request.Request(url, data=body, method=method)
+    for h, v in headers_fn(key).items():
+        req.add_header(h, v)
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        open_fn = opener or urllib.request.urlopen
+        with open_fn(req, timeout=timeout) as resp:
+            return 200 <= getattr(resp, "status", 200) < 300
+    except urllib.error.HTTPError:
+        return False
+    except Exception:                       # noqa: BLE001 — rede indisponível não é chave morta
+        return None
+
+
+def _sources_from_inventory(inventory: Optional[dict], probe=None) -> list[dict]:
+    """Declare sources only when the matching secret file/var is present in secrets/.
+
+    Com `probe` (callable(name) -> True/False/None), cada fonte candidata é PERGUNTADA antes de
+    entrar no roster e recebe `status`: "on" quando respondeu, "dark" quando a chave existe e não
+    responde, "unverified" quando não houve como perguntar. Sem probe o comportamento é o
+    histórico — os chamadores é que decidem verificar."""
     if not inventory:
         return []
     files = set(inventory.get("files") or [])
@@ -461,6 +530,10 @@ def _sources_from_inventory(inventory: Optional[dict]) -> list[dict]:
         }
         if kind == "api":
             entry["secret_ref"] = f"{secret_file}:{var}"
+        if probe is not None:
+            answered = probe(sname)
+            entry["status"] = ("on" if answered is True
+                               else "dark" if answered is False else "unverified")
         out.append(entry)
     return out
 
@@ -784,8 +857,12 @@ def emit_phenotype(
     project_dir: Optional[str] = None,
     sources: Optional[list] = None,
     language: Optional[str] = None,
+    probe=None,
 ) -> Path:
-    """Write agent.yaml as onboarding output (atomic)."""
+    """Write agent.yaml as onboarding output (atomic).
+
+    `probe` é callable(nome)->True/False/None; None monta o probe real contra os secrets desta
+    casa. O fenótipo só carrega fonte que JÁ SENTIU — presença de chave não é chave viva."""
     import yaml
     import _provision
 
@@ -843,7 +920,11 @@ def emit_phenotype(
             "files": list(inv.get("files") or []),
             "vars": list(inv.get("vars") or []),
         }
-        cfg["sources"] = _sources_from_inventory(inv)
+        if probe is None:
+            _sdir = secrets_dir(home)
+            def probe(name, _d=_sdir):      # noqa: E306 — probe real desta casa
+                return probe_source(name, _d)
+        cfg["sources"] = _sources_from_inventory(inv, probe=probe)
     if sources:
         # mentor-authorized roster wins by name; secrets-derived entries the mentor did not
         # mention stay (a real key is a real source) — sources exist beyond secrets (pasta


### PR DESCRIPTION
Closes #598.

### Provado ao vivo
No nascimento de um install real: `x` (xai) entrou no `agent.yaml` automaticamente com uma chave que responde **HTTP 403** — fonte morta declarada viva. `exa` entrou pelo mesmo caminho e, **por acaso**, respondia.

### Por que o dano é assimétrico
Uma fonte morta declarada viva transforma um delta vazio em *"nada novo no mundo"*. O operador não vê uma falha — vê **calmaria**. É o pior modo possível para um órgão cuja função é notar o que mudou.

### Três estados, não dois
| probe | status | significado |
|---|---|---|
| `True` | `on` | perguntei e respondeu |
| `False` | `dark` | a chave existe e não responde |
| `None` | `unverified` | não houve como perguntar |

A terceira coluna é a que importa: **queda de rede não é chave morta**. Marcar `dark` ali condenaria uma fonte viva por um problema do host — trocaria um erro por outro.

### Contrato preservado
O valor do secret é lido para o probe e **nunca sai dali** — teste explícito garante que o roster não o carrega (CONTRACT C4). Sem probe, o comportamento histórico é mantido e **nenhum status é afirmado**: declarar `on` sem perguntar é exatamente o defeito.

`test_onboarding*`: **77/77**.