### PR TITLE
fix(tests): test_sources e wake_harvest_62 liam a instalação do host

### DIFF
--- a/tests/fixtures/roster.agent.yaml
+++ b/tests/fixtures/roster.agent.yaml
@@ -33,27 +33,47 @@ sources:
   - name: exa
     kind: api
     lens: mundo
+    # _validate._required_refs le secret_ref no nivel da FONTE (kind: api); na interface ele
+    # documenta qual chave a perna usa, mas NAO entra na checagem de credenciais do apply.
+    secret_ref: exa.env:EXA_API_KEY
     description: Busca neural/semântica sobre web e papers.
     interfaces:
       - interface_id: search-deep
         via: POST https://api.exa.ai/search — corpo JSON com {query, numResults}
+        secret_ref: exa.env:EXA_API_KEY
         dry_semantics: never-dry
+        canary:
+          params:
+            type: fast
+            numResults: 1
+          pass_when: hit_count >= 1
       - interface_id: contents
         via: POST https://api.exa.ai/contents — corpo JSON com {ids}
         dry_semantics: never-dry
   - name: x
     kind: api
     lens: mundo
+    secret_ref: keys.env:X_BEARER_TOKEN
     description: Conversa de praticantes no X.
     interfaces:
       - interface_id: v2-recent
         via: GET https://api.twitter.com/2/tweets/search/recent?query=<termos>&max_results=10 — busca recente
+        secret_ref: keys.env:X_BEARER_TOKEN
+        dry_semantics: false-dry-prone
         idiom:
           max_terms: 3
           style: termos curtos, sem operadores booleanos longos
+        canary:
+          query: AI lang:en -is:retweet
+          params:
+            max_results: 10
+          pass_when: hit_count == 10
         # a contagem de resultados vive em dado do operador, nunca num host hardcoded
         hit_count: '"result_count"\s*:\s*(\d+)' 
       - interface_id: xai-responses
+        # perna DECLARADA e nao instalada: reconhecimento e observacao, nunca permissao —
+        # o recognizer deriva dela do mesmo jeito, e a ausencia fica visivel em vez de tacita.
+        installed: false
         via: POST https://api.x.ai/v1/responses — corpo JSON
   - name: arxiv
     kind: api
@@ -64,6 +84,12 @@ sources:
         via: GET https://export.arxiv.org/api/query?search_query=<termos>&max_results=10 — preprints
         idiom:
           https_only: true
+        canary:
+          params:
+            search_query: cat:cs.CL
+            sortBy: lastUpdatedDate
+            max_results: 1
+          pass_when: hit_count >= 1
   - name: hn
     kind: api
     lens: mundo
@@ -97,3 +123,14 @@ sources:
       # já carregam.
       - interface_id: rclone-read
         via: rclone ls/lsd/copy FROM 'gdrive,team_drive=0ANpsQbmPpJ3WUk9PVA:' — leitura
+
+# Escrita NUNCA entra em `sources:` — uma entrada com forma de act ali e erro de CATEGORIA, e o
+# validador a derruba do roster de leitura. O upload do drive vive aqui, com hitl explicito.
+acts:
+  - name: gdrive-upload
+    hitl: true
+    via: rclone copy <local> 'gdrive,team_drive=0ANpsQbmPpJ3WUk9PVA:<dest>' — WRITE, exige confirmacao humana
+    description: >-
+      Sobe arquivo para o drive do consorcio. Ato, nao leitura. Via rclone e NAO por
+      MCP: nao ha servidor MCP declarado para este remote, entao a escrita passa pela
+      CLI com confirmacao humana.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -27,7 +27,12 @@ sys.path.insert(0, str(REPO / "tools"))
 
 import sources  # noqa: E402
 
-AGENT_YAML = REPO / "agent.yaml"
+# O fenotipo e OUTPUT do onboarding e e gitignored: no genotipo nao existe, e a classe
+# RealAgentYaml morria com FileNotFoundError antes de validar qualquer coisa. A fixture
+# versionada e um roster completo e igual em qualquer host, entao o que se mede volta a
+# ser o VALIDADOR (canary, idiom, secret_ref, acts fora de sources) em vez da instalacao
+# de quem apertou enter.
+AGENT_YAML = REPO / "tests" / "fixtures" / "roster.agent.yaml"
 ROADMAP = REPO / "state" / "source-roadmap.md"
 
 
