### PR TITLE
fix(blog): _bootstrap_install_env foi apagada em silêncio — e dois módulos não carregavam

### DIFF
--- a/.agents/skills/edge-autonomia/SKILL.md
+++ b/.agents/skills/edge-autonomia/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: edge-autonomia
+description: Edge wrapper for autonomia. Select @edge-autonomia in the skills picker (or ask for `edge-autonomia` by name) to follow the canonical skills/autonomia/SKILL.md contract.
+---
+Select this skill as `@edge-autonomia` (or name `edge-autonomia` in the prompt). Then read `skills/autonomia/SKILL.md` completely and follow it as the active Edge skill. This wrapper exists only to expose the repo-local Codex skill name `edge-autonomia`; do not duplicate or reinterpret the canonical contract here.

--- a/.agents/skills/edge-onboard/SKILL.md
+++ b/.agents/skills/edge-onboard/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: edge-onboard
+description: Edge wrapper for onboard. Select @edge-onboard in the skills picker (or ask for `edge-onboard` by name) to follow the canonical skills/onboard/SKILL.md contract.
+---
+Select this skill as `@edge-onboard` (or name `edge-onboard` in the prompt). Then read `skills/onboard/SKILL.md` completely and follow it as the active Edge skill. This wrapper exists only to expose the repo-local Codex skill name `edge-onboard`; do not duplicate or reinterpret the canonical contract here.

--- a/.agents/skills/edge-setup/SKILL.md
+++ b/.agents/skills/edge-setup/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: edge-setup
+description: Edge wrapper for setup. Select @edge-setup in the skills picker (or ask for `edge-setup` by name) to follow the canonical skills/setup/SKILL.md contract.
+---
+Select this skill as `@edge-setup` (or name `edge-setup` in the prompt). Then read `skills/setup/SKILL.md` completely and follow it as the active Edge skill. This wrapper exists only to expose the repo-local Codex skill name `edge-setup`; do not duplicate or reinterpret the canonical contract here.

--- a/blog/server.py
+++ b/blog/server.py
@@ -1512,13 +1512,47 @@ def _cortex_live(group):
             pass
 
 
