### PR TITLE
fix(publisher): o Objective duplicava na PROJEÇÃO, não no log

### DIFF
--- a/blog/server.py
+++ b/blog/server.py
@@ -1164,6 +1164,8 @@ _TRUST_BY_LABEL = {
     "Experiment": "asserted",
     # Structured Activity/Direction lenses: log-fold spine (mirrors cortex_provenance._ASSERTED_LABELS).
     "Atividade": "asserted", "Map": "asserted", "Ticket": "asserted",
+    # #633 — the per-`operacao` MARCO_OF hub; it used to borrow the :Objective label.
+    "Operacao": "asserted",
     "Entity": "extracted", "Source": "extracted", "Topic": "extracted",
     "Episodic": "episodic", "VozFragment": "episodic",
 }
@@ -1193,6 +1195,7 @@ _TITLE_FIELDS = {
     "Atividade": ("finalidade", "num", "ref", "ulid"),
     "Map": ("titulo", "num", "ref", "ulid"),
     "Ticket": ("titulo", "question", "num", "ref", "ulid"),
+    "Operacao": ("operacao", "ref"),
     "Entity": ("name",),
     "Source": ("name", "source_description", "key"),
     "Topic": ("title", "name", "topic_id", "key"),
@@ -1419,7 +1422,7 @@ def _context_only(label, props):
         # would mis-mark a low-tier Episodic as order-bearing, codex final [P3]). Asserted spine →
         # order-bearing; everything else (extracted, episodic, unknown) → context_only (fail-safe).
         return label not in ("Genesis", "Objective", "Direction", "Artefato", "Experiment",
-                             "Atividade", "Map", "Ticket")
+                             "Atividade", "Map", "Ticket", "Operacao")
 
 
 def _map_node(id_, label, props):
@@ -1654,7 +1657,7 @@ def _cortex_dark():
 # the island maps a label → its node class and shows/hides deterministically over the loaded payload.
 # Every known projected label is listed so noise can be opted in (Finding D — Community/Claim/…).
 _CORTEX_FILTER_LABELS = ("Genesis", "Objective", "Direction", "Artefato", "Experiment",
-                         "Atividade", "Map", "Ticket",
+                         "Atividade", "Map", "Ticket", "Operacao",
                          "Entity", "Source", "Topic", "Episodic", "VozFragment",
                          "Hypothesis", "Claim", "Community", "Doc")
 