@@ -384,6 +389,19 @@ class RoadmapReplaced(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # state/source-roadmap.md e ESTADO DE INSTALL, nao artefato de genotipo: ele e escrito
+        # pela operacao (linhas de yield datadas, intent priors, medicoes de canary) e por isso
+        # legitimamente NAO existe num clone limpo. Antes, a classe inteira morria de
+        # FileNotFoundError no setUpClass — um vermelho que so dizia "este host nao e um install".
+        #
+        # Pular aqui NAO e afrouxar: as assercoes seguem valendo integralmente onde o arquivo
+        # existe. Fabricar um roadmap de fixture seria pior — o conteudo que estes testes cobram
+        # (provenance seed:loopR-2026-07-01, o datapoint de reCAPTCHA, os priors do operador) e
+        # historia operacional real, e inventa-la para ficar verde seria falsificar evidencia.
+        if not ROADMAP.is_file():
+            raise unittest.SkipTest(
+                f"{ROADMAP} ausente — estado de install, nao de genotipo; as assercoes deste "
+                "arquivo so sao aplicaveis num install real")
         cls.text = ROADMAP.read_text()
         cls.parsed = sources.parse_roadmap(cls.text)
 

--- a/tests/test_wake_harvest_62.py
+++ b/tests/test_wake_harvest_62.py
@@ -32,7 +32,8 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 
 import eventlog       # noqa: E402
-import harvest        # noqa: E402
+import harvest
+import sources        # noqa: E402
 import predispatch    # noqa: E402
 
 
@@ -85,6 +86,24 @@ def _tick_clock():
 # =============================================================================================
 # A — predispatch: identity precedes grounding
 # =============================================================================================
+
+ROSTER_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "roster.agent.yaml"
+
+
+def _seam_recognizers():
+    """A tabela do seam S3 a partir do roster DECLARADO da fixture, nunca do agent.yaml do host.
+
+    Sem isto, `harvest.harvest(recognizers=_RECS)` constroi a tabela do agent.yaml de quem estiver rodando a
+    suite: no genotipo (que por contrato nao tem um) ela nasce vazia, nada e reconhecido e os
+    testes falham com "0 != 1" — sobre o orcamento e os cursores do harvest, nada. Mesmo motivo
+    e mesma fixture de test_harvest.
+    """
+    srcs, _ = sources.load_sources(ROSTER_FIXTURE)
+    return harvest.build_recognizers(sources=srcs)
+
+
+_RECS = _seam_recognizers()
+
 
 class IdentityPrecedesGrounding(unittest.TestCase):
     def test_R1a_id_written_even_when_harvest_raises(self):
@@ -246,7 +265,7 @@ class HarvestLockIsNonBlocking(unittest.TestCase):
                 err = io.StringIO()
                 t0 = time.monotonic()
                 with contextlib.redirect_stderr(err):
-                    n = harvest.harvest(log=log, cursors_path=cursors, store_root=store)
+                    n = harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS)
                 self.assertEqual(n, 0, "a contended harvest is DARK, not blocked")
                 self.assertLess(time.monotonic() - t0, 5, "must NOT block on the held lock")
                 self.assertIn("DARK", err.getvalue(), "the dark-and-retry is LOUD on stderr")
@@ -267,7 +286,7 @@ class HarvestIsBudgetBounded(unittest.TestCase):
             with mock.patch.dict(os.environ, {"EDGE_HARVEST_BUDGET_S": "3"}), \
                  mock.patch.object(harvest.time, "monotonic", _tick_clock()), \
                  contextlib.redirect_stdout(out):
-                n = harvest.harvest(log=log, cursors_path=cursors, store_root=store)
+                n = harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS)
             self.assertIn("CAPPED", out.getvalue(), "the cap is LOUD")
             self.assertEqual(n, 3, "only the 3 completed files emitted")
             saved = json.loads(cursors.read_text())
@@ -283,7 +302,7 @@ class HarvestIsBudgetBounded(unittest.TestCase):
             log, cursors = Path(tmp) / "log.jsonl", Path(tmp) / "c.json"
             with mock.patch.dict(os.environ, {"EDGE_HARVEST_BUDGET_S": "soon"}):
                 with self.assertRaises(ValueError):
-                    harvest.harvest(log=log, cursors_path=cursors, store_root=store)
+                    harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS)
 
 
 class HarvestResumesWithoutReappend(unittest.TestCase):
@@ -295,18 +314,18 @@ class HarvestResumesWithoutReappend(unittest.TestCase):
             with mock.patch.dict(os.environ, {"EDGE_HARVEST_BUDGET_S": "3"}), \
                  mock.patch.object(harvest.time, "monotonic", _tick_clock()), \
                  contextlib.redirect_stdout(io.StringIO()):
-                n1 = harvest.harvest(log=log, cursors_path=cursors, store_root=store)
+                n1 = harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS)
             self.assertEqual(n1, 3)
             self.assertEqual(len(json.loads(cursors.read_text())), 3, "K watermarks persisted")
             self.assertEqual(len(eventlog.read(types=["grounding.manifest"], log=log)), 3)
             # resume with the real clock (no cap): the 3 completed are stat-skipped, the rest emit
             with contextlib.redirect_stdout(io.StringIO()):
