### PR TITLE
fix(sessions): a sessão interativa do operador no Codex sumia do corpus de voz

### DIFF
--- a/tests/test_close_residuals_floor.py
+++ b/tests/test_close_residuals_floor.py
@@ -27,6 +27,10 @@ from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
+# two tests below reuse test_harvest's golden transcript shapes (`from test_harvest import …`).
+# That import only resolves when the tests dir is importable, which `-m unittest tests.<mod>`
+# does NOT arrange — same fix test_publisher_floor_split.py already carries for the same reuse.
+sys.path.insert(0, str(REPO / "tests"))
 import close      # noqa: E402
 import harvest    # noqa: E402
 import eventlog   # noqa: E402
@@ -306,6 +310,22 @@ class CloseFloorWrapperKnobLogic(unittest.TestCase):
             p.write_text(json.dumps(line) + "\n")
         return store
 
+    def _fixture_recognizers(self):
+        """O roster DECLARADO deste teste — a fixture versionada, nunca o agent.yaml do host.
+
+        `harvest.close_floor` cai em `build_recognizers()` sem argumento, que lê
+        `sources.load_sources()` — o agent.yaml de quem roda a suíte. Num genótipo (que POR
+        CONTRATO não tem agent.yaml) a tabela nasce VAZIA, o X_CMD do transcript golden não é
+        reconhecido e o teste do caminho "themed COM leitura reconhecida" falha por instalação,
+        não por código. Mesma injeção que test_harvest._seam_sources já faz."""
+        import sources as sources_mod
+        import harvest as harvest_mod
+        srcs, findings = sources_mod.load_sources(
+            Path(__file__).resolve().parent / "fixtures" / "roster.agent.yaml")
+        errors = [f for f in findings if f.get("level") == "error"]
+        assert srcs and not errors, f"fixture de roster inválida: {errors}"
+        return harvest_mod.build_recognizers(sources=srcs)
+
     def _log_with_open(self, tmp, session_id, geometry):
         log = Path(tmp) / "log.jsonl"
         if geometry is not None:
@@ -330,7 +350,8 @@ class CloseFloorWrapperKnobLogic(unittest.TestCase):
             log = self._log_with_open(tmp, "sT", "themed")
             store = self._store_with_transcript(tmp, "sT", recognized=False)
             out = harvest.close_floor(log=log, store_root=store, session_id="sT",
-                                      child_session="")
+                                      child_session="",
+                                      recognizers=self._fixture_recognizers())
             self.assertEqual(out, [harvest.FLOOR_VIOLATION])
 
     def test_gate_passes_themed_dispatch_with_a_recognized_read(self):
@@ -338,7 +359,8 @@ class CloseFloorWrapperKnobLogic(unittest.TestCase):
             log = self._log_with_open(tmp, "sR", "themed")
             store = self._store_with_transcript(tmp, "sR", recognized=True)
             out = harvest.close_floor(log=log, store_root=store, session_id="sR",
-                                      child_session="")
+                                      child_session="",
+                                      recognizers=self._fixture_recognizers())
             self.assertEqual(out, [])
 
     def test_observe_counts_the_would_be_violation_but_never_blocks(self):

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -17,6 +17,13 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import eventlog  # noqa: E402
 
