### PR TITLE
fix(tests): doze módulos vazavam EDGE_BLOG_* e a suíte dependia da ordem

### DIFF
--- a/tests/_blog_env.py
+++ b/tests/_blog_env.py
@@ -1,0 +1,38 @@
+"""Guarda das variáveis de ambiente do blog — restaura o que o teste sujar.
+
+Doze módulos setavam `EDGE_BLOG_STATIC`, onze `EDGE_BLOG_ENTRIES` e doze `EDGE_BLOG_LOG`
+apontando para o próprio `TemporaryDirectory`. Um limpava. Como o diretório é apagado no
+`tearDown` mas a VARIÁVEL fica, o módulo seguinte que não declarasse o próprio caminho lia um
+diretório que não existe mais — e o resultado da suíte passava a depender da ORDEM dos módulos.
+
+O modo de falha não é erro: é silêncio. O servidor degrada (sem `style.css`, sem entradas), o
+teste vê uma página vazia e afirma o que der. Num `assertIn` isso vira um vermelho legítimo —
+foi assim que o #623 apareceu. Num `assertNotIn` ou num `assertEqual(..., [])` vira VERDE
+FALSO, e ninguém olha um verde.
+
+Uso, na primeira linha do `setUp` que mexe no ambiente:
+
+    from _blog_env import guard_blog_env
+    ...
+    guard_blog_env(self)
+
+`addCleanup` roda depois do `tearDown` e sobrevive a exceção no meio do teste, que é
+justamente quando o vazamento seria pior.
+"""
+import os
+
+BLOG_ENV_VARS = ("EDGE_BLOG_STATIC", "EDGE_BLOG_ENTRIES", "EDGE_BLOG_LOG")
+
+
+def guard_blog_env(testcase, *extra):
+    """Tira uma foto das variáveis do blog e agenda a restauração ao fim do teste."""
+    for name in BLOG_ENV_VARS + tuple(extra):
+        before = os.environ.get(name)
+        testcase.addCleanup(_restore, name, before)
+
+
+def _restore(name, before):
+    if before is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = before

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from _blog_env import guard_blog_env
 
 
 def _ev(seq, ts, type_, slug, payload_extra=None):
@@ -44,6 +45,7 @@ class TestBlog(unittest.TestCase):
                 {"text": "First teaser paragraph.\n\nSecond teaser paragraph."}),
         ]) + "\n")
 
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(entries)
         os.environ["EDGE_BLOG_STATIC"] = str(root)
         os.environ["EDGE_BLOG_LOG"] = str(log)
@@ -115,6 +117,7 @@ class TestVozRail(unittest.TestCase):
                 {"intent": "open: beta."}),
         ]) + "\n")
 
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(entries)
         os.environ["EDGE_BLOG_STATIC"] = str(root)
         os.environ["EDGE_BLOG_LOG"] = str(self.log)

--- a/tests/test_blog_auth.py
+++ b/tests/test_blog_auth.py
@@ -19,6 +19,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from _blog_env import guard_blog_env
 
 
 def _ev(seq, ts, type_, slug, payload_extra=None):
@@ -53,6 +54,7 @@ class _Base(unittest.TestCase):
                 {"intent": "open: beta."}),
         ]) + "\n")
 
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(entries)
         os.environ["EDGE_BLOG_STATIC"] = str(root)
         os.environ["EDGE_BLOG_LOG"] = str(self.log)

--- a/tests/test_briefing_surface.py
+++ b/tests/test_briefing_surface.py
@@ -21,6 +21,7 @@ import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from _blog_env import guard_blog_env
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -64,6 +65,7 @@ class _BriefingBase(unittest.TestCase):
         self.log = root / "log.jsonl"
         self.log.write_text("\n".join(self.LOG_LINES) + ("\n" if self.LOG_LINES else ""))
 
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(entries)
         os.environ["EDGE_BLOG_STATIC"] = str(root)
         os.environ["EDGE_BLOG_LOG"] = str(self.log)