+def _bootstrap_install_env():
+    """Load install secrets/*.env into os.environ once per process.
+
+    The cortex fold needs EDGE_NEO4J_PASSWORD; when the process is started without a unit that
+    exports secrets (bare `python blog/server.py`), the password sits in secrets/neo4j.env and
+    never reaches os.environ → cortex_fold goes dark even though neo4j is up. This loads the
+    install's secrets dir (agent.yaml edge_home/secrets, else <repo>/secrets) without hardcoding
+    host paths. Env already set wins (same contract as tools/_secrets.load_env).
+    """
+    tools = str(BASE.parent / "tools")
+    if tools not in sys.path:
+        sys.path.insert(0, tools)
+    try:
+        import _secrets
+        import _identity
+        env_dir = _identity._env_dir()
+        _secrets.load_env(env_dir)
+        # Also source the repo-adjacent secrets/ when edge_home ≠ checkout (common on fleet
+        # members whose agent.yaml points at ~/edge while the process cwd is the same tree).
+        repo_secrets = BASE.parent / "secrets"
+        if repo_secrets.resolve() != Path(env_dir).resolve():
+            _secrets.load_env(repo_secrets)
+    except Exception:
+        try:
+            import _secrets
+            _secrets.load_env(BASE.parent / "secrets")
+        except Exception:
+            pass
+
+
 def _neo4j_password():
     """The install's neo4j password via _identity (genotype tool), or the env fallback. Imported
-    lazily so the blog runs even where tools/ is absent."""
+    lazily so the blog runs even where tools/ is absent. Always re-attempts the secrets load so a
+    process that started before secrets were present can recover without a hard-coded password."""
+    _bootstrap_install_env()
     try:
-        sys.path.insert(0, str(BASE.parent / "tools"))
+        tools = str(BASE.parent / "tools")
+        if tools not in sys.path:
+            sys.path.insert(0, tools)
         import _identity
-        return _identity.neo4j_password()
+        return _identity.neo4j_password() or os.environ.get("EDGE_NEO4J_PASSWORD")
     except Exception:
         return os.environ.get("EDGE_NEO4J_PASSWORD")
 
@@ -1526,8 +1560,11 @@ def _neo4j_password():
 def _group():
     """The install's graph group_id via _identity (EDGE_GROUP → agent.yaml). None if unresolved →
     the fold goes dark rather than running an unscoped, cross-install query."""
+    _bootstrap_install_env()
     try:
-        sys.path.insert(0, str(BASE.parent / "tools"))
+        tools = str(BASE.parent / "tools")
+        if tools not in sys.path:
+            sys.path.insert(0, tools)
         import _identity
         return _identity.group()
     except Exception:
@@ -2719,6 +2756,8 @@ def sources_panel():
 
 # Migrate on import so the very first read surface (index / chat) already reflects the switch.
 _migrate_voz_lifecycle()
+# Load install secrets at import (systemd/WSGI/bare python) so cortex is not dark for lack of env.
+_bootstrap_install_env()
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,7 @@ neo4j==6.2.0
 openai==2.41.0
 flask==3.0.3
 PyYAML==6.0.3
-vl-convert-python
+# the visual backend (tools/render.py's closed Vega recipe set) — pinned like every other
+# runtime dep: f40c4cd landed it unpinned, so two hosts provisioned from the same genotype could
+# render different SVG bytes. The pin is the version the recipe set was verified on.
+vl-convert-python==1.9.0.post1

--- a/tests/test_apply_authoritative.py
+++ b/tests/test_apply_authoritative.py
@@ -5,16 +5,27 @@ The Codex gate finding: after provisioning, edge-apply called `validate_install`
 `_healthy`, and exited 0 UNCONDITIONALLY — a fresh install "finished successfully" even when identity
 validation FAILED. The `--validate` path had the same missing agent_yaml arg.
 
-This guards the fix on the `--validate` path (offline — no venv/docker provisioned):
+This guards the fix on the `--validate` path:
   • a THIN applied agent.yaml (no declared sources → briefing fail-closed) makes the IDENTITY check
     FAIL, and edge-apply exits NONZERO (today it would read the checkout default and pass);
-  • a COMPLETE applied agent.yaml keeps identity OK and the install HEALTHY → exit 0.
+  • a COMPLETE applied agent.yaml keeps identity OK — the SAME substrate, the applied config the only
+    variable, which is exactly the claim "identity validates the APPLIED config, not the default".
 
-Invoked via subprocess (the test_beat_launch.py pattern). `--home` defaults to the real edge_home
-(genuinely healthy substrate); only `--claude-home` is pointed at a tmp dir so the run never touches
-the real ~/.claude. The applied agent.yaml is the only variable — proving identity now validates the
-APPLIED config, not the checkout default.
+Host-independence: the run is pointed at a THROWAWAY install tree (`--home`, plus `EDGE_HOME` so
+`briefing`'s doctrine/identity paths resolve there too) built from the versioned genotype —
+`seeds/memory/` for the doctrine, the checkout's own `skills/` + `blog/server.py` for the genotype
+leg. Before, `--home` was left DEFAULT, i.e. whatever install the person running the suite happens to
+have: on a genotype the whole report came back broken, and on a live install it depended on that
+host's venv and neo4j. The applied agent.yaml is the only variable, on every host.
+
+The health/exit-0 leg is different in kind: `--validate` runs the venv + graph probes, so
+INSTALL HEALTHY asserts a genuinely PROVISIONED install (a built `.venv`, a reachable neo4j with a
+populated group) — real install data no throwaway tree can honestly supply. It is asserted where the
+substrate is actually healthy and SKIPPED with the substrate's own [XX] lines as the declared reason
+where it is not, rather than being faked or dropped.
 """
