### PR TITLE
fix(sweep): falha de ingest ficava soterrada — o wake reportava calmaria

### DIFF
--- a/tests/test_ingest_failure_is_loud.py
+++ b/tests/test_ingest_failure_is_loud.py
@@ -1,0 +1,52 @@
+"""Uma falha de ingest tem que ser ALTA no resumo do wake — não uma linha soterrada.
+
+Caso de campo (2026-08-16): o modelo do extractor foi trocado por um que a dependência não
+aceita (`graphiti_core` envia `reasoning.effort="minimal"` fixo; o modelo devolveu HTTP 400).
+O efeito não foi degradação — foi apagão: a sessão inteira deixou de ser filmada.
+
+O wake seguiu e reportou sucesso em todas as outras pernas. As falhas por episódio ERAM
+impressas, uma a uma, e foi exatamente por isso que sumiram: soterradas num traço longo, com
+todas as linhas de resumo seguintes ('communities consolidadas — 0 clusters') parecendo
+normais. O operador não viu uma falha; viu calmaria. Só apareceu num grep.
+
+Ingest é o órgão do qual todo o resto depende. Sua falha não pode custar um grep.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import sweep  # noqa: E402
+
+
+class IngestFailureIsLoud(unittest.TestCase):
+    def test_a_clean_run_says_nothing(self):
+        self.assertIsNone(sweep._ingest_summary(3, []),
+                          "sem falha não há linha — ruído em run limpo treina a ignorar a linha")
+
+    def test_total_blackout_is_reported_with_the_first_cause(self):
+        line = sweep._ingest_summary(
+            0, ["session-abc: BadRequestError: 'minimal' is not supported"])
+        self.assertIsNotNone(line)
+        self.assertIn("FALHARAM", line)
+        self.assertIn("1 de 1", line)
+        self.assertIn("BadRequestError", line,
+                      "a causa tem que vir junto: 'falhou' sem por quê ainda custa um grep")
+
+    def test_partial_failure_shows_the_proportion(self):
+        line = sweep._ingest_summary(2, ["session-y: TimeoutError: t"])
+        self.assertIn("1 de 3", line,
+                      "proporção, não contagem solta: 1 de 3 e 1 de 300 pedem reações diferentes")
+
+    def test_the_summary_is_emitted_by_the_ingest_path(self):
+        """O helper existir não basta — o caminho de ingest tem que chamá-lo."""
+        source = (REPO / "tools" / "sweep.py").read_text()
+        self.assertIn("_ingest_summary(len(", source)
+        marker = source.index("def graphiti_ingest(")
+        self.assertIn("_ingest_summary", source[marker:],
+                      "graphiti_ingest tem que emitir o resumo, não só o módulo defini-lo")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -950,6 +950,24 @@ def chunk_episode_body(body, max_chars=MAX_EPISODE_CHARS):
     return chunks
 
 
+def _ingest_summary(ingested, failures):
+    """A linha ALTA do ingest, ou None quando tudo entrou.
+
+    As falhas por episódio já são impressas uma a uma — e é exatamente por isso que elas somem:
+    ficam soterradas num traço longo, e TODAS as linhas de resumo seguintes ('communities
+    consolidadas — 0 clusters', etc.) continuam parecendo normais. Um wake que não filmou NADA
+    reportava sucesso em todas as outras pernas. O operador não via uma falha; via calmaria.
+
+    Ingest que falha é a memória parando de avançar — o órgão do qual todo o resto depende — e
+    isso não pode custar um grep para ser notado."""
+    if not failures:
+        return None
+    first = failures[0]
+    total = ingested + len(failures)
+    return (f"sweep: graph ingest — {len(failures)} de {total} episódio(s) FALHARAM; "
+            f"a memória NÃO avançou neles. Primeiro: {first}")
+
+
 def graphiti_ingest(items):
     """Incremental Graphiti extraction (C2): one episode per session-delta, into THIS install's
     own group (agent.yaml identity, #21). Robust: a per-episode failure is logged and skipped (the
@@ -984,6 +1002,8 @@ def graphiti_ingest(items):
             total += size
         return chosen
 
+    _ingested, _failures = [], []
+
     async def go():
         # gpt-5.6-luna NÃO serve aqui: graphiti_core fixa reasoning.effort="minimal"
         # (openai_base_client.py:36) e o luna recusa esse valor — o extractor morre com 400 e
@@ -1008,12 +1028,18 @@ def graphiti_ingest(items):
                     print(f"  + ingested {name} ({len(chunk)} chars)")
                 except Exception as e:
                     failed = True
+                    _failures.append(f"{name}: {type(e).__name__}: {e}")
                     print(f"  ! FAILED {name}: {type(e).__name__}: {e}")
+                else:
+                    _ingested.append(name)
             if not failed:           # a session counts as ingested only if every sub-episode landed
                 ok.add(it["id"])
         await g.close()
 
     asyncio.run(go())
+    summary = _ingest_summary(len(_ingested), _failures)
+    if summary:
+        print(summary)
     return ok
 
 


### PR DESCRIPTION
Closes #599.

### O caso
O extractor foi trocado por um modelo que a dependência não aceita (`graphiti_core` envia `reasoning.effort="minimal"` fixo; o modelo devolveu HTTP 400). Não foi degradação — foi **apagão**: a sessão inteira deixou de ser filmada.

O wake seguiu reportando sucesso em todas as outras pernas. As falhas por episódio **eram** impressas, uma a uma — e foi por isso que sumiram: soterradas num traço longo, com todas as linhas de resumo seguintes parecendo normais.

**O operador não viu uma falha. Viu calmaria.** Só apareceu num grep.

### O fix
`_ingest_summary` emite **uma linha alta** quando algo falhou — proporção e primeira causa — e silêncio quando tudo entrou.

Decisões que os testes fixam:
- **proporção, não contagem solta** — "1 de 3" e "1 de 300" pedem reações diferentes
- **a causa vem junto** — "falhou" sem o porquê ainda custa um grep
- **silêncio em run limpo** — ruído em run limpo treina a ignorar a linha
- um teste verifica que o **caminho de ingest chama** o helper, não só que ele existe: um resumo que ninguém emite é a mesma cegueira com mais código

`test_sweep*`: mesmas 2 falhas pré-existentes, antes e depois.