### PR TITLE
fix(tests): deriva de vocabulário na ADR-0024 e um tripwire que respondia coisa diferente por host

### DIFF
--- a/tests/test_frontend_contract.py
+++ b/tests/test_frontend_contract.py
@@ -9,6 +9,7 @@ the templates emit the same markers).
 """
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -239,13 +240,41 @@ class DefaultLogNotPollutedBySmokeTests(unittest.TestCase):
     checked-in baseline; auth/browser coverage belongs in hermetic tests that point EDGE_BLOG_LOG at
     a tmp file. So the guard is STRUCTURAL, not a literal-body denylist (round-2 [high]: a denylist of
     known strings lets a NEW body slip through the same way): the committed log must carry ZERO voz.*
-    events of ANY type/body — any present is pollution by construction."""
+    events of ANY type/body — any present is pollution by construction.
 
-    LOG = BLOG.parent / "state" / "events" / "log.jsonl"
+    The subject is the COMMITTED blob, never the working tree. `/state/` is gitignored (the genotype
+    ships no state), so on a fresh clone this path does not exist while on a live install it is the
+    HOST's runtime log — a log that legitimately carries voz.* events. Reading the working tree made
+    this tripwire answer a different question depending on who ran it: dead in the genotype, and a
+    false alarm against real runtime Voz in an install. So the guard asks git, not the filesystem:
+    it reads `HEAD:state/events/log.jsonl` and skips when nothing is tracked there. Same answer in
+    every checkout; the tripwire still fires the day a `git add -A` commits the log."""
 
-    def _committed_events(self):
+    REL = "state/events/log.jsonl"
+
+    @classmethod
+    def _committed_blob(cls):
+        """The tracked content of the default log at HEAD, or None when it is not tracked."""
+        try:
+            out = subprocess.run(
+                ["git", "show", f"HEAD:{cls.REL}"],
+                cwd=BLOG.parent, capture_output=True, check=False)
+        except OSError:
+            return None
+        if out.returncode != 0:
+            return None
+        return out.stdout.decode("utf-8", errors="replace")
+
+    def _require_committed_log(self):
+        blob = self._committed_blob()
+        if blob is None:
+            self.skipTest(f"{self.REL} is not tracked at HEAD (/state/ is gitignored) — "
+                          "no committed log to guard")
+        return blob
+
+    def _committed_events(self, blob):
         out = []
-        for line in self.LOG.read_text().splitlines():
+        for line in blob.splitlines():
             line = line.strip()
             if not line:
                 continue
@@ -261,9 +290,8 @@ class DefaultLogNotPollutedBySmokeTests(unittest.TestCase):
         # STRUCTURAL guard (round-2 [high]): not a denylist of known smoke-test bodies, but the whole
         # class — ANY voz.* event in the committed baseline is ad-hoc pollution (the baseline has none;
         # real Voz lands at runtime on the live log). A new manual POST with any body fails this.
-        if not self.LOG.is_file():
-            self.skipTest("no committed default log in this checkout")
-        voz = [e.get("type") for e in self._committed_events()
+        blob = self._require_committed_log()
+        voz = [e.get("type") for e in self._committed_events(blob)
                if str(e.get("type", "")).startswith("voz.")]
         self.assertEqual(voz, [],
                          f"the committed authoritative log carries {len(voz)} ad-hoc voz.* event(s) "
@@ -273,11 +301,16 @@ class DefaultLogNotPollutedBySmokeTests(unittest.TestCase):
     def test_committed_log_is_intact(self):
         # the committed default log must satisfy the SAME strict integrity check the drain gates on —
         # contiguous int seqs, dict envelopes, no poisoned payload (a polluted/seq-gapped commit fails).
-        if not self.LOG.is_file():
-            self.skipTest("no committed default log in this checkout")
+        blob = self._require_committed_log()
         import grill_drain
-        self.assertTrue(grill_drain.log_is_intact(self.LOG),
-                        "the committed default authoritative log is not intact")
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
+            fh.write(blob)
+            staged = Path(fh.name)
+        try:
+            self.assertTrue(grill_drain.log_is_intact(staged),
+                            "the committed default authoritative log is not intact")
+        finally:
+            staged.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_def.py
+++ b/tests/test_pipeline_def.py
@@ -9,7 +9,9 @@ it names live in tools/. This test pins the load-bearing claims:
     run_close bounce/brake) and tools/publisher.py (atomic publish + C3 kernel);
   * the close lives at the SKILL'S EXIT — a standalone /ed-report observes the same close
     (honors ADR-0008);
-  * the close-roles (reviewers, publisher) are NOT round-robinable (only producer-skills are).
+  * the close-roles (reviewers, publisher) are NOT selectable — they are not producers, they
+    run at every producer's exit (ADR-0024 replaced the beat's round-robin rotation with the
+    Pauta's `forma` selection; the guard is unchanged, only the word for "chooseable" moved).
 
 Grep-based, case-insensitive: the doc is prose, so the test reads it and asserts the
 load-bearing tokens are present.
@@ -57,10 +59,15 @@ class PipelineHasThreePhasesAndCloseAtExit(unittest.TestCase):
         self.assertIn("/ed-report", self.lower)
         self.assertIn("standalone", self.lower)
 
-    def test_close_roles_are_not_round_robinable(self):
-        self.assertIn("round-robin", self.lower)
-        # the close-roles (reviewers, publisher) are NOT round-robinable; only producers are.
-        self.assertIn("not round-robinable", self.lower)
+    def test_close_roles_are_not_selectable(self):
+        # ADR-0024 (a9a6b17, "beat rotation + its test" demolished) killed the round-robin: the
+        # Pauta's PROPOSTA now names the `forma`/producer. The guard this test exists for did not
+        # move — the close-roles are still the fixed gate every producer funnels through — so it is
+        # re-pinned to the CURRENT word for "chooseable" instead of the retired one.
+        self.assertIn("pauta", self.lower)
+        self.assertIn("not selectable", self.lower)
+        # and the roles it applies to are still named as the close-roles
+        self.assertIn("close-roles", self.lower)
 
     def test_is_the_deyamld_publish_only_rewrite(self):
         self.assertIn("consolidate-state", self.lower)


### PR DESCRIPTION
Parte de #609. Dois consertos; os outros três achados do cluster viram issues próprias e **ficam vermelhos de propósito**.

**`test_pipeline_def`** — `test_close_roles_are_not_round_robinable` fazia grep de `"round-robin"` no `pipeline.md`. A ADR-0024 (`a9a6b17`) matou a rotação do beat de propósito — a mensagem dela diz que demoliu *"beat rotation + its test"* — e reescreveu a seção para `Producers are chosen by the Pauta; close-roles are fixed`. A afirmação guardada continua lá, no vocabulário novo. Teste re-pinado na palavra atual; **número de asserções subiu**, não desceu.

**`test_frontend_contract`** — o tripwire do CONTRACT C1 resolvia "o log autoritativo committado" pela **working tree**. Só que `/state/` é gitignored e `state/events/log.jsonl` **nunca foi versionado neste repo**. O guarda respondia uma pergunta diferente por runner: skip morto num clone, e num install vivo lia o **log de runtime do host** — que legitimamente carrega eventos `voz.*`, ou seja, um alarme falso esperando o operador usar a Voz. Passa a perguntar ao git (`HEAD:state/events/log.jsonl`) e a pular com razão declarada quando nada está versionado. Mesma resposta em qualquer checkout, e ainda dispara no dia em que alguém realmente commitar o log — o único evento que ele existiu para pegar.