+import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -23,6 +34,8 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 APPLY = REPO / "tools" / "edge-apply"
+SEEDS_MEMORY = REPO / "seeds" / "memory"
+LAYOUT_DIRS = ("blog/entries", "state", "memory", "threads", "secrets")
 
 # A THIN applied config: declares no sources → briefing source_roster is fail-closed → identity FAIL.
 THIN_YAML = "name: probe\n"
@@ -40,16 +53,39 @@ sources:
 """
 
 
+def _install_tree(tmp):
+    """Build the THROWAWAY install home under `tmp` and return it.
+
+    Everything the substrate checks read comes from the VERSIONED genotype, never from the host's
+    own install: the layout dirs, `skills/` + `blog/server.py` (the genotype leg) and the canonical
+    doctrine from `seeds/memory/` (the seed an install's `memory/` is provisioned from — the
+    genotype itself has no `memory/`, it is an output of onboarding).
+    """
+    home = Path(tmp) / "home"
+    for d in LAYOUT_DIRS:
+        (home / d).mkdir(parents=True, exist_ok=True)
+    (home / "skills").symlink_to(REPO / "skills", target_is_directory=True)
+    shutil.copy(REPO / "blog" / "server.py", home / "blog" / "server.py")
+    for doc in ("personality.md", "method.md", "canone.md"):
+        shutil.copy(SEEDS_MEMORY / doc, home / "memory" / doc)
+    return home
+
+
 def _run_validate(yaml_text):
-    """Run `edge-apply --yaml <tmp> --validate --claude-home <tmp>` and return the CompletedProcess.
-    --home is left default (the real edge_home, a genuinely healthy substrate); only the applied
-    agent.yaml and --claude-home vary, so the run stays offline and never touches the real ~/.claude."""
+    """Run `edge-apply --yaml <tmp> --validate` against the throwaway tree; the applied agent.yaml is
+    the only variable. `--claude-home` also points at tmp so the run never touches the real
+    ~/.claude, and EDGE_HOME points at the throwaway home so the briefing composer resolves the
+    seeded doctrine there instead of the runner's install."""
     with tempfile.TemporaryDirectory() as tmp:
+        home = _install_tree(tmp)
         y = Path(tmp) / "agent.yaml"
         y.write_text(yaml_text)
+        env = dict(os.environ, EDGE_HOME=str(home))
+        env.pop("EDGE_GROUP", None)
         return subprocess.run(
-            [sys.executable, str(APPLY), "--yaml", str(y), "--validate", "--claude-home", tmp],
-            capture_output=True, text=True,
+            [sys.executable, str(APPLY), "--yaml", str(y), "--validate",
+             "--home", str(home), "--claude-home", tmp],
+            capture_output=True, text=True, env=env,
         )
 
 
@@ -62,10 +98,20 @@ class ValidateIsAuthoritativeOverAppliedConfig(unittest.TestCase):
         # AUTHORITATIVE: an unhealthy report exits NONZERO.
         self.assertNotEqual(res.returncode, 0, res.stdout + res.stderr)
 
-    def test_complete_applied_yaml_is_healthy_and_exits_zero(self):
+    def test_complete_applied_yaml_passes_identity(self):
         res = _run_validate(COMPLETE_YAML)
         self.assertIn("[OK] identity:", res.stdout, res.stdout + res.stderr)
-        self.assertIn("INSTALL HEALTHY", res.stdout)
+
+    def test_healthy_report_exits_zero(self):
+        """The other direction of the AUTHORITATIVE contract: a HEALTHY report exits 0.
+
+        Needs a genuinely provisioned install (venv built, neo4j reachable and the group populated);
+        those probes read real install data, which a throwaway tree cannot supply without inventing
+        it. Where the substrate is not provisioned this SKIPS with the failing checks named."""
+        res = _run_validate(COMPLETE_YAML)
+        if "INSTALL HEALTHY" not in res.stdout:
+            broken = [ln.strip() for ln in res.stdout.splitlines() if ln.strip().startswith("[XX]")]
+            self.skipTest("substrate not provisioned on this host: " + "; ".join(broken))
         self.assertEqual(res.returncode, 0, res.stdout + res.stderr)
 
 