--- a/tests/test_cortex_correct.py
+++ b/tests/test_cortex_correct.py
@@ -67,6 +67,7 @@ class _Base(unittest.TestCase):
             _ev(2, "2026-06-10T09:00:01+00:00", "intent.kernel", "alpha-post",
                 {"intent": "open: alpha."}),
         ]) + "\n")
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(entries)
         os.environ["EDGE_BLOG_STATIC"] = str(root)
         os.environ["EDGE_BLOG_LOG"] = str(self.log)
@@ -323,6 +324,7 @@ def _load_server(env):
 
 import shutil
 import subprocess
+from _blog_env import guard_blog_env
 
 NODE = shutil.which("node")
 CORTEX_JS = BLOG / "static" / "cortex.js"

--- a/tests/test_direction_surface.py
+++ b/tests/test_direction_surface.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from _blog_env import guard_blog_env
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -43,6 +44,7 @@ class _DirectionBase(unittest.TestCase):
         entries.mkdir()
         self.log = root / "log.jsonl"
         self.log.write_text("\n".join(self.LOG_LINES) + ("\n" if self.LOG_LINES else ""))
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(entries)
         os.environ["EDGE_BLOG_STATIC"] = str(root)
         os.environ["EDGE_BLOG_LOG"] = str(self.log)

--- a/tests/test_docs_surface.py
+++ b/tests/test_docs_surface.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from _blog_env import guard_blog_env
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -59,6 +60,7 @@ class _DocsBase(unittest.TestCase):
         self.log = root / "log.jsonl"
         self.log.write_text("\n".join(self.LOG_LINES) + ("\n" if self.LOG_LINES else ""))
 
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(root / "entries")
         os.environ["EDGE_BLOG_STATIC"] = str(root / "static")
         os.environ["EDGE_BLOG_LOG"] = str(self.log)

--- a/tests/test_frontend_contract.py
+++ b/tests/test_frontend_contract.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from _blog_env import guard_blog_env
 
 BLOG = Path(__file__).resolve().parent.parent / "blog"
 sys.path.insert(0, str(BLOG))
