### PR TITLE
fix(consolidate): None deixa de ser silêncio — e a causa da frota NÃO era o #603

### DIFF
--- a/tests/test_communities.py
+++ b/tests/test_communities.py
@@ -145,5 +145,168 @@ class TestSweepKnob(unittest.TestCase):
             os.environ.pop("EDGE_COMMUNITIES", None)
 
 
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def data(self):
+        return self._rows
+
+    def single(self):
+        return self._rows[0] if self._rows else None
+
+
+class _FakeSession:
+    """O mínimo do driver neo4j que `consolidate` toca: as duas leituras e a escrita."""
+
+    def __init__(self, ents=(), rels=(), raise_on_read=None):
+        self.ents, self.rels, self.raise_on_read = list(ents), list(rels), raise_on_read
+        self.writes = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def run(self, query, **params):
+        if self.raise_on_read:
+            raise self.raise_on_read
+        if "MATCH (n:Entity" in query:
+            return _FakeResult(self.ents)
+        if "RELATES_TO" in query and "RETURN a.uuid" in query:
+            return _FakeResult(self.rels)
+        self.writes.append(query)
+        return _FakeResult([])
+
+    def execute_write(self, fn):
+        return fn(self)
+
+
+class _FakeDriver:
+    def __init__(self, session):
+        self._session = session
+
+    def session(self):
+        return self._session
+
+
+class TestConsolidateNoneIsAFailure(unittest.TestCase):
+    """O dente da #635.
+
+    `consolidate()` devolvia None em três situações que são coisas DIFERENTES — sem grupo, sem
+    driver, e erro no meio do grafo — e o chamador imprimia "0 clusters" para todas. Um órgão que
+    não rodou lia-se exatamente como um grafo que ainda não tem o que agrupar; foi essa
+    indistinção que fez o apagão de identidade (lida em tempo de import, corrigido no #603)
+    passar por ESCASSEZ por meses. Ausência de resultado só é sucesso quando o órgão rodou."""
+
+    def _patched_driver(self, driver):
+        original = communities._driver
+        communities._driver = lambda **kw: driver
+        self.addCleanup(lambda: setattr(communities, "_driver", original))
+
+    def test_no_group_is_a_failure_not_a_silent_none(self):
+        """A FIXTURE do sintoma relatado: a chamada que devolvia None na hora, antes de tocar o
+        grafo. Vermelha no comportamento antigo — lá isto era `assertIsNone`."""
+        with self.assertRaises(communities.ConsolidationFailed) as caught:
+            communities.consolidate(group=None)
+        self.assertEqual(caught.exception.reason, "no-group")
+        self.assertEqual(caught.exception.severity, "dark")   # não pude rodar
+
+    def test_unreachable_graph_is_a_failure(self):
+        self._patched_driver(None)
+        with self.assertRaises(communities.ConsolidationFailed) as caught:
+            communities.consolidate(group="g")
+        self.assertEqual(caught.exception.reason, "graph-unreachable")
+        self.assertEqual(caught.exception.severity, "dark")
+
+    def test_error_mid_sweep_is_a_failure_and_keeps_the_cause(self):
+        boom = RuntimeError("Neo4jError: transaction terminated")
+        self._patched_driver(_FakeDriver(_FakeSession(raise_on_read=boom)))
+        with self.assertRaises(communities.ConsolidationFailed) as caught:
+            communities.consolidate(group="g")
+        self.assertEqual(caught.exception.reason, "graph-error")
+        self.assertEqual(caught.exception.severity, "fail")   # rodei e quebrei
+        self.assertIs(caught.exception.__cause__, boom)
+
+    def test_the_severities_are_group_healths_words(self):
+        """#638 já separa `dark` (não pude medir) de `fail` (medi e está ruim) e diz, no
+        próprio verdict de Community, que ZERO só é legítimo se o consolidate falhou ALTO.
+        Este módulo fala a MESMA língua — um terceiro vocabulário reabriria a indistinção
+        num outro lugar."""
+        import group_health
+        vocabulary = {sev for sev, _ in group_health.verdicts(
+            {"group": "g", "nodes": 0, "genesis": 0, "objectives": 0, "directions_total": 0,
+             "directions_with_handle": 0, "directions_with_lifecycle": 0, "communities": 0,
+             "has_topic_edges": 0, "has_topic_degree": 0.0})} | {"dark", "warn"}
+        self.assertTrue(set(communities.ConsolidationFailed.SEVERITIES.values()) <= vocabulary)
+
+    def test_nothing_to_group_is_a_legitimate_empty_list(self):
+        """O outro lado do dente: um grafo alcançável e vazio NÃO é falha — devolve []."""
+        self._patched_driver(_FakeDriver(_FakeSession(ents=[], rels=[])))
+        self.assertEqual(communities.consolidate(group="g"), [])
+
+    def test_only_dust_is_also_an_empty_list(self):
+        """Entidades existem mas nenhuma forma cluster >= min_size: rodou, não achou. []"""
+        ents = [{"u": u, "name": u, "summ": ""} for u in ("a", "b")]
+        self._patched_driver(_FakeDriver(_FakeSession(ents=ents, rels=[])))
+        self.assertEqual(communities.consolidate(group="g", summarize_fn=lambda m: "NOME: x"), [])
+
+    def test_a_real_cluster_still_writes_and_returns_it(self):
+        ents = [{"u": u, "name": u, "summ": ""} for u in ("a", "b", "c")]
+        rels = [{"a": x, "b": y} for x, y in TRI_A]
+        session = _FakeSession(ents=ents, rels=rels)
+        self._patched_driver(_FakeDriver(session))
+        out = communities.consolidate(
+            group="g", summarize_fn=lambda m: "NOME: Tema | SUMÁRIO: resumo")
+        self.assertEqual(out, [{"name": "Tema", "size": 3}])
+        self.assertTrue(any("CREATE (c:Community" in q for q in session.writes))
+
+
+class TestSweepReportsConsolidationFailureLoud(unittest.TestCase):
+    """"0 clusters" tem que significar UMA coisa só. O chamador é onde a indistinção era visível
+    para o operador, então é onde o teste morde."""
+
+    def _run_maybe_consolidate(self, fake):
+        import contextlib
+        import io
+        import os
+        import sweep
+        original = communities.consolidate
+        os.environ["EDGE_COMMUNITIES"] = "1"
+        buf = io.StringIO()
+        try:
+            communities.consolidate = fake
+            with contextlib.redirect_stdout(buf):
+                sweep._maybe_consolidate()
+        finally:
+            communities.consolidate = original
+            os.environ.pop("EDGE_COMMUNITIES", None)
+        return buf.getvalue()
+
+    def test_nothing_to_group_reads_as_zero_clusters(self):
+        out = self._run_maybe_consolidate(lambda **kw: [])
+        self.assertIn("0 clusters", out)
+
+    def test_failure_does_not_read_as_zero_clusters(self):
+        def fail(**kw):
+            raise communities.ConsolidationFailed("no-group", "sem identidade de grupo")
+
+        out = self._run_maybe_consolidate(fail)
+        self.assertNotIn("0 clusters", out)      # a linha calma da escassez NÃO pode aparecer
+        self.assertIn("FALHARAM", out)
+        self.assertIn("no-group", out)
+        self.assertIn("[dark]", out)             # a severidade de group_health, no terminal
+        self.assertIn("PARADAS", out)            # paradas, não vazias
+
+    def test_an_unexpected_error_is_also_loud_and_never_raises(self):
+        def boom(**kw):
+            raise RuntimeError("boom")
+
+        out = self._run_maybe_consolidate(boom)   # não derruba o sweep
+        self.assertNotIn("0 clusters", out)
+        self.assertIn("FALHARAM", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -2133,5 +2133,136 @@ class PublishCarriesResidualsFromTheProof(unittest.TestCase):
             self.assertIsNone(ev["payload"]["residuals"])
 
 
+class _RecordingSession:
+    """Grava as queries que a projeção emite — o grau de HAS_TOPIC é contável sem Neo4j."""
+
+    def __init__(self):
+        self.calls = []
+
+    def run(self, query, **params):
+        self.calls.append((query, params))
+        return []
+
+    def edges(self, rel):
+        return [p for q, p in self.calls if f"MERGE (se)-[r:{rel}]" in q or f"MERGE (vf)-[r:{rel}]" in q]
+
+
+class SessionTopicDegreeHasACeiling(unittest.TestCase):
+    """#635, o segundo dente. O vocabulário de Topic é global e pequeno (8 specs + o genérico
+    `session-voice`) e a indexação usa `min_score=1`: um fragmento que cita um termo já abre um
+    Topic para a sessão. Sem teto, a frota mediu 21357 arestas HAS_TOPIC contra ~15400 nós — cada
+    sessão ancorando na maioria do vocabulário. Um grafo em que tudo é sobre tudo não aponta."""
+
+    TOPICS = ["edge-episteme-install", "mentor-experiment", "report-rite", "artifact-html-js",
+              "source-sufficiency", "session-memory-navigation"]
+
+    def _log_with_a_wide_session(self, tmp):
+        """Uma sessão ancorada em 6 tópicos. A FORÇA por sessão é o nº de fragmentos DESTA
+        sessão sob o tópico: os dois primeiros da lista são os fortes (3 e 2 fragmentos), os
+        outros quatro têm 1 — o teto tem que ficar com os fortes, não com os primeiros."""
+        log = Path(tmp) / "log.jsonl"
+        strength = {"report-rite": 3, "mentor-experiment": 2}
+        for topic_id in self.TOPICS:
+            n = strength.get(topic_id, 1)
+            eventlog.record_session_topic(
+                "s1", topic_id, title=f"titulo {topic_id}", surface="claude",
+                path="/tmp/s1.jsonl", score=1,
+                fragments=[{"turn": i, "snippet": f"{topic_id} fragmento {i}"}
+                           for i in range(1, n + 1)],
+                log=log)
+        return log
+
+    def _project(self, log):
+        session = _RecordingSession()
+        publisher._project_session_topic_index(
+            session, "g1", eventlog.session_topics_at(log=log), log=log)
+        return session
+
+    def test_has_topic_degree_is_capped_at_three(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = self._log_with_a_wide_session(tmp)
+            index = eventlog.session_topics_at(log=log)
+            self.assertEqual(len(index["sessions"]["s1"]["topics"]), 6)   # o fold guarda TUDO
+            anchored = [p["tid"] for p in self._project(log).edges("HAS_TOPIC")]
+            self.assertEqual(len(anchored), 3)                            # o grafo, não
+
+    def test_the_cap_keeps_the_strongest_topics_of_this_session(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = self._log_with_a_wide_session(tmp)
+            anchored = sorted(p["tid"] for p in self._project(log).edges("HAS_TOPIC"))
+            self.assertIn("report-rite", anchored)        # 3 fragmentos desta sessão
+            self.assertIn("mentor-experiment", anchored)  # 2
+
+    def test_a_narrow_session_is_untouched(self):
+        """Compatibilidade: quem já está abaixo do teto não perde nenhuma aresta."""
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            for topic_id in ("report-rite", "mentor-experiment"):
+                eventlog.record_session_topic(
+                    "s1", topic_id, title="t", surface="claude",
+                    fragments=[{"turn": 1, "snippet": f"{topic_id} um"}], log=log)
+            anchored = sorted(p["tid"] for p in self._project(log).edges("HAS_TOPIC"))
+            self.assertEqual(anchored, ["mentor-experiment", "report-rite"])
+
+    def test_a_cut_topic_does_not_come_back_through_about(self):
+        """O ABOUT do fragmento é a porta dos fundos do mesmo grau: um tópico cortado não pode
+        continuar com membros — senão a limpeza de Topic órfão nunca o apaga."""
+        with tempfile.TemporaryDirectory() as tmp:
+            log = self._log_with_a_wide_session(tmp)
+            session = self._project(log)
+            anchored = {p["tid"] for p in session.edges("HAS_TOPIC")}
+            about = {p["tid"] for p in session.edges("ABOUT")}
+            self.assertTrue(about <= anchored, f"ABOUT vazou para {about - anchored}")
+
+    def test_the_ceiling_is_a_knob(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = self._log_with_a_wide_session(tmp)
+            try:
+                os.environ["EDGE_TOPIC_MAX_PER_SESSION"] = "1"
+                self.assertEqual(len(self._project(log).edges("HAS_TOPIC")), 1)
+                os.environ["EDGE_TOPIC_MAX_PER_SESSION"] = "0"   # 0 = sem teto (escape hatch)
+                self.assertEqual(len(self._project(log).edges("HAS_TOPIC")), 6)
+            finally:
+                os.environ.pop("EDGE_TOPIC_MAX_PER_SESSION", None)
+
+    def test_the_cap_scales_the_edge_count_the_fleet_arithmetic_assumes(self):
+        """O que o teto GARANTE, e é o passo de que a conta da frota depende: o total de
+        HAS_TOPIC do group vira `teto / grau_médio` do que era, porque o teto morde toda sessão
+        larga e não mexe em nó nenhum. Em `group_health` (#638) o critério é por NÓ
+        (`HAS_TOPIC_DEGREE_CEILING`), e o denominador é o grafo inteiro — Entity, Direction,
+        Artefato — que esta projeção não controla; por isso a conta 21357/15400 = 1.39 -> ~0.73
+        vive na frota real, e o que se pina AQUI é o numerador."""
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            for i in range(1, 41):                       # 40 sessões, 6 tópicos globais cada
+                for topic_id in self.TOPICS:
+                    eventlog.record_session_topic(
+                        f"s{i}", topic_id, title="t", surface="claude",
+                        fragments=[{"turn": 1, "snippet": f"{topic_id} s{i}"}], log=log)
+
+            def edges(cap):
+                os.environ["EDGE_TOPIC_MAX_PER_SESSION"] = str(cap)
+                try:
+                    return len(self._project(log).edges("HAS_TOPIC"))
+                finally:
+                    os.environ.pop("EDGE_TOPIC_MAX_PER_SESSION", None)
+
+            before = edges(0)                            # 0 = sem teto = comportamento antigo
+            after = edges(publisher.SESSION_TOPIC_CAP_DEFAULT)
+            self.assertEqual(before, 40 * len(self.TOPICS))
+            self.assertEqual(after, 40 * publisher.SESSION_TOPIC_CAP_DEFAULT)
+            self.assertAlmostEqual(after / before,
+                                   publisher.SESSION_TOPIC_CAP_DEFAULT / len(self.TOPICS))
+
+    def test_a_topic_with_no_members_is_deleted(self):
+        """"Topic sem membros some" — a limpeza roda em toda projeção, não só quando dá sorte."""
+        with tempfile.TemporaryDirectory() as tmp:
+            log = self._log_with_a_wide_session(tmp)
+            joined = "\n".join(q for q, _ in self._project(log).calls)
+            self.assertIn("MATCH (t:Topic {group_id:$g}) "
+                          "WHERE NOT (()-[:HAS_TOPIC]->(t)) AND NOT (()-[:ABOUT]->(t)) "
+                          "DETACH DELETE t", joined)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/communities.py
+++ b/tools/communities.py
@@ -8,9 +8,11 @@ Curadoria humana fica onde erro machuca (harm-bearing), nunca como porteiro da v
 
 READ navigation is exposed through the Modulo-2 door (cortex.communities/community/locate —
 late-binding, ADR-0019); the WRITE side (consolidate) is called by sweep/heartbeat directly,
-mirroring the eventlog split (writes direct, reads through the door). All graph adapters are
-lazy imports that degrade DARK (None), the same contract as briefing.graph_clusters; this
-module imports bare (no top-level neo4j/urllib) so bare-python callers can hold the door.
+mirroring the eventlog split (writes direct, reads through the door). The READ adapters are
+lazy imports that degrade DARK (None), the same contract as briefing.graph_clusters; the WRITE
+one does NOT — `consolidate` raises ConsolidationFailed, because a write that could not happen
+is a failure and not an empty result (#635). This module imports bare (no top-level
+neo4j/urllib) so bare-python callers can hold the door.
 """
 import json
 import os
@@ -19,6 +21,36 @@ import uuid as uuidlib
 from collections import Counter, defaultdict
 
 _AUTO = object()   # "resolva pelo seam" — DISTINTO de None/"" , que significam "sem grupo"
+
+
+class ConsolidationFailed(RuntimeError):
+    """`consolidate()` NÃO conseguiu agrupar — distinto de `[]` ("não havia o que agrupar").
+
+    O dente da #635. `consolidate()` devolvia None em três situações que são coisas diferentes
+    — sem grupo, sem driver, e grafo inalcançável/erro no meio — e o chamador (`sweep`) fazia
+    `len(written or [])` e imprimia "0 clusters" para TODAS. Um grafo que não pôde ser
+    consolidado lia-se, no terminal do operador, idêntico a um grafo que ainda não tem o que
+    consolidar. Foi essa indistinção que fez o apagão (identidade lida em tempo de import,
+    corrigido no PR #603) passar por ESCASSEZ durante meses: a frota inteira imprimia
+    "0 clusters" e ninguém viu falha nenhuma.
+
+    Ausência de resultado só é sucesso quando o órgão RODOU. Falha em rodar é falha, e falha
+    tem que ser alta.
+
+    O vocabulário é o de `group_health.verdicts` (#638), não um terceiro inventado:
+      · `dark` — NÃO PUDE rodar (sem identidade de grupo, sem Bolt). Nada foi medido, o que é
+        MUITO diferente de "tudo bem": lá o `main` já sai 2 nesse caso.
+      · `fail` — rodei contra o grafo e quebrei no meio.
+    `.severity` é essa palavra, `.reason` é a máquina (`no-group` · `graph-unreachable` ·
+    `graph-error`), `.detail` é o humano. Nenhuma das três é `[]`."""
+
+    SEVERITIES = {"no-group": "dark", "graph-unreachable": "dark", "graph-error": "fail"}
+
+    def __init__(self, reason, detail=""):
+        self.reason = reason
+        self.severity = self.SEVERITIES.get(reason, "fail")
+        self.detail = detail
+        super().__init__(f"{reason}: {detail}" if detail else reason)
 
 
 def _resolve_group(group):
@@ -253,14 +285,23 @@ def _default_summarize(members_text):
 def consolidate(group=_AUTO, summarize_fn=None, min_size=3, min_cross=2, **kw):
     """The offline consolidation sweep (WRITE side — called by heartbeat/sweep, NOT the door):
     entities+RELATES_TO → cluster() → merge_pass() → summarize each → wipe-rebuild Community/
-    HAS_MEMBER (their own lifecycle; the log stays the truth, ADR-0006). Returns the list of
-    {name, size} written, or None on a dark graph. Dust count is logged, never silent."""
+    HAS_MEMBER (their own lifecycle; the log stays the truth, ADR-0006).
+
+    Returns the list of {name, size} written — `[]` means the sweep RAN and there was nothing to
+    group (no entities, or every candidate was dust). It NEVER returns None: a consolidation that
+    could not run raises `ConsolidationFailed`, because the read side's dark contract (None) is
+    wrong for a WRITE — a write that did not happen is not "no data", it is a failure, and it
+    must reach the operator as one. Dust count is logged, never silent."""
     group = _resolve_group(group)
     if not group:
-        return None
+        raise ConsolidationFailed(
+            "no-group", "sem identidade de grupo (EDGE_GROUP ou agent.yaml name/codename) — "
+            "nada foi lido nem escrito no grafo")
     drv = _driver(**kw)
     if drv is None:
-        return None
+        raise ConsolidationFailed(
+            "graph-unreachable", f"sem driver Neo4j para o grupo {group!r} "
+            "(bolt fora, ou senha ausente em EDGE_NEO4J_PASSWORD / _identity)")
     summarize_fn = summarize_fn or _default_summarize
     try:
         with drv.session() as s:
@@ -316,8 +357,10 @@ def consolidate(group=_AUTO, summarize_fn=None, min_size=3, min_cross=2, **kw):
             s.execute_write(_rebuild)
         return [{"name": n, "size": len(g)} for _, n, _, g in payloads]
     except Exception as e:
-        # ed: never swallow silently — a raised consolidate reads identically to an empty
-        # graph ("0 clusters"), which hid the schema-name collision above for weeks.
+        # ed: never swallow silently — a swallowed consolidate reads identically to an empty
+        # graph ("0 clusters"), which hid the schema-name collision above for weeks. The
+        # traceback stays (it is the only diagnosis of a mid-write failure) and the failure now
+        # PROPAGATES: the caller decides how loud, and `edge-python -c "...consolidate()"`
+        # exits non-zero instead of printing a reassuring None.
         import traceback; traceback.print_exc()
-        print(f"communities: consolidate degraded ({type(e).__name__}: {e}) — 0 clusters written")
-        return None
+        raise ConsolidationFailed("graph-error", f"{type(e).__name__}: {e}") from e

--- a/tools/publisher.py
+++ b/tools/publisher.py
@@ -1090,28 +1090,88 @@ def project_artefato_asset(asset_slug, *, path, kind, sha256, skill=None, parent
             pass
 
 
+SESSION_TOPIC_CAP_DEFAULT = 3
+
+
+def _session_topic_cap():
+    """Quantos Topics uma sessão pode ancorar no grafo. `EDGE_TOPIC_MAX_PER_SESSION`; <=0 desliga.
+
+    O vocabulário de Topic é GLOBAL e pequeno (topic_threads.TOPIC_SPECS + o genérico
+    `session-voice`), e `infer_session_topics` indexa com `min_score=1`: UM fragmento que cita um
+    termo já abre um Topic para a sessão inteira. Sem teto, cada sessão acaba ancorando na maioria
+    do vocabulário — a frota mediu 21357 arestas HAS_TOPIC contra ~15400 nós — e um grafo em que
+    toda sessão é sobre quase todo tópico não aponta para lugar nenhum: "tudo é sobre tudo" (#635).
+    O teto é do lado da ESCRITA e a projeção é wipe-rebuild por sessão, então a próxima projeção
+    conserta um grafo já inchado sem migração destrutiva.
+
+    O 3 sai do critério de frota, não do gosto: `group_health.HAS_TOPIC_DEGREE_CEILING` (#638)
+    reprova acima de 1.2 arestas HAS_TOPIC por NÓ do group, e a frota está em 21357/15400 = 1.39.
+    Medido sobre o fold real, o grau por sessão cai de 5.72 para 3.00 — as arestas caem para ~52%
+    e, sobre a MESMA contagem de nós da frota (o teto corta aresta, não nó), 1.39 vira ~0.73. Um
+    teto de 4 daria ~0.97: passa, mas sem margem para o vocabulário crescer. O denominador do
+    critério é o grafo inteiro e esta projeção não o controla — o que o teto garante é o
+    numerador."""
+    raw = os.environ.get("EDGE_TOPIC_MAX_PER_SESSION")
+    if raw is None:
+        return SESSION_TOPIC_CAP_DEFAULT
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        print(f"publisher: EDGE_TOPIC_MAX_PER_SESSION={raw!r} não é inteiro — usando "
+              f"{SESSION_TOPIC_CAP_DEFAULT}")
+        return SESSION_TOPIC_CAP_DEFAULT
+
+
+def _ranked_session_topics(session, topics, cap):
+    """Os Topics que ESTA sessão ancora, os mais fortes primeiro, cortados no teto.
+
+    A força é por sessão, nunca global: quantos fragmentos DESTA sessão o fold listou sob o tópico
+    (a interseção entre `session["fragments"]` e `topic["fragments"]`). Ordenar pelo `score` global
+    daria a MESMA cabeça de lista para toda sessão do install — trocaria "tudo é sobre tudo" por
+    "tudo é sobre os mesmos três". O score global e o topic_id só desempatam, para a projeção ser
+    determinística. Devolve na ordem ordenada do fold (estabilidade do wipe-rebuild)."""
+    ids = [t for t in (session.get("topics") or []) if isinstance(t, str)]
+    if cap <= 0 or len(ids) <= cap:
+        return ids
+    own = set(session.get("fragments") or [])
+
+    def rank(tid):
+        topic = topics.get(tid) or {}
+        mine = len(own.intersection(topic.get("fragments") or ()))
+        score = topic.get("score") if isinstance(topic.get("score"), (int, float)) else 0
+        return (-mine, -score, tid)
+
+    return sorted(sorted(ids, key=rank)[:cap])
+
+
 def _project_session_topic_index(s, g, index, log=eventlog.LOG):
     """Project the automatic Voz/session topic index.
 
     The log is the source of truth; these nodes are navigational hypotheses. Rebuild the owned
     Session->Topic/Fragment edges for sessions present in the fold so a changed topic extraction does
     not strand stale fragments.
+
+    Only the session's strongest `_session_topic_cap()` topics reach the graph — the fold keeps
+    every one of them, and the log is still the truth; the graph is the NAVIGATION, and navigation
+    dies of too many edges before it dies of too few.
     """
     if not isinstance(index, dict):
         return
     topics = index.get("topics") or {}
     fragments = index.get("fragments") or {}
+    cap = _session_topic_cap()
     for session in (index.get("sessions") or {}).values():
         sid = session.get("session_id")
         if not sid:
             continue
+        kept = _ranked_session_topics(session, topics, cap)
         s.run(
             "MERGE (se:Episodic {group_id:$g, session_id:$sid}) "
             "SET se.name=$sid, se.key=$sid, se.uuid=$uuid, se.surface=$surface, se.path=$path, "
             "se.summary=$summary, se.medium_tier='low', se.projected_at=$pat",
             g=g, sid=sid, uuid=f"session:{sid}", surface=session.get("surface"),
             path=session.get("path"),
-            summary=f"session topic index: {len(session.get('topics') or [])} topic(s)",
+            summary=f"session topic index: {len(kept)} topic(s)",
             pat=session.get("latest_ts") or _dt.now(_tz.utc).isoformat())
         s.run(
             "MATCH (se:Episodic {group_id:$g, session_id:$sid})-[r:HAS_TOPIC]->(:Topic) DELETE r",
@@ -1120,7 +1180,7 @@ def _project_session_topic_index(s, g, index, log=eventlog.LOG):
             "MATCH (se:Episodic {group_id:$g, session_id:$sid})-[:HAS_FRAGMENT]->"
             "(vf:VozFragment {group_id:$g}) DETACH DELETE vf",
             g=g, sid=sid)
-        for topic_id in session.get("topics") or []:
+        for topic_id in kept:
             topic = topics.get(topic_id) or {}
             s.run(
                 "MERGE (t:Topic {group_id:$g, topic_id:$tid}) "
@@ -1152,7 +1212,10 @@ def _project_session_topic_index(s, g, index, log=eventlog.LOG):
                 "(vf:VozFragment {group_id:$g, fragment_id:$fid}) "
                 "MERGE (se)-[r:HAS_FRAGMENT]->(vf) SET r.provenance_class='extracted'",
                 g=g, sid=sid, fid=fid)
-            if topic_id:
+            # o fragmento só aponta para um Topic que a sessão ancorou: um ABOUT sobrevivente de
+            # um tópico cortado reabriria pela porta de trás exatamente o grau que o teto fecha,
+            # e ainda seguraria vivo um Topic que a limpeza de órfãos deveria apagar.
+            if topic_id and topic_id in kept:
                 s.run(
                     "MATCH (vf:VozFragment {group_id:$g, fragment_id:$fid}),"
                     "(t:Topic {group_id:$g, topic_id:$tid}) "

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1088,15 +1088,33 @@ def embed_and_signal(slug, body, cites, embed_fn=None, log=eventlog.LOG):
 def _maybe_consolidate():
     """Communities consolidation behind EDGE_COMMUNITIES=1 (dark by default, padrão EDGE_CONDUCTOR).
     Vazão×confiança: a vazão é automática atrás do knob; a confiança fica no harm-bearing. Best-effort
-    como o graph-ingest — NUNCA derruba um sweep (grafo/LLM fora → skip logado)."""
+    como o graph-ingest — NUNCA derruba um sweep (grafo/LLM fora → skip logado).
+
+    Mas "não derruba" nunca quis dizer "não conta". `len(written or [])` colapsava as duas
+    respostas possíveis num único "0 clusters": o grafo que rodou e não tinha o que agrupar, e o
+    grafo que NÃO CONSEGUIU rodar. A frota inteira imprimia a linha calma da escassez enquanto o
+    órgão estava parado (#635)."""
     if os.environ.get("EDGE_COMMUNITIES") != "1":
         return
     try:
         import communities
-        written = communities.consolidate()
-        print(f"sweep: communities consolidadas — {len(written or [])} clusters")
     except Exception as e:
-        print(f"sweep: communities skipped ({type(e).__name__}: {e}) — graph/LLM leg dark")
+        print(f"sweep: communities skipped ({type(e).__name__}: {e}) — módulo indisponível")
+        return
+    try:
+        written = communities.consolidate()
+    except communities.ConsolidationFailed as e:
+        # severidade na língua de group_health.verdicts (#638): `dark` = não pude rodar,
+        # `fail` = rodei e quebrei. As duas são altas; nenhuma é "0 clusters".
+        print(f"sweep: communities [{e.severity}] FALHARAM ({e.reason}) — a consolidação NÃO "
+              f"rodou; as Community deste grupo estão PARADAS (não vazias) e a navegação por "
+              f"cluster segue no estado da última passagem que funcionou. {e.detail}")
+        return
+    except Exception as e:   # noqa: BLE001 — best-effort leg: loga alto, nunca derruba o sweep
+        print(f"sweep: communities [fail] FALHARAM ({type(e).__name__}: {e}) — a consolidação "
+              f"NÃO rodou; as Community deste grupo estão PARADAS, não vazias")
+        return
+    print(f"sweep: communities consolidadas — {len(written)} clusters")
 
 
 def _topic_direction_window_days():


### PR DESCRIPTION
Closes #635.

## Eu estava errado sobre a frota, e o agente provou

Eu havia postado nesta issue que os 0 Community da frota eram o #603 (o `EDGE_GROUP` lido em tempo de import). **Não são.** `sweep._maybe_consolidate` abre assim:

```python
if os.environ.get("EDGE_COMMUNITIES") != "1":
    return
```

Dark por padrão, de propósito. E `EDGE_COMMUNITIES=1` existe num único lugar — `secrets/communities.env`, **escrito à mão**. Nada no genótipo o cria: nem `onboard`, nem `edge-apply`, nem `bootstrap`. Em roberto e petertosh o `return` dispara **antes do `import communities`**: o bug do #603 está num ramo que nunca executou lá.

**Confirmado num segundo install hoje:** o `turing` também não tem `communities.env`. Consolidate nunca rodou para ele.

Ranking honesto: **(1) knob desligado** — documentado e suficiente sozinho; (2) camada Entity fina — não verificável sem o Bolt; (3) #603 — real, mas provavelmente nunca alcançado.

**O knob não foi ligado por este PR.** Ligá-lo custa LLM por sweep em toda a frota e é decisão do operador, não contrabando.

## O dente

`consolidate()` **nunca mais devolve `None`.** `[]` passou a significar uma coisa só — rodou, não havia o que agrupar. Quem não conseguiu rodar levanta `ConsolidationFailed` com `.severity` **no vocabulário do #638** (`dark` = não pude rodar; `fail` = rodei e quebrei), não num terceiro. O `sweep` só imprime `"0 clusters"` quando a consolidação **aconteceu**.

Era essa indistinção que fazia o sintoma passar por escassez: a linha calma da falta de material saindo de um órgão parado.

## O teto de HAS_TOPIC

`EDGE_TOPIC_MAX_PER_SESSION`, default 3. A força é medida **por sessão**, nunca pelo score global — ordenar pelo global trocaria *"tudo é sobre tudo"* por *"tudo é sobre os mesmos três"*.

| medida | antes | depois |
|---|---|---|
| fixture com a forma da frota | 5.72 topics/sessão | **3.00** |
| frota, arestas/nó (teto 1.2 do #638) | 1.39 → **reprova** | ~0.73 |

O 3 sai daí, não do gosto: teto 4 daria 0.97 — passa sem margem. E a projeção é wipe-rebuild por sessão, então **um reproject cura um grafo inchado, sem migração destrutiva**.

Três mutações, cada uma matou um teste.