--- a/tests/test_briefing_lifecycle.py
+++ b/tests/test_briefing_lifecycle.py
@@ -9,10 +9,17 @@ the corpus it should.
 
 Each stage builds from a THROWAWAY tree (CONTRACT C1 — never the real `state/`): a fresh temp log,
 a temp `agent.yaml` (identity + a non-empty `sources` list + `ground_truth.documents` pointing at
-temp CONTEXT glossaries), and the REAL `memory/` doctrine COPIED into a temp `memory/` (so the
-content is the genuine personality/method doctrine while `state_dir` resolves to the temp tree, not
-real `state/idiom.md`). Offline: `clusters=None` (no graph), the roster is read from the real
-`agent.yaml` read-only (the REAL declared roster the audit's stage-(i) row 4 demands).
+temp CONTEXT glossaries), and the CANONICAL `seeds/memory/` doctrine COPIED into a temp `memory/`
+(so the content is the genuine personality/method/canone doctrine while `state_dir` resolves to the
+temp tree, not real `state/idiom.md`). Offline: `clusters=None` (no graph), the roster is read from
+the versioned `tests/fixtures/roster.agent.yaml` (the DECLARED roster the audit's stage-(i) row 4
+demands).
+
+Host-independence: the genotype has, BY CONTRACT, no `agent.yaml` and no `memory/` — both are
+outputs of onboarding. Reading them at import time made this whole module fail to LOAD on a
+genotype (`unittest.loader._FailedTest`, hiding every test here). `seeds/memory/` is the versioned
+seed the install's `memory/` is provisioned FROM, and `tests/fixtures/roster.agent.yaml` the
+versioned declared phenotype — same doctrine, same roster, on any host.
 """
 import shutil
 import sys
@@ -27,17 +34,22 @@ import eventlog    # noqa: E402
 import briefing    # noqa: E402
 import grill_gate  # noqa: E402
 
-# The REAL declared source roster, read from the real agent.yaml READ-ONLY (never state/). The
-# audit's stage-(i) row 4 requires the briefing inject the REAL roster, not a generic inference.
-REAL_ROSTER = briefing.source_roster(agent_yaml=REPO / "agent.yaml")
+ROSTER_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "roster.agent.yaml"
+SEEDS_MEMORY = REPO / "seeds" / "memory"
+
+# The DECLARED source roster, read READ-ONLY from the versioned fixture (never state/, never the
+# host's agent.yaml). The audit's stage-(i) row 4 requires the briefing inject the DECLARED roster,
+# not a generic inference — the fixture is that declaration, identical on every host.
+REAL_ROSTER = briefing.source_roster(agent_yaml=ROSTER_FIXTURE)
 
 
 def _genotype(tmp):
     """Build a throwaway genotype tree under `tmp` and return (agent_yaml, memory, log).
 
-    - memory/: the REAL doctrine (personality.md.tpl + method.md) COPIED in, so the briefing's
-      tattoos carry the genuine content while `state_dir` (memory.parent/state) stays the temp
-      tree — no read of the real `state/idiom.md` (CONTRACT C1).
+    - memory/: the canonical doctrine from `seeds/memory/` (personality + method + canone) COPIED
+      in, so the briefing's tattoos carry the genuine content while `state_dir`
+      (memory.parent/state) stays the temp tree — no read of the real `state/idiom.md`
+      (CONTRACT C1).
     - agent.yaml: full identity (name/mission/voice — the personality `.tpl` substitutes them),
       a non-empty `sources` list, and `ground_truth.documents` pointing at a temp CONTEXT glossary.
     - log: a path under tmp (the fresh, empty log each stage starts from).
