### PR TITLE
fix(tests): fixtures de sessão anteriores ao piso de diálogo (#153)

### DIFF
--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -445,6 +445,7 @@ class MenteeDialogueForRationalize(unittest.TestCase):
                 {"type": "assistant", "message": {"role": "assistant",
                     "content": [{"type": "tool_use", "name": "Bash", "input": {}}]}},
                 _msg("assistant", "ok, testes no seam"),
+                _msg("user", "e o watermark, fecha junto?"),
             ])
             session = sessions.Session(id="op", path=p, surface="claude")
             packed = sessions.mentee_dialogue_for_rationalize(session)
@@ -452,8 +453,9 @@ class MenteeDialogueForRationalize(unittest.TestCase):
             turns, watermark = packed
             self.assertEqual([(t.role, t.text) for t in turns],
                              [("human", "vamos fechar o MIN.1"),
-                              ("edge", "ok, testes no seam")])
-            self.assertEqual(watermark, 3)  # raw lines, including tool line
+                              ("edge", "ok, testes no seam"),
+                              ("human", "e o watermark, fecha junto?")])
+            self.assertEqual(watermark, 4)  # raw lines, including tool line
 
     def test_claude_sidechain_returns_none(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -473,13 +475,14 @@ class MenteeDialogueForRationalize(unittest.TestCase):
                  "payload": {"id": "c1", "thread_source": "user"}},
                 _codex_msg("user", "emprego do mentee"),
                 _codex_msg("assistant", "portfolio_at only"),
+                _codex_msg("user", "e o resto do emprego?"),
             ])
             session = sessions.Session(id="c1", path=p, surface="codex")
             packed = sessions.mentee_dialogue_for_rationalize(session)
             self.assertIsNotNone(packed)
             turns, watermark = packed