@@ -1662,7 +1665,7 @@ _CORTEX_FILTER_LABELS = ("Genesis", "Objective", "Direction", "Artefato", "Exper
 # readable. Non-spine labels in _CORTEX_FILTER_LABELS are opt-in only.
 _CORTEX_SPINE_LABELS = frozenset({
     "Genesis", "Objective", "Direction", "Artefato", "Experiment",
-    "Atividade", "Map", "Ticket",
+    "Atividade", "Map", "Ticket", "Operacao",
 })
 
 

--- a/tests/test_objective_singleton.py
+++ b/tests/test_objective_singleton.py
@@ -1,0 +1,402 @@
+"""#633 — the spine :Objective is a SINGLETON.
+
+The rite promises ONE Objective per group. In the fleet's Bolt, `petertosh` carried **6**
+`:Objective` nodes with the IDENTICAL body. The append was NEVER in the eventlog — `objective.set`
+is latest-wins and `cortex.objective_at` folds it to one record, so no amount of re-setting the
+objective can grow a second node. It was in the **projection**, where two writers shared one label:
+
+  * `publisher.project_lentes` minted one `:Objective` per `operacao` (keyed `{group_id, ref}`) as
+    the MARCO_OF hub — an operation is not the group's north, it only borrowed the label; and
+  * `publisher._project_backbone` wrote the spine with a bare `MERGE (o:Objective {group_id:$g})`.
+
+A bare MERGE has no discriminating key, so it MATCHED the operation hubs instead of creating the
+spine node — and `SET o.body=$b` stamped the SAME body on EVERY one of them. That is the exact
+petertosh signature (N nodes, one text), and the `MATCH (a:Artefato),(o:Objective {group_id:$g})
+MERGE (a)-[:SERVES]->(o)` fan then hung every Artefato off all N. Recall's "one north" becomes
+"aligned with any of them".
+
+The live tests run against the install's own Neo4j in a DISPOSABLE synthetic group (never `ed`,
+never `turing`), torn down in tearDown. No graph → skip (the repo's degrade convention).
+"""
+import inspect
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import eventlog  # noqa: E402
+import group_health  # noqa: E402
+import publisher  # noqa: E402
+
+
+def _neo4j_reachable():
+    """True iff the install's Neo4j is reachable — gates the live tests (mirrors
+    tests/test_recall_surf.py). Offline/CI degrades to skip, never fails."""
+    try:
+        import _identity
+        from neo4j import GraphDatabase
+        uri, user, pw = _identity.neo4j_conn()
+        drv = GraphDatabase.driver(uri, auth=(user, pw))
+        drv.verify_connectivity()
+        drv.close()
+        return True
+    except Exception:  # noqa: BLE001 — no graph → skip the live tests
+        return False
+
+
+_NEO4J = _neo4j_reachable()
+
+# Every disposable group this module mints is `t633…` + a uuid4 slice. No real install carries that
+# prefix, so the sweep below can never reach `ed`, `turing` or any fleet group.
+_GROUP_PREFIX = "t633"
+
+
+def tearDownModule():
+    """Sweep EVERY `t633…` group off the live Bolt when the module finishes.
+
+    Each test already wipes its own group in tearDown, but a run KILLED between setUp and tearDown
+    (crash, Ctrl-C, a harness that reaps the process) strands the fixture in the graph — where a
+    passer-by reads six synthetic :Objective as real duplicated memory. Prefix-scoped, so it is
+    idempotent and cannot touch a real group."""
+    if not _NEO4J:
+        return
+    try:
+        import _identity
+        from neo4j import GraphDatabase
+        uri, user, pw = _identity.neo4j_conn()
+        with GraphDatabase.driver(uri, auth=(user, pw)) as drv:
+            with drv.session() as s:
+                s.run("MATCH (n) WHERE n.group_id STARTS WITH $p DETACH DELETE n",
+                      p=_GROUP_PREFIX)
+    except Exception as exc:  # noqa: BLE001 — the sweep is hygiene; it must never fail a green run
+        print(f"test_objective_singleton: leftover sweep skipped ({type(exc).__name__}: {exc})")
+
+
+class SingletonKeyIsAParameter(unittest.TestCase):
+    """#578 (corpus N×N, open) pins Genesis/Objective/Direction as `{group_id, agent}`. When it
+    lands, unicity becomes per-(group_id, agent) — that must be a PARAMETER, not a rewrite."""
+
+    def test_the_key_is_one_module_level_tuple(self):
+        self.assertEqual(publisher.OBJECTIVE_SINGLETON_KEY, ("group_id",))
+        self.assertEqual(publisher.spine_objective_key("g"), {"group_id": "g"})
+
+    def test_flipping_the_key_carries_the_agent_with_no_other_edit(self):
+        original = publisher.OBJECTIVE_SINGLETON_KEY
+        publisher.OBJECTIVE_SINGLETON_KEY = ("group_id", "agent")
+        try:
+            self.assertEqual(publisher.spine_objective_key("g", agent="ed"),
+                             {"group_id": "g", "agent": "ed"})
+            self.assertIn("o.agent = $agent",
+                          publisher._spine_where(publisher.spine_objective_key("g", "ed")))
+        finally:
+            publisher.OBJECTIVE_SINGLETON_KEY = original
+
+
+class SpineStatementsAreDiscriminated(unittest.TestCase):
+    """Hermetic guards (they run with no graph)."""
+
+    def test_no_bare_group_only_objective_match_in_the_write_path(self):
+        """No statement that means THE SPINE may address `:Objective` by `group_id` alone — that is
+        the bug, and it reads as correct."""
+        src = inspect.getsource(publisher)
+        for stmt in re.findall(r'"[^"]*:Objective \{group_id:\$g\}[^"]*"(?:\s*"[^"]*")*', src):
+            self.assertIn("spine", stmt,
+                          f"spine statement addresses :Objective by group alone: {stmt[:120]}")
+
+    def test_the_operacao_hub_no_longer_borrows_the_objective_label(self):
+        """`group_health` (#638) counts EVERY `:Objective` in a group and fails at >1 — so the
+        per-`operacao` MARCO_OF hub cannot keep sharing the label."""
+        self.assertEqual(publisher.OPERACAO_LABEL, "Operacao")
+        src = inspect.getsource(publisher.project_lentes)
+        self.assertIn("OPERACAO_LABEL", src)
+        self.assertNotIn('"Objective"', src,
+                         "project_lentes still mints the operation hub as :Objective")
+
+
+@unittest.skipUnless(_NEO4J, "no Neo4j reachable — live singleton tests skipped")
+class _LiveGroup(unittest.TestCase):
+    """A disposable synthetic group on the install's own Neo4j. Never `ed`, never `turing`."""
+
+    PREFIX = "t633-"
+
+    def setUp(self):
+        import _identity
+        from neo4j import GraphDatabase
+        uri, user, pw = _identity.neo4j_conn()
+        self.g = self.PREFIX + uuid.uuid4().hex[:10]
+        self.drv = GraphDatabase.driver(uri, auth=(user, pw))
+        self.s = self.drv.session()
+        self._wipe()
+        self.seed()
+
+    def seed(self):
+        pass
+
+    def tearDown(self):
+        try:
+            self._wipe()
+        finally:
+            self.s.close()
+            self.drv.close()
+
+    def _wipe(self):
+        self.s.run("MATCH (n {group_id:$g}) DETACH DELETE n", g=self.g)
+
+    def _objectives(self):
+        return [dict(r) for r in self.s.run(
+            "MATCH (o:Objective {group_id:$g}) RETURN elementId(o) AS id, o.ref AS ref, "
+            "o.body AS body, o.spine AS spine ORDER BY coalesce(o.ref,'')", g=self.g)]
+
+
+def _lentes_log(tmpdir, operations):
+    """A tiny canonical log with one open Atividade per operation — the lentes plane's input."""
+    log = Path(tmpdir) / "lentes.jsonl"
+    for name in operations:
+        eventlog.open_atividade(operacao=name, finalidade=f"trilho {name}", tier="asserted",
+                                author="operador", log=log)
+    return log
+
+
+def _live_store(driver, group_id):
+    """The live GraphStore port, scoped to the disposable group — what `sweep` hands project_lentes."""
+    import graph_store
+    return graph_store.Neo4jGraphStore(driver, group_id=group_id)
+
+
+class ObjectiveWriteIsIdempotent(_LiveGroup):
+    BODY = "invariante ATENDENTE: lead -> consulta -> receita -> laudo"
+
+    def seed(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.log = Path(self.tmp.name) / "log.jsonl"
+        eventlog.set_objective(self.BODY, log=self.log)
+
+    def _legacy_hub(self, name):
+        """What project_lentes used to write — the hub, wearing the :Objective label."""
+        self.s.run("MERGE (o:Objective {group_id:$g, ref:$r}) SET o.operacao=$n",
+                   g=self.g, r=f"operacao:{name}", n=name)
+
+    def _backbone(self):
+        publisher._project_backbone(self.s, self.g, self.log)
+
+    # --- the criteria ----------------------------------------------------------------------
+    def test_writing_the_same_body_twice_yields_one_node(self):
+        """The issue's literal acceptance criterion."""
+        self._backbone()
+        self._backbone()
+        self.assertEqual(len(self._objectives()), 1)
+
+    def test_the_spine_write_never_stamps_the_operacao_hubs(self):
+        """THE #633 REPRODUCTION: with the lentes plane present, the bare spine MERGE matched the
+        operation hubs and stamped every one with the identical body — petertosh's 6 copies."""
+        for name in ("closavo", "blog", "frota", "cortex", "rito", "frontier"):
+            self._legacy_hub(name)
+        self._backbone()
+        carrying = [r for r in self._objectives() if r["body"]]
+        self.assertEqual(len(carrying), 1,
+                         f"{len(carrying)} :Objective carry the spine body (expected exactly 1)")
+        self.assertIsNone(carrying[0]["ref"], "the spine body landed on an operacao hub")
+        self.assertEqual(
+            self.s.run("MATCH (o:Objective {group_id:$g}) WHERE o.ref IS NOT NULL "
+                       "RETURN count(*) AS n", g=self.g).single()["n"], 6,
+            "the pre-rename hubs must survive untouched (MARCO_OF depends on them)")
+
+    def test_group_health_stops_reporting_duplicate_objectives(self):
+        """#638's `group_health` is the acceptance criterion written from outside: it counts EVERY
+        :Objective in the group and fails at >1. A freshly projected group must pass it."""
+        publisher.project_lentes(_lentes_log(self.tmp.name, ("closavo", "blog", "frota")),
+                                 _live_store(self.drv, self.g))
+        self._backbone()
+        card = group_health.health(self.s, self.g)
+        self.assertEqual(card["objectives"], 1, "group_health still counts duplicate Objectives")
+        self.assertEqual([m for _sev, m in group_health.verdicts(card) if "#633" in m], [],
+                         "group_health still fails this group on the #633 criterion")
+
+    def test_a_legacy_unstamped_objective_is_ADOPTED_not_forked(self):
+        """Compat (BRIEF #4): every install alive today carries an :Objective written BEFORE the
+        `spine` stamp existed (`ed` and `turing` both do). The new keyed write must ADOPT it — if it
+        forked instead, the fix would hand every install in the fleet a second copy."""
+        legacy = self.s.run(
+            "CREATE (o:Objective {group_id:$g, body:'um norte antigo, sem carimbo'}) "
+            "RETURN elementId(o) AS id", g=self.g).single()["id"]
+        self._backbone()
+        rows = self._objectives()
+        self.assertEqual(len(rows), 1, "the legacy Objective was forked, not adopted")
+        self.assertEqual(rows[0]["id"], legacy)
+        self.assertEqual(rows[0]["body"], self.BODY)
+        self.assertTrue(rows[0]["spine"], "the adopted node was not stamped")
+
+    def test_a_new_body_supersedes_in_place_it_does_not_create(self):
+        self._backbone()
+        first = self._objectives()
+        eventlog.set_objective("um norte novo, abduzido da conduta", log=self.log)
+        self._backbone()
+        rows = self._objectives()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["id"], first[0]["id"],
+                         "a new body forked the node instead of superseding it")
+        self.assertEqual(rows[0]["body"], "um norte novo, abduzido da conduta")
+
+    def test_serves_and_grounds_target_only_the_spine(self):
+        """Six hubs must not each collect a SERVES star — the hub that reaches everything
+        discriminates nothing, and six of them make 'aligned' meaningless."""
+        for name in ("closavo", "blog", "frota"):
+            self._legacy_hub(name)
+        self.s.run("MERGE (a:Artefato {group_id:$g, slug:'a-1'})", g=self.g)
+        self._backbone()
+        served = self.s.run(
+            "MATCH (:Artefato {group_id:$g})-[:SERVES]->(o:Objective {group_id:$g}) "
+            "RETURN count(DISTINCT o) AS n", g=self.g).single()["n"]
+        self.assertEqual(served, 1, f"the artefato SERVES {served} objectives")
+        grounded = self.s.run(
+            "MATCH (:Genesis {group_id:$g})-[:GROUNDS]->(o:Objective {group_id:$g}) "
+            "RETURN count(DISTINCT o) AS n", g=self.g).single()["n"]
+        self.assertEqual(grounded, 1, f"Genesis GROUNDS {grounded} objectives")
+
+    def test_the_guard_reports_a_second_live_objective_without_deleting_it(self):
+        """The guard REPORTS; it never deletes on the write path (deletion is the migration's job,
+        behind --dry-run). An install that already duplicated must keep sweeping."""
+        self._backbone()
+        self.s.run("CREATE (o:Objective {group_id:$g, body:'copia', spine:true})", g=self.g)
+        self.assertEqual(len(publisher.objective_singleton_violation(self.s, self.g)), 1)
+        self._backbone()  # must not raise
+        self.assertEqual(len(self._objectives()), 2, "the write path deleted a node")
+
+
+@unittest.skipUnless(_NEO4J, "no Neo4j reachable — live migration tests skipped")
+class MigrationCollapsesAndRewires(_LiveGroup):
+    """`tools/migrate_objective_singleton.py` — dry-run by default; the SERVES edges that pointed at
+    the collapsed copies must SURVIVE on the survivor (else duplication becomes orphanhood)."""
+
+    PREFIX = "t633m-"
+    TOOL = REPO / "tools" / "migrate_objective_singleton.py"
+
+    def seed(self):
+        # the petertosh shape: 1 keyless spine + 1 extra copy + 1 stamped operation hub, each with
+        # its own slice of the SERVES star, plus a MARCO_OF that only the hub carries.
+        self.s.run(
+            "CREATE (o:Objective {group_id:$g, body:$b, created_at:'2026-01-01'}) "
+            "CREATE (d1:Objective {group_id:$g, body:$b, created_at:'2026-02-01'}) "
+            "CREATE (h:Objective {group_id:$g, ref:'operacao:closavo', operacao:'closavo', body:$b}) "
+            "CREATE (a1:Artefato {group_id:$g, slug:'art-1'}) "
+            "CREATE (a2:Artefato {group_id:$g, slug:'art-2'}) "
+            "CREATE (m:Artefato {group_id:$g, slug:'marco-1'}) "
+            "CREATE (a1)-[:SERVES]->(o) CREATE (a1)-[:SERVES]->(d1) CREATE (a1)-[:SERVES]->(h) "
+            "CREATE (a2)-[:SERVES]->(d1) "
+            "CREATE (m)-[:MARCO_OF]->(h)", g=self.g, b="o norte")
+
+    def _run(self, *args):
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(REPO / "tools")
+        return subprocess.run([sys.executable, str(self.TOOL), "--group", self.g, *args],
+                              capture_output=True, text=True, env=env, cwd=str(REPO))
+
+    def _counts(self):
+        objs = self.s.run("MATCH (o:Objective {group_id:$g}) RETURN count(*) AS n",
+                          g=self.g).single()["n"]
+        serves = self.s.run(
+            "MATCH (a:Artefato {group_id:$g})-[:SERVES]->(o:Objective {group_id:$g}) "
+            "RETURN collect(DISTINCT a.slug) AS slugs", g=self.g).single()["slugs"]
+        return objs, sorted(serves)
+
+    def test_dry_run_is_the_default_and_changes_nothing(self):
+        before = self._counts()
+        out = self._run()
+        self.assertEqual(out.returncode, 0, out.stderr)
+        self.assertIn("dry-run", out.stdout)
+        self.assertEqual(self._counts(), before, "the DEFAULT invocation mutated the graph")
+
+    def test_apply_without_confirmation_refuses(self):
+        before = self._counts()
+        out = self._run("--apply")
+        self.assertNotEqual(out.returncode, 0)
+        self.assertEqual(self._counts(), before)
+
+    def test_apply_collapses_to_one_and_the_serves_edges_survive(self):
+        out = self._run("--apply", "--yes")
+        self.assertEqual(out.returncode, 0, out.stderr)
+        objs, serves = self._counts()
+        self.assertEqual(objs, 1, "the group still carries more than one :Objective")
+        # both artefatos still SERVE a north — the edges were RELINKED, not dropped
+        self.assertEqual(serves, ["art-1", "art-2"])
+        # the operation hub survives, relabelled, with its own topology and no stamped body
+        hub = self.s.run(f"MATCH (o:`{publisher.OPERACAO_LABEL}` {{group_id:$g}}) "
+                         "RETURN o.ref AS ref, o.body AS body", g=self.g).single()
+        self.assertEqual(hub["ref"], "operacao:closavo")
+        self.assertIsNone(hub["body"], "the operation hub kept the stamped spine body")
+        marco = self.s.run("MATCH (:Artefato {group_id:$g})-[:MARCO_OF]->() RETURN count(*) AS n",
+                           g=self.g).single()["n"]
+        self.assertEqual(marco, 1, "MARCO_OF was collateral damage")
+
+    def test_after_apply_group_health_passes(self):
+        self._run("--apply", "--yes")
+        card = group_health.health(self.s, self.g)
+        self.assertEqual(card["objectives"], 1)
+        self.assertEqual([m for _sev, m in group_health.verdicts(card) if "#633" in m], [])
+
+
+@unittest.skipUnless(_NEO4J, "no Neo4j reachable — live migration tests skipped")
+class MigrationWhenEveryObjectiveIsAHub(_LiveGroup):
+    """The likely petertosh state: `project_lentes` ran BEFORE the first backbone, so the bare
+    `MERGE (o:Objective {group_id:$g})` never created a spine node at all — it only ever matched the
+    hubs. Every :Objective in the group is an operation hub wearing the same stamped body."""
+
+    PREFIX = "t633h-"
+    TOOL = REPO / "tools" / "migrate_objective_singleton.py"
+    BODY = "invariante ATENDENTE: lead -> consulta -> receita -> laudo"
+
+    def seed(self):
+        for name in ("closavo", "blog", "frota", "cortex", "rito", "frontier"):
+            self.s.run("CREATE (o:Objective {group_id:$g, ref:$r, operacao:$n, body:$b})",
+                       g=self.g, r=f"operacao:{name}", n=name, b=self.BODY)
+        self.s.run("CREATE (a:Artefato {group_id:$g, slug:'art-1'})", g=self.g)
+        self.s.run("MATCH (a:Artefato {group_id:$g}) MATCH (o:Objective {group_id:$g}) "
+                   "MERGE (a)-[:SERVES]->(o)", g=self.g)
+
+    def _run(self, *args):
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(REPO / "tools")
+        return subprocess.run([sys.executable, str(self.TOOL), "--group", self.g, *args],
+                              capture_output=True, text=True, env=env, cwd=str(REPO))
+
+    def test_the_north_is_rebuilt_from_the_stamped_body_and_the_hubs_survive(self):
+        out = self._run("--apply", "--yes")
+        self.assertEqual(out.returncode, 0, out.stderr)
+        rows = self._objectives()
+        self.assertEqual(len(rows), 1, "the group still carries more than one :Objective")
+        self.assertEqual(rows[0]["body"], self.BODY, "the rebuilt north lost the text")
+        hubs = self.s.run(f"MATCH (o:`{publisher.OPERACAO_LABEL}` {{group_id:$g}}) "
+                          "RETURN count(*) AS n, count(o.body) AS stamped", g=self.g).single()
+        self.assertEqual(hubs["n"], 6, "the operation hubs were destroyed")
+        self.assertEqual(hubs["stamped"], 0, "the hubs kept the stamped spine body")
+        served = self.s.run(
+            "MATCH (:Artefato {group_id:$g})-[:SERVES]->(o:Objective {group_id:$g}) "
+            "RETURN count(DISTINCT o) AS n", g=self.g).single()["n"]
+        self.assertEqual(served, 1, "the artefato lost its north, or still serves several")
+        card = group_health.health(self.s, self.g)
+        self.assertEqual([m for _sev, m in group_health.verdicts(card) if "#633" in m], [])
+
+    def test_it_refuses_to_guess_when_the_hubs_disagree_on_the_north(self):
+        """Two different texts and no spine node: there is no evidence which one is the north.
+        Refusing beats silently canonising the alphabetically-first body."""
+        self.s.run("MATCH (o:Objective {group_id:$g, ref:'operacao:blog'}) SET o.body='outro norte'",
+                   g=self.g)
+        before = self.s.run("MATCH (o:Objective {group_id:$g}) RETURN count(*) AS n",
+                            g=self.g).single()["n"]
+        out = self._run("--apply", "--yes")
+        self.assertIn("REFUSING", out.stdout)
+        self.assertEqual(self.s.run("MATCH (o:Objective {group_id:$g}) RETURN count(*) AS n",
+                                    g=self.g).single()["n"], before,
+                         "it mutated the graph while refusing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cortex_provenance.py
+++ b/tools/cortex_provenance.py
@@ -32,6 +32,8 @@ _ASSERTED_LABELS = {
     "Genesis", "Objective", "Direction", "Artefato", "Experiment",
     # Structured Activity/Direction lenses: every node is a deterministic log fold (A40).
     "Atividade", "Run", "Fato", "Arco", "Map", "Ticket", "Move", "Claim",
+    # #633 — the per-`operacao` MARCO_OF hub, which used to borrow the :Objective label.
+    "Operacao",
 }
 _EXTRACTED_LABELS = {"Entity", "Source", "Episodic", "Topic", "VozFragment"}
 

--- a/tools/migrate_objective_singleton.py
+++ b/tools/migrate_objective_singleton.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""#633 — make the spine :Objective of a group a SINGLETON again, RELINKING every edge it carries.
+
+The write path (tools/publisher.py) is fixed forward-only: it can no longer mint or stamp a second
+Objective, and the per-`operacao` hub is now labelled :Operacao. This is the one-shot repair for
+graphs that ALREADY duplicated — the fleet's `petertosh` carried 6 :Objective with one identical
+body, which is what `tools/group_health.py` reports as `N Objectives vivos`.
+
+Two damages, two repairs:
+
+  * COLLAPSE — extra spine copies (`ref IS NULL`, i.e. never an operation hub). Every relationship
+    they carry is re-created on the survivor, THEN the copy is DETACH DELETEd. Deleting 5 nodes
+    without relinking would trade duplication for orphanhood: an Artefato whose only SERVES pointed
+    at a copy would stop being reachable from space-0.
+
+  * RELABEL — the `operacao:<name>` hubs `publisher.project_lentes` used to mint as :Objective.
+    These nodes are LEGITIMATE (MARCO_OF hangs off them) and are NEVER deleted, only relabelled to
+    :Operacao. The spine fan they wrongly collected (incoming SERVES from :Artefato, incoming
+    GROUNDS from :Genesis, outgoing ANCHORS to :Direction) is moved to the survivor and the stamped
+    `body`/`spine` properties are cleared. When a sweep already ran on the fixed code, an :Operacao
+    twin exists for that ref — the hub's remaining edges are relinked onto the twin instead.
+
+DRY-RUN IS THE DEFAULT. `--apply` additionally requires `--yes`. Nothing is written otherwise.
+
+    tools/edge-python tools/migrate_objective_singleton.py --group petertosh
+    tools/edge-python tools/migrate_objective_singleton.py --group petertosh --apply --yes
+
+The unicity key is publisher.OBJECTIVE_SINGLETON_KEY — `("group_id",)` today, `("group_id",
+"agent")` once #578 (corpus N×N) lands. Pass `--agent` when that key is in force.
+"""
+import argparse
+import collections
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import publisher  # noqa: E402
+
+# Relationship types are interpolated into Cypher (they cannot be parameterised). Only names that
+# came back from `type(r)` on this very graph AND match this shape are ever spliced in.
+_REL_TYPE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# The edges the spine fan wrongly hung on an operation hub — the only ones moved off it.
+_FAN = (("SERVES", "in", "Artefato"), ("GROUNDS", "in", "Genesis"), ("ANCHORS", "out", "Direction"))
+
+
+def _rel_type(name):
+    if not isinstance(name, str) or not _REL_TYPE.match(name):
+        raise ValueError(f"refusing to splice an unexpected relationship type: {name!r}")
+    return name
+
+
+def _edges_of(s, node_ids):
+    """Every relationship touching these nodes: (owner, kind, outgoing, other, props)."""
+    if not node_ids:
+        return []
+    rows = s.run(
+        "MATCH (o) WHERE elementId(o) IN $ids "
+        "MATCH (o)-[r]-(x) "
+        "RETURN elementId(o) AS owner, type(r) AS kind, startNode(r) = o AS outgoing, "
+        "elementId(x) AS other, properties(r) AS props", ids=list(node_ids))
+    return [dict(r) for r in rows]
+
+
+def _fan_edges_of(s, node_ids):
+    """Only the spine-fan edges on these nodes — what the old bare MERGE wrongly attached."""
+    if not node_ids:
+        return []
+    edges = []
+    for kind, direction, label in _FAN:
+        arrow = (f"(o)-[r:{kind}]->(x:{label})" if direction == "out"
+                 else f"(x:{label})-[r:{kind}]->(o)")
+        rows = s.run(f"MATCH (o) WHERE elementId(o) IN $ids MATCH {arrow} "
+                     "RETURN elementId(o) AS owner, type(r) AS kind, "
+                     f"{'true' if direction == 'out' else 'false'} AS outgoing, "
+                     "elementId(x) AS other, properties(r) AS props", ids=list(node_ids))
+        edges.extend(dict(r) for r in rows)
+    return edges
+
+
+def _relink(s, target, edges):
+    """Re-create `edges` on `target`. MERGE, so an edge the target already has is reused."""
+    for e in edges:
+        if e["other"] == target:
+            continue  # would become a self-loop on the target
+        kind = _rel_type(e["kind"])
+        pattern = f"(a)-[r:{kind}]->(b)" if e["outgoing"] else f"(b)-[r:{kind}]->(a)"
+        s.run("MATCH (a) WHERE elementId(a) = $target "
+              "MATCH (b) WHERE elementId(b) = $other "
+              f"MERGE {pattern} SET r += $props",
+              target=target, other=e["other"], props=e["props"] or {})
+
+
+def _hubs(s, key):
+    """`:Objective` nodes that are really per-`operacao` MARCO_OF hubs (pre-rename)."""
+    where = " AND ".join(f"o.{field} = ${field}" for field in key)
+    rows = s.run(f"MATCH (o:Objective) WHERE {where} AND o.ref IS NOT NULL "
+                 "RETURN elementId(o) AS id, o.ref AS ref, o.body AS body ORDER BY o.ref", **key)
+    return [dict(r) for r in rows]
+
+
+def _twin_of(s, key, ref):
+    """An already-relabelled :Operacao with this ref (a sweep ran before the migration)."""
+    where = " AND ".join(f"n.{field} = ${field}" for field in key)
+    rec = s.run(f"MATCH (n:`{publisher.OPERACAO_LABEL}`) WHERE {where} AND n.ref = $ref "
+                "RETURN elementId(n) AS id", ref=ref, **key).single()
+    return rec["id"] if rec else None
+
+
+def plan(s, group_id, agent=None):
+    """READ-ONLY. What the migration WOULD do, as a dict — the dry-run print and apply share it."""
+    key = publisher.spine_objective_key(group_id, agent)
+    spine = publisher.spine_objectives(s, group_id, agent)
+    hubs = _hubs(s, key)
+    for hub in hubs:
+        hub["twin"] = _twin_of(s, key, hub["ref"])
+    survivor = spine[0] if spine else None
+    dead = spine[1:]
+    body = survivor["body"] if survivor else None
+    ambiguous = None
+    if survivor is None and hubs:
+        # every "objective" in this group was an operation hub — no spine node was ever created.
+        # Rebuild it from the stamped text, but only when the graph agrees on ONE text.
+        bodies = collections.Counter(h["body"] for h in hubs if h["body"])
+        if len(bodies) > 1:
+            ambiguous = sorted(bodies)
+        elif bodies:
+            body = next(iter(bodies))
+    return {"key": key, "survivor": survivor, "dead": dead, "hubs": hubs,
+            "body": body, "ambiguous": ambiguous,
+            "collapse_edges": _edges_of(s, [d["id"] for d in dead]),
+            "fan_edges": _fan_edges_of(s, [h["id"] for h in hubs])}
+
+
+def render(p, group_id):
+    out = [f"group: {group_id}   key: {p['key']}"]
+    if p["ambiguous"]:
+        out.append("REFUSING: no spine :Objective survives and the operation hubs carry "
+                   f"{len(p['ambiguous'])} DIFFERENT bodies — pick the north by hand first.")
+        return "\n".join(out)
+    live = 1 if (p["survivor"] or p["body"]) else 0
+    now = (1 + len(p["dead"]) if p["survivor"] else 0) + len(p["hubs"])
+    out.append(f":Objective in this group now: {now}   (of which operation hubs: {len(p['hubs'])})")
+    if p["survivor"]:
+        out.append(f"  survivor (oldest): {p['survivor']['id']} — body kept as-is")
+    elif p["body"]:
+        out.append("  survivor: NONE — will MERGE the spine node from the stamped body "
+                   f"({p['body'][:60]!r})")
+    for d in p["dead"]:
+        out.append(f"  collapse: {d['id']} → survivor (relink every edge, then DETACH DELETE)")
+    for h in p["hubs"]:
+        how = (f"merge into existing :{publisher.OPERACAO_LABEL} {h['twin']}" if h["twin"]
+               else f"relabel :Objective → :{publisher.OPERACAO_LABEL}")
+        out.append(f"  hub {h['ref']}: {how}; clear the stamped body/spine")
+    out.append(f"  relink: {len(p['collapse_edges'])} edge(s) off the collapsed copies, "
+               f"{len(p['fan_edges'])} spine-fan edge(s) off the hubs")
+    out.append(f"after: {live} :Objective, {len(p['hubs'])} :{publisher.OPERACAO_LABEL} intact")
+    return "\n".join(out)
+
+
+def apply(s, group_id, agent=None):
+    """DESTRUCTIVE. Runs the plan. Callers gate this behind --apply --yes."""
+    p = plan(s, group_id, agent)
+    if p["ambiguous"]:
+        raise SystemExit("refusing: the operation hubs carry different bodies — resolve by hand")
+
+    survivor = p["survivor"]["id"] if p["survivor"] else None
+    if survivor is None and p["body"]:
+        props = ", ".join(f"{field}:${field}" for field in p["key"])
+        survivor = s.run(f"MERGE (o:Objective {{{props}, spine:true}}) SET o.body = $body "
+                         "RETURN elementId(o) AS id", body=p["body"], **p["key"]).single()["id"]
+    elif survivor is not None:
+        s.run("MATCH (o) WHERE elementId(o) = $id SET o.spine = true", id=survivor)
+
+    # 1. the extra spine copies: relink everything they carry, then delete.
+    if survivor is not None:
+        _relink(s, survivor, p["collapse_edges"])
+    dead_ids = [d["id"] for d in p["dead"]]
+    if dead_ids:
+        s.run("MATCH (o) WHERE elementId(o) IN $ids DETACH DELETE o", ids=dead_ids)
+
+    # 2. the operation hubs: move the spine fan to the survivor, drop the stamp, relabel.
+    hub_ids = [h["id"] for h in p["hubs"]]
+    if hub_ids:
+        if survivor is not None:
+            _relink(s, survivor, p["fan_edges"])
+        for kind, direction, label in _FAN:
+            arrow = (f"(o)-[r:{kind}]->(:{label})" if direction == "out"
+                     else f"(:{label})-[r:{kind}]->(o)")
+            s.run(f"MATCH (o) WHERE elementId(o) IN $ids MATCH {arrow} DELETE r", ids=hub_ids)
+        s.run("MATCH (o) WHERE elementId(o) IN $ids REMOVE o.body, o.spine", ids=hub_ids)
+        for hub in p["hubs"]:
+            if hub["twin"]:
+                _relink(s, hub["twin"], _edges_of(s, [hub["id"]]))
+                s.run("MATCH (o) WHERE elementId(o) = $id DETACH DELETE o", id=hub["id"])
+            else:
+                s.run("MATCH (o) WHERE elementId(o) = $id "
+                      f"REMOVE o:Objective SET o:`{publisher.OPERACAO_LABEL}`", id=hub["id"])
+    return p
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--group", help="group_id to repair (default: this install's identity)")
+    ap.add_argument("--agent", default=None,
+                    help="agent, when OBJECTIVE_SINGLETON_KEY includes it (#578)")
+    ap.add_argument("--apply", action="store_true", help="WRITE the plan (also needs --yes)")
+    ap.add_argument("--yes", action="store_true", help="confirm the destructive apply")
+    args = ap.parse_args(argv)
+
+    import _identity
+    from neo4j import GraphDatabase
+    group = args.group or _identity.require_group()
+    uri, user, pw = _identity.neo4j_conn()
+    drv = GraphDatabase.driver(uri, auth=(user, pw))
+    try:
+        with drv.session() as s:
+            print(render(plan(s, group, args.agent), group))
+            if not args.apply:
+                print("\n-- dry-run (nothing written). Re-run with --apply --yes to write. --")
+                return 0
+            if not args.yes:
+                print("\nrefusing --apply without --yes: this DELETES and RELABELS nodes.",
+                      file=sys.stderr)
+                return 2
+            apply(s, group, args.agent)
+            print("\n-- applied --")
+            print(render(plan(s, group, args.agent), group))
+    finally:
+        drv.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/publisher.py
+++ b/tools/publisher.py
@@ -1051,8 +1051,11 @@ def _project_artefato_asset(s, g, asset):
               "MERGE (p)-[r:HAS_ASSET]->(a) "
               "SET r.provenance_class='asserted', r.role=$role",
               g=g, parent=parent, slug=asset_slug, role=asset.get("role"))
-    s.run("MATCH (a:Artefato {group_id:$g, slug:$slug}),(o:Objective {group_id:$g}) "
-          "MERGE (a)-[:SERVES]->(o)", g=g, slug=asset_slug)
+    # #633 — SERVES targets the SPINE Objective, never an `operacao` hub.
+    obj_key = spine_objective_key(g)
+    s.run(f"MATCH (a:Artefato {{group_id:$g, slug:$slug}}) MATCH (o:Objective) "
+          f"WHERE {_spine_where(obj_key)} MERGE (a)-[:SERVES]->(o)",
+          g=g, slug=asset_slug, **obj_key)
 
 
 def project_artefato_asset(asset_slug, *, path, kind, sha256, skill=None, parent_slug=None,
@@ -1403,6 +1406,100 @@ def _project_parceiros(s, g, log):
               g=g, name=p["name"])
 
 
+# --- the spine :Objective is a SINGLETON (#633) ------------------------------------------------
+# The rite promises ONE Objective per group; the fleet's `petertosh` carried SIX, all with the
+# identical body. The append was NOT in the eventlog — `objective.set` is latest-wins and
+# `cortex.objective_at` folds it to one record. It was in the PROJECTION, where two writers shared
+# one label:
+#
+#   * project_lentes minted one `:Objective` per `operacao` (keyed {group_id, ref}) as the MARCO_OF
+#     hub — an operation is NOT the group's north, it only borrowed the label; and
+#   * _project_backbone wrote the spine with a bare `MERGE (o:Objective {group_id:$g})`.
+#
+# A bare MERGE has no discriminating key: it MATCHED those hubs instead of creating the spine node,
+# and `SET o.body=$b` stamped the SAME body on EVERY one of them. The SERVES fan then hung every
+# Artefato off all of them — "aligned with any of the six".
+#
+# The spine is told apart by `spine=true` (what this module writes) OR by `ref IS NULL` (nodes
+# written before the stamp existed — read compat per install, no backfill required); the operation
+# hub always carries a `ref`, because graph_store.merge_node puts it in the MERGE key.
+
+
+OPERACAO_LABEL = "Operacao"
+
+
+def spine_predicate(alias="o"):
+    """The Cypher predicate that tells the spine Objective apart from an operation hub."""
+    return f"({alias}.spine = true OR {alias}.ref IS NULL)"
+
+
+# The identity of the singleton. #578 (corpus N×N, open) pins Genesis/Objective/Direction as
+# {group_id, agent}; when it lands, unicity becomes per-(group_id, agent) — flip THIS TUPLE and the
+# write, the guard and tools/migrate_objective_singleton.py all follow. It is a parameter, not a
+# rewrite: nothing below spells `group_id` on its own.
+OBJECTIVE_SINGLETON_KEY = ("group_id",)
+
+
+def spine_objective_key(group_id, agent=None):
+    """The property map that identifies THE spine Objective, per OBJECTIVE_SINGLETON_KEY."""
+    values = {"group_id": group_id, "agent": agent}
+    return {field: values[field] for field in OBJECTIVE_SINGLETON_KEY}
+
+
+def _spine_where(key, alias="o"):
+    """WHERE fragment pinning `alias` to the singleton key AND to the spine. Field names come from
+    OBJECTIVE_SINGLETON_KEY — a fixed module tuple, never caller input."""
+    pinned = " AND ".join(f"{alias}.{field} = ${field}" for field in key)
+    return f"{pinned} AND {spine_predicate(alias)}"
+
+
+def spine_objectives(s, group_id, agent=None):
+    """Every node that IS (or reads as) the spine Objective for this key, OLDEST FIRST — the view
+    the guard and the migration share. More than one row is the #633 violation."""
+    key = spine_objective_key(group_id, agent)
+    rows = s.run(f"MATCH (o:Objective) WHERE {_spine_where(key)} "
+                 "RETURN elementId(o) AS id, o.body AS body, "
+                 "coalesce(o.created_at, '') AS created_at "
+                 "ORDER BY created_at, id", **key)
+    return [dict(r) for r in rows]
+
+
+def objective_singleton_violation(s, group_id, agent=None):
+    """The guard: at most ONE live spine :Objective per singleton key. Returns the EXTRA nodes
+    (empty == healthy). It REPORTS — it never deletes and never raises into a sweep: an install
+    that already duplicated must keep projecting (CONTRACT C1, fail-dark not fail-stop), and node
+    deletion only ever runs behind the migration's --dry-run/--apply gate."""
+    return spine_objectives(s, group_id, agent)[1:]
+
+
+def merge_spine_objective(s, group_id, body, agent=None):
+    """IDEMPOTENT singleton write of the spine :Objective. Same body → the node is reused as-is.
+    NEW body → superseded IN PLACE (same node, previous text kept in `superseded_body`) — never a
+    CREATE. Returns the elementId of the live spine Objective, or None when there is no body.
+
+    Pre-existing duplicates are NOT collapsed here (that is destructive): the write targets the
+    OLDEST survivor, so it can neither widen the damage nor stamp an operation hub."""
+    if not body:
+        return None
+    key = spine_objective_key(group_id, agent)
+    rows = spine_objectives(s, group_id, agent)
+    if not rows:
+        # MERGE (not CREATE) on the full key + the spine stamp: two sweeps racing converge on one
+        # node instead of each minting its own — the other way a group grows identical copies.
+        props = ", ".join(f"{field}:${field}" for field in key)
+        rec = s.run(f"MERGE (o:Objective {{{props}, spine:true}}) "
+                    "SET o.body = $body RETURN elementId(o) AS id", body=body, **key).single()
+        return rec["id"]
+    live = rows[0]
+    if live["body"] != body:
+        s.run("MATCH (o) WHERE elementId(o) = $id "
+              "SET o.superseded_body = o.body, o.body = $body, o.spine = true",
+              id=live["id"], body=body)
+    else:
+        s.run("MATCH (o) WHERE elementId(o) = $id SET o.spine = true", id=live["id"])
+    return live["id"]
+
+
 def _project_backbone(s, g, log):
     """Project the canonical SPINE BACKBONE on an open session `s`: :Genesis (space-0) -GROUNDS->
     :Objective + the ANCHORS rebuild (the active steers, DESTRUCTIVE DELETE-then-readd from the
@@ -1417,24 +1514,34 @@ def _project_backbone(s, g, log):
           "gen.method='memory/method.md', gen.personality='memory/personality.md'",
           g=g, c=cfg.get("codename") or cfg.get("name"), v=cfg.get("voice"))
     obj = cortex.objective_at(log=log) or {}
+    key = spine_objective_key(g)
+    spine = _spine_where(key)
     if obj.get("body"):
-        s.run("MERGE (o:Objective {group_id:$g}) SET o.body=$b", g=g, b=obj["body"])
-        s.run("MATCH (gen:Genesis {group_id:$g}),(o:Objective {group_id:$g}) "
-              "MERGE (gen)-[:GROUNDS]->(o)", g=g)
+        merge_spine_objective(s, g, obj["body"])
+        s.run(f"MATCH (gen:Genesis {{group_id:$g}}) MATCH (o:Objective) WHERE {spine} "
+              "MERGE (gen)-[:GROUNDS]->(o)", g=g, **key)
         # ENSURE every Artefato SERVES the objective (Codex P2): an Artefato published BEFORE the
         # Objective existed had its SERVES no-op at projection time; the backbone (run every canonical
         # sweep, once an Objective exists) guarantees the hub link so it is reachable from space-0 —
         # cheap idempotent MERGEs, no embeddings, independent of the per-slug skip-present recovery.
-        s.run("MATCH (a:Artefato {group_id:$g}),(o:Objective {group_id:$g}) "
-              "MERGE (a)-[:SERVES]->(o)", g=g)
+        # #633: pinned to the SPINE — the fan used to hang every Artefato off every operation hub too.
+        s.run(f"MATCH (a:Artefato {{group_id:$g}}) MATCH (o:Objective) WHERE {spine} "
+              "MERGE (a)-[:SERVES]->(o)", g=g, **key)
+        extras = objective_singleton_violation(s, g)
+        if extras:
+            print(f"publisher: {len(extras) + 1} live :Objective in group {g} — the spine must be a "
+                  "singleton (#633). Wrote the oldest only; collapse the rest with "
+                  f"`tools/edge-python tools/migrate_objective_singleton.py --group {g}` "
+                  "(dry-run first).")
     # ANCHORS = the CURRENTLY active steers — REBUILD each sync (DESTRUCTIVE) so a dropped/superseded
     # Direction stops being anchored (recall from space-0 must match the log).
     dirs = cortex.direction_at(log=log) or {}
-    s.run("MATCH (o:Objective {group_id:$g})-[r:ANCHORS]->(:Direction) DELETE r", g=g)
+    s.run(f"MATCH (o:Objective)-[r:ANCHORS]->(:Direction) WHERE {spine} DELETE r", **key)
     for it in dirs.get("set", []) + dirs.get("proposed", []):
         s.run("MERGE (d:Direction {group_id:$g, body:$b})", g=g, b=it["body"])
-        s.run("MATCH (o:Objective {group_id:$g}),(d:Direction {group_id:$g, body:$b}) "
-              "MERGE (o)-[:ANCHORS]->(d)", g=g, b=it["body"])
+        s.run(f"MATCH (o:Objective) WHERE {spine} "
+              "MATCH (d:Direction {group_id:$g, body:$b}) "
+              "MERGE (o)-[:ANCHORS]->(d)", g=g, b=it["body"], **key)
     # Ticket A — the episteme spine rides the same canonical sync: :Hypothesis nodes fold from
     # hypothesis.declared/superseded; the §6 parceiro mark folds from parceiro.promoted.
     _project_hypotheses(s, g, log)
@@ -1622,8 +1729,11 @@ def project_artefato(slug, intent, *, skill, distills=None, proposes=None, cites
                 s.run("MATCH (a:Artefato {group_id:$g, slug:$slug}) SET a += $props",
                       g=g, slug=slug, props=gate_props)
             # every Artefato SERVES the objective — the hub keeping it reachable from space-0.
-            s.run("MATCH (a:Artefato {group_id:$g, slug:$slug}),(o:Objective {group_id:$g}) "
-                  "MERGE (a)-[:SERVES]->(o)", g=g, slug=slug)
+            # #633 — the SPINE objective only, never an `operacao` hub.
+            obj_key = spine_objective_key(g)
+            s.run(f"MATCH (a:Artefato {{group_id:$g, slug:$slug}}) MATCH (o:Objective) "
+                  f"WHERE {_spine_where(obj_key)} MERGE (a)-[:SERVES]->(o)",
+                  g=g, slug=slug, **obj_key)
             # embed the CONTENT (Codex P2): a concept in the body but not the kernel must still be
             # semantically recallable over a.embedding. Re-embed only when the EMBED INPUT CHANGED
             # (Codex P2): store a hash of (slug+intent+spec_text); a republish with changed
@@ -2259,8 +2369,13 @@ def project_lentes(log, store):
     })
     for operation_name in operation_names:
         ref = f"operacao:{operation_name}"
+        # #633 — an `operacao` is the MARCO_OF hub, NOT the group's north. It used to borrow the
+        # :Objective label, which is why `MATCH (o:Objective {group_id:$g})` counted six of them on
+        # petertosh, why the bare spine MERGE stamped its body onto every one, and why #638's
+        # group_health (which counts the label) reports the group as duplicated. Existing graphs are
+        # relabelled by tools/migrate_objective_singleton.py.
         operations.append((ref, lambda ref=ref, operation_name=operation_name:
-                           store.merge_node(ref, "Objective", {"operacao": operation_name})))
+                           store.merge_node(ref, OPERACAO_LABEL, {"operacao": operation_name})))
 
     edge_sets = {}
 


### PR DESCRIPTION
Closes #633.

### Qual ponta duplicava — a resposta é não-óbvia
`eventlog.set_objective` é latest-wins e `cortex.objective_at` dobra tudo para **um** registro: nenhum número de chamadas faz crescer um segundo nó. **O log está correto** — por isso a migração é só de grafo.

A duplicação vivia em `publisher.py`, onde **dois escritores dividiam um rótulo**:
- `project_lentes` cunhava um `:Objective` por `operacao`, chaveado `{group_id, ref}`, como hub do `MARCO_OF`;
- `_project_backbone` escrevia a espinha com `MERGE (o:Objective {group_id:$g})` — **sem chave discriminante**.

Sem chave, esse MERGE **casava com os hubs** em vez de criar o nó da espinha, e o `SET o.body` carimbava o mesmo body em todos. Depois o leque de `SERVES` pendurava cada Artefato em todos eles. **É a assinatura exata dos 6 Objectives do petertosh.**

### O critério literal da issue passa hoje
Registrado no commit para ninguém reabrir a #633 alegando que o teste de aceite dela é verde. O MERGE nu é idempotente **enquanto nada mais usar o rótulo**; o defeito só aparece com o plano de lentes presente. O teste que fica vermelho é outro, e reproduz o número da issue: `6 != 1 : 6 :Objective carry the spine body`.

### Quatro mutações, cada uma matou um teste
A que mais importa: pular o ramo de **adoção** do nó legado mata `the legacy Objective was forked, not adopted` — sem ela, o fix entregaria a **todo install vivo** uma segunda cópia, porque `ed` e `turing` carregam Objectives sem carimbo.

### Julgamento que merece seu olho
O hub de `operacao` foi rerrotulado `:Operacao`. Ele nunca foi o norte do group, e o `group_health` (#638) conta o rótulo `:Objective` — deixá-los como Objective tornava o critério impossível de passar para qualquer group com plano de lentes. `Operacao` foi registrado **aditivamente** em `blog/server.py` e `cortex_provenance.py` para os hubs não sumirem do `/cortex`.

### Fora, de propósito
Nenhuma constraint de unicidade no Neo4j: `communities.py` documenta uma colisão anterior de nome de schema cuja exceção foi engolida e virou "0 clusters" silencioso por semanas.