@@ -45,9 +57,8 @@ def _genotype(tmp):
     tmp = Path(tmp)
     memory = tmp / "memory"
     memory.mkdir(parents=True, exist_ok=True)
-    shutil.copy(REPO / "memory" / "personality.md.tpl", memory / "personality.md.tpl")
-    shutil.copy(REPO / "memory" / "method.md", memory / "method.md")
-    shutil.copy(REPO / "memory" / "canone.md", memory / "canone.md")
+    for doc in ("personality.md", "method.md", "canone.md"):
+        shutil.copy(SEEDS_MEMORY / doc, memory / doc)
     (tmp / "state").mkdir(parents=True, exist_ok=True)  # temp state_dir; intentionally no idiom.md
 
     glossary = tmp / "project-CONTEXT.md"
@@ -98,7 +109,12 @@ class StageIFreshInstall(unittest.TestCase):
             self.assertIn("### Personality", out)
             self.assertIn("distrust the rationality, not the person", out)  # real personality doctrine
             self.assertIn("### Method", out)
-            self.assertIn("Feynman Method", out)                            # real method doctrine
+            # the method doctrine is anchored by its SUBSTANCE, not by a label: e4db5de rewrote
+            # seeds/memory/method.md from "Feynman Method" to "The Method — o abate". The two
+            # engines identify the text; the old bigram identified only the old heading
+            # (same anchor test_briefing.py already uses).
+            self.assertIn("Feynman", out)                                   # o motor de derivação
+            self.assertIn("o abate", out)                                   # o motor de abate
             # Idiom glossary FLOOR — the temp ground_truth.documents content is injected
             self.assertIn("## Idiom", out)
             self.assertIn("the act that yields a decision", out)            # the temp CONTEXT glossary
@@ -136,6 +152,11 @@ class StageIIAfterGrill(unittest.TestCase):
             grill_writeback.leveling(
                 "diario", "sem update de persona; residual = lifecycle audit",
                 root=Path(tmp) / "leveling", log=log)
+            # the wayfind MAPA — grill_gate's fifth stage-(ii) piece (operator 2026-07-28):
+            # Direction is the direção, the map is the MAPA, and every mentor updates both.
+            eventlog.open_map(operacao="edge", titulo="Mapa do close",
+                              rationale="o mapa que acompanha o steer do close",
+                              dispatch_id="lifecycle-map", author="grill", log=log)
 
             # the post-grill gate confirms no stage-(ii) gap remains
             self.assertEqual(grill_gate.grill_complete(log=log), [])

--- a/tests/test_codex_skill_wrappers.py
+++ b/tests/test_codex_skill_wrappers.py
@@ -4,28 +4,30 @@ The Edge skill contract stays canonical under skills/<slug>/SKILL.md. Codex disc
 repo-local skills from .agents/skills, so every user-facing Edge skill gets small prefixed
 wrappers that point back to the canonical file instead of duplicating it. These are Codex
 skills selected with @ / /skills, not slash commands.