+# The CANONICAL batch one `publish_artefato_atomic` lands, in order — named ONCE so the batch's
+# shape is asserted in a single place instead of being re-typed (and left behind) in every test
+# that reads a publish back. It grew: published+kernel (#3) → +adoption (R6/S10) → +assembly.pending
+# (tkt-003, the Assemble queue is log truth). Extend HERE when the canon grows again, never inline.
+ATOMIC_PUBLISH_BATCH = ["artefato.published", "intent.kernel", "artefato.adoption",
+                        "assembly.pending"]
+
 
 class AppendThenReadRoundTrips(unittest.TestCase):
     """The tracer bullet: an appended event lands as one JSONL line, stamped with a
@@ -726,8 +733,7 @@ class ExperimentCurationFoldsCuratedFirst(unittest.TestCase):
                 log=log)
             events = eventlog.read(log=log)
             self.assertEqual([e["type"] for e in events],
-                             ["artefato.published", "intent.kernel", "artefato.adoption",
-                              "experiment.curated"])
+                             ATOMIC_PUBLISH_BATCH + ["experiment.curated"])
             exp = eventlog.experiment_at("exp40", log=log)
             self.assertEqual(exp["canonical"]["typed"]["claim"], "GN wins.")
             self.assertEqual(exp["canonical_artifacts"][0],
@@ -1181,9 +1187,9 @@ class AtomicPublishHasNoCrashWindow(unittest.TestCase):
             # batch also carries the adoption telemetry (here synthesized: no caller-supplied payload).
             self.assertEqual(writes["count"], 1)
             evs = eventlog.read(log=log)
-            self.assertEqual([e["type"] for e in evs],
-                             ["artefato.published", "intent.kernel", "artefato.adoption"])
-            self.assertEqual([e["seq"] for e in evs], [1, 2, 3])
+            self.assertEqual([e["type"] for e in evs], ATOMIC_PUBLISH_BATCH)
+            self.assertEqual([e["seq"] for e in evs],
+                             list(range(1, len(ATOMIC_PUBLISH_BATCH) + 1)))
             self.assertEqual(eventlog.artefatos_without_kernel(log=log), [])
 
 
@@ -1204,8 +1210,7 @@ class ProducerFacingPublishPairsItsKernel(unittest.TestCase):
             # the adoption telemetry in the same indivisible batch (synthesized here).
             self.assertEqual(eventlog.artefatos_without_kernel(log=log), [])
             evs = eventlog.read(log=log)
-            self.assertEqual([e["type"] for e in evs],
-                             ["artefato.published", "intent.kernel", "artefato.adoption"])
+            self.assertEqual([e["type"] for e in evs], ATOMIC_PUBLISH_BATCH)
 
     def test_publish_artefato_with_empty_intent_raises_and_lands_nothing(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1257,10 +1262,13 @@ class AppendBatchIsSerializedAcrossConcurrentWriters(unittest.TestCase):
                     t.join()
 
                 seqs = [e["seq"] for e in eventlog.read(log=log)]
-                # each atomic publish lands THREE events under R6 (published + kernel + adoption) → 3n
-                # events, seqs 1..3n with no dupes
-                self.assertEqual(len(seqs), 3 * n)
-                self.assertEqual(sorted(seqs), list(range(1, 3 * n + 1)))
+                # each atomic publish lands the canonical batch (published + kernel + adoption +
+                # assembly.pending) → k*n events, seqs 1..k*n with no dupes. k comes from the named
+                # canon, not a hand-typed literal: what this test guards is the flock serialization
+                # (unique, strictly-monotonic seqs), and that guard must not rot when the batch grows.
+                k = len(ATOMIC_PUBLISH_BATCH)
+                self.assertEqual(len(seqs), k * n)
+                self.assertEqual(sorted(seqs), list(range(1, k * n + 1)))
                 self.assertEqual(seqs, sorted(seqs))  # strictly monotonic in file order
 
 

--- a/tests/test_sweep_lentes.py
+++ b/tests/test_sweep_lentes.py
@@ -73,12 +73,19 @@ class RationalizationPlanning(unittest.TestCase):
                 rows = [{"type": "session_meta", "payload": {
                     "id": session_id, "thread_source": "user",
                     "source": source, "originator": originator,
-                }}, {
-                    "type": "response_item", "payload": {
-                        "type": "message", "role": "user",
-                        "content": [{"type": "input_text", "text": "conteúdo arbitrário"}],
-                    },
-                }]
+                }}]
+                # DOIS turnos humanos: o piso de diálogo (#153) exige ≥2 para uma sessão contar
+                # como voz, e a fixture de um turno só fazia a sessão do OPERADOR sair excluída
+                # por `codex-sem-dialogo` — ruído que não é o que este teste mede (ele mede a
+                # exclusão por PROVENIÊNCIA, `codex-source:exec`, e sua idempotência).
+                for index in range(2):
+                    rows.append({
+                        "type": "response_item", "payload": {
+                            "type": "message", "role": "user",
+                            "content": [{"type": "input_text",
+                                         "text": f"conteúdo arbitrário ({index})"}],
+                        },
+                    })
                 (codex_dir / filename).write_text(
                     "\n".join(json.dumps(row) for row in rows) + "\n")
 

--- a/tools/sessions.py
+++ b/tools/sessions.py
@@ -427,8 +427,14 @@ def _user_session_exclusion_reason(session: Session) -> str | None:
         # de agente-a-agente; a suavização pré-nascimento NUNCA se aplica aqui
         # (caso edgesandbox 2026-07-25: os turnos "user" eram o claude falando).
         originator = str(meta.get("originator") or "").strip()
-        if originator and originator.lower().replace(" ", "_") not in (
-                "codex", "codex_cli", "codex_exec"):
+        # O marcador é OUTRO harness dirigindo o codex. ca9965e mirou esse caso (originator=
+        # "Claude Code" via plugin) mas fixou uma allowlist LITERAL — ("codex", "codex_cli",
+        # "codex_exec") — que deixou de fora os próprios front-ends do codex: `codex-tui` (o
+        # operador no terminal), `codex_cli_rs`, `codex_vscode`. Com isso a sessão INTERATIVA do
+        # operador passou a ser lida como prova de delegação e sumiu do corpus de voz. Qualquer
+        # originator do PRÓPRIO codex é o codex, não outro agente — daí o prefixo, não a lista.
+        native = originator.lower().replace(" ", "_").replace("-", "_").startswith("codex")
+        if originator and not native:
             return f"codex-originator:{originator.lower().replace(' ', '-')}"
         thread_source = meta.get("thread_source")
         if thread_source != "user":


### PR DESCRIPTION
Parte de #609. O cluster de testes era o pretexto; **o achado é um bug de produção**.

## O bug

`ca9965e` introduziu o `originator` como marcador positivo de delegação — o caso real era `originator="Claude Code"` dirigindo o codex por plugin. Mas fixou uma allowlist **literal**:

```python
if originator and originator.lower().replace(" ", "_") not in (
        "codex", "codex_cli", "codex_exec"):
    return f"codex-originator:{originator...}"     # EXCLUÍDA do corpus
```

Ficaram de fora os front-ends do **próprio codex**: `codex-tui` (o operador no terminal), `codex_cli_rs`, `codex_vscode`.

**Consequência:** a sessão **interativa** do operador passou a ser lida como prova de delegação agente-a-agente e a sumir do corpus de voz. O filme perdia as sessões de codex dele — silenciosamente, que é o modo de falha desta casa.

Que `codex-tui` é o operador não é suposição: as próprias fixtures do repo carregam `"originator": "codex-tui"` num teste que exige que a sessão seja **mantida**, ao lado de `"Claude Code"` no teste que exige que seja excluída.

Correção: prefixo em vez de lista. Qualquer originator do próprio codex **é** o codex, não outro agente — a intenção do `ca9965e` (detectar OUTRO harness) fica intacta.

## O cluster de testes: 8 → 0 (195 testes, mesmo número com e sem `EDGE_HOME`)

- **`test_eventlog` (4)** — `48 != 36` era `4n` vs `3n`: `publish_artefato_atomic` passou a emitir **4** eventos por publish, o quarto sendo `assembly.pending`. O batch estava re-tipado à mão em 4 lugares; agora tem **um nome só** (`ATOMIC_PUBLISH_BATCH`) e as asserções derivam dele — é o que impede este teste de envelhecer de novo. A guarda de serialização por flock foi preservada, não afrouxada.
- **`test_sweep_lentes` (2)** e **`test_topic_threads` (1)** — sintomas do bug acima, mais uma fixture anterior ao piso de diálogo #153 (≥2 turnos humanos).
- **`test_close_residuals_floor` (2, o briefing previa 1)** — import quebrado escondendo o segundo, mais `close_floor` caindo no `agent.yaml` do host.

## Evidência para a #612

A pilha de *assembly* está **partida em duas**, e eu havia juntado as metades na issue:
- **a metade do log está inteira e viva** — `assembly.pending` é emitido no batch atômico, drenado por `assemble_drain`, lido por `assemble_ready`, documentado no `CONTEXT.md` e já coberto por `test_assembly_pending`. 256 testes verdes nessa área;
- **a metade do close é que nunca foi escrita** — `close._sign_assembly` não existe e `git log -S` retorna vazio em todo o histórico.

A #612 deve apontar para `tools/close.py`, não para o tipo de evento.