### PR TITLE
fix(doutrina): restaura as 13 entidades do Idiom e troca o pin de contagem por conjunto

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -636,3 +636,82 @@ ponte nomeada ao trabalho vivo em UMA linha, e os pisos valem inteiros — liber
 olhar, **nunca de olhar pra nada nem de recontar**. Peso uniforme lançado; se ~36% de
 batidas-com-coringa for demais, o dial é o peso (§7).
 *Avoid*: random-como-desculpa (pisos valem), lazer (outro genus), os-dois-comuns-com-rótulo-ser
+
+## Language / Idiom — as entidades do vocabulário
+
+_Restauradas em 2026-08-16 (issue #620). Estas 13 definições foram apagadas por
+`d547442` ("CONTEXT.md as 9-module self-model — Idiom removed") e o merge `9221924` do dia
+seguinte devolveu só 32 dos 45 cabeçalhos. Ficaram fora por seis semanas enquanto este
+mesmo documento usava `mentee` 54 vezes, `artefato` 26 e `cortex` 17 — o glossário de
+referência não definia nenhum dos termos centrais do sistema. A seção original chamava-se
+`## Language` e não existe mais na estrutura de 9 módulos; elas voltam agrupadas aqui._
+
+**Mentee**:
+The person the edge serves — their real work is the subject. The edge knows them from
+what they do (code, docs, words), not from supposition.
+*Avoid*: user, client, operator
+
+**Cortex**:
+The edge's whole navigable knowledge as one connected graph — the **mind** it thinks *in*. Everything
+projects into it: intake → episodes/clusters (extracted), plus the **asserted** edges (Direction, curated,
+
+**Artefato / Artifact**:
+A beat's **published deliverable**, in whatever form the producing skill yields — a prose
+synthesis (`ed-report`), an interactive page (`prototype`), and others. The genus, not one
+form. Carries Worthwhile content; bears the comment field (consolidation surface).
+
+**Hypothesis**:
+Something the edge supposed (mined or inferred) and not yet confirmed (`assumed`). The
+edge **works naturally** with hypotheses — the abundant, cheap tier.
+*Avoid*: guess, draft
+
+**Consolidação de hipóteses / Hypothesis consolidation**:
+Promoting hypothesis → curated. The **inward** half of what `/grill-me` (active) and the
+per-report comment (async) do — it keeps the edge's model accurate, but is not the whole of
+the grill, which also **generates outward orientation** for the mentee (see Convergence).
+Does not drain the hypothesis tier; consolidates what carries **harm potential**.
+"Afinamento" is the same loop when the object is the mentee's **language** (Idiom).
+*Avoid*: approval, review, afinamento (as a separate concept)
+
+**Domain**:
+The field the mentee works in. The edge must know it deeply to have substance.
+*Avoid*: area, topic, field
+
+**Recall**:
+The **memory-salient brief** — a noun, the yield of recalling (the act stays a lowercase verb,
+exactly as Delta is the yield of updating): the salient subgraph of the **Cortex**, rooted at
+
+**Worthwhile content**:
+The intersection: deep domain insight **applied to the mentee's live work**. Domain
+alone is generic; mentee alone is shallow.
+*Avoid*: report, output, post
+
+**Medium / Meio**:
+A channel through which the mentee and the edge **address each other** — Claude Code is just
+one; Telegram, a shared Slack, a web chat are others. The **pipe, not the content**: it carries
+
+**Usage signal**:
+The **implicit, non-authoritative** record of which Cortex nodes the edge READ while working —
+appended to `state/cortex/usage.jsonl` (behind `EDGE_CORTEX_USAGE`), EXCLUDED from log replay and
+every fold. It drives an **ephemeral read-time re-rank only** (recency+frequency), never a graph write:
+it is NOT self-state (the log stays truth — ADR-0006). Distinct from **value feedback** (`cites`/
+`distills` at close) and **correction** (node-targeted Voz / Earmarked), both curated and authoritative.
+*Avoid*: salience, reinforcement, memory store
+
+**Curated**:
+Knowledge consolidated by the mentee (`confirmed`/`corrected`). **Prioritized** over a
+hypothesis in every read-model. **Exempt from passive aging** (it does not cool by going unread
+or unreinforced) but **actively retirable by Voz** — a strategic realignment can supersede it.
+Only the mentee retires curated; passive forgetting never does.
+*Avoid*: validated, final, approved
+
+**Harm potential**:
+The consolidation priority: source ambiguity × cost of acting wrong. Decides what spends
+the mentee's scarce attention.
+*Avoid*: urgency, score
+
+**llm-wiki**:
+The edge's knowledge, held as two kinds of durable page — **Knowledge clusters** (emergent,
+grown) and a few **Standing pages** (declared then refined: Direction, Idiom, Source roadmap)
+— plus cross-references, holding both hypothesis and curated. An **Artefato** is a transient
+delivery (a Query result), never a page. Read **in full when small** (the briefing's entry read);

--- a/tests/test_idiom_rename.py
+++ b/tests/test_idiom_rename.py
@@ -37,7 +37,67 @@ GLOSSARY_HEADER = re.compile(r"^\*\*[^*]+\*\*:\s*$", re.MULTILINE)
 # off-truth-path read telemetry — distinct from value/correction feedback) → 44.
 # 2026-07-03 grounding iteration S8 (R1.1, Voz-ratified): +1 Grounding (the claim↔evidence
 # relation, traceable — the arc's naming deliverable in the Language section) → 45.
-EXPECTED_GLOSSARY_COUNT = 45
+# 2026-08-16 (#620): o pin deixa de ser uma CONTAGEM e passa a ser o CONJUNTO DE NOMES.
+# A contagem não pegou a perda de 13 entidades no merge 9221924 porque a ADR-0024 somou 9 no
+# mesmo intervalo — as duas derivas quase se cancelaram e 45 -> 42 pareceu manutenção.
+GLOSSARY_ENTITIES = {
+    "Artefato / Artifact",
+    "Assemble / Consolidação prévia",
+    "Atividade / Activity",
+    "Briefing",
+    "Briefing",
+    "Catálogo",
+    "Close",
+    "Consolidação de hipóteses / Hypothesis consolidation",
+    "Convergence",
+    "Coringa / serendipidade (`ser`)",
+    "Corpus",
+    "Cortex",
+    "Curated",
+    "Delta",
+    "Direction",
+    "Directive",
+    "Dispatch",
+    "Domain",
+    "Envelhecimento / Aging",
+    "Experiment / Experimento",
+    "Gate de PROPOSTA / plan-gate",
+    "Genotype",
+    "Grill",
+    "Grounding",
+    "Harm potential",
+    "Hypothesis",
+    "Idiom",
+    "Install",
+    "Intent kernel",
+    "Knowledge cluster",
+    "Lint",
+    "Medium / Meio",
+    "Mentee",
+    "Mineração / Mining",
+    "Mundo / World",
+    "PROPOSTA",
+    "Pauta",
+    "Producer-skill / Producer",
+    "Recall",
+    "Recap",
+    "Rich rite / Rito rico",
+    "Shortlist A",
+    "Source feedback",
+    "Source roadmap",
+    "Space-0",
+    "Standing page",
+    "Steer",
+    "Usage signal",
+    "Vote",
+    "Voz / Voice",
+    "Wake",
+    "Worthwhile content",
+    "delta_voz / Redigest",
+    "llm-wiki",
+}
+
+GLOSSARY_HEADER_NAMED = re.compile(r"^\*\*([^*]+)\*\*:\s*$", re.MULTILINE)
 
 
 def _glossary_header_count(text):
@@ -63,14 +123,25 @@ class NoInsumosRemain(unittest.TestCase):
             "files still contain 'insumos': %s" % offenders,
         )
 
-    def test_glossary_entity_count_unchanged(self):
+    def test_glossary_entities_are_exactly_the_declared_set(self):
+        """O pin é o CONJUNTO DE NOMES, não a contagem — e a diferença não é estilo.
+
+        Até 2026-08-16 este guarda fixava um número (45). Ele não pegou a perda de 13 entidades
+        no merge `9221924` porque a ADR-0024 adicionou 9 no mesmo intervalo: -13 e +9 viraram uma
+        diferença de 4, pequena o bastante para parecer manutenção. Uma contagem sabe QUANTOS;
+        só um conjunto sabe QUAIS. Ver issue #620.
+
+        Quem adicionar ou aposentar uma entidade acrescenta ou remove o nome aqui no mesmo
+        commit — e o diff passa a mostrar o termo, não um número."""
         with open(CONTEXT, encoding="utf-8") as fh:
-            count = _glossary_header_count(fh.read())
+            found = {m.group(1).strip() for m in GLOSSARY_HEADER_NAMED.finditer(fh.read())}
+        missing = sorted(GLOSSARY_ENTITIES - found)
+        added = sorted(found - GLOSSARY_ENTITIES)
         self.assertEqual(
-            count,
-            EXPECTED_GLOSSARY_COUNT,
-            "CONTEXT.md glossary entity count changed (no NEW entity allowed): "
-            "got %d, expected %d" % (count, EXPECTED_GLOSSARY_COUNT),
+            (missing, added), ([], []),
+            "o glossário do CONTEXT.md divergiu do conjunto declarado.\n"
+            "  SUMIRAM (doutrina perdida — restaure ou aposente explicitamente): %s\n"
+            "  ENTRARAM (declare no conjunto, no mesmo commit): %s" % (missing, added),
         )
 
 


### PR DESCRIPTION
Closes #620. Closes #609.

As 13 voltam com a definição original de `d547442^`. Ficaram fora **seis semanas** enquanto o próprio `CONTEXT.md` usava `mentee` 54 vezes, `artefato` 26 e `cortex` 17 — o glossário de referência não definia nenhum dos termos centrais do sistema.

A seção original (`## Language`) não existe mais na estrutura de 9 módulos; elas voltam agrupadas sob um cabeçalho próprio que carrega a proveniência, em vez de soltas no fim.

### O guarda muda de natureza

Era um pin de **contagem** (45) e **não pegou a perda**: a ADR-0024 somou 9 entidades no mesmo intervalo, então −13 e +9 viraram uma diferença de 4 — pequena o bastante para parecer manutenção.

Passa a fixar o **conjunto de nomes**. A diferença não é estilo:

| | remove `Mentee` |
|---|---|
| guarda antigo | `got 53, expected 54` |
| **guarda novo** | **`SUMIRAM: ['Mentee']`** |

Verificado por mutação. Uma contagem sabe *quantos*; só um conjunto sabe *quais*. E quem adicionar ou aposentar uma entidade agora declara o nome no mesmo commit — o diff passa a mostrar o termo.

### Estado da suíte
**3400 testes, verde**, mesmo número com e sem `EDGE_HOME`.