+
+Prefix: `.agents/skills/` is REPO-LOCAL, versioned genotype content — it ships with the
+checkout, unlike CODEX_HOME/skills which `_codex_provision` renders per install from the
+phenotype's tool_prefix/skill_prefix. So the prefix this file checks is the **stable family
+alias** `edge-*` (`_grok_provision.grok_prefixes`: "tool_prefix keeps the stable family alias
+(edge-*)"), not whatever the person running the suite happens to have in their agent.yaml.
+Before, both prefixes were read from `REPO/agent.yaml` with an `or "edge"` genotype fallback —
+but the read was `.read_text()`, which RAISES on the genotype (no agent.yaml by contract)
+instead of falling back, so both tests here errored at that line and the coverage check they
+exist for never ran on any clean checkout.
 """
 from pathlib import Path
-import re
 import unittest
 
 REPO = Path(__file__).resolve().parent.parent
 
-
-def _agent_yaml_value(key: str) -> str:
-    text = (REPO / "agent.yaml").read_text()
-    match = re.search(rf"(?m)^\s*{re.escape(key)}:\s*[\"']?([^\"'\n#]+)", text)
-    if not match:
-        return ""
-    return match.group(1).strip()
+# The stable family alias every versioned repo-local wrapper carries (install-specific aliases
+# like ed-*/roberto-* are rendered per host by _codex_provision, not required of the checkout).
+PREFIXES = ("edge",)
 
 
 class CodexSkillWrappers(unittest.TestCase):
     def test_every_edge_skill_has_prefixed_codex_wrappers(self):
-        prefixes = {
-            _agent_yaml_value("tool_prefix") or "edge",
-            _agent_yaml_value("skill_prefix") or _agent_yaml_value("codename") or "edge",
-        }
+        prefixes = PREFIXES
 
         missing = []
         for skill_file in sorted((REPO / "skills").glob("*/SKILL.md")):
@@ -46,11 +48,7 @@ class CodexSkillWrappers(unittest.TestCase):
         self.assertEqual(missing, [])
 
     def test_shared_skill_is_not_invocable_in_codex(self):
-        prefixes = {
-            _agent_yaml_value("tool_prefix") or "edge",
-            _agent_yaml_value("skill_prefix") or _agent_yaml_value("codename") or "edge",
-        }
-        for prefix in prefixes:
+        for prefix in PREFIXES:
             self.assertFalse((REPO / ".agents" / "skills" / f"{prefix}-_shared").exists())
 
 

--- a/tests/test_llm_routes.py
+++ b/tests/test_llm_routes.py
@@ -166,9 +166,17 @@ class CompleterFor(unittest.TestCase):
         self.assertEqual(seen["model"], "grok-4.5")
 
     def test_api_route_without_key_raises_transport_error(self):
+        # hermético (mesma cura de test_credential_present_vs_absent): a rota chat é openai e
+        # o que se cobra é a AUSÊNCIA da chave. Um OPENAI_API_KEY exportado no ambiente de quem
+        # roda a suíte vence o secrets/ do repo temporário (override explícito vence, como
+        # _secrets.load_env) e o transporte resolve — o teste passava ou falhava conforme o HOST
+        # tivesse chave, medindo a instalação em vez do código.
+        from unittest import mock
+        env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
         repo = temp_repo(openai_key=None)
-        with self.assertRaises(_llm.LLMTransportError):
-            llm_routes.completer_for("chat", repo=repo)
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(_llm.LLMTransportError):
+                llm_routes.completer_for("chat", repo=repo)
 
 
 if __name__ == "__main__":

--- a/tests/test_rito_runtime.py
+++ b/tests/test_rito_runtime.py
@@ -40,6 +40,22 @@ APPROVED_GENERATOR = Path(
     "/home/vboxuser/edge/drafts/exp072-report-quality/post-gate-grounding-arm/"
     "generate_post_gate_grounding_arm.py")
 
+
+def _approved_generator_present():
+    """Is the exp072 arm's generator readable HERE? — the byte-identity check below is a
+    HOST-SPECIFIC luxury (the draft tree lives in the author's install, never in the genotype).
+
+    `Path.is_file()` is not a safe probe for an absolute path outside our own home: on a host
+    where `/home/<other>` exists but is not traversable, `os.stat` raises PermissionError
+    instead of returning False. That escaped the `skipUnless` argument at CLASS-BODY time, so
+    the whole MODULE failed to import (`unittest.loader._FailedTest`) and every test in this
+    file — the rite's stage table, the detector, the publisher seam — silently vanished from
+    the suite. Any OSError means 'not available on this host', which is exactly a skip."""
+    try:
+        return APPROVED_GENERATOR.is_file()
+    except OSError:
+        return False
+
 # Canned cognitive outputs — scan-clean (no draft/grounding/prompt/harness vocabulary), so the
 # deterministic treatment gates pass and treatment_cleanup takes the deterministic-copy branch.
 CANNED = {
@@ -167,7 +183,7 @@ class RendererPromotionTest(unittest.TestCase):
     def test_renderer_id_is_pinned(self):
         self.assertEqual(render.RENDERER_ID, "exp072-neutral-markdown/v1")
 
-    @unittest.skipUnless(APPROVED_GENERATOR.is_file(), "approved generator not on this host")
+    @unittest.skipUnless(_approved_generator_present(), "approved generator not on this host")
     def test_promoted_renderer_is_byte_identical_to_the_approved_one(self):
         spec = importlib.util.spec_from_file_location("approved_gen", APPROVED_GENERATOR)
         approved = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
Parte de #609. **9 vermelhos → 2**, e os 2 que ficam são a #614.

## Bug de produção: uma correção apagada sem uma palavra

`3d504c8` (12/07, *"fix(cortex): blog secrets bootstrap"*) criou `_bootstrap_install_env()` porque o blog subia **sem `EDGE_NEO4J_PASSWORD`** e o cortex ficava dark com o neo4j de pé.

`db73704` (*"feat(mineracao+episteme)"*) apagou a função, as duas chamadas e o hook de import. A mensagem do commit não menciona nada disso, e **nada a substituiu**. Restaurada.

Verificado: a função existia em `3d504c8:blog/server.py` com 4 ocorrências.

## Bug de produção: pin frouxo no genótipo

`f40c4cd` trouxe `vl-convert-python` **sem `==`**, violando o contrato de pin exato (#20). É o backend visual do `tools/render.py` — dois hosts provisionados do mesmo genótipo podiam renderizar bytes de SVG diferentes. Pinado em `1.9.0.post1`, a versão realmente instalada aqui.

## Dois módulos que não carregavam escondiam 36 testes

O unittest contava **1 vermelho** para cada; eram 33 + 3.

- `test_rito_runtime`: `is_file()` sobre a casa de outro usuário levanta `PermissionError` em py&lt;3.13, e isso escapava no corpo da classe. Mesmo diagnóstico a que o cluster do publisher chegou por conta própria (#621) — resolvido lá, mantido aqui.
- `test_briefing_lifecycle`: lia `REPO/agent.yaml` e `REPO/memory/`. Duas asserções envelhecidas vieram junto: o rótulo `"Feynman Method"` que a doutrina abandonou, e um grill simulado que não fechava `wayfind` — a quinta peça do `grill_gate` desde 2026-07-28, a mesma do #604.

## Host-dependência (3)

`test_llm_routes` passava ou falhava conforme o host ter `OPENAI_API_KEY` no ambiente. `test_apply_authoritative` usava a instalação de quem roda como `--home` default — chegou a **contar entidades do grupo `ed` no neo4j vivo**. `test_codex_skill_wrappers` fazia `.read_text()` em `REPO/agent.yaml` com um `or "edge"` logo abaixo: a leitura **levanta**, nunca cai no fallback.

## Lacuna real revelada pelo conserto da carga

`setup`, `autonomia` e `onboard` (skills de 2026-07-13) nunca ganharam wrapper `.agents/skills/edge-*` — o conjunto é de 2026-07-06 e ninguém o atualizou. Escritos no molde exato dos 23 existentes.

## Precisa da sua decisão

`fea9407` acrescentou `.agents/` ao `.gitignore` **no mesmo commit** em que adicionou arquivos rastreados ali dentro — 48 seguem rastreados, e os 3 wrappers novos precisaram de `git add -f`. Se `.agents/` é saída de install e não genótipo, quem deveria mudar é o teste, não o `.gitignore`.

## Fica vermelho: 2, ambos #614

`test_codex_provision` e `test_grok_provision` — a mesma contradição `/nome` vs `@nome` de `test_apply_codex`/`grok`. Verde só sairia afrouxando a guarda ou mudando o produto.