### PR TITLE
fix(gitignore): .agents/ é genótipo versionado, não saída de install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,17 @@ state/cortex/
 .env
 state/harvest-cursors.json
 docs/.loopR_research_raw.json
-.agents/
+# .agents/ NÃO é ignorado: `tests/test_codex_skill_wrappers.py` o define como "REPO-LOCAL,
+# versioned genotype content" e `_grok_provision`/`_codex_provision` o consomem como ENTRADA.
+# fea9407 adicionou este ignore no MESMO commit em que adicionou arquivos rastreados aqui —
+# 51 seguem rastreados apesar dele. O efeito não era inofensivo: todo wrapper novo exigia
+# `git add -f`, e por isso as skills setup/autonomia/onboard (2026-07-13) nunca ganharam o seu.
 memory/*token*.md
 agent.yaml
 /state/
 /memory/
 /blog/entries/
 /drafts/
+
+# worktrees efêmeros de subagentes — criados e removidos por sessão, nunca genótipo
+.claude/worktrees/


### PR DESCRIPTION
Fecha a decisão pendente levantada no #622.

`fea9407` acrescentou `.agents/` ao `.gitignore` **no mesmo commit** em que adicionou arquivos rastreados ali dentro. Hoje são **51 arquivos rastreados apesar do ignore**.

Que é genótipo não é opinião minha — está no próprio teste:

> `tests/test_codex_skill_wrappers.py:8` — *"`.agents/skills/` is **REPO-LOCAL, versioned genotype content** — it ships with the repo"*

E `_grok_provision`/`_codex_provision` o consomem como **entrada** para renderizar os wrappers.

### O ignore não escondeu um arquivo — congelou uma superfície

Todo wrapper novo passava a exigir `git add -f`, e ninguém lembra de um `-f`. É por isso que as skills `setup`, `autonomia` e `onboard` (2026-07-13) **nunca ganharam wrapper**: o conjunto em `.agents/skills` é de 2026-07-06 e ficou congelado ali por seis semanas.

Verificado antes de remover: **zero** arquivos não-rastreados em `.agents/` — tirar o ignore não traz ruído, só para de esconder o que já deveria estar versionado.

Vai junto `.claude/worktrees/` no ignore: worktrees efêmeros de subagente, esses sim nunca são genótipo.