@@ -62,6 +63,7 @@ class FlaskUsesJinja(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         log = Path(self.tmp.name) / "log.jsonl"
         log.write_text("")
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_LOG"] = str(log)
         # /ux-catalog parseia os tokens AO VIVO de <static>/style.css, e `_static()` resolve
         # por EDGE_BLOG_STATIC. Dez módulos de teste setam essa variável e NENHUM a limpa
@@ -83,6 +85,7 @@ class FlaskUsesJinja(unittest.TestCase):
         if self._static_before is None:
             os.environ.pop("EDGE_BLOG_STATIC", None)
         else:
+            guard_blog_env(self)
             os.environ["EDGE_BLOG_STATIC"] = self._static_before
 
     def test_app_has_jinja_template_folder(self):
@@ -107,6 +110,7 @@ class SelfHostedJS(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         log = Path(self.tmp.name) / "log.jsonl"
         log.write_text("")
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_LOG"] = str(log)
         self.fix = Path(self.tmp.name) / "cortex.json"
         self.fix.write_text(json.dumps(
@@ -190,6 +194,7 @@ class UxCatalog(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         log = Path(self.tmp.name) / "log.jsonl"
         log.write_text("")
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_LOG"] = str(log)
         # mesma razão da classe acima: `_static()` resolve por EDGE_BLOG_STATIC, dez módulos a
         # setam e nenhum a limpa — sem declarar o próprio static, este teste herda o tmpdir já
@@ -205,6 +210,7 @@ class UxCatalog(unittest.TestCase):
         if self._static_before is None:
             os.environ.pop("EDGE_BLOG_STATIC", None)
         else:
+            guard_blog_env(self)
             os.environ["EDGE_BLOG_STATIC"] = self._static_before
 
     def test_ux_catalog_route_lists_tokens_and_macros(self):
@@ -234,6 +240,7 @@ class TablerOverDarkIdentity(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         log = Path(self.tmp.name) / "log.jsonl"
         log.write_text("")
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_LOG"] = str(log)
         # mesma razão da classe acima: `_static()` resolve por EDGE_BLOG_STATIC, dez módulos a
         # setam e nenhum a limpa — sem declarar o próprio static, este teste herda o tmpdir já
@@ -249,6 +256,7 @@ class TablerOverDarkIdentity(unittest.TestCase):
         if self._static_before is None:
             os.environ.pop("EDGE_BLOG_STATIC", None)
         else:
+            guard_blog_env(self)
             os.environ["EDGE_BLOG_STATIC"] = self._static_before
 
     def test_tabler_vendored_and_loaded(self):

--- a/tests/test_grill_drain.py
+++ b/tests/test_grill_drain.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from _blog_env import guard_blog_env
 
 BLOG = Path(__file__).resolve().parent.parent / "blog"
 sys.path.insert(0, str(BLOG))
@@ -46,6 +47,7 @@ class _Base(unittest.TestCase):
             _ev(3, "2026-06-12T15:30:00+00:00", "artefato.published", "artefato:beta-post",
                 {"slug": "beta-post", "cites": [], "distills": [], "proposes": []}),
         ]) + "\n")
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_LOG"] = str(self.log)
         os.environ["EDGE_BLOG_ENTRIES"] = str(root)
         os.environ["EDGE_BLOG_STATIC"] = str(root)
@@ -452,6 +454,7 @@ class TestClarifyAnswerGated(unittest.TestCase):
         self.log.write_text(_ev(1, "2026-06-10T09:00:00+00:00", "voz.clarify", "voz:alpha-post",
                                  {"comment_id": "c1", "clarify_id": "q1", "question": "which?",
                                   "grill_run_id": "g0"}) + "\n")
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_LOG"] = str(self.log)
         os.environ["EDGE_BLOG_ENTRIES"] = str(root)
         os.environ["EDGE_BLOG_STATIC"] = str(root)
@@ -492,6 +495,7 @@ class TestStartupMigrationGuarded(unittest.TestCase):
             '{"seq": 1, "type": "voz.comment", "payload": {"target_ref": null, '
             '"comment_id": "c1", "body": "oi"}}\n'
             '{"seq": 3, "type": "voz.reply", "payload": {"comment_id": "c1", "body": "hand reply"}}\n')
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_LOG"] = str(self.log)
         os.environ["EDGE_BLOG_ENTRIES"] = str(root)
         os.environ["EDGE_BLOG_STATIC"] = str(root)
@@ -523,6 +527,7 @@ class TestDrainRouteAuthGate(unittest.TestCase):
             _ev(1, "2026-06-10T09:00:00+00:00", "artefato.published", "artefato:alpha-post",
                 {"slug": "alpha-post", "cites": [], "distills": [], "proposes": []}),
         ]) + "\n")
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_LOG"] = str(self.log)
         os.environ["EDGE_BLOG_ENTRIES"] = str(root)
         os.environ["EDGE_BLOG_STATIC"] = str(root)

--- a/tests/test_grounding_yield_render.py
+++ b/tests/test_grounding_yield_render.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(REPO / "tools"))
 
 import eventlog          # noqa: E402
 import grounding_yield   # noqa: E402
+from _blog_env import guard_blog_env
 
 
 class BriefingNeverBlank(unittest.TestCase):
@@ -169,6 +170,7 @@ class SourcesPanel(unittest.TestCase):
                                             "kind": "mundo", "similarity": 0.7})
         log.write_text("\n".join(rows) + "\n")
 
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(root / "entries")
         os.environ["EDGE_BLOG_STATIC"] = str(root)
         os.environ["EDGE_BLOG_LOG"] = str(log)