-            self.assertEqual([t.role for t in turns], ["human", "edge"])
-            self.assertEqual(watermark, 3)
+            self.assertEqual([t.role for t in turns], ["human", "edge", "human"])
+            self.assertEqual(watermark, 4)
 
     def test_codex_subagent_returns_none(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -501,6 +504,7 @@ class MenteeDialogueForRationalize(unittest.TestCase):
             p.write_text("".join(json.dumps(o) + "\n" for o in [
                 _grok_user("que dia o virtualbox foi criado?"),
                 _grok_assistant("vou checar"),
+                _grok_user("e o snapshot, de quando é?"),
             ]))
             (root / "summary.json").write_text(json.dumps({
                 "info": {"id": "g1", "cwd": "/tmp"},
@@ -512,8 +516,9 @@ class MenteeDialogueForRationalize(unittest.TestCase):
             turns, watermark = packed
             self.assertEqual([(t.role, t.text) for t in turns],
                              [("human", "que dia o virtualbox foi criado?"),
-                              ("edge", "vou checar")])
-            self.assertEqual(watermark, 2)
+                              ("edge", "vou checar"),
+                              ("human", "e o snapshot, de quando é?")])
+            self.assertEqual(watermark, 3)
 
     def test_grok_worker_session_kind_returns_none(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_sessions_user_filter.py
+++ b/tests/test_sessions_user_filter.py
@@ -16,18 +16,24 @@ def _write(path, rows):
     return path
 
 
-def _claude(path, prompt, *, sidechain=False):
+def _claude(path, prompt, *, sidechain=False, follow_up=None):
+    """Claude transcript. ``follow_up`` = segunda fala humana (piso de diálogo #153)."""
     rows = []
     if sidechain:
         rows.append({"type": "user", "isSidechain": True, "message": {
             "role": "user", "content": prompt}})
     else:
         rows.append({"type": "user", "message": {"role": "user", "content": prompt}})
+    if follow_up is not None:
+        rows.append({"type": "assistant", "message": {
+            "role": "assistant", "content": [{"type": "text", "text": "ja vejo"}]}})
+        rows.append({"type": "user", "message": {"role": "user", "content": follow_up}})
     return _write(path, rows)
 
 
 def _codex(path, *, thread_source="user", parent=None, prompt="vamos trabalhar",
-           source="cli", originator="codex-tui"):
+           source="cli", originator="codex-tui", follow_up=None):
+    """Codex rollout. ``follow_up`` = segunda fala humana (piso de diálogo #153)."""
     payload = {"id": "codex-1", "thread_source": thread_source,
                "source": source, "originator": originator}
     if parent:
@@ -37,21 +43,32 @@ def _codex(path, *, thread_source="user", parent=None, prompt="vamos trabalhar",
         {"type": "response_item", "payload": {"type": "message", "role": "user",
          "content": [{"type": "input_text", "text": prompt}]}},
     ]
+    if follow_up is not None:
+        rows.append({"type": "response_item", "payload": {
+            "type": "message", "role": "assistant",
+            "content": [{"type": "output_text", "text": "ja vejo"}]}})
+        rows.append({"type": "response_item", "payload": {
+            "type": "message", "role": "user",
+            "content": [{"type": "input_text", "text": follow_up}]}})
     return _write(path, rows)
 
 
 
 
-def _grok(path, prompt, *, session_kind=None, session_id="g1"):
-    """Real-shaped Grok store: chat_history.jsonl + sibling summary.json."""
+def _grok(path, prompt, *, session_kind=None, session_id="g1", follow_up=None):
+    """Real-shaped Grok store: chat_history.jsonl + sibling summary.json.
+
+    ``follow_up`` = segunda fala humana (piso de diálogo #153)."""
     root = Path(path)
     root.mkdir(parents=True, exist_ok=True)
     chat = root / "chat_history.jsonl"
-    body = f"<user_query>\n{prompt}\n</user_query>"
-    chat.write_text(json.dumps({
-        "type": "user",
-        "content": [{"type": "text", "text": body}],
-    }) + "\n")
+    rows = [{"type": "user",
+             "content": [{"type": "text", "text": f"<user_query>\n{prompt}\n</user_query>"}]}]
+    if follow_up is not None:
+        rows.append({"type": "assistant", "content": [{"type": "text", "text": "ja vejo"}]})
+        rows.append({"type": "user", "content": [
+            {"type": "text", "text": f"<user_query>\n{follow_up}\n</user_query>"}]})
+    chat.write_text("".join(json.dumps(r) + "\n" for r in rows))
     summary = {
         "info": {"id": session_id, "cwd": "/tmp"},
         "session_summary": prompt[:80],
@@ -64,7 +81,8 @@ def _grok(path, prompt, *, session_kind=None, session_id="g1"):
 class UserSessionFilter(unittest.TestCase):
     def test_claude_direct_operator_session_is_kept(self):
         with tempfile.TemporaryDirectory() as td:
-            p = _claude(Path(td) / "s.jsonl", "que dia esse virtualbox foi criado?")
+            p = _claude(Path(td) / "s.jsonl", "que dia esse virtualbox foi criado?",
+                        follow_up="e o disco, cresceu quando?")
             s = sessions.Session(id="s", path=p, surface="claude")
             self.assertIsNone(sessions.user_session_exclusion_reason(s))
 
@@ -79,6 +97,7 @@ class UserSessionFilter(unittest.TestCase):
             p = _claude(
                 Path(td) / "s.jsonl",
                 "Implement ticket 42 e faça um adversarial review da solução.",
+                follow_up="agora implement ticket 43 e reporte de volta.",
             )
             s = sessions.Session(id="s", path=p, surface="claude")
             self.assertIsNone(sessions.user_session_exclusion_reason(s))
@@ -108,7 +127,7 @@ class UserSessionFilter(unittest.TestCase):
 
     def test_codex_user_thread_is_kept(self):
         with tempfile.TemporaryDirectory() as td:
-            p = _codex(Path(td) / "s.jsonl")
+            p = _codex(Path(td) / "s.jsonl", follow_up="e agora o segundo passo")
             s = sessions.Session(id="codex-1", path=p, surface="codex")
             self.assertIsNone(sessions.user_session_exclusion_reason(s))
 
@@ -188,22 +207,33 @@ class UserSessionFilter(unittest.TestCase):
             )
 
     def test_grok_operator_session_is_kept(self):
-        """An authoritative operator marker keeps even a one-turn Grok conversation."""
+        """An authoritative operator marker keeps the conversation.
+
+        O marcador `session_kind=operator` não é exclusão; o que ainda tem de haver é
+        DIÁLOGO — o piso de #153 é a última porta de toda inclusão, nenhum marcador o
+        atravessa (era one-turn aqui até 5270e9f)."""
         with tempfile.TemporaryDirectory() as td:
             p = _grok(Path(td) / "019f-op", "que dia esse virtualbox foi criado?",
-                      session_kind="operator", session_id="019f-op")
+                      session_kind="operator", session_id="019f-op",
+                      follow_up="e o disco, cresceu quando?")
             s = sessions.Session(id="019f-op", path=p, surface="grok")
             self.assertIsNone(sessions.user_session_exclusion_reason(s))
 
     def test_grok_unmarked_one_shot_fails_closed_without_reading_its_vocabulary(self):
+        """One-shot sem marcador continua fora — por topologia, nunca por vocabulário.
+
+        O veredito mudou de nome em 5270e9f: o `grok-unknown-provenance` específico do
+        grok virou o piso de diálogo universal (`<surface>-sem-dialogo`); a exclusão é
+        a mesma e continua sem olhar o texto."""
         with tempfile.TemporaryDirectory() as td:
             p = _grok(Path(td) / "019f-one", "uma mensagem de conteúdo arbitrário",
                       session_id="019f-one")
             s = sessions.Session(id="019f-one", path=p, surface="grok")
             self.assertEqual(
                 sessions.user_session_exclusion_reason(s),
-                "grok-unknown-provenance",
+                "grok-sem-dialogo",
             )
+            self.assertFalse(sessions.is_user_session(s))
 
     def test_grok_unmarked_multi_turn_dialogue_is_kept(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Parte de #609. `test_sessions` 32/32 e `test_sessions_user_filter` 15/15, mesmo número com e sem `EDGE_HOME`. Só `tests/`.

### Causa
`5270e9f` (#153) instalou o **piso de diálogo universal** — voz é conversa, ≥2 turnos humanos — como "última porta de TODA inclusão", que nem a suavização pré-nascimento atravessa. Esse commit atualizou as fixtures de `test_sessions_pre_edge` e `test_onboarding_estimate`, mas **não** as destes dois módulos, cujos transcripts tinham 1 turno humano.

Daí `claude-sem-dialogo` / `codex-sem-dialogo` / `grok-sem-dialogo` e os `packed is None` em `mentee_dialogue_for_rationalize`.

Fixtures ganham a segunda fala humana na forma real de cada superfície, o mesmo padrão que o commit do piso usou. **Nenhuma asserção afrouxada** — exclusão continua exclusão (entrou um `assertFalse(is_user_session)` explícito no one-shot), inclusão continua exata.

### Corroboração independente do #617
Este cluster diagnosticou o **mesmo** bug de `originator` por caminho próprio, e trouxe a evidência que faltava: o binário nativo do codex 0.147.0 contém `codex_tui` **70×**, `codex-tui` **5×**, além de `codex_cli_rs` e `codex_exec`. A allowlist literal deixava a **família inteira** de fora — não era um front-end esquecido, eram todos.

O conserto de produção já veio pelo #617; esta branch entrega só testes.

### Código morto observado, deixado intacto
O ramo `grok_unmarked` / `del grok_unmarked` (`tools/sessions.py` ~447-467) está morto desde `5270e9f`, e a suavização pré-nascimento ainda lista `grok-unknown-provenance` — veredito que o grok não produz mais. Fora do escopo deste cluster.