### PR TITLE
fix(tests): a família apply/fase0 apontava para um fenótipo que não existe

### DIFF
--- a/tests/fixtures/roster.agent.yaml
+++ b/tests/fixtures/roster.agent.yaml
@@ -17,6 +17,18 @@ language: pt-BR
 mission: Missao de fixture — existe para os testes terem identidade conhecida.
 voice: Voz de fixture — deterministica, igual em qualquer host.
 mentee: Fixture Mentee
+# blog_domain e DERIVADO desta URL por tools/edge-render (derive_vars), nunca
+# declarado direto — declarar `blog_domain:` nao tem efeito nenhum.
+blog_public_url: https://edge.edgeofchaos.net
+blog_port: 8766
+routers:
+  # com secret_ref declarado, o apply CHECA a credencial e relata quando falta — que é
+  # exatamente o que test_reports_missing_credentials exercita. Um roster todo keyless
+  # não tem o que cobrar, e o substrate-check passa a não ter nada para dizer.
+  embedding:
+    provider: openai
+    secret_ref: openai.env:OPENAI_API_KEY
+    model: text-embedding-3-small
 sources:
   - name: exa
     kind: api

--- a/tests/test_apply_claude.py
+++ b/tests/test_apply_claude.py
@@ -16,7 +16,11 @@ import yaml
 
 REPO = Path(__file__).resolve().parent.parent
 APPLY = REPO / "tools" / "edge-apply"
-YAML = REPO / "agent.yaml"
+# O fenotipo NAO existe no genotipo (contrato: agent.yaml e output do onboarding, e
+# gitignored). Apontar para REPO/agent.yaml fazia estes testes falharem por construcao com
+# FileNotFoundError — sobre o edge-apply, nada. A fixture versionada e um agent.yaml completo
+# e igual em qualquer host.
+YAML = REPO / "tests" / "fixtures" / "roster.agent.yaml"
 
 
 def load_cfg() -> dict:

--- a/tests/test_apply_codex.py
+++ b/tests/test_apply_codex.py
@@ -9,7 +9,11 @@ import yaml
 
 REPO = Path(__file__).resolve().parent.parent
 APPLY = REPO / "tools" / "edge-apply"
-YAML = REPO / "agent.yaml"
+# O fenotipo NAO existe no genotipo (contrato: agent.yaml e output do onboarding, e
+# gitignored). Apontar para REPO/agent.yaml fazia estes testes falharem por construcao com
+# FileNotFoundError — sobre o edge-apply, nada. A fixture versionada e um agent.yaml completo
+# e igual em qualquer host.
+YAML = REPO / "tests" / "fixtures" / "roster.agent.yaml"
 sys.path.insert(0, str(REPO / "tools"))
 from _codex_provision import codex_prefixes  # noqa: E402
 

--- a/tests/test_apply_grok.py
+++ b/tests/test_apply_grok.py
@@ -9,7 +9,11 @@ import yaml
 
 REPO = Path(__file__).resolve().parent.parent
 APPLY = REPO / "tools" / "edge-apply"
-YAML = REPO / "agent.yaml"
+# O fenotipo NAO existe no genotipo (contrato: agent.yaml e output do onboarding, e
+# gitignored). Apontar para REPO/agent.yaml fazia estes testes falharem por construcao com
+# FileNotFoundError — sobre o edge-apply, nada. A fixture versionada e um agent.yaml completo
+# e igual em qualquer host.
+YAML = REPO / "tests" / "fixtures" / "roster.agent.yaml"
 sys.path.insert(0, str(REPO / "tools"))
 from _grok_provision import grok_prefixes  # noqa: E402
 

--- a/tests/test_fase0.py
+++ b/tests/test_fase0.py
@@ -3,15 +3,22 @@
 Sucesso: `edge-apply --yaml agent.yaml --home <tmp>` produz um layout instalado,
 com Caddyfile pro domínio, server.py no lugar, e um relatório do que falta (credenciais).
 """
+import re
 import subprocess
 import sys
 import tempfile
+
+import yaml
 import unittest
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 APPLY = REPO / "tools" / "edge-apply"
-YAML = REPO / "agent.yaml"
+# O fenotipo NAO existe no genotipo (contrato: agent.yaml e output do onboarding, e
+# gitignored). Apontar para REPO/agent.yaml fazia estes testes falharem por construcao com
+# FileNotFoundError — sobre o edge-apply, nada. A fixture versionada e um agent.yaml completo
+# e igual em qualquer host.
+YAML = REPO / "tests" / "fixtures" / "roster.agent.yaml"
 
 
 def run_apply(home: Path, claude_home: Path, codex_home: Path):
@@ -48,9 +55,16 @@ class Fase0(unittest.TestCase):
         caddy = self.home / "Caddyfile"
         self.assertTrue(caddy.exists(), "Caddyfile renderizado")
         txt = caddy.read_text()
-        self.assertIn("edge.edgeofchaos.net", txt)
+        # lê do yaml em vez de cravar o domínio de produção: o que se testa é o RENDER
+        # (o template recebeu as variáveis e as substituiu), não uma string mágica que
+        # amarra o teste ao host de um install específico. `blog_domain` é DERIVADO de
+        # `blog_public_url` por tools/edge-render (derive_vars) — declarar blog_domain
+        # direto no yaml não tem efeito nenhum, então o teste deriva do mesmo jeito.
+        cfg = yaml.safe_load(YAML.read_text()) or {}
+        domain = re.sub(r"^https?://", "", str(cfg["blog_public_url"])).rstrip("/")
+        self.assertIn(domain, txt)
         self.assertIn("reverse_proxy", txt)
-        self.assertIn("8766", txt)
+        self.assertIn(str(cfg.get("blog_port", 8766)), txt)
 
     def test_blog_server_placed(self):
         self.assertTrue((self.home / "blog" / "server.py").exists())


### PR DESCRIPTION
Parte de #609.

`YAML = REPO / "agent.yaml"` em quatro arquivos. O `agent.yaml` é **output** do onboarding e é gitignored — no genótipo não existe. Os testes morriam com `FileNotFoundError` **antes de exercitar uma linha** do `edge-apply`: 16 problemas que não diziam nada sobre o apply.

### Dois achados que valem mais que o verde

**1.** `blog_domain` é **derivado** de `blog_public_url` por `edge-render` (`derive_vars`). Declarar `blog_domain:` no yaml **não tem efeito nenhum** — eu declarei primeiro e o Caddyfile renderizou com o domínio **vazio**, sem reclamar de nada.

**2.** `test_reports_missing_credentials` só tem o que exercitar se o roster declarar ao menos um `secret_ref`. Com tudo keyless, o substrate-check não tem o que cobrar e o teste afirma sobre um silêncio — verde vazio.

### O teste do Caddyfile deixa de cravar o domínio de produção
Passa a derivar do yaml como o render deriva. O que se testa é a **substituição**, não uma string mágica que amarra a suíte ao host de um install específico — a mesma doença dos outros 124.

`test_fase0` **5/5** · `test_apply_claude` **5/5**.

Ficam de fora os 2 de `test_apply_codex`/`grok`: contradição de contrato entre teste e código, não fixture. Issue à parte.