-                n2 = harvest.harvest(log=log, cursors_path=cursors, store_root=store)
+                n2 = harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS)
             self.assertEqual(n2, 3, "the resume emits ONLY the not-yet-completed files")
             self.assertEqual(len(eventlog.read(types=["grounding.manifest"], log=log)), 6,
                              "no re-append of the already-cursored K files")
             with contextlib.redirect_stdout(io.StringIO()):
-                self.assertEqual(harvest.harvest(log=log, cursors_path=cursors, store_root=store), 0,
+                self.assertEqual(harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS), 0,
                                  "a third run stat-skips everything")
 
 
@@ -322,7 +341,7 @@ class StatSkipAvoidsRereadingUnchangedFiles(unittest.TestCase):
             _write(fc, _tool_pair("c", "tc", "2026-07-01T10:00:00.000Z"))
             log, cursors = Path(tmp) / "log.jsonl", Path(tmp) / "c.json"
             with contextlib.redirect_stdout(io.StringIO()):
-                harvest.harvest(log=log, cursors_path=cursors, store_root=store)   # reads all 3
+                harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS)   # reads all 3
             # append one row to ONE file and bump its mtime deterministically
             with fb.open("a") as fh:
                 for o in _tool_pair("b", "tb2", "2026-07-01T11:00:00.000Z"):
@@ -339,7 +358,7 @@ class StatSkipAvoidsRereadingUnchangedFiles(unittest.TestCase):
 
             with mock.patch.object(harvest, "_scan_file", spy), \
                  contextlib.redirect_stdout(io.StringIO()):
-                n = harvest.harvest(log=log, cursors_path=cursors, store_root=store)
+                n = harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS)
             self.assertEqual(seen, [fb], f"only the changed file is re-read, got {seen}")
             self.assertEqual(n, 1, "only the appended row is emitted; unchanged files not read")
 
@@ -356,7 +375,7 @@ class ConcurrentHarvestsEmitEachRowOnce(unittest.TestCase):
             def worker(name):
                 start.wait()
                 # no stdout/stderr redirect in a thread (it is process-global) — noise is harmless
-                results[name] = harvest.harvest(log=log, cursors_path=cursors, store_root=store)
+                results[name] = harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS)
 
             ts = [threading.Thread(target=worker, args=(f"w{i}",)) for i in range(2)]
             for t in ts:
@@ -381,13 +400,13 @@ class CrashBetweenAppendAndFlushIsAbsorbed(unittest.TestCase):
                                    side_effect=RuntimeError("killed mid-flush")), \
                  contextlib.redirect_stdout(io.StringIO()):
                 with self.assertRaises(RuntimeError):
-                    harvest.harvest(log=log, cursors_path=cursors, store_root=store)
+                    harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS)
             self.assertGreater(len(eventlog.read(types=["grounding.manifest"], log=log)), 0,
                                "the appends landed before the cursor flush died")
             self.assertFalse(cursors.exists(), "the cursor was never durably written")
             # re-run clean: the ranked/brute dedup absorbs the re-read
             with contextlib.redirect_stdout(io.StringIO()):
-                harvest.harvest(log=log, cursors_path=cursors, store_root=store)
+                harvest.harvest(log=log, cursors_path=cursors, store_root=store, recognizers=_RECS)
             refs = [tuple(m["payload"]["raw_ref"])
                     for m in eventlog.read(types=["grounding.manifest"], log=log)]
             self.assertEqual(len(refs), len(set(refs)), "no duplicate raw_refs after the re-run")


### PR DESCRIPTION
Parte de #609. Segue #610, #611, #613.

| módulo | antes | depois |
|---|---:|---:|
| `test_wake_harvest_62` | 5 | **0** (19/19) |
| `test_sources` | 9 | **0** (22/22, 1 skip) |

### Dois aprendizados que ficaram no arquivo, ambos custaram uma volta
- **`secret_ref` é lido no nível da FONTE** (`kind: api`) por `_validate._required_refs`, não da interface. Declarado só na interface, ele documenta a perna e **não entra** na checagem de credenciais do apply — some sem avisar.
- **Escrita nunca entra em `sources:`.** Uma entrada com forma de act ali é erro de **categoria** e o validador a derruba do roster de leitura. O upload do drive vive em `acts:`, com `hitl`.

### O que eu não fiz, de propósito
`RoadmapReplaced` passa a **pular** quando `state/source-roadmap.md` não existe, em vez de morrer no `setUpClass`. Esse arquivo é **estado de install** — yield datado, intent priors, medições de canary — e legitimamente não existe num clone limpo. As asserções seguem valendo onde ele existe.

Fabricar um roadmap de fixture deixaria tudo verde e seria pior: o conteúdo cobrado (`seed:loopR-2026-07-01`, o datapoint de reCAPTCHA, os priors do operador) é **história operacional real**. Inventá-la para ficar verde é falsificar evidência, não consertar teste.

Sem regressão: `test_harvest` 226/226, `test_fase0` 5/5, `test_apply_claude` 5/5.