### PR TITLE
fix(publisher): a promessa de "pending_distills é retentado no reproject" era falsa

### DIFF
--- a/tests/test_project_doc.py
+++ b/tests/test_project_doc.py
@@ -27,10 +27,11 @@ class _Result:
 
 
 class _State:
-    def __init__(self, clusters=()):
+    def __init__(self, clusters=(), communities=()):
         self.nodes = {}
         self.distills = set()
-        self.clusters = list(clusters)
+        self.clusters = list(clusters)        # Entity.curated_cluster (grill attach)
+        self.communities = list(communities)  # Community.name (communities.consolidate)
 
 
 class _Session:
@@ -57,6 +58,11 @@ class _Session:
             return _Result()
         if "RETURN DISTINCT e.curated_cluster AS l" in query:
             return _Result([{"l": label} for label in state.clusters])
+        # the SECOND catalog the resolution reads (publisher._distill_catalog): automatic
+        # Communities. communities.consolidate never stamps `curated_cluster`, so without this
+        # catalog a Community-only thread could never resolve. Group-scoped, no slug param.
+        if "RETURN c.name AS n" in query:
+            return _Result([{"n": name} for name in state.communities])
         node = state.nodes[(params["g"], params["slug"])]
         if "RETURN d.embedding IS NOT NULL" in query:
             return _Result([{
@@ -70,8 +76,14 @@ class _Session:
         if "[r:DISTILLS]" in query and "DELETE r" in query:
             state.distills.clear()
             return _Result()
-        if "MERGE (d)-[:DISTILLS]->(e)" in query:
+        if "MERGE (d)-[:DISTILLS]->" in query:
             state.distills.add(params["label"])
+            return _Result()
+        if "SET d.pending_distills=$p" in query:
+            node["pending_distills"] = list(params["p"])
+            return _Result()
+        if "REMOVE d.pending_distills" in query:
+            node.pop("pending_distills", None)
             return _Result()
         if "SET d.projection_complete=true" in query:
             node["projection_complete"] = True
@@ -157,6 +169,28 @@ class ProjectDocContract(unittest.TestCase):
         self.assertEqual(state.distills, {"Alpha"})
         self.assertEqual(len(embed_calls), 1)
         self.assertTrue(all(driver.closed for driver in drivers))
+
+    def test_thread_resolves_against_an_automatic_community(self):
+        # the catalog the aged double was blind to: a thread whose cluster exists only as an
+        # automatic Community (never stamped `curated_cluster`) still links, and nothing pends.
+        state = _State(communities=["Alpha"])
+        publisher.project_doc(
+            self._payload(), driver_factory=lambda _uri, *, auth: _Driver(state),
+            identity=_Identity, embed_fn=lambda _text: [0.25],
+        )
+        self.assertEqual(state.distills, {"Alpha"})
+        self.assertNotIn("pending_distills", state.nodes[("edge-test", "doc-v10")])
+
+    def test_unresolved_thread_is_recorded_pending_never_fabricated(self):
+        # no Entity, no Community: the ref is recorded for the next sweep, never invented.
+        state = _State()
+        publisher.project_doc(
+            self._payload(), driver_factory=lambda _uri, *, auth: _Driver(state),
+            identity=_Identity, embed_fn=lambda _text: [0.25],
+        )
+        self.assertEqual(state.distills, set())
+        self.assertEqual(state.nodes[("edge-test", "doc-v10")]["pending_distills"],
+                         ["cluster:alpha"])
 
     def test_malformed_payloads_degrade_before_opening_a_driver(self):
         valid = self._payload()

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -134,8 +134,10 @@ def _signed_bar_chart(title, rows):
 
 def _floored_spec():
     # Valid for EVERY roster skill's presentation floor at once. Map owes two renderable visuals;
-    # plan owes one renderable visual plus framed steps; discovery owes contextual framing.
-    # report/research owe no extra floor. No executive_summary: prose-synthesis moves aren't owed.
+    # plan owes one renderable visual plus framed steps; discovery owes contextual framing;
+    # critique (added by declaration in producer_descriptor, Phase 4) owes a side-by-side
+    # COMPARISON plus a marked UNCERTAINTY. report/research owe no extra floor. No
+    # executive_summary: prose-synthesis moves aren't owed.
     return {"sections": [{"title": "Body", "blocks": [
         {"type": "paragraph", "text": "atomic publish plus kernel in one act."},
         _signed_bar_chart(
@@ -148,7 +150,163 @@ def _floored_spec():
         ),
         {"type": "next-steps-grid", "items": ["step one", "step two"]},
         {"type": "callout", "text": "framing context"},
+        {"type": "comparison-table",
+         "headers": ["axis", "before", "after"],
+         "rows": [{"cells": ["publish", "two acts", "one atomic act"]},
+                  {"cells": ["kernel", "optional", "required"]}]},
+        {"type": "gap-table",
+         "gaps": [{"description": "the projection retry was not measured under a live outage",
+                   "need": "one reproject sweep against a real graph",
+                   "status": "open"}]},
     ]}]}
+
+
+# ── the offline graph double ────────────────────────────────────────────────────────────────────
+#
+# project_artefato has no driver seam (it does `from neo4j import GraphDatabase` inside the body),
+# so the projection used to be pinned by reading its SOURCE TEXT — assertions that broke the moment
+# the distill resolution moved into `_distill_catalog`/`_link_distill` even though nothing about the
+# behaviour changed. These fakes run the REAL projection against a recording stand-in driver (the
+# same double tests/test_project_doc.py already uses for project_doc), so the tests below exercise
+# behaviour: what the projection WRITES, and the Cypher it actually PUTS ON THE WIRE.
+class _FakeResult:
+    def __init__(self, rows=()):
+        self._rows = [dict(r) for r in rows]
+
+    def single(self):
+        return self._rows[0] if self._rows else None
+
+    def data(self):
+        return list(self._rows)
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _FakeGraph:
+    """The projected state a session's writes produce, plus every query that reached the driver."""
+
+    def __init__(self, entity_clusters=(), communities=(), entity_names=()):
+        self.entity_clusters = list(entity_clusters)   # Entity.curated_cluster labels (ACTIVE ones)
+        self.communities = list(communities)           # Community.name labels
+        self.entity_names = list(entity_names)         # Entity.name (the MENTIONS catalog)
+        self.queries = []                              # [(cypher, params)] actually executed
+        self.props = {}                                # the :Artefato node's projected props
+        self.distills = []                             # labels linked via DISTILLS
+        self.closed = False
+
+    def entity_link_queries(self):
+        return [q for q, _ in self.queries if "[:DISTILLS]->(e)" in q]
+
+    def catalog_queries(self):
+        return [q for q, _ in self.queries if "e.curated_cluster AS l" in q]
+
+
+class _FakeSession:
+    def __init__(self, graph):
+        self.graph = graph
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+    def run(self, query, **params):
+        g = self.graph
+        g.queries.append((query, dict(params)))
+        if "a.projection_complete=false" in query:      # the MERGE that opens the projection
+            g.props["projection_complete"] = False
+            return _FakeResult()
+        if "RETURN a.embedding IS NOT NULL AS e" in query:
+            return _FakeResult([{"e": "embedding" in g.props,
+                                 "h": g.props.get("embedding_input_hash")}])
+        if "SET a.embedding=$e" in query:
+            g.props.update(embedding=list(params["e"]), embedding_input_hash=params["h"])
+            return _FakeResult()
+        if "e.curated_cluster AS l" in query:
+            return _FakeResult([{"l": label} for label in g.entity_clusters])
+        if "RETURN c.name AS n" in query:
+            return _FakeResult([{"n": name} for name in g.communities])
+        if "RETURN DISTINCT e.name AS name" in query:
+            return _FakeResult([{"name": n} for n in g.entity_names])
+        if "MERGE (a)-[:DISTILLS]->" in query:
+            g.distills.append(params["label"])
+            return _FakeResult()
+        if "SET a.pending_distills=$pending" in query:
+            g.props["pending_distills"] = list(params["pending"])
+            return _FakeResult()
+        if "REMOVE a.pending_distills" in query:
+            g.props.pop("pending_distills", None)
+            return _FakeResult()
+        if "SET a.projection_complete=$done" in query:
+            g.props["projection_complete"] = params["done"]
+            return _FakeResult()
+        if "RETURN count(" in query:                    # lineage/bears/para resolution probes
+            return _FakeResult([{"n": 0}])
+        return _FakeResult()
+
+
+class _FakeDriver:
+    def __init__(self, graph):
+        self.graph = graph
+
+    def session(self):
+        return _FakeSession(self.graph)
+
+    def close(self):
+        self.graph.closed = True
+
+
+class _FakeIdentity:
+    GROUP = "edge-test"
+
+    @staticmethod
+    def require_group():
+        return _FakeIdentity.GROUP
+
+    @staticmethod
+    def neo4j_conn():
+        return "bolt://unused", "neo4j", "secret"
+
+
+def _project_offline(graph, slug="projected", *, embed=(0.1, 0.2), **kwargs):
+    """Run the REAL project_artefato against `graph`. `embed=None` makes the embed FAIL (the
+    key/service-down path). Never reads the host: the identity, the driver and the OpenAI client
+    are all injected, and the install/dev key loader is stubbed out."""
+    import types
+    from unittest import mock
+
+    class _Embeddings:
+        @staticmethod
+        def create(*_a, **_k):
+            if embed is None:
+                raise RuntimeError("embedding service down")
+            return types.SimpleNamespace(
+                data=[types.SimpleNamespace(embedding=list(embed))])
+
+    class _OpenAI:
+        def __init__(self, *_a, **_k):
+            self.embeddings = _Embeddings()
+
+    fake_modules = {
+        "_identity": types.SimpleNamespace(
+            require_group=_FakeIdentity.require_group,
+            neo4j_conn=_FakeIdentity.neo4j_conn),
+        "neo4j": types.SimpleNamespace(
+            GraphDatabase=types.SimpleNamespace(
+                driver=lambda _uri, auth=None: _FakeDriver(graph))),
+        "openai": types.SimpleNamespace(OpenAI=_OpenAI),
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        # a NON-canonical log: the destructive backbone rebuild is canonical-log only, so the
+        # projection under test is exactly the Artefato + its edges.
+        kwargs.setdefault("log", Path(tmp) / "log.jsonl")
+        kwargs.setdefault("skill", _LEGACY_SKILL)
+        with mock.patch.dict(sys.modules, fake_modules), \
+                mock.patch.object(publisher, "_load_openai_key", lambda: None):
+            _REAL_PROJECT(slug, "open: x; bet: y", **kwargs)
+    return graph
 
 
 class PublishIsAtomicAndKerneled(unittest.TestCase):
@@ -933,34 +1091,101 @@ class ProjectAfterPublishIsAGuaranteedSideEffect(unittest.TestCase):
         self.assertIn("edge-sandbox-kit", loader)
 
     def test_failed_embed_leaves_projection_incomplete(self):
-        # Codex P2: a FAILED embed (key/service down) must NOT mark the projection complete — the
-        # completion marker is gated on `embed_current`, so recovery retries the embed once creds
-        # recover instead of skipping the slug forever.
-        import inspect
-        src = inspect.getsource(_REAL_PROJECT)
-        self.assertIn("embed_current", src, "project_artefato must track embed success")
-        # the completion marker is gated on embed_current AND no unresolved distills
-        self.assertIn("embed_current and not unresolved_distills", src,
-                      "the completion marker must require a current embedding")
+        # Codex P2: a FAILED embed (key/service down) must NOT mark the projection complete — so
+        # recovery retries the embed once creds recover instead of skipping the slug forever.
+        # BEHAVIOUR, not source text: the same projection runs twice against the same offline
+        # graph, and only the embed differs.
+        down = _project_offline(_FakeGraph(), distills=[], embed=None)
+        self.assertFalse(down.props["projection_complete"],
+                         "a failed embed must leave the projection incomplete")
+        self.assertNotIn("embedding", down.props)   # nothing stale was written either
 
-    def test_unresolved_distill_leaves_projection_incomplete(self):
-        # Codex P2: a distill ref whose cluster is not in the graph yet must leave the projection
-        # INCOMPLETE (so recovery revisits once the grill attaches the cluster), not mark it done.
-        import inspect
-        src = inspect.getsource(_REAL_PROJECT)
-        self.assertIn("unresolved_distills", src,
-                      "project_artefato must track unresolved distills")
-        # the completion marker is conditional on no unresolved distills
-        self.assertIn("not unresolved_distills", src,
-                      "the completion marker must be gated on resolved distills")
+        up = _project_offline(_FakeGraph(), distills=[], embed=(0.1, 0.2))
+        self.assertTrue(up.props["projection_complete"])
+        self.assertEqual(up.props["embedding"], [0.1, 0.2])
+
+    def test_unresolved_distill_is_recorded_pending_and_replayed(self):
+        # SUPERSEDED CONTRACT, kept honest. This test used to demand that an unresolved distill
+        # leave `projection_complete=false`. That gate was deliberately dropped (project_artefato:
+        # "Soft-pending: ... does NOT strand projection_complete=false forever (that hid Artefatos
+        # from recall)") — recall filters on projection_complete=true, so a missing cluster used to
+        # hide the whole Artefato. The INTENT the test guarded survives and is what is asserted
+        # here: the ref is never silently dropped, and recovery revisits the slug once the grill
+        # attaches the cluster.
+        ghost = _project_offline(_FakeGraph(), distills=["cluster:ghost"])
+        self.assertEqual(ghost.props["pending_distills"], ["cluster:ghost"])
+        self.assertEqual(ghost.distills, [])                     # nothing fabricated
+        self.assertTrue(ghost.props["projection_complete"],      # and NOT hidden from recall
+                        "a pending distill must not hide the Artefato from recall")
+
+        # once the cluster exists, the ref links and the pending mark is CLEARED.
+        attached = _project_offline(_FakeGraph(entity_clusters=["Ghost"]),
+                                    distills=["cluster:ghost"])
+        self.assertEqual(attached.distills, ["Ghost"])
+        self.assertNotIn("pending_distills", attached.props)
+
+    def test_pending_distills_keep_the_slug_in_the_recovery_sweep(self):
+        # The other half of the soft-pending contract: "retried on reproject" is only true if the
+        # recovery sweep still VISITS the slug. reproject_graph skips whatever present_slugs()
+        # reports, so a complete-but-pending node must NOT be reported present — otherwise the
+        # pending ref is never retried and the distill is lost for good.
+        import types
+        from unittest import mock
+
+        rows = [{"slug": "settled", "pat": "2026-06-08T00:00:00+00:00", "pending": None},
+                {"slug": "waiting", "pat": "2026-06-08T00:00:00+00:00",
+                 "pending": ["cluster:ghost"]}]
+
+        class _Result(list):
+            pass
+
+        class _Session:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_a):
+                return False
+
+            def run(self, query, **_params):
+                self.query = query
+                return _Result(rows)
+
+        session = _Session()
+
+        class _Driver:
+            def session(self):
+                return session
+
+            def close(self):
+                pass
+
+        fake_modules = {
+            "_identity": types.SimpleNamespace(
+                require_group=_FakeIdentity.require_group,
+                neo4j_conn=_FakeIdentity.neo4j_conn),
+            "neo4j": types.SimpleNamespace(
+                GraphDatabase=types.SimpleNamespace(driver=lambda _uri, auth=None: _Driver())),
+        }
+        with mock.patch.dict(sys.modules, fake_modules):
+            present = publisher._graph_present_slugs()
+        self.assertEqual(present, {"settled": "2026-06-08T00:00:00+00:00"},
+                         "a node with pending distills must stay in the recovery sweep")
 
     def test_distill_resolution_uses_active_clusters_only(self):
         # Codex P2: archived/merged entities are hidden by graph_clusters, so the projection must
         # resolve distills against ACTIVE clusters only (never link/push a retired cluster).
-        import inspect
-        src = inspect.getsource(_REAL_PROJECT)
-        self.assertIn("coalesce(e.archived,false)=false", src)
-        self.assertIn("e.merged_into IS NULL", src)
+        #
+        # This clause IS the contract, and it lives inside Cypher no offline double can evaluate —
+        # so it is asserted, deliberately, as a literal. But against the query the projection
+        # ACTUALLY PUT ON THE WIRE, not against the text of a function: the filter must reach the
+        # database on the live code path, wherever the helper that carries it happens to live.
+        graph = _project_offline(_FakeGraph(entity_clusters=["Alpha"]), distills=["cluster:alpha"])
+        self.assertEqual(graph.distills, ["Alpha"])       # the entity path really ran
+        for query in graph.catalog_queries() + graph.entity_link_queries():
+            self.assertIn("coalesce(e.archived,false)=false", query)
+            self.assertIn("e.merged_into IS NULL", query)
+        self.assertTrue(graph.catalog_queries(), "the cluster catalog query must reach the graph")
+        self.assertTrue(graph.entity_link_queries(), "the DISTILLS link query must reach the graph")
 
     def test_lineage_edges_are_a_fixed_allowlist_directed_this_to_prior(self):
         # Cortex-v1 (brick-1, L4): project_artefato materializes the AUTHORED typed lineage as

--- a/tests/test_rito_runtime.py
+++ b/tests/test_rito_runtime.py
@@ -40,6 +40,18 @@ APPROVED_GENERATOR = Path(
     "/home/vboxuser/edge/drafts/exp072-report-quality/post-gate-grounding-arm/"
     "generate_post_gate_grounding_arm.py")
 
+
+def _approved_generator_present():
+    """The pinned generator lives in ONE operator's draft folder — it is not part of the genotype.
+    Probing it must never decide the fate of this module: on a host where the path's parent is
+    another user's home, `Path.is_file()` RAISES PermissionError (py<3.13) at import time and the
+    WHOLE module fails to load, taking every other rito test — and tests.test_publisher, which
+    drives `_green_run` from here — down with it. Any OSError means "not on this host" → skip."""
+    try:
+        return APPROVED_GENERATOR.is_file()
+    except OSError:
+        return False
+
 # Canned cognitive outputs — scan-clean (no draft/grounding/prompt/harness vocabulary), so the
 # deterministic treatment gates pass and treatment_cleanup takes the deterministic-copy branch.
 CANNED = {
@@ -167,7 +179,7 @@ class RendererPromotionTest(unittest.TestCase):
     def test_renderer_id_is_pinned(self):
         self.assertEqual(render.RENDERER_ID, "exp072-neutral-markdown/v1")
 
-    @unittest.skipUnless(APPROVED_GENERATOR.is_file(), "approved generator not on this host")
+    @unittest.skipUnless(_approved_generator_present(), "approved generator not on this host")
     def test_promoted_renderer_is_byte_identical_to_the_approved_one(self):
         spec = importlib.util.spec_from_file_location("approved_gen", APPROVED_GENERATOR)
         approved = importlib.util.module_from_spec(spec)

--- a/tests/test_wiki_surface.py
+++ b/tests/test_wiki_surface.py
@@ -362,6 +362,18 @@ class TestWikiReachableFromBriefingAndDistills(unittest.TestCase):
     def test_artefato_distills_a_cluster_link_into_the_wiki(self):
         # an Artefato's distilled cluster (`distills: ["cluster:foo"]`) is a live drill-down into the
         # cluster thread — the graph→knowledge bridge from the work feed.
+        #
+        # KNOWN RED — an unresolved conflict between two LIVE documents, deliberately left failing
+        # rather than relaxed (a green bought by dropping this assertion would hide the conflict):
+        #   * PLAN.md §"Slice 5b … Accept" still reads "clusters are reachable from /briefing AND
+        #     from an Artefato's `distills` (not just a standalone route)";
+        #   * commit b4f917a (ADR-0018, "blog home: layout A … artifact chips removed") deleted
+        #     `_artifact_items` from blog/server.py, so `_render_post` no longer emits the
+        #     cites/distills/proposes chips and /wiki/<id> is now linked ONLY from /wiki itself.
+        # The layout decision was intentional; the Slice 5b criterion was never amended to match.
+        # Resolving it is an operator call — either restore a distills→/wiki/<id> affordance in the
+        # feed, or amend PLAN.md Slice 5b to drop the `distills` half of the reachability criterion.
+        # The two sibling tests below still guard the half that survives (the wiki is not orphaned).
         html = self.client.get("/").get_data(as_text=True)
         self.assertIn("/wiki/foo", html)
 

--- a/tools/publisher.py
+++ b/tools/publisher.py
@@ -2505,7 +2505,14 @@ def _graph_present_slugs():
     ONLY as project_artefato's last step) OR STALE (its `projected_at` is older than the log's latest
     published ts for that slug — a republish whose projection never reached the graph). Returns a dict
     `{slug: projected_at}`, or None on a degrade (no group / no driver / unreachable) — the caller then
-    skips the replay entirely (there is nothing to recover into a graph it cannot read)."""
+    skips the replay entirely (there is nothing to recover into a graph it cannot read).
+
+    A node with `pending_distills` is ALSO withheld from the present set. Distills are soft since the
+    projection stopped stranding `projection_complete=false` on an unresolved ref (that hid Artefatos
+    from recall); the promise that replaced the hard gate is "retried on reproject", and that promise
+    is only real if the sweep still VISITS the slug. Filtered in PYTHON, not in the Cypher WHERE, so
+    the rule is provable offline. The mark is REMOVEd as soon as every ref resolves, so a settled
+    slug drops straight back out of the sweep."""
     try:
         import _identity
         from neo4j import GraphDatabase
@@ -2518,7 +2525,9 @@ def _graph_present_slugs():
         with drv.session() as s:
             return {r["slug"]: r["pat"] for r in s.run(
                 "MATCH (a:Artefato {group_id:$g}) WHERE a.projection_complete = true "
-                "RETURN a.slug AS slug, a.projected_at AS pat", g=g)}
+                "RETURN a.slug AS slug, a.projected_at AS pat, "
+                "a.pending_distills AS pending", g=g)
+                if not r["pending"]}
     except Exception:  # noqa: BLE001
         return None
     finally:


### PR DESCRIPTION
Parte de #609. O cluster de testes era o pretexto; **o achado é um bug de produção**, e ele nasceu de uma correção anterior.

## O bug

`project_artefato` deixou de travar `projection_complete=false` num ref de distill não resolvido — decisão **certa**, porque `recall` filtra por `projection_complete=true` e um cluster faltando escondia o Artefato inteiro. O docstring registrou a troca: *"Soft-pending: … does NOT strand projection_complete=false forever (that hid Artefatos from recall)"*.

A promessa que substituiu o portão duro foi *"pending_distills retried on reproject"*. **Ela era falsa.**

`_graph_present_slugs` reportava o nó como presente (`projection_complete=true`), e `reproject_graph` pula todo slug presente e fresco. O ref pendente **nunca era revisitado** — o link se perdia em definitivo. O portão duro foi removido e a rede que deveria substituí-lo não existia.

Correção: nós com `pending_distills` são retirados do conjunto "presente". Filtrado em **Python, não no `WHERE` do Cypher**, de propósito — para a regra ser provável offline. `test_pending_distills_keep_the_slug_in_the_recovery_sweep` é a prova, e ela foi **verificada por mutação**: desfazendo a linha do filtro, o teste fica vermelho.

## Os testes que liam o código-fonte como string

Três testes faziam `inspect.getsource()` e procuravam literais dentro da implementação. `401feee` extraiu a resolução de distills para `_distill_catalog`/`_link_distill` e os quebrou sem mudar comportamento. Cada um recebeu tratamento diferente, e a distinção importa:

- **`test_distill_resolution_uses_active_clusters_only` — o literal FICA.** `coalesce(e.archived,false)=false AND e.merged_into IS NULL` é a única coisa que impede a projeção de ligar um cluster aposentado, vive dentro do Cypher, e nenhum dublê offline avalia um `WHERE`. Reescrever como comportamento exigiria Neo4j vivo e o teste **pularia** em CI — apagando a guarda em silêncio. O que mudou foi contra o que o literal é afirmado: não mais o texto de uma função, mas **as queries que a projeção de fato colocou no fio**, capturadas por um driver falso que grava. Sobrevive a qualquer extração futura e ainda morre no dia em que a cláusula sumir.
- **`test_failed_embed_leaves_projection_incomplete`** → comportamento real: a mesma projeção roda duas vezes, a única diferença sendo embed que falha vs. sucede.
- **`test_unresolved_distill_leaves_projection_incomplete`** → não era vítima de refactor: o contrato foi **deliberadamente invertido**. Reescrito para o contrato atual preservando a intenção original (o ref nunca é descartado), com a supersessão documentada inline.

## Colateral: um módulo inteiro que não carregava

`test_rito_runtime` avaliava `APPROVED_GENERATOR.is_file()` no corpo da classe, sobre `/home/vboxuser/edge/drafts/…` — a casa de **outro usuário**. Em py&lt;3.13, `is_file()` não devolve False quando o pai não é atravessável: `os.stat` levanta `PermissionError`, que escapou em tempo de import e matou o módulo. **33 testes invisíveis**, e `test_publisher` junto (importa `_green_run` de lá). Qualquer `OSError` agora significa "não é neste host" → skip, que é o que o `skipUnless` sempre quis dizer.

## Deixado vermelho de propósito — 1

`test_wiki_surface.test_artefato_distills_a_cluster_link_into_the_wiki`: dois documentos **vivos** se contradizem. O `PLAN.md` §Slice 5b ainda exige que clusters sejam alcançáveis *"from an Artefato's `distills`"*; o `b4f917a` (ADR-0018) removeu os chips de artefato do feed de propósito. Não afrouxei a asserção (verde compraria o silêncio) nem restaurei a ponte (é decisão de UI que a ADR tomou). O teste carrega as duas saídas possíveis nomeadas.