### PR TITLE
fix(tests): superfícies do wake liam a instalação do host

### DIFF
--- a/tests/test_briefing_surface.py
+++ b/tests/test_briefing_surface.py
@@ -155,7 +155,31 @@ class TestBriefingMakesNoApiCall(_BriefingBase):
             self.assertNotIn(forbidden, src)
 
 
-class TestHealthStrip(_BriefingBase):
+class _PinnedGraphLeg(_BriefingBase):
+    """Base para as baterias do strip que afirmam o ESTADO da banda: a perna do grafo é PINADA.
+
+    `_graph_reachable()` sonda o neo4j de quem roda a suíte, e `degraded` é `swept_degraded or
+    (not graph_reachable) or consistency or log_corrupt`. Sem pinar, o mesmo log fixo dá bandas
+    diferentes por host: num genótipo/CI (sem neo4j, sem EDGE_GROUP) a banda sai sempre
+    `degraded`, então a bateria saudável falha e a bateria degradada fica verde pela razão
+    ERRADA — o grafo escuro, não a causa que ela declara. Pinando a sonda no seam GRAPH_PROBE
+    (o mesmo que TestGraphProbeIsHardBounded usa) sobra sob teste exatamente o que o log diz."""
+
+    GRAPH_OK = True
+
+    def setUp(self):
+        super().setUp()
+        os.environ.pop("EDGE_CORTEX_FIXTURE", None)   # não curto-circuitar a sonda
+        os.environ["EDGE_GROUP"] = "test-group"       # _group() truthy → a sonda roda
+        self.server.GRAPH_PROBE = lambda: self.GRAPH_OK
+
+    def tearDown(self):
+        os.environ.pop("EDGE_GROUP", None)
+        self.server.GRAPH_PROBE = None
+        super().tearDown()
+
+
+class TestHealthStrip(_PinnedGraphLeg):
     """The read-model health strip — a compact band folded from the log, above the briefing."""
 
     LOG_LINES = [
@@ -189,7 +213,7 @@ class TestHealthStrip(_BriefingBase):
         self.assertIn('data-metric="swept-sessions">3', body)
 
 
-class TestHealthStripFailsDark(_BriefingBase):
+class TestHealthStripFailsDark(_PinnedGraphLeg):
     """The strip is the degraded-mode signal — a composed briefing can read plausible while the folds
     beneath it are stale (SURFACE.md: swept_sessions:0 yet the briefing composes clean). So a degraded
     fold renders a VISIBLE degraded band, never a blank."""

--- a/tests/test_lentes_role_surfaces.py
+++ b/tests/test_lentes_role_surfaces.py
@@ -18,6 +18,17 @@ import quente  # noqa: E402
 import recall  # noqa: E402
 
 
+ROSTER_FIXTURE = REPO / "tests" / "fixtures" / "roster.agent.yaml"
+MEMORY_FIXTURE = REPO / "seeds" / "memory"
+"""A identidade DECLARADA para compor o briefing — fixture de roster + doutrina canônica de seeds/.
+
+`compose_briefing` é fail-closed (ADR-0009) e por default lê o `memory/` e o `agent.yaml` DA CASA
+de quem roda a suíte; o genótipo, por contrato, não tem nenhum dos dois, e a composição morria em
+`BriefingIdentityError` antes de o teste poder olhar a superfície. As fixtures dão SÓ identidade
+(tatuagens, idioma, roster) — as seções que poderiam vazar um mapa são dobras do LOG, e o log
+continua sendo o temporário deste teste. A cegueira segue sendo medida no mesmo lugar."""
+
+
 SUBGRAPH = {
     "codename": "ed",
     "objective": "orientar sem cabresto",
@@ -376,11 +387,20 @@ class SharedWakeSurfacesStayMapBlind(unittest.TestCase):
 
             briefing_text = briefing.compose_briefing(
                 log=log, clusters=[], roster=[],
+                agent_yaml=ROSTER_FIXTURE, memory=MEMORY_FIXTURE,
             )
             quente_text, _window = quente.build_bundle(
                 store_dir=store, repos=(), eventlog_path=log, codex_dir=False,
             )
             recall_text = recall.compose_recall_brief(subgraph=SUBGRAPH)
+
+            # controle POSITIVO: a ref é de fato vazável a partir DESTE log — a superfície opt-in
+            # a exibe. Sem isto, um assertNotIn sobre um texto que degradou (ou sobre um mapa que
+            # nunca entrou no log) passaria sem verificar cegueira nenhuma.
+            self.assertIn(map_ref, recall.compose_portfolio_recall_brief(
+                subgraph=SUBGRAPH, portfolio_fn=portfolio.portfolio_at, log=log))
+            self.assertTrue(briefing_text.strip() and quente_text.strip() and recall_text.strip(),
+                            "uma superfície vazia não prova cegueira — ela não foi renderizada")
 
             self.assertNotIn(map_ref, briefing_text)
             self.assertNotIn(map_ref, quente_text)

--- a/tests/test_predispatch_grounding.py
+++ b/tests/test_predispatch_grounding.py
@@ -41,9 +41,35 @@ def _seed(log, *rows):
         eventlog.append("grounding.manifest", "grounding", r, log=log)
 
 
-def _run(log, probe_fn, harvest_fn=lambda: 0, **kw):
-    return predispatch.run(ready_fn=lambda: None, drain_fn=lambda: None, sweep_fn=lambda: 0, briefing_fn=lambda: "B", recall_fn=lambda: "R",
-                           harvest_fn=harvest_fn, probe_fn=probe_fn, log=log, dispatch_id="d1", **kw)
+ROSTER_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "roster.agent.yaml"
+
+
+def _declared_roster():
+    """O roster DECLARADO deste módulo — sempre a fixture versionada, nunca o agent.yaml do host.
+
+    A bateria de canários itera `sources.load_sources()`, isto é, o agent.yaml de QUEM RODA a
+    suíte. Num genótipo (que por contrato não tem agent.yaml) o roster nasce vazio: nenhuma
+    interface casa com a dry pendente, nenhum `canary.result` é escrito e a dobra devolve
+    `suspect` — o teste passa a medir a instalação do host em vez do código da perna de
+    grounding. Com a fixture, x/v2-recent e exa/search-deep são declaradas (com canary e
+    dry_semantics) em qualquer host, e o que sobra sob teste é o CÓDIGO.
+
+    Validar o roster REAL de um install é outra coisa, e tem dono: test_sources.RealAgentYaml."""
+    srcs, findings = sources.load_sources(ROSTER_FIXTURE)
+    errors = [f for f in findings if f.get("level") == "error"]
+    assert srcs and not errors, f"fixture de roster inválida: {errors}"
+    return srcs, findings
+
+
+def _run(log, probe_fn, harvest_fn=lambda: 0, roster=None, **kw):
+    """Roda o piso com o roster declarado injetado no seam S3 (E8: a bateria deriva TUDO do
+    yaml — o teste troca o yaml, nunca o código)."""
+    with mock.patch.object(predispatch.sources_mod, "load_sources",
+                           return_value=(roster or _declared_roster())):
+        return predispatch.run(ready_fn=lambda: None, drain_fn=lambda: None, sweep_fn=lambda: 0,
+                               briefing_fn=lambda: "B", recall_fn=lambda: "R",
+                               harvest_fn=harvest_fn, probe_fn=probe_fn, log=log,
+                               dispatch_id="d1", **kw)
 
 
 def _dry(log, cell):
@@ -201,9 +227,7 @@ class E8CanaryIteratesDeclaredInterfacesNeverASourceByName(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             _seed(log, _suspect_row("overleaf", "v2-search", idiom_conforme=True))
-            with mock.patch.object(predispatch.sources_mod, "load_sources",
-                                   return_value=(srcs, findings)):
-                _run(log, probe_fn=probe)
+            _run(log, probe_fn=probe, roster=(srcs, findings))
             self.assertIn(("overleaf", "v2-search"), seen,
                           "the never-seen interface was probed straight from agent.yaml")
             cell = ("overleaf", "v2-search", "mundo", "ambient", None)  # lens from the seeded row
@@ -213,7 +237,9 @@ class E8CanaryIteratesDeclaredInterfacesNeverASourceByName(unittest.TestCase):
         # the canary battery must derive everything from the yaml — assert no declared source
         # name appears as a literal in predispatch.py (E8 no-hardcode guard for S5)
         src = (REPO / "tools" / "predispatch.py").read_text()
-        declared, _ = sources.load_sources()
+        # o roster DECLARADO vem da fixture versionada, não do agent.yaml do host: no genótipo
+        # `load_sources()` devolve [] e o guarda rodava a vazio — verde sem verificar nada.
+        declared, _ = _declared_roster()
         names = [s["name"] for s in declared]
         self.assertTrue(names, "guard must not run vacuous — agent.yaml declares sources")
         for n in names:

--- a/tests/test_recall_brief.py
+++ b/tests/test_recall_brief.py
@@ -15,6 +15,16 @@ sys.path.insert(0, str(REPO / "tools"))
 import briefing   # noqa: E402
 import recall     # noqa: E402
 
+ROSTER_FIXTURE = REPO / "tests" / "fixtures" / "roster.agent.yaml"
+MEMORY_FIXTURE = REPO / "seeds" / "memory"
+"""A identidade DECLARADA destes testes — a fixture de roster e a doutrina canônica de seeds/.
+
+`compose_briefing` é fail-closed (ADR-0009): sem personality/method/canone inscritos ele levanta
+`BriefingIdentityError`. Por default ele lê o `memory/` e o `agent.yaml` DA CASA de quem roda a
+suíte — e o genótipo, por contrato, não tem nenhum dos dois. Os dois testes abaixo, que só querem
+saber se a perna de recall SAIU do briefing, morriam nessa recusa antes de olhar o texto. Com as
+fixtures versionadas eles medem o composer, igual em qualquer host."""
+
 
 class RecallSubgraphLivesInRecallModule(unittest.TestCase):
     """The salient-subgraph read moves out of briefing.py into tools/recall.py, keeping its
@@ -145,7 +155,8 @@ class BriefingNoLongerCarriesTheRecallLeg(unittest.TestCase):
     def test_compose_briefing_emits_no_recall_section(self):
         with tempfile.TemporaryDirectory() as tmp:
             text = briefing.compose_briefing(
-                log=Path(tmp) / "log.jsonl", clusters=None, roster=[])
+                log=Path(tmp) / "log.jsonl", clusters=None, roster=[],
+                agent_yaml=ROSTER_FIXTURE, memory=MEMORY_FIXTURE)
             self.assertNotIn("recall — your own memory", text.lower())
 
     def test_briefing_module_no_longer_owns_the_subgraph_leg(self):
@@ -158,7 +169,8 @@ class BriefingNoLongerCarriesTheRecallLeg(unittest.TestCase):
         # the four parts all survive the extraction — only the recall leg leaves
         with tempfile.TemporaryDirectory() as tmp:
             text = briefing.compose_briefing(
-                log=Path(tmp) / "log.jsonl", clusters=None, roster=[])
+                log=Path(tmp) / "log.jsonl", clusters=None, roster=[],
+                agent_yaml=ROSTER_FIXTURE, memory=MEMORY_FIXTURE)
             low = text.lower()
             for marker in ("objective — the anchor", "1. direction", "2. what is open",
                            "3. corpus", "4. source orientation", "5. knowledge clusters", "recap"):


### PR DESCRIPTION
Parte de #609. Segue #610, #611, #613, #615.

| módulo | antes | depois |
|---|---:|---:|
| `test_predispatch_grounding` | 8/13 | **13/13** |
| `test_recall_brief` | 19/21 | **21/21** |
| `test_briefing_surface` | 33/34 | **34/34** |
| `test_lentes_role_surfaces` | 15/16 | **16/16** |

Nenhum código de produção tocado — só `tests/`. Verificado nos dois regimes: **84/84 com e sem `EDGE_HOME`**.

### Causa
`predispatch._run_canary` chama `load_sources()` sem argumento: o roster de quem roda a suíte. No genótipo ele nasce `[]`, nenhuma interface casa com a dry pendente, nenhum `canary.result` é escrito. O guarda E8 caía com a própria mensagem — *"guard must not run vacuous"* — ele já sabia que sem roster não verificava nada.

`compose_briefing` é fail-closed (ADR-0009) e lê `memory/` e `agent.yaml` da casa; o genótipo não tem nenhum dos dois.

### Dois achados que valem mais que o verde

**A bateria degradada do health-strip estava verde pelo motivo errado.** `TestHealthStripFailsDark` declara testar causas específicas (sweep zerado, `voz.resolved` duplicado) mas passava porque o **grafo do host estava escuro**. A saudável, espelhada, falhava em qualquer host sem grafo. As duas passam a pinar a perna do grafo no seam `GRAPH_PROBE` — e a degradada segue vermelha **por mérito**, com o grafo pinado alcançável.

**A cegueira ganhou controle positivo.** `test_lentes_role_surfaces` guarda que superfícies compartilhadas do wake não vazam ref de mapa — mas um `assertNotIn` sobre texto degradado passa à toa. Agora o teste exige que a mesma ref **apareça** na superfície opt-in e que as três superfícies tenham renderizado não-vazias. A cegueira passa a ser verificada, não presumida.

As fixtures dão **só identidade**; as seções por onde um mapa vazaria são dobras do log, e o log continua sendo o temporário do próprio teste.