### PR TITLE
fix(provision): o Codex invoca por @ e o Grok por barra — o conserto é assimétrico

### DIFF
--- a/tests/test_apply_grok.py
+++ b/tests/test_apply_grok.py
@@ -58,7 +58,9 @@ class ApplyGrok(unittest.TestCase):
             self.assertIn(f"name: {name}", text)
             self.assertIn(f"@{name}", text)
             self.assertIn(str(self.edge_home / "skills" / "wake" / "SKILL.md"), text)
-            self.assertNotIn(f"/{name}", text)
+            # O Grok invoca skill por SLASH — ao contrário do Codex, que é @ (palavra do
+            # operador, 2026-08-16). Este assertNotIn exigia o contrário do produto.
+            self.assertIn(f"/{name}", text)
 
     def test_stdout_reports_grok_home(self):
         self.assertIn("provisionando Grok skills", self.res.stdout)

--- a/tests/test_grok_provision.py
+++ b/tests/test_grok_provision.py
@@ -52,7 +52,10 @@ class TestGrokProvision(unittest.TestCase):
                 self.assertIn(f"name: {prefix}-{skill_dir.name}", text)
                 self.assertIn(f"@{prefix}-{skill_dir.name}", text)
                 self.assertIn(str(self.edge_home / "skills" / skill_dir.name / "SKILL.md"), text)
-                self.assertNotIn(f"/{prefix}-{skill_dir.name}", text)
+                # O Grok invoca skill por SLASH (palavra do operador, 2026-08-16) — ao contrário do
+                # Codex, que é @. Este assertNotIn exigia o contrário do produto e
+                # deixava o teste vermelho contra código correto.
+                self.assertIn(f"/{prefix}-{skill_dir.name}", text)
 
     def test_shared_skill_is_not_global_invocable(self):
         gp.provision_grok(CFG, REPO, self.edge_home, self.grok_home)

--- a/tools/_codex_provision.py
+++ b/tools/_codex_provision.py
@@ -41,8 +41,12 @@ def render_codex_skill(*, slug: str, prefix: str, canonical_skill: Path) -> str:
     return (
         "---\n"
         f"name: {name}\n"
-        f"description: \"Edge `{slug}` (`/{name}` / `@{name}`). Use when the user invokes "
-        f"`/{name}`, `@{name}`, or asks for Edge {slug} (wake, mentor, beat, report, …). "
+        # O Codex invoca skill por `@nome`, NUNCA por slash (palavra do operador, 2026-08-16).
+        # Anunciar `/nome` aqui ensina o modelo a sugerir um comando que não existe nesta
+        # superfície — e a description é justamente o que decide quando a skill ativa. O grok é
+        # o oposto (barra), e por isso os dois provisionadores divergem de propósito.
+        f"description: \"Edge `{slug}` (`@{name}`). Use when the user invokes "
+        f"`@{name}` or asks for Edge {slug} (wake, mentor, beat, report, …). "
         f"Then read `{canonical}` completely and follow that contract.\"\n"
         "---\n"
         f"You are running the Edge skill **{name}**.\n\n"


### PR DESCRIPTION
Closes #614.

A informação que faltava veio do operador: **Codex = `@nome`, Grok = `/nome`**. Nem os docs do repo nem `codex --help` respondiam isso, e por isso eu não decidi sozinho.

Com ela, a contradição se resolve **nos dois sentidos opostos**:

| | quem estava errado | conserto |
|---|---|---|
| **Codex** | o **código** | a barra sai da `description` |
| **Grok** | os **testes** | `assertNotIn` → `assertIn` |

### Codex
`_codex_provision` anunciava `(/nome / @nome)`. Anunciar invocação que não existe naquela superfície ensina o modelo a sugerir comando inexistente — e a `description` é o que decide quando a skill ativa.

Os testes já afirmavam isso desde `cc411a0` (*"Fix Codex skill installation for Edge"*, 06/07) e **estavam certos o tempo todo**. `18dc349` (19/07) desfez a correção sem dizer — o mesmo commit dos 37 órfãos da #612.

### Grok
`test_apply_grok` e `test_grok_provision` copiaram o `assertNotIn` do codex e passaram a exigir o contrário do produto: vermelho contra código correto.

Os dois provisionadores divergem agora **de propósito**, e o comentário no código diz por quê — para a próxima cópia-e-cola não reintroduzir a simetria falsa.