--- a/tests/test_llm_panel.py
+++ b/tests/test_llm_panel.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from _blog_env import guard_blog_env
 
 AGENT_YAML = """\
 name: tester
@@ -46,6 +47,7 @@ class TestLLMPanel(unittest.TestCase):
             "subject": "close", "payload": {"status": 429, "detail": "insufficient_quota"},
         }) + "\n")
 
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(root / "entries")
         os.environ["EDGE_BLOG_STATIC"] = str(root)
         os.environ["EDGE_BLOG_LOG"] = str(log)

--- a/tests/test_three_act.py
+++ b/tests/test_three_act.py
@@ -30,6 +30,7 @@ import eventlog  # noqa: E402
 import predispatch  # noqa: E402
 import producer_descriptor as pd  # noqa: E402
 import publisher  # noqa: E402
+from _blog_env import guard_blog_env
 
 
 # --- origin: user_requested | beat -----------------------------------------------------------
@@ -181,6 +182,7 @@ class ProtoPagesAreServedUnderARestrictiveCSP(unittest.TestCase):
             (entries / "demo.proto.abc123def456.html").write_text(PAGE)
             (entries / "normal-entry.html").write_text("<html><body>ok</body></html>")
             import os
+            guard_blog_env(self)
             os.environ["EDGE_BLOG_ENTRIES"] = str(entries)
             os.environ["EDGE_BLOG_STATIC"] = str(root)
             os.environ["EDGE_BLOG_LOG"] = str(root / "log.jsonl")

--- a/tests/test_wiki_surface.py
+++ b/tests/test_wiki_surface.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from _blog_env import guard_blog_env
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -79,6 +80,7 @@ class _WikiBase(unittest.TestCase):
         self.log = root / "log.jsonl"
         self.log.write_text("\n".join(self.LOG_LINES) + ("\n" if self.LOG_LINES else ""))
 
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(root / "entries")
         os.environ["EDGE_BLOG_STATIC"] = str(root / "static")
         os.environ["EDGE_BLOG_LOG"] = str(self.log)
@@ -346,6 +348,7 @@ class TestWikiReachableFromBriefingAndDistills(unittest.TestCase):
                 {"slug": "alpha-post", "intent": "open: alpha."}),
         ]) + "\n")
 
+        guard_blog_env(self)
         os.environ["EDGE_BLOG_ENTRIES"] = str(root / "entries")
         os.environ["EDGE_BLOG_STATIC"] = str(root / "static")
         os.environ["EDGE_BLOG_LOG"] = str(self.log)


### PR DESCRIPTION
Closes #624.

| variável | setam | limpavam |
|---|---:|---:|
| `EDGE_BLOG_STATIC` | 12 | **1** |
| `EDGE_BLOG_ENTRIES` | 11 | **1** |
| `EDGE_BLOG_LOG` | 12 | **3** |

O diretório é apagado no `tearDown`, mas a **variável fica**. Medido antes do conserto — depois de rodar só os módulos de blog:

```
EDGE_BLOG_STATIC  = /tmp/tmp5b8la0lr        ← já apagado
EDGE_BLOG_ENTRIES = /tmp/tmp5b8la0lr/entries
EDGE_BLOG_LOG     = /tmp/tmp5b8la0lr/log.jsonl
```

### Por que isso é pior que um vermelho
O modo de falha é **silêncio**. O servidor degrada, o teste vê uma página vazia e afirma o que der. Num `assertIn` vira vermelho legítimo — foi assim que o #623 apareceu. Num `assertNotIn` vira **verde falso**, e ninguém investiga um verde.

### O conserto
`tests/_blog_env.py` fotografa as três variáveis e agenda restauração por `addCleanup` — que roda **depois** do `tearDown` e **sobrevive a exceção** no meio do teste, que é justamente quando o vazamento seria pior. Uma linha por `setUp`, 23 no total, nos 12 módulos.

### A terceira variante da mesma doença
Resultado que depende do **host** (#610, #611, #615), da **ordem dos módulos** (#623 e este) e do **ambiente herdado** (#622). Nas três o teste não controla a própria entrada — e nas três o modo de falha é silêncio.

**3400 testes, verde**, mesmo número com e sem `EDGE_HOME`. Vazamento verificado fechado.