### PR TITLE
feat(frota): o critério de saúde da #636 como instrumento read-only

### DIFF
--- a/tests/test_group_health.py
+++ b/tests/test_group_health.py
@@ -1,0 +1,130 @@
+"""O critério de saúde de frota (#636) — medido contra um grafo FALSO, de propósito.
+
+Este módulo é hermético: nada aqui abre o Neo4j. O instrumento existe para dizer se um grafo é
+navegável, e um teste que precisasse de um grafo vivo mediria o host de quem roda a suíte — a
+doença que os PRs #610/#611/#615/#623/#630 passaram o dia extirpando.
+
+O dublê responde às consultas por assinatura. Se `group_health` mudar de query, o dublê deixa de
+reconhecê-la e devolve zero — o teste fica vermelho em vez de mentir. Foi assim que
+`test_project_doc` escondeu uma projeção quebrada por meses (PR #621).
+"""
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import group_health  # noqa: E402
+
+
+class _Record(dict):
+    def single(self):
+        return self
+
+    def data(self):
+        return self.get("_rows", [])
+
+
+class FakeSession:
+    """Um grafo declarado como números, não como nós — o instrumento só conta."""
+
+    def __init__(self, spec, group_counts=None):
+        self.spec = spec
+        self.group_counts = group_counts or [(g, s["nodes"]) for g, s in spec.items()]
+        self.queries = []
+
+    def run(self, cypher, **kw):
+        self.queries.append(cypher)
+        g = kw.get("g")
+        s = self.spec.get(g, {})
+        if "RETURN n.group_id AS g" in cypher:
+            rec = _Record()
+            rec["_rows"] = [{"g": name, "c": c} for name, c in self.group_counts]
+            return rec
+        if ":Genesis" in cypher:
+            return _Record(n=s.get("genesis", 0))
+        if ":Objective" in cypher:
+            return _Record(n=s.get("objectives", 0))
+        if ":Direction" in cypher:
+            return _Record(total=s.get("directions", 0),
+                           with_handle=s.get("handles", 0),
+                           with_lifecycle=s.get("lifecycles", 0))
+        if ":Community" in cypher:
+            return _Record(n=s.get("communities", 0))
+        if "HAS_TOPIC" in cypher:
+            return _Record(n=s.get("has_topic", 0))
+        if "MATCH (n {group_id:$g})" in cypher:
+            return _Record(n=s.get("nodes", 0))
+        raise AssertionError(f"consulta não reconhecida pelo dublê: {cypher[:70]}")
+
+
+HEALTHY = {"nodes": 200, "genesis": 1, "objectives": 1, "directions": 3,
+           "handles": 3, "lifecycles": 3, "communities": 2, "has_topic": 40}
+
+
+class TheCriterionAnswersWithoutReadingBody(unittest.TestCase):
+    def test_a_navigable_group_has_no_verdicts(self):
+        s = FakeSession({"ok": HEALTHY})
+        self.assertEqual(group_health.verdicts(group_health.health(s, "ok")), [])
+
+    def test_no_query_reads_a_body(self):
+        """A restrição É o teste: se para saber no que o agente trabalha for preciso abrir o
+        body, o grafo é diário e não memória. O instrumento não pode contornar isso lendo."""
+        s = FakeSession({"ok": HEALTHY})
+        group_health.health(s, "ok")
+        self.assertTrue(s.queries, "o dublê não recebeu consulta nenhuma")
+        for q in s.queries:
+            self.assertNotIn(".body", q, f"o critério leu body: {q[:80]}")
+            self.assertNotIn("n.content", q, f"o critério leu conteúdo: {q[:80]}")
+
+
+class TheFourFailuresAreDetected(unittest.TestCase):
+    def _msgs(self, **over):
+        spec = dict(HEALTHY, **over)
+        card = group_health.health(FakeSession({"g": spec}), "g")
+        return [m for _sev, m in group_health.verdicts(card)]
+
+    def test_direction_without_handle_is_named(self):
+        """#632: o caso roberto — 788 Directions e nenhuma listável."""
+        msgs = self._msgs(directions=788, handles=0, lifecycles=0)
+        self.assertTrue(any("788 Directions sem handle" in m for m in msgs), msgs)
+        self.assertTrue(any("acima do teto" in m for m in msgs), msgs)
+
+    def test_objective_is_not_a_singleton(self):
+        """#633: o caso petertosh — 6 cópias do mesmo norte."""
+        self.assertTrue(any("6 Objectives vivos" in m for m in self._msgs(objectives=6)))
+
+    def test_zero_community_on_a_big_graph_is_a_failure_not_scarcity(self):
+        """#635: zero Community só é legítimo se o consolidate falhou ALTO. Num grafo grande,
+        silêncio é falha — foi essa indistinção que fez o apagão da frota durar meses."""
+        self.assertTrue(any("grafo write-only" in m for m in self._msgs(communities=0)))
+
+    def test_a_small_graph_with_no_community_is_not_accused(self):
+        """O contrapeso: 20 nós sem cluster é escassez de verdade, não apagão. Um critério que
+        acusa os dois igual treina o operador a ignorar o critério."""
+        self.assertEqual([], self._msgs(nodes=20, communities=0, directions=1,
+                                        handles=1, lifecycles=1, has_topic=2))
+
+    def test_has_topic_saturation_is_named(self):
+        """#635: 21357 arestas para ~15400 nós — tudo liga em tudo, o grafo deixa de apontar."""
+        self.assertTrue(any("HAS_TOPIC" in m for m in self._msgs(nodes=15400, has_topic=21357)))
+
+
+class LeftoversAreTheFenceHidingTheDead(unittest.TestCase):
+    def test_a_group_that_is_not_an_install_is_flagged(self):
+        """#634: `peter tosh` 269 + `petertosh` 2490 são o mesmo agente em dois tenants."""
+        s = FakeSession({}, group_counts=[("petertosh", 2490), ("peter tosh", 269)])
+        msgs = [m for _s, m in group_health.leftovers(s, {"petertosh"})]
+        self.assertEqual(len(msgs), 1)
+        self.assertIn("peter tosh", msgs[0])
+
+    def test_nodes_without_a_group_are_a_failure(self):
+        """Nó sem group_id é invisível a qualquer filtro por tenant — e uma query sem `$g` o
+        vê como fantasma."""
+        s = FakeSession({}, group_counts=[("ed", 21), (None, 9)])
+        sev = [sv for sv, _m in group_health.leftovers(s, {"ed"})]
+        self.assertIn("fail", sev)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/group_health.py
+++ b/tools/group_health.py
@@ -1,0 +1,186 @@
+"""group_health — o critério de saúde de frota da issue #636, como instrumento read-only.
+
+A cerca de `group_id` funciona (zero aresta cross-group nos grafos medidos). O MAPA é que não:
+nos installs velhos o write-path funciona e o read-path morreu — 788 Directions sem título no
+roberto, 6 Objectives idênticos no petertosh, dois tenants para o mesmo agente, zero Community.
+
+Este módulo responde "este group está navegável?" SEM VARRER BODY. Essa restrição não é
+performance, é o teste: se para saber no que o agente trabalha for preciso abrir oitocentos
+parágrafos, o grafo é diário, não memória. Um campo que só existe dentro da prosa não conta
+como handle — e o relatório acusa isso como defeito em vez de silenciosamente ler o body.
+
+READ-ONLY por construção: só executa MATCH/RETURN. Nada aqui escreve, renomeia ou apaga; o
+rename e o GC são a #634 e moram noutro lugar, com dry-run e confirmação.
+"""
+import os
+
+# Tetos do critério de frota. Não são leis da natureza — são a linha onde "muitas" vira
+# "ninguém consegue ler". Ajustar aqui, não espalhado pelos chamadores.
+OPEN_DIRECTIONS_CEILING = 25
+HAS_TOPIC_DEGREE_CEILING = 1.2          # arestas HAS_TOPIC por nó do group
+
+
+def _driver(uri=None, user=None, password=None):
+    from neo4j import GraphDatabase
+    uri = uri or os.environ.get("EDGE_NEO4J_URI", "bolt://127.0.0.1:7687")
+    user = user or os.environ.get("EDGE_NEO4J_USER", "neo4j")
+    password = password or os.environ.get("EDGE_NEO4J_PASSWORD")
+    if not password:
+        return None
+    return GraphDatabase.driver(uri, auth=(user, password))
+
+
+def groups(session):
+    """Todo group_id presente no Bolt, com contagem — inclusive o balde `None` (unlabeled)."""
+    rows = session.run(
+        "MATCH (n) RETURN n.group_id AS g, count(n) AS c ORDER BY c DESC").data()
+    return [(r["g"], r["c"]) for r in rows]
+
+
+def health(session, group):
+    """O cartão de saúde de UM group. Só MATCH/RETURN; nenhum body é lido."""
+    def one(cypher, **kw):
+        rec = session.run(cypher, g=group, **kw).single()
+        return dict(rec) if rec else {}
+
+    genesis = one("MATCH (n:Genesis {group_id:$g}) RETURN count(n) AS n")["n"]
+    objectives = one("MATCH (n:Objective {group_id:$g}) RETURN count(n) AS n")["n"]
+
+    # Directions: o handle é o que permite listar sem abrir. `title`/`name` ausentes são o
+    # defeito da #632 — contados, não contornados lendo o body.
+    d = one(
+        "MATCH (n:Direction {group_id:$g}) "
+        "RETURN count(n) AS total, "
+        "  count(CASE WHEN coalesce(n.title, n.name) IS NOT NULL THEN 1 END) AS with_handle, "
+        "  count(CASE WHEN n.expires_at IS NOT NULL OR n.supersedes IS NOT NULL THEN 1 END) "
+        "    AS with_lifecycle")
+    communities = one("MATCH (n:Community {group_id:$g}) RETURN count(n) AS n")["n"]
+    nodes = one("MATCH (n {group_id:$g}) RETURN count(n) AS n")["n"]
+    topics = one(
+        "MATCH (a {group_id:$g})-[r:HAS_TOPIC]->() RETURN count(r) AS n")["n"]
+
+    return {
+        "group": group,
+        "nodes": nodes,
+        "genesis": genesis,
+        "objectives": objectives,
+        "directions_total": d.get("total", 0),
+        "directions_with_handle": d.get("with_handle", 0),
+        "directions_with_lifecycle": d.get("with_lifecycle", 0),
+        "communities": communities,
+        "has_topic_edges": topics,
+        "has_topic_degree": round(topics / nodes, 2) if nodes else 0.0,
+    }
+
+
+def verdicts(card):
+    """As falhas do cartão, em linguagem do critério. Lista vazia = navegável.
+
+    Cada item é (severidade, mensagem). `dark` é reservado para o que NÃO PUDE ser medido —
+    distinto de `fail`, que é medido e ruim. Confundir os dois foi o defeito que fez os 0
+    Community da frota passarem por escassez durante meses (#635)."""
+    out = []
+    g = card["group"]
+
+    if card["genesis"] != 1:
+        out.append(("fail", f"{g}: {card['genesis']} Genesis (esperado exatamente 1)"))
+    if card["objectives"] > 1:
+        out.append(("fail", f"{g}: {card['objectives']} Objectives vivos — o rito promete 1 (#633)"))
+    elif card["objectives"] == 0 and card["nodes"]:
+        out.append(("warn", f"{g}: nenhum Objective — o agente não tem norte declarado"))
+
+    total, handled = card["directions_total"], card["directions_with_handle"]
+    if total and handled < total:
+        out.append(("fail",
+                    f"{g}: {total - handled} de {total} Directions sem handle — não dá para "
+                    f"listar no que este agente trabalha sem abrir o body (#632)"))
+    if total > OPEN_DIRECTIONS_CEILING:
+        out.append(("fail",
+                    f"{g}: {total} Directions acima do teto de {OPEN_DIRECTIONS_CEILING} — "
+                    "barato propor, caro encerrar (#632)"))
+    if total and card["directions_with_lifecycle"] == 0:
+        out.append(("warn",
+                    f"{g}: nenhuma das {total} Directions tem expiry/supersedes — sem lifecycle "
+                    "consolidate não tem o que fundir (#632)"))
+
+    if card["communities"] == 0 and card["nodes"] > 50:
+        out.append(("fail",
+                    f"{g}: 0 Community em {card['nodes']} nós — grafo write-only; ZERO só é "
+                    "legítimo se o consolidate falhou ALTO (#635)"))
+
+    if card["has_topic_degree"] > HAS_TOPIC_DEGREE_CEILING:
+        out.append(("fail",
+                    f"{g}: HAS_TOPIC grau {card['has_topic_degree']} (>{HAS_TOPIC_DEGREE_CEILING}) "
+                    "— tudo liga no mesmo punhado de tópicos; o grafo deixa de apontar (#635)"))
+    return out
+
+
+def leftovers(session, installed):
+    """Groups sem install e nós sem group_id — o lixo que a cerca esconde (#634).
+
+    `installed` é o conjunto de groups que ESTE host declara. Um group_id no Bolt que não está
+    nele é tenant órfão: rename sem migrate, ou install morto que ninguém enterrou."""
+    out = []
+    for g, c in groups(session):
+        if g is None:
+            out.append(("fail", f"<sem group_id>: {c} nó(s) — invisíveis a qualquer filtro por "
+                                "tenant, e uma query sem $g os vê como fantasma (#634)"))
+        elif g not in installed:
+            out.append(("warn", f"{g}: {c} nó(s) de um group que não é install deste host — "
+                                "rename sem migrate, ou tenant morto sem GC (#634)"))
+    return out
+
+
+def report(session, installed=(), only=None):
+    """O relatório da frota: um cartão por group + os leftovers. Devolve (linhas, falhas)."""
+    lines, failures = [], 0
+    for g, _count in groups(session):
+        if g is None or (only and g != only):
+            continue
+        card = health(session, g)
+        lines.append(
+            f"{g:<14} nós={card['nodes']:<6} genesis={card['genesis']} "
+            f"obj={card['objectives']} dir={card['directions_with_handle']}/"
+            f"{card['directions_total']} com handle  comm={card['communities']}  "
+            f"has_topic={card['has_topic_degree']}")
+        for sev, msg in verdicts(card):
+            lines.append(f"  [{sev}] {msg}")
+            failures += sev == "fail"
+    if not only:
+        for sev, msg in leftovers(session, set(installed)):
+            lines.append(f"  [{sev}] {msg}")
+            failures += sev == "fail"
+    return lines, failures
+
+
+def main(argv=None):
+    import sys
+    argv = list(sys.argv[1:] if argv is None else argv)
+    only = argv[0] if argv else None
+
+    installed = set()
+    try:
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        import _identity
+        g = _identity.group()
+        if g:
+            installed.add(g)
+    except Exception:  # noqa: BLE001 — a saúde não depende de identidade resolver
+        pass
+
+    drv = _driver()
+    if drv is None:
+        print("group_health: DARK — sem EDGE_NEO4J_PASSWORD; nada medido (≠ 'tudo bem')")
+        return 2
+    try:
+        with drv.session() as s:
+            lines, failures = report(s, installed=installed, only=only)
+    finally:
+        drv.close()
+    print("\n".join(lines) if lines else "group_health: nenhum group no Bolt")
+    print(f"\ngroup_health: {failures} falha(s) de critério")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Parte de #636 (a issue-mãe pede o critério, não a implementação das irmãs).

### Rodado no grafo real deste host, primeira execução
```
turing   nós=141  genesis=1 obj=1 dir=0/14 com handle  comm=1  has_topic=0.09
  [fail] 14 de 14 Directions sem handle (#632)
  [warn] nenhuma tem expiry/supersedes (#632)
ed       nós=21   genesis=1 obj=1 dir=0/1  com handle  comm=1  has_topic=0.05
  [fail] 1 de 1 Directions sem handle (#632)
  [warn] turing: 141 nós de um group que não é install deste host (#634)
```

### E corrige um detalhe da #632
Ela aponta o `ed` como contraexemplo bom, *"1 Direction com prazo explícito"*. Tem — **em prosa**. O instrumento acusa `sem lifecycle` mesmo nela, porque prazo que mora dentro do body não é campo e não é legível por máquina.

O contraexemplo é evidência **a favor** da parte 2 da #632, não contra.

### Decisões que os testes fixam
- **`dark` ≠ `fail`** — "não pude medir" e "medi e está ruim" são estados diferentes. Confundi-los foi o que fez os 0 Community da frota passarem por escassez durante meses (#635).
- **0 Community em 20 nós não é acusado; em 200, é.** Um critério que acusa os dois igual treina o operador a ignorá-lo — e aí deixa de ser critério.
- **Read-only por construção.** Rename e GC são a #634, com dry-run e confirmação.

### Teste hermético, sem Neo4j
O instrumento existe para dizer se um grafo é navegável. Um teste que precisasse de grafo vivo mediria **o host de quem roda a suíte** — a doença que os PRs #610, #611, #615, #623 e #630 extirparam hoje.

O dublê responde por **assinatura de consulta**: se o instrumento mudar de query, o dublê não a reconhece e o teste fica **vermelho em vez de mentir**. Foi exatamente assim que `test_project_doc` escondeu uma projeção quebrada por meses (#621).

Verificado por mutação duas vezes — fazer o critério ler `.body`, e desligar a regra de 0-Community, derrubam o teste.