### PR TITLE
fix(tests): a fixture do bisect é anterior ao contrato de attribution

### DIFF
--- a/tests/test_portfolio_bisect.py
+++ b/tests/test_portfolio_bisect.py
@@ -95,7 +95,26 @@ class PortfolioBisect(unittest.TestCase):
             _write_seven_node_tree(log, "alpha")
             output = {
                 "operacoes": ["beta"],
-                "stitch": {"goal": "Comparar", "acao": "Medir", "entidades": []},
+                # attribution passou a ser obrigatório no validador (_validated_attribution);
+                # esta fixture não acompanhou e o teste ficou vermelho por contrato, não por
+                # comportamento. É o ÚNICO teste deste arquivo que atravessa rationalize() de
+                # verdade — os outros escrevem o evento direto e por isso não sentiram a mudança.
+                "stitch": {
+                    "goal": "Comparar", "acao": "Medir", "entidades": [],
+                    "attribution": {
+                        "human_purpose": "comparar os resultados dos dois braços",
+                        "edge_execution": "medir e tabular o que cada braço produziu",
+                        "shared_outcome": "saber qual braço sustenta a decisão",
+                        # a atribuição aponta o turno humano de onde ela sai; a sessão
+                        # deste teste tem um único turno
+                        "human_turn_indexes": [0],
+                        # False de propósito: este teste é sobre pertencimento de presunção a
+                        # operação, não sobre atividade. Com True o rationalize também abre e
+                        # toca uma Atividade (3 eventos), o que mudaria a asserção sem que o
+                        # comportamento sob teste tivesse mudado.
+                        "activity_relevant": False,
+                    },
+                },
                 "epistemico": {"presuncoes": [{
                     "texto": "Presunção beta ligada a evidência alpha",
                     "confirmaria": "evidência C", "refutaria": "evidência D",


### PR DESCRIPTION
Closes #600.

`_validated_attribution` passou a exigir **cinco** campos em `stitch.attribution`; a fixture não tinha nenhum. `rationalize` recusava com `invalid_output` e o teste falhava com `0 != 1` — uma falha que **não diz nada** sobre o comportamento que ele testa.

### Por que só este quebrou
É o **único teste do arquivo que atravessa `rationalize()` de verdade**. Os outros escrevem `sessao.racionalizada` direto no log e por isso não sentiram a mudança de contrato.

O teste que exercita o caminho real é o que envelhece — e é o que vale.

### `activity_relevant: False`, de propósito
Com `True`, o `rationalize` também abre e toca uma Atividade (3 eventos em vez de 1), o que obrigaria a mexer na asserção **sem que o comportamento sob teste tivesse mudado**. A fixture ganha só o mínimo que o contrato exige.

### A outra metade
`test_lentes_role_surfaces` já tinha sido resolvida pelo **#589** — o fold de mapa rejeitando o autor `mentor` era a causa, e o teste ficou verde no merge.

`test_portfolio*` **57/57** · `test_racionalizador*` **41/41** · `test_lentes*` **97/97**.