### PR TITLE
fix(direction): sem handle e sem fim — e o nó era chaveado pelo BODY

### DIFF
--- a/SURFACE.md
+++ b/SURFACE.md
@@ -132,10 +132,16 @@ a fold, no parallel store, `group_id`-scoped per install.
   (`retired-direction`); absent for `replied` / `acknowledged`.
 
 **Direction events** (tier-disjoint provenance)
-- `direction.set {id, body, origin_comment_id?, ts}` — curated tier (Voz-only). A `folded-to-direction`
-  Directive emits **this**, carrying `origin_comment_id`.
-- `direction.proposed {id, body, from_artefato?, relates_to?, ts}` — candidate tier (artefato / grill
-  achados). **Never** carries `origin_comment_id`.
+- `direction.set {id, title, body, expires_at?, supersedes?, origin_comment_id?, ts}` — curated tier
+  (Voz-only). A `folded-to-direction` Directive emits **this**, carrying `origin_comment_id`.
+- `direction.proposed {id, title, body, expires_at?, title_generated?, from_artefato?, relates_to?, ts}`
+  — candidate tier (artefato / grill achados). **Never** carries `origin_comment_id`.
+- `title` is **required** on a new write (≤ 80 chars, one line) — the handle a reader lists by
+  (#632). A Directive whose plan carries no usable title **parks** the chat asking for one; it never
+  raises inside the atomic append and never lands body-only. `title_generated: true` marks a handle
+  derived from the body by `tools/direction_backfill.py`, never one somebody authored.
+- `expires_at` (ISO date/datetime; date-only is inclusive of that day) is the steer's declared end.
+  Past it, the item leaves both tiers of the fold and `eventlog.expired_directions` lists it.
 - `direction.dropped {id, origin_comment_id?, ts}` — retire a steer. Dropping a **`set`** is
   **Voz-only** and carries `origin_comment_id` (appended atomically with its `voz.resolved` when
   Directive-driven); a **non-Voz** actor (grill / artefato) may only **propose** a retirement via

--- a/blog/grill_drain.py
+++ b/blog/grill_drain.py
@@ -135,7 +135,7 @@ _OPTIONAL_STRING_FIELDS = {
     # direction.set.id is the fold's dict KEY (`items[iid]` in fold_direction) — a non-string is
     # unhashable and TypeErrors the fold / consistency check / direction_at. PRESENT-only: a legacy
     # {plan} blob with no id folds to a single "_plan" item, so absence is valid, a non-string is not.
-    "direction.set": ("body", "id"),
+    "direction.set": ("body", "id", "title"),
 }
 
 
@@ -374,6 +374,16 @@ def _is_standing_directive(plan):
     return bool(plan.get("directive") or plan.get("direction_body"))
 
 
+def _usable_title(title):
+    """True iff `title` would survive the #632 write contract — asked BEFORE building the batch, so
+    an unusable one parks the chat instead of raising inside the atomic append."""
+    try:
+        eventlog.require_direction_title(title, "direction.set")
+    except ValueError:
+        return False
+    return True
+
+
 def _unchanged_since(log, comment_id, start_cursor):
     """The version guard predicate: True iff NO voz.resolved or voz.clarify for `comment_id` has
     appeared since `start_cursor` (SURFACE.md "Atomic close"). `still_open` alone is insufficient —
@@ -417,6 +427,15 @@ def _close_one(log, comment, plan, grill_run_id, start_cursor):
         if not _unchanged_since(log, cid, start_cursor):
             raise StaleDrain(cid)
 
+    # #632: a standing steer needs a HANDLE. A plan that would fold WITHOUT one is not closable —
+    # but it must not crash the rail and must not silently degrade to a plain reply (that would
+    # lose the steer, ADR-0017). It PARKS, which is this module's existing fail-safe: the chat
+    # stays open and the mentee is asked to name the steer. `parse_live_plan` already guarantees a
+    # title for live plans; this covers any other reply-generator.
+    if _is_standing_directive(plan) and not _usable_title(plan.get("direction_title")):
+        plan = {"park": True,
+                "question": "This reads as a standing steer. What should it be CALLED "
+                            f"(<= {eventlog.DIRECTION_TITLE_MAX} chars)?"}
     if plan.get("park"):
         # Parked: a non-terminal voz.clarify keeps the chat open (autonomous grill may only park).
         events = [("voz.clarify", subject,
@@ -432,6 +451,12 @@ def _close_one(log, comment, plan, grill_run_id, start_cursor):
             ("direction.set", "direction",
              {"id": direction_id, "body": plan.get("direction_body", comment["body"]),
               "kind": plan.get("kind", "thread"), "supersedes": None,
+              # This batch bypasses eventlog.set_direction (it must land ATOMICALLY with the reply
+              # and the resolution), so the #632 title contract is enforced HERE with the same
+              # validator — the write path has one rule, not two.
+              "title": eventlog.require_direction_title(plan.get("direction_title"),
+                                                        "direction.set"),
+              "expires_at": None,
               "origin_comment_id": cid}),
             ("voz.resolved", subject,
              {"comment_id": cid, "outcome": "folded-to-direction",
@@ -545,7 +570,8 @@ _LIVE_PROMPT = (
     "skeptically — name the tradeoff. Decide the OUTCOME and return ONLY JSON:\n"
     '  - a plain answer:      {"outcome":"reply","reply":"<your reply>"}\n'
     '  - a STANDING steer     {"outcome":"directive","reply":"<your reply>",'
-    '"direction_body":"<the steer, imperative>"}  (use this only when the Directive moves strategy)\n'
+    '"direction_title":"<<=80 chars naming the steer>","direction_body":"<the steer, imperative>"}'
+    "  (use this only when the Directive moves strategy)\n"
     '  - you must ASK first:  {"outcome":"park","question":"<your clarifying question>"}\n'
     "Directive:\n\n")
 
@@ -602,9 +628,16 @@ def parse_live_plan(raw):
         return {"park": True, "question": q} if q else park
     if outcome == "directive":
         reply, body = _str(d.get("reply")), _str(d.get("direction_body"))
-        if reply and body:
-            return {"reply": reply, "directive": True, "direction_body": body}
-        return park  # a directive with no valid reply+steer body is not a fold → park, don't fake
+        title = _str(d.get("direction_title"))
+        # #632: a standing steer needs a HANDLE, and the drain's fail-safe is already the right one
+        # — an unusable directive PARKS (asks the mentee) rather than landing a body-only Direction
+        # or blocking the rail. A title too long / multi-line is unusable in exactly that sense.
+        if title and (len(title) > eventlog.DIRECTION_TITLE_MAX or "\n" in title or "\r" in title):
+            title = None
+        if reply and body and title:
+            return {"reply": reply, "directive": True,
+                    "direction_title": title, "direction_body": body}
+        return park  # a directive with no valid reply+title+steer body is not a fold → park
     if outcome == "reply":
         reply = _str(d.get("reply"))
         return {"reply": reply} if reply else park

--- a/docs/adr/0007-direction-is-a-two-tier-addressable-projection.md
+++ b/docs/adr/0007-direction-is-a-two-tier-addressable-projection.md
@@ -41,11 +41,21 @@ proposed (2026-06-06; Voz ratifies)
   `curado > hipótese`: `set` outranks `proposed`. "A correção sempre ganha" — `set` is always Voz-originated.
 - **Addressable items.** Each thread has a stable `id` and an optional `kind ∈ {phase, priority,
   constraint, thread}`. Events (asserted per ADR-0006 — direct Cypher, no LLM, replayable):
-  - `direction.proposed {id, body, kind, from_artefato?, relates_to?}`
-  - `direction.set {id, body, supersedes?}`
+  - `direction.proposed {id, title, body, kind, expires_at?, title_generated?, from_artefato?, relates_to?}`
+  - `direction.set {id, title, body, expires_at?, supersedes?}`
   - `direction.dropped {id, reason}`
-- **Persist-until-dropped.** A thread survives until an explicit `direction.dropped`. Never lost by
-  omission — the anti-evaporation property, the whole point.
+- **A thread has a HANDLE (#632).** `title` (≤ 80 chars, one line) is REQUIRED on a new write —
+  `eventlog.propose` / `eventlog.set_direction` raise without it, and the Voz drain parks the chat
+  rather than land a body-only steer. Rationale: a group with 788 body-only Directions cannot
+  answer "what is this agent working on?" without opening 788 paragraphs, and `consolidate` has no
+  short name to merge on, so every beat appends one more. `title_generated: true` marks a handle
+  DERIVED from the body by the backfill — legible, but never mistaken for one somebody authored.
+- **Persist-until-dropped, unless an end was declared.** A thread survives until an explicit
+  `direction.dropped` — never lost by omission, the anti-evaporation property. The one exception is
+  a steer that named its own end: `expires_at` (ISO date/datetime, date-only = inclusive of that
+  day) leaves the live fold once passed, and `expired_directions` still lists it, so the successor
+  is an open hole in the map rather than silence. `supersedes` retires a steer BY NAME, `expires_at`
+  BY DATE with no beat present to do it — peers, not alternatives.
 - **Fold/replay per id.** Last event per `id` wins; `set` outranks `proposed` for the same `id`;
   `dropped` removes it. `direction_at(t)` folds to the as-of-then page (both tiers). **Strategic
   versioning = replay.**

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -89,7 +89,7 @@ class ObjectiveIsTheBriefingSpine(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             eventlog.set_objective("ship durable steer before tuning the grill", log=log)
-            eventlog.set_direction("a", "ship the briefing composer", log=log)
+            eventlog.set_direction("a", "ship the briefing composer", log=log, title="ship the briefing composer")
             text = briefing.compose_briefing(log=log, agent_yaml=ROSTER_FIXTURE, memory=MEMORY_FIXTURE)
             self.assertIn("ship durable steer before tuning the grill", text)
             self.assertLess(text.index("ship durable steer before tuning the grill"),
@@ -144,8 +144,8 @@ class DirectionInscribedCuratedFirst(unittest.TestCase):
     def test_set_appears_before_proposed(self):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.set_direction("a", "ship the briefing composer", log=log)
-            eventlog.propose("b", "explore Tier-1 clusters", log=log)
+            eventlog.set_direction("a", "ship the briefing composer", log=log, title="ship the briefing composer")
+            eventlog.propose("b", "explore Tier-1 clusters", log=log, title="explore Tier-1 clusters")
             text = briefing.compose_briefing(log=log, agent_yaml=ROSTER_FIXTURE, memory=MEMORY_FIXTURE)
             self.assertIn("ship the briefing composer", text)
             self.assertIn("explore Tier-1 clusters", text)

--- a/tests/test_briefing_lifecycle.py
+++ b/tests/test_briefing_lifecycle.py
@@ -145,8 +145,8 @@ class StageIIAfterGrill(unittest.TestCase):
             # simulate the grill — steers + leveling-state floor land on the temp log
             eventlog.set_objective("ship the durable steer before tuning the grill",
                                    rationale="says mission A, behavior shows B", log=log)
-            eventlog.set_direction("d1", "tighten the close path", kind="priority", log=log)
-            eventlog.propose("d2", "explore the source-feedback loop", log=log)
+            eventlog.set_direction("d1", "tighten the close path", kind="priority", log=log, title="tighten the close path")
+            eventlog.propose("d2", "explore the source-feedback loop", log=log, title="explore the source-feedback loop")
             eventlog.report_direction("the live steer: anchor on the close, defer the loop", log=log)
             import grill_writeback
             grill_writeback.leveling(
@@ -189,7 +189,7 @@ class StageIIIAfterTwoBeats(unittest.TestCase):
             agent_yaml, memory, log = _genotype(tmp)
             # a grill first (the realistic order), so the steer is present going into the beats
             eventlog.set_objective("ship the durable steer", log=log)
-            eventlog.set_direction("d1", "tighten the close path", kind="priority", log=log)
+            eventlog.set_direction("d1", "tighten the close path", kind="priority", log=log, title="tighten the close path")
             eventlog.report_direction("the live steer", log=log)
 
             # two beats — each an Artefato + its kernel (atomic, zero C3 debt)

--- a/tests/test_cortex_correct.py
+++ b/tests/test_cortex_correct.py
@@ -664,6 +664,7 @@ class TestCorrectionRoundTrip(_Base):
         # the stub classifies it a STANDING Directive → the drain folds it to a curated steer
         stub = lambda comment: {"reply": "agreed — retiring that trust.",
                                 "directive": True,
+                                "direction_title": "distrust the flagged source",
                                 "direction_body": "Distrust the unsafe source flagged on the node."}
         drain.drain(self.log, stub, grill_run_id="g2")
         # the terminal outcome carries the fold provenance: origin_comment_id == the correction comment

--- a/tests/test_cortex_query.py
+++ b/tests/test_cortex_query.py
@@ -35,7 +35,7 @@ class TestFrontDoor(unittest.TestCase):
         phenotype relies on (test_sweep._isolate), and the red that created these wrappers."""
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.propose("d1", "steer body", log=log)
+            eventlog.propose("d1", "steer body", log=log, title="steer body")
             d = cortex.direction_at(log=log)
             self.assertIn("d1", [i["id"] for i in d["proposed"]])
         original = eventlog.direction_at

--- a/tests/test_direction_backfill.py
+++ b/tests/test_direction_backfill.py
@@ -1,0 +1,186 @@
+"""The #632 backfill — give the Directions already in the fleet a handle, MARKED AS GENERATED.
+
+The contract in `eventlog` binds NEW writes. It does nothing for the 788 nodes already in
+`roberto` or the 577 in `petertosh`: those were written body-only and cannot be re-authored. This
+migration derives a handle from the first sentence of each body so `group_health` can count them
+and `recall` can list them — and stamps `title_generated` on every one, because a derived handle
+is a legible placeholder, never a claim that somebody named the steer.
+
+Hermetic, like test_group_health: no Neo4j is opened. The double answers by query signature, so a
+changed query goes RED instead of silently matching nothing.
+
+BRIEF rule 3 (migration): dry-run is the DEFAULT and shows the plan; writing takes an explicit
+flag, and this file pins that with a WRITE LEDGER rather than by reading the source.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import direction_backfill  # noqa: E402
+import eventlog  # noqa: E402
+
+
+class _Result(list):
+    def single(self):
+        return self[0] if self else None
+
+
+class FakeSession:
+    """A handful of :Direction rows, and a ledger of every write attempted."""
+
+    def __init__(self, rows):
+        self.rows = rows
+        self.writes = []
+
+    def run(self, cypher, **kw):
+        if "SET " in cypher or "DELETE" in cypher or "MERGE" in cypher:
+            self.writes.append((cypher, kw))
+            # the guard in BACKFILL_QUERY: only a still-untitled node comes back
+            hit = [r for r in self.rows
+                   if r["body"] == kw.get("node_id") and not r.get("title")]
+            return _Result({"node_id": kw.get("node_id")} for _ in hit)
+        if "count(d)" in cypher:
+            return _Result([{
+                "total": len(self.rows),
+                "titled": sum(1 for r in self.rows if r.get("title")),
+                "derived": sum(1 for r in self.rows if r.get("title_generated")),
+                "with_expiry": sum(1 for r in self.rows if r.get("expires_at")),
+            }])
+        if ":Direction" in cypher:
+            return _Result({"node_id": r["body"], "direction_id": r.get("id"), "body": r["body"]}
+                           for r in self.rows if not r.get("title"))
+        raise AssertionError(f"query not recognised by the double: {cypher[:70]}")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class FakeDriver:
+    def __init__(self, rows):
+        self.fake = FakeSession(rows)
+
+    def session(self):
+        return self.fake
+
+    @property
+    def writes(self):
+        return self.fake.writes
+
+
+UNTITLED = {"body": "Fechar o rito de onboarding antes de qualquer outra coisa. O resto espera.",
+            "id": "d1", "title": None}
+TITLED = {"body": "ja tem handle", "id": "d2", "title": "handle existente"}
+DERIVED_TITLE = "Fechar o rito de onboarding antes de qualquer outra coisa"
+
+
+class ThePlanIsReadOnlyAndNamesEveryChange(unittest.TestCase):
+
+    def test_planning_writes_nothing(self):
+        d = FakeDriver([UNTITLED, TITLED])
+        direction_backfill.plan(group="roberto", driver=d)
+        self.assertEqual(d.writes, [], "planning must not touch the graph")
+
+    def test_only_the_handle_less_nodes_are_planned(self):
+        d = FakeDriver([UNTITLED, TITLED])
+        rows = direction_backfill.plan(group="roberto", driver=d)
+        self.assertEqual([r["direction_id"] for r in rows], ["d1"],
+                         "a node that already has a handle is left alone")
+
+    def test_the_derived_title_is_the_first_sentence(self):
+        d = FakeDriver([UNTITLED])
+        self.assertEqual(direction_backfill.plan(group="g", driver=d)[0]["title"], DERIVED_TITLE)
+
+    def test_a_long_first_sentence_is_cut_to_the_handle_budget(self):
+        d = FakeDriver([{"body": "palavra " * 60, "id": "d9", "title": None}])
+        title = direction_backfill.plan(group="g", driver=d)[0]["title"]
+        self.assertLessEqual(len(title), eventlog.DIRECTION_TITLE_MAX)
+        self.assertTrue(title.endswith("…"), "a cut handle must show that it was cut")
+
+    def test_a_body_with_nothing_to_derive_from_is_reported_not_invented(self):
+        # An empty body has no first sentence. Inventing a handle would be fabricating data about
+        # a steer nobody can read — the row is reported with title=None and skipped at write time.
+        d = FakeDriver([{"body": "   ", "id": "d0", "title": None}])
+        rows = direction_backfill.plan(group="g", driver=d)
+        self.assertEqual([r["title"] for r in rows], [None])
+
+
+class ApplyingIsExplicitAndAlwaysMarksTheTitleGenerated(unittest.TestCase):
+
+    def test_apply_stamps_title_generated_on_every_row(self):
+        d = FakeDriver([UNTITLED])
+        written = direction_backfill.apply(group="roberto", driver=d)
+        self.assertEqual(written, 1)
+        cypher, params = d.writes[0]
+        self.assertIn("d.title_generated = true", cypher)
+        self.assertEqual(params["title"], DERIVED_TITLE)
+
+    def test_a_row_with_no_derivable_title_is_skipped_not_written(self):
+        d = FakeDriver([{"body": "   ", "id": "d0", "title": None}])
+        self.assertEqual(direction_backfill.apply(group="g", driver=d), 0)
+        self.assertEqual(d.writes, [], "an empty handle is worse than none — never write it")
+
+    def test_apply_never_deletes_or_rewrites_a_body(self):
+        d = FakeDriver([UNTITLED])
+        direction_backfill.apply(group="roberto", driver=d)
+        for cypher, _ in d.writes:
+            self.assertNotIn("DELETE", cypher.upper())
+            self.assertNotIn("d.body =", cypher)
+
+    def test_apply_reguards_against_a_handle_that_appeared_meanwhile(self):
+        # The plan is read before the write; in between, a beat may have authored a real title.
+        # The write re-checks emptiness so a derived handle never clobbers an authored one.
+        d = FakeDriver([UNTITLED])
+        direction_backfill.apply(group="roberto", driver=d)
+        cypher, _ = d.writes[0]
+        self.assertIn("coalesce(d.title,'') = ''", cypher)
+
+    def test_a_second_run_is_a_no_op(self):
+        # Idempotence: after the first pass the nodes carry titles, so the untitled query returns
+        # nothing and the tool writes nothing. Safe to re-run on the fleet.
+        rows = [dict(UNTITLED)]
+        d = FakeDriver(rows)
+        direction_backfill.apply(group="roberto", driver=d)
+        rows[0]["title"] = DERIVED_TITLE  # the graph now reflects the first pass
+        d2 = FakeDriver(rows)
+        self.assertEqual(direction_backfill.apply(group="roberto", driver=d2), 0)
+        self.assertEqual(d2.writes, [])
+
+
+class TheCommandLineIsDryRunByDefault(unittest.TestCase):
+
+    def _run(self, argv, rows):
+        d = FakeDriver(rows)
+        out = []
+        direction_backfill.main(argv + ["--group", "roberto"], driver=d, echo=out.append)
+        return d, "\n".join(str(x) for x in out)
+
+    def test_default_run_prints_the_plan_and_writes_nothing(self):
+        d, out = self._run([], [UNTITLED, TITLED])
+        self.assertEqual(d.writes, [], "a bare run must never write (BRIEF rule 3)")
+        self.assertIn("DRY-RUN", out)
+        self.assertIn(DERIVED_TITLE, out)
+
+    def test_the_plan_reports_the_census_before_and_the_count_to_change(self):
+        d, out = self._run([], [UNTITLED, TITLED])
+        self.assertIn("2 Direction(s)", out)
+        self.assertIn("1 with a handle", out)
+        self.assertIn("1 without a handle", out)
+
+    def test_apply_flag_writes(self):
+        d, out = self._run(["--apply"], [UNTITLED])
+        self.assertEqual(len(d.writes), 1)
+        self.assertIn("applied: 1", out)
+
+    def test_a_graph_with_nothing_to_do_writes_nothing(self):
+        d, out = self._run([], [TITLED])
+        self.assertEqual(d.writes, [])
+        self.assertIn("0 without a handle", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_direction_handle.py
+++ b/tests/test_direction_handle.py
@@ -1,0 +1,352 @@
+"""Issue #632 — a Direction needs a HANDLE and an END.
+
+The fleet read of 2026-08-16 found 788 `:Direction` nodes in `roberto`, 577 in `petertosh`,
+each carrying only a `body`. The question "what is this agent working on?" had no answer short
+of opening eight hundred paragraphs, and `consolidate` had nothing to merge on — so every beat
+just appended one more.
+
+Two defects, one root: a Direction has no SHORT NAME and no END.
+
+  (1) HANDLE — the write path accepted a body-only steer. These tests pin the contract: a NEW
+      `direction.proposed` / `direction.set` requires a `title` of <= 80 chars, on one line, or
+      the write FAILS. Nothing lands.
+
+  (2) END — the live counterexample is this host's own graph. Group `ed` holds exactly ONE
+      Direction, and it is the WELL-WRITTEN one: it names its own deadline in the body,
+      "PRAZO EXPLICITO: esta Direction expira no nascimento de ed". The agent.yaml was emitted
+      the same day, so the deadline PASSED — and nothing in the system can tell, because the
+      deadline is PROSE, not a field. `expires_at` makes the fold able to read it.
+
+Compatibility (BRIEF rule 4): the contract binds NEW writes. Legacy events with no title/expiry
+must keep folding and rendering exactly as before — `LegacyDirectionsKeepReading` pins that.
+"""
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import eventlog  # noqa: E402
+
+NOW = datetime(2026, 8, 16, 12, 0, tzinfo=timezone.utc)
+TITLE = "audit the install path"
+
+
+class ANewDirectionRequiresATitle(unittest.TestCase):
+    """Part 1 of #632: 'toda Direction nova exige titulo curto (<=80) + body. Sem titulo, a
+    escrita FALHA (nao "body-only ok")'. The gate is on the WRITE, not on a linter downstream:
+    a steer with no handle must never reach the log in the first place."""
+
+    def test_propose_without_a_title_fails_and_nothing_lands(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            with self.assertRaises(ValueError):
+                eventlog.propose("d1", "a long steer body", log=log)
+            self.assertEqual(eventlog.read(log=log), [], "no title must mean no write")
+
+    def test_set_direction_without_a_title_fails_and_nothing_lands(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            with self.assertRaises(ValueError):
+                eventlog.set_direction("d1", "a long steer body", log=log)
+            self.assertEqual(eventlog.read(log=log), [], "no title must mean no write")
+
+    def test_blank_and_overlong_and_multiline_titles_all_fail(self):
+        # A whitespace title is no title; >80 chars is a paragraph wearing a handle's name; a
+        # newline turns the "short handle" back into the body it was supposed to replace.
+        bad = ["", "   ", "\n\t ", "x" * (eventlog.DIRECTION_TITLE_MAX + 1),
+               "two\nlines", 123, ["a"]]
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            for t in bad:
+                with self.subTest(title=t):
+                    with self.assertRaises(ValueError):
+                        eventlog.propose("d1", "body", title=t, log=log)
+                    with self.assertRaises(ValueError):
+                        eventlog.set_direction("d1", "body", title=t, log=log)
+            self.assertEqual(eventlog.read(log=log), [])
+
+    def test_a_title_at_the_limit_writes_and_is_stripped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            edge = "x" * eventlog.DIRECTION_TITLE_MAX
+            eventlog.propose("d1", "body", title=f"  {edge}  ", log=log)
+            self.assertEqual(eventlog.read(log=log)[0]["payload"]["title"], edge)
+
+    def test_the_title_folds_through_to_both_tiers(self):
+        # The handle is useless if the fold drops it: recall/briefing read the FOLD, not the log.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.propose("d1", "long body one", title="close the grill", log=log)
+            eventlog.set_direction("d2", "long body two", title=TITLE, log=log)
+            d = eventlog.direction_at(log=log)
+            self.assertEqual(d["proposed"][0]["title"], "close the grill")
+            self.assertEqual(d["set"][0]["title"], TITLE)
+
+    def test_the_body_is_still_required(self):
+        # The title does not BUY OFF the body — a handle with nothing behind it is worse than
+        # a body with no handle (it reads as substance in every list).
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            with self.assertRaises(ValueError):
+                eventlog.set_direction("d1", "   ", title=TITLE, log=log)
+            self.assertEqual(eventlog.read(log=log), [])
+
+
+class ADirectionCanDeclareItsEnd(unittest.TestCase):
+    """Part 2 of #632: lifecycle. `supersedes` was ALREADY honored by the fold (a set retires the
+    id it supersedes), so the missing half is the CALENDAR one — a steer that dies on a date with
+    nobody there to retire it. The live counterexample is group `ed` on this host: one Direction,
+    well written, whose deadline is a sentence in the body and therefore unreadable by anything."""
+
+    def test_an_expired_direction_leaves_the_live_fold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.set_direction("dead", "the install-path audit", title="audit install",
+                                   expires_at="2026-08-15", log=log)
+            eventlog.set_direction("live", "the next steer", title="next steer",
+                                   expires_at="2026-12-31", log=log)
+            d = eventlog.direction_at(now=NOW, log=log)
+            self.assertEqual([i["id"] for i in d["set"]], ["live"])
+
+    def test_expiry_is_inclusive_of_its_own_day(self):
+        # "expires 2026-08-16" must still be live DURING 2026-08-16 — a date-only expiry names
+        # the last day the steer holds, not the first day it is gone.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.set_direction("d1", "body", title=TITLE, expires_at="2026-08-16", log=log)
+            self.assertEqual([i["id"] for i in eventlog.direction_at(now=NOW, log=log)["set"]],
+                             ["d1"])
+            later = NOW + timedelta(days=1)
+            self.assertEqual(eventlog.direction_at(now=later, log=log)["set"], [])
+
+    def test_expired_directions_are_listed_not_silently_gone(self):
+        # Leaving the live fold must not mean vanishing: an expired steer is still readable, so a
+        # beat can see WHAT ran out and write the successor (#632: "sucessora e buraco aberto no
+        # mapa, nao silencio").
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.set_direction("dead", "body", title="audit install",
+                                   expires_at="2026-08-15", log=log)
+            gone = eventlog.expired_directions(now=NOW, log=log)
+            self.assertEqual([i["id"] for i in gone], ["dead"])
+            self.assertEqual(gone[0]["title"], "audit install")
+
+    def test_a_dropped_direction_does_not_resurface_as_expired(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.set_direction("d1", "body", title=TITLE, expires_at="2026-08-15", log=log)
+            eventlog.drop("d1", "retired by hand", log=log)
+            self.assertEqual(eventlog.expired_directions(now=NOW, log=log), [])
+
+    def test_a_ts_cursor_is_its_own_clock_not_the_wall_clock(self):
+        # `direction_at` promises that replaying to a cursor reconstructs the world AT that cursor.
+        # Expiry must therefore be read against the CURSOR, not against wall-clock: the same steer
+        # is live at a cursor inside its window and gone at one past it, and neither answer moves
+        # when the machine's clock does.
+        far = (datetime.now(timezone.utc) + timedelta(days=30)).date().isoformat()
+        inside = (datetime.now(timezone.utc) + timedelta(days=10)).isoformat()
+        outside = (datetime.now(timezone.utc) + timedelta(days=60)).isoformat()
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.set_direction("d1", "body", title=TITLE, expires_at=far, log=log)
+            self.assertEqual([i["id"] for i in eventlog.direction_at(ts=inside, log=log)["set"]],
+                             ["d1"], "a cursor inside the window must see the steer live")
+            self.assertEqual(eventlog.direction_at(ts=outside, log=log)["set"], [],
+                             "a cursor past the window must see it retired")
+
+    def test_a_seq_cursor_still_answers_to_now(self):
+        # A seq cursor carries no clock of its own, so the live read decides: the wall clock is the
+        # only thing that can notice a deadline passing with no beat present to retire the steer.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            ev = eventlog.set_direction("d1", "body", title=TITLE,
+                                        expires_at="2026-08-15", log=log)
+            self.assertEqual(eventlog.direction_at(seq=ev["seq"], now=NOW, log=log)["set"], [])
+
+    def test_a_garbage_expiry_fails_the_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            for bad in ("someday", "2026-13-40", "", 20260816, []):
+                with self.subTest(expires_at=bad):
+                    with self.assertRaises(ValueError):
+                        eventlog.set_direction("d1", "body", title=TITLE,
+                                               expires_at=bad, log=log)
+            self.assertEqual(eventlog.read(log=log), [])
+
+    def test_supersedes_is_honored_not_a_dead_field(self):
+        # Pinned here because #632 asked whether `supersedes` was live: it IS (fold_direction
+        # pops the superseded id). This test is the receipt, so the answer survives the issue.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.propose("old", "the prior steer", title="prior", log=log)
+            eventlog.set_direction("new", "the successor", title="successor",
+                                   supersedes="old", log=log)
+            d = eventlog.direction_at(log=log)
+            self.assertEqual([i["id"] for i in d["set"]], ["new"])
+            self.assertEqual(d["proposed"], [])
+
+
+class LegacyDirectionsKeepReading(unittest.TestCase):
+    """BRIEF rule 4: the new contract binds NEW writes; the 788 nodes already in the fleet have
+    no title and no expiry, and every read path over them must keep working unchanged."""
+
+    def test_a_title_less_legacy_event_still_folds(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.append("direction.set", "direction",
+                            {"id": "legacy", "body": "the old steer"}, log=log)
+            d = eventlog.direction_at(now=NOW, log=log)
+            self.assertEqual([i["id"] for i in d["set"]], ["legacy"])
+            self.assertIsNone(d["set"][0]["title"])
+
+    def test_a_corrupt_expiry_in_a_legacy_event_does_not_crash_the_fold(self):
+        # Fail-dark, as the fold already does for a corrupt id: an unparseable expiry on a
+        # historical event means "no declared end", never a crashed briefing.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.append("direction.set", "direction",
+                            {"id": "legacy", "body": "old", "expires_at": ["nonsense"]}, log=log)
+            d = eventlog.direction_at(now=NOW, log=log)
+            self.assertEqual([i["id"] for i in d["set"]], ["legacy"])
+
+
+class TheHandleReachesTheReader(unittest.TestCase):
+    """Acceptance criterion 3 of #632: 'Recall/briefing lista Directions por titulo, nao por
+    truncagem de body.' A title that only lives in the log is not a fix."""
+
+    def test_the_direction_page_leads_with_the_title(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            out = Path(tmp) / "direction.md"
+            eventlog.set_direction("d1", "a very long steer body that nobody wants in a list",
+                                   title=TITLE, log=log)
+            text = eventlog.project_direction(log=log, out=out)
+            self.assertIn(TITLE, text)
+            self.assertLess(text.index(TITLE), text.index("a very long steer body"),
+                            "the handle must come before the paragraph")
+
+    def test_the_briefing_section_leads_with_the_title(self):
+        import briefing
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.set_direction("d1", "a very long steer body that nobody wants in a list",
+                                   title=TITLE, log=log)
+            text = briefing._section_direction(log, None, None)
+            self.assertIn(TITLE, text)
+            self.assertLess(text.index(TITLE), text.index("a very long steer body"))
+
+    def test_a_legacy_title_less_item_still_renders_its_body(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            out = Path(tmp) / "direction.md"
+            eventlog.append("direction.set", "direction",
+                            {"id": "legacy", "body": "the old steer"}, log=log)
+            self.assertIn("the old steer", eventlog.project_direction(log=log, out=out))
+
+
+class TheProjectionCarriesTheHandleToTheGraph(unittest.TestCase):
+    """A title that stops at the log is not a fix: `group_health` (#636) counts a Direction as
+    handled only when the NODE carries `coalesce(title, name)`, and as having lifecycle only when
+    the NODE carries `expires_at` or `supersedes`. This pins the projection that feeds it.
+
+    The bug underneath: the node was MERGE'd by body alone and SET nothing, so even the fold's `id`
+    never reached the graph — this host's one :Direction has keys ['body','group_id'] and no id.
+    Body-as-only-key is exactly how a group accumulates 788 of them."""
+
+    class _Rec(list):
+        def single(self):
+            return self[0] if self else None
+
+    class _Session:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, cypher, **kw):
+            self.calls.append((cypher, kw))
+            return TheProjectionCarriesTheHandleToTheGraph._Rec()
+
+    def _project(self, log):
+        import publisher
+        s = self._Session()
+        publisher._project_backbone(s, "ed", log)
+        return s
+
+    def _direction_writes(self, s):
+        return [(c, kw) for c, kw in s.calls if "MERGE (d:Direction" in c]
+
+    def test_a_new_direction_lands_with_its_handle_and_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.set_objective("ship the handle", log=log)
+            eventlog.set_direction("d1", "the long steer body", title=TITLE, log=log)
+            writes = self._direction_writes(self._project(log))
+            self.assertEqual(len(writes), 1)
+            cypher, params = writes[0]
+            self.assertEqual(params["t"], TITLE, "the handle must reach the node")
+            self.assertEqual(params["id"], "d1", "the fold's id must reach the node")
+            self.assertIn("d.title=", cypher)
+
+    def test_a_declared_end_reaches_the_node_so_health_can_see_lifecycle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.set_objective("ship the handle", log=log)
+            eventlog.set_direction("d1", "body", title=TITLE, expires_at="2099-01-01", log=log)
+            _cypher, params = self._direction_writes(self._project(log))[0]
+            self.assertTrue(params["x"], "expires_at must reach the node, not stay in the log")
+
+    def test_the_projection_never_wipes_a_backfilled_title_with_a_null(self):
+        # A legacy (title-less) steer re-projects every canonical sweep. If the SET were
+        # unconditional it would null out the handle the backfill just wrote, and the fleet would
+        # silently regress to 788 unreadable nodes on the next wake.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.set_objective("ship the handle", log=log)
+            eventlog.append("direction.set", "direction",
+                            {"id": "legacy", "body": "the old steer"}, log=log)
+            cypher, params = self._direction_writes(self._project(log))[0]
+            self.assertIsNone(params["t"])
+            self.assertIn("coalesce($t,d.title)", cypher)
+
+
+class TheDrainParksRatherThanBlocks(unittest.TestCase):
+    """The one place the title contract could hurt: the Voz rail. A standing Directive whose plan
+    carries no handle must NOT crash the drain (a blocked rail) and must NOT quietly close as a
+    plain reply (a lost steer, ADR-0017). It PARKS — the module's existing fail-safe — and asks the
+    mentee to name the steer, so the chat stays open and nothing is lost."""
+
+    def _drain(self):
+        sys.path.insert(0, str(REPO / "blog"))
+        import grill_drain
+        return grill_drain
+
+    def test_a_titleless_directive_parks_instead_of_raising(self):
+        drain = self._drain()
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "log.jsonl"
+            eventlog.append("voz.comment", "chat",
+                            {"comment_id": "c1", "body": "always cite a benchmark"}, log=log)
+            drain.drain(log, lambda c: {"reply": "r", "directive": True,
+                                        "direction_body": "always cite a benchmark"},
+                        grill_run_id="g1")
+            types = [e["type"] for e in eventlog.read(log=log)]
+            self.assertIn("voz.clarify", types, "no handle → park, never crash the rail")
+            self.assertNotIn("direction.set", types, "a body-only steer must not land")
+            self.assertNotIn("voz.resolved", types, "parking is non-terminal — the chat stays open")
+
+
+class RecallReadsTheHandle(unittest.TestCase):
+    """The graph read path: the spine query must return a handle, falling back to the body for a
+    node the backfill has not reached yet."""
+
+    def test_the_spine_query_prefers_the_title_over_the_body(self):
+        import recall
+        self.assertIn("d.title", recall.SPINE_QUERY)
+        self.assertIn("d.body", recall.SPINE_QUERY,
+                      "a legacy node with no title must still yield its body")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_direction_surface.py
+++ b/tests/test_direction_surface.py
@@ -576,7 +576,8 @@ class TestDirectionLiveRoundTrip(_DirectionBase):
         folds it to direction.set. NO LLM call (a live one would spend the edge's OpenAI API)."""
         def gen(comment):
             return {"reply": "folding this into a curated steer",
-                    "directive": True, "direction_body": "standing: " + comment["body"]}
+                    "directive": True, "direction_title": "standing steer",
+                    "direction_body": "standing: " + comment["body"]}
         return gen
 
     def test_a_new_directive_lands_as_a_set_steer_linked_to_its_comment(self):

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -95,8 +95,8 @@ class DirectionFoldsPerIdIntoTwoTiers(unittest.TestCase):
     def test_two_tiers_by_id(self):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.propose("a", "explore X", log=log)
-            eventlog.set_direction("b", "ship Y", log=log)
+            eventlog.propose("a", "explore X", log=log, title="explore X")
+            eventlog.set_direction("b", "ship Y", log=log, title="ship Y")
             d = eventlog.direction_at(log=log)
             self.assertEqual([i["id"] for i in d["proposed"]], ["a"])
             self.assertEqual([i["id"] for i in d["set"]], ["b"])
@@ -104,9 +104,9 @@ class DirectionFoldsPerIdIntoTwoTiers(unittest.TestCase):
     def test_set_outranks_proposed_same_id(self):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.propose("a", "maybe X", log=log)
-            eventlog.set_direction("a", "X ratified", log=log)
-            eventlog.propose("a", "waffle", log=log)  # cannot demote a set id
+            eventlog.propose("a", "maybe X", log=log, title="maybe X")
+            eventlog.set_direction("a", "X ratified", log=log, title="X ratified")
+            eventlog.propose("a", "waffle", log=log, title="waffle")  # cannot demote a set id
             d = eventlog.direction_at(log=log)
             self.assertEqual([i["id"] for i in d["set"]], ["a"])
             self.assertEqual(d["proposed"], [])
@@ -114,7 +114,7 @@ class DirectionFoldsPerIdIntoTwoTiers(unittest.TestCase):
     def test_dropped_removes_and_stays_gone(self):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.propose("a", "X", log=log)
+            eventlog.propose("a", "X", log=log, title="X")
             eventlog.drop("a", "noise", log=log)
             self.assertEqual(eventlog.direction_at(log=log), {"set": [], "proposed": []})
 
@@ -135,7 +135,7 @@ class DirectionFoldsPerIdIntoTwoTiers(unittest.TestCase):
         # `set` tier; a proposed item carries from_artefato/relates_to and origin_comment_id is None.
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.propose("a", "explore X", from_artefato="alpha-post", log=log)
+            eventlog.propose("a", "explore X", from_artefato="alpha-post", log=log, title="explore X")
             d = eventlog.direction_at(log=log)
             self.assertIsNone(d["proposed"][0].get("origin_comment_id"))
             self.assertEqual(d["proposed"][0]["from_artefato"], "alpha-post")
@@ -147,8 +147,9 @@ class DirectionFoldsPerIdIntoTwoTiers(unittest.TestCase):
         # active alongside the new ruling.
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.propose("introspection-ratio-watch", "watch recall/research ratio", log=log)
+            eventlog.propose("introspection-ratio-watch", "watch recall/research ratio", log=log, title="watch recall/research ratio")
             eventlog.set_direction("worthwhile-test", "ship the worthwhile-test metric",
+                                   title="the worthwhile test",
                                    supersedes="introspection-ratio-watch", log=log)
             d = eventlog.direction_at(log=log)
             self.assertEqual([i["id"] for i in d["set"]], ["worthwhile-test"])
@@ -159,8 +160,8 @@ class DirectionFoldsPerIdIntoTwoTiers(unittest.TestCase):
         # guard: supersedes pointing at the set's own id must NOT delete the item it just set.
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.propose("a", "maybe X", log=log)
-            eventlog.set_direction("a", "X ratified", supersedes="a", log=log)
+            eventlog.propose("a", "maybe X", log=log, title="maybe X")
+            eventlog.set_direction("a", "X ratified", supersedes="a", log=log, title="X ratified")
             d = eventlog.direction_at(log=log)
             self.assertEqual([i["id"] for i in d["set"]], ["a"])
             self.assertEqual(d["proposed"], [])
@@ -168,8 +169,8 @@ class DirectionFoldsPerIdIntoTwoTiers(unittest.TestCase):
     def test_replay_to_past_cursor(self):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            p = eventlog.propose("a", "X", log=log)              # seq 1
-            eventlog.set_direction("a", "X ratified", log=log)   # seq 2
+            p = eventlog.propose("a", "X", log=log, title="X")              # seq 1
+            eventlog.set_direction("a", "X ratified", log=log, title="X ratified")   # seq 2
             past = eventlog.direction_at(seq=p["seq"], log=log)
             self.assertEqual([i["id"] for i in past["proposed"]], ["a"])
             self.assertEqual(past["set"], [])
@@ -289,8 +290,8 @@ class ProjectDirectionRendersBothTiers(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             out = Path(tmp) / "direction.md"
-            eventlog.set_direction("b", "ship Y", kind="priority", log=log)
-            eventlog.propose("c", "name the full-read budget", from_artefato="recall-report", log=log)
+            eventlog.set_direction("b", "ship Y", kind="priority", log=log, title="ship Y")
+            eventlog.propose("c", "name the full-read budget", from_artefato="recall-report", log=log, title="name the full-read budget")
             eventlog.project_direction(log=log, out=out)
             text = out.read_text()
             self.assertIn("do not edit", text.lower())
@@ -304,8 +305,8 @@ class ProjectDirectionRendersBothTiers(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             out = Path(tmp) / "direction.md"
-            eventlog.propose("a", "alpha", log=log)
-            eventlog.set_direction("a", "omega", log=log)
+            eventlog.propose("a", "alpha", log=log, title="alpha")
+            eventlog.set_direction("a", "omega", log=log, title="omega")
             eventlog.project_direction(seq=1, log=log, out=out)
             text = out.read_text()
             self.assertIn("alpha", text)
@@ -914,7 +915,7 @@ class WriteHelpersRejectEmptyBodies(unittest.TestCase):
             log = Path(tmp) / "log.jsonl"
             for bad in ("", "   ", "\n\t "):
                 with self.assertRaises(ValueError):
-                    eventlog.propose("d1", bad, log=log)
+                    eventlog.propose("d1", bad, title="a valid handle", log=log)
             self.assertEqual(eventlog.read(log=log), [])
 
     def test_set_direction_rejects_empty_and_whitespace(self):
@@ -922,7 +923,7 @@ class WriteHelpersRejectEmptyBodies(unittest.TestCase):
             log = Path(tmp) / "log.jsonl"
             for bad in ("", "   ", "\n\t "):
                 with self.assertRaises(ValueError):
-                    eventlog.set_direction("d1", bad, log=log)
+                    eventlog.set_direction("d1", bad, title="a valid handle", log=log)
             self.assertEqual(eventlog.read(log=log), [])
 
     def test_report_direction_rejects_empty_and_whitespace(self):
@@ -937,8 +938,8 @@ class WriteHelpersRejectEmptyBodies(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
-            eventlog.set_direction("d2", "ratify the steer", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
+            eventlog.set_direction("d2", "ratify the steer", log=log, title="ratify the steer")
             eventlog.report_direction("the steer prose", log=log)
             self.assertEqual(len(eventlog.read(log=log)), 4)
 

--- a/tests/test_grill_drain.py
+++ b/tests/test_grill_drain.py
@@ -898,7 +898,8 @@ class TestFoldToDirection(_Base):
     def _directive_stub():
         def gen(comment):
             return {"reply": "folding this into a steer",
-                    "directive": True, "direction_body": "standing: " + comment["body"]}
+                    "directive": True, "direction_title": "standing steer",
+                    "direction_body": "standing: " + comment["body"]}
         return gen
 
     def test_standing_directive_folds_to_direction_atomically(self):
@@ -978,7 +979,9 @@ class TestLiveGeneratorStructuredPlan(_Base):
     with the model call stubbed — NO real LLM (a live call would spend the edge OpenAI API)."""
 
     def test_parse_plan_classifies_a_standing_directive_as_folded(self):
-        raw = '{"outcome": "directive", "reply": "folding this", "direction_body": "always cite a benchmark"}'
+        raw = ('{"outcome": "directive", "reply": "folding this", '
+               '"direction_title": "cite a benchmark", '
+               '"direction_body": "always cite a benchmark"}')
         plan = self.drain.parse_live_plan(raw)
         self.assertTrue(plan.get("directive"))
         self.assertEqual(plan["reply"], "folding this")
@@ -1017,6 +1020,7 @@ class TestLiveGeneratorStructuredPlan(_Base):
         # standing-directive classification folds to direction.set through the real drain.
         cid = self._comment("always cite an outside benchmark", "alpha-post")
         fake_model = lambda prompt: ('{"outcome": "directive", "reply": "folding", '
+                                     '"direction_title": "cite an outside benchmark", '
                                      '"direction_body": "always cite an outside benchmark"}')
         gen = self.drain.structured_reply_generator(fake_model)
         self.drain.drain(self.log, gen, grill_run_id="g1")
@@ -1176,7 +1180,8 @@ class TestConsistencyErrors(_Base):
         # the real drain fold carries matching origin_comment_id on both events → clean.
         cid = self._comment("a standing steer", "alpha-post")
         self.drain.drain(self.log,
-                         lambda c: {"reply": "r", "directive": True, "direction_body": "x"},
+                         lambda c: {"reply": "r", "directive": True,
+                                    "direction_title": "a steer", "direction_body": "x"},
                          grill_run_id="g1")
         errs = self.drain.consistency_errors(self.log)
         self.assertEqual([e for e in errs if "provenance" in e["kind"]], [])

--- a/tests/test_grill_gate.py
+++ b/tests/test_grill_gate.py
@@ -50,7 +50,7 @@ class GrillCompleteNamesMissingPieces(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             eventlog.report_direction("the steer", log=log)
             self.assertEqual(
                 set(grill_gate.grill_complete(log=log)), {"leveling", "wayfind"})
@@ -60,7 +60,7 @@ class GrillCompleteNamesMissingPieces(unittest.TestCase):
             log = Path(tmp) / "log.jsonl"
             root = Path(tmp) / "lv"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             eventlog.report_direction("the steer", log=log)
             import grill_writeback
             grill_writeback.leveling(
@@ -75,7 +75,7 @@ class GrillCompleteNamesMissingPieces(unittest.TestCase):
             root = Path(tmp) / "lv"
             import grill_writeback
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             grill_writeback.leveling("diario", "early", root=root, log=log)
             eventlog.report_direction("the steer after leveling", log=log)
             self.assertIn("leveling", grill_gate.grill_complete(log=log))
@@ -88,12 +88,12 @@ class GrillCompleteNamesMissingPieces(unittest.TestCase):
             log = Path(tmp) / "log.jsonl"
             root = Path(tmp) / "lv"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.set_direction("d1", "tighten the close", log=log)
+            eventlog.set_direction("d1", "tighten the close", log=log, title="tighten the close")
             eventlog.report_direction("the steer", log=log)
             import grill_writeback
             grill_writeback.leveling("diario", "close", root=root, log=log)
             _wayfind(log)
-            eventlog.propose("topic-7d:report-rite", "inferida pelo sweep", log=log)
+            eventlog.propose("topic-7d:report-rite", "inferida pelo sweep", log=log, title="inferida pelo sweep")
             self.assertEqual(grill_gate.grill_complete(log=log), [])
 
     def test_direction_set_also_satisfies_direction(self):
@@ -101,7 +101,7 @@ class GrillCompleteNamesMissingPieces(unittest.TestCase):
             log = Path(tmp) / "log.jsonl"
             root = Path(tmp) / "lv"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.set_direction("d1", "tighten the close", log=log)
+            eventlog.set_direction("d1", "tighten the close", log=log, title="tighten the close")
             eventlog.report_direction("the steer", log=log)
             import grill_writeback
             grill_writeback.leveling("diario", "close", root=root, log=log)
@@ -129,7 +129,7 @@ class EmptyBodiedFeedersDoNotCountAsLanded(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             self._append_empty_objective(log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             eventlog.report_direction("the steer", log=log)
             self.assertIn("objective", grill_gate.grill_complete(log=log))
 
@@ -145,7 +145,7 @@ class EmptyBodiedFeedersDoNotCountAsLanded(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             self._append_empty_report(log)
             self.assertIn("direcionamento", grill_gate.grill_complete(log=log))
 
@@ -153,7 +153,7 @@ class EmptyBodiedFeedersDoNotCountAsLanded(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             self._append_empty_report(log)  # report event present but its body is whitespace
             res = subprocess.run(
                 [sys.executable, str(GATE), "close", "--log", str(log)],
@@ -167,7 +167,7 @@ class EmptyBodiedFeedersDoNotCountAsLanded(unittest.TestCase):
             log = Path(tmp) / "log.jsonl"
             root = Path(tmp) / "lv"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             eventlog.report_direction("the steer", log=log)
             import grill_writeback
             grill_writeback.leveling("diario", "close", root=root, log=log)
@@ -194,7 +194,7 @@ class AssertGrillCompleteRaisesOnGaps(unittest.TestCase):
             log = Path(tmp) / "log.jsonl"
             root = Path(tmp) / "lv"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             eventlog.report_direction("the steer", log=log)
             import grill_writeback
             grill_writeback.leveling("diario", "close", root=root, log=log)
@@ -205,7 +205,7 @@ class AssertGrillCompleteRaisesOnGaps(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             eventlog.report_direction("the steer", log=log)
             with self.assertRaises(ValueError) as ctx:
                 grill_gate.assert_grill_complete(log=log)
@@ -240,7 +240,7 @@ class CloseCLIIsFailClosed(unittest.TestCase):
             log = Path(tmp) / "log.jsonl"
             root = Path(tmp) / "lv"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             eventlog.report_direction("the steer", log=log)
             import grill_writeback
             grill_writeback.leveling("diario", "close", root=root, log=log)
@@ -252,7 +252,7 @@ class CloseCLIIsFailClosed(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             eventlog.set_objective("ship the gate", log=log)
-            eventlog.propose("d1", "tighten the close", log=log)
+            eventlog.propose("d1", "tighten the close", log=log, title="tighten the close")
             eventlog.report_direction("the steer", log=log)
             res = self._close(log)
             self.assertNotEqual(res.returncode, 0)

--- a/tests/test_md_to_mem.py
+++ b/tests/test_md_to_mem.py
@@ -159,7 +159,7 @@ class InjectThreadRefs(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
             # a thread EXISTE = há uma direction.set kind=thread com esse id (log-nativo)
-            eventlog.set_direction("cluster:v10", "thread viva", kind="thread", log=log)
+            eventlog.set_direction("cluster:v10", "thread viva", kind="thread", log=log, title="thread viva")
             md_to_mem.inject("idx", slug="v10doc", threads=["cluster:v10"], log=log,
                              docs_dir=Path(tmp) / "docs")
             self.assertIn("v10doc", md_to_mem.docs_for_thread("cluster:v10", log=log))
@@ -226,7 +226,7 @@ class BriefingCanonSection(unittest.TestCase):
     def test_live_thread_index_always_shows(self):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.set_direction("cluster:v10", "thread viva", kind="thread", log=log)
+            eventlog.set_direction("cluster:v10", "thread viva", kind="thread", log=log, title="thread viva")
             md_to_mem.inject("índice v10", slug="v10doc", threads=["cluster:v10"], log=log,
                              docs_dir=Path(tmp) / "docs")
             grill_writeback.elect_canon("md", "v10doc", thread="cluster:v10", log=log)
@@ -236,7 +236,7 @@ class BriefingCanonSection(unittest.TestCase):
     def test_thread_out_of_direction_drops_from_top(self):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.set_direction("cluster:v10", "thread viva", kind="thread", log=log)
+            eventlog.set_direction("cluster:v10", "thread viva", kind="thread", log=log, title="thread viva")
             md_to_mem.inject("índice v10", slug="v10doc", threads=["cluster:v10"], log=log,
                              docs_dir=Path(tmp) / "docs")
             grill_writeback.elect_canon("md", "v10doc", thread="cluster:v10", log=log)
@@ -266,8 +266,8 @@ class RelevanceTopK(unittest.TestCase):
     def test_thread_A_doc_absent_in_thread_B_context(self):
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "log.jsonl"
-            eventlog.set_direction("cluster:A", "thread A", kind="thread", log=log)
-            eventlog.set_direction("cluster:B", "thread B", kind="thread", log=log)
+            eventlog.set_direction("cluster:A", "thread A", kind="thread", log=log, title="thread A")
+            eventlog.set_direction("cluster:B", "thread B", kind="thread", log=log, title="thread B")
             md_to_mem.inject("doc de A", slug="da", threads=["cluster:A"], log=log,
                              docs_dir=Path(tmp) / "docs")
             grill_writeback.elect_canon("md", "da", thread="cluster:A", log=log)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -337,7 +337,7 @@ class OnboardingCompletePath(unittest.TestCase):
         onboarding.run_bootstrap(home=home, name="ed", backfill_days=14, provision_skills=False)
         onboarding.emit_phenotype(home, mission="learn", voice="direct")
         eventlog.set_objective("learn well", log=log)
-        eventlog.propose("d1", "first direction", log=log)
+        eventlog.propose("d1", "first direction", log=log, title="first direction")
         eventlog.report_direction("steer body", log=log)
         grill_writeback.leveling(
             "diario",
@@ -515,7 +515,7 @@ class FinishOnboarding(unittest.TestCase):
                 home=home, name="ed", backfill_days=14, provision_skills=False
             )
             eventlog.set_objective("learn", log=log)
-            eventlog.propose("d1", "direction body", log=log)
+            eventlog.propose("d1", "direction body", log=log, title="direction body")
             eventlog.report_direction("steer", log=log)
             grill_writeback.leveling(
                 "diario", "sem update de persona; residual = x",
@@ -552,7 +552,7 @@ class FinishOnboarding(unittest.TestCase):
                 home=home, name="ed", backfill_days=14, provision_skills=False
             )
             eventlog.set_objective("learn", log=log)
-            eventlog.propose("d1", "direction body", log=log)
+            eventlog.propose("d1", "direction body", log=log, title="direction body")
             eventlog.report_direction("steer", log=log)
             grill_writeback.leveling(
                 "diario", "sem update de persona", root=home / "lv", log=log

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -970,6 +970,7 @@ class ProjectAfterPublishIsAGuaranteedSideEffect(unittest.TestCase):
                 "topic-7d:session-memory-navigation",
                 "Construir memoria navegavel por Voz -> Topic -> Thread.",
                 kind="thread",
+                title="Memoria de sessoes navegavel",
                 log=log,
             )
             seen = []

--- a/tests/test_topic_threads.py
+++ b/tests/test_topic_threads.py
@@ -70,6 +70,7 @@ class TopicThreadsProjectDirection(unittest.TestCase):
                             "snippet": "arbitrary delegated content"}], log=log)
             eventlog.propose(
                 "topic-7d:implementation-noise", "automatic proposal",
+                title="implementation noise",
                 relates_to=[{"kind": "voz.fragment", "session": "grok:delegated"}], log=log)
             eventlog.append("sessao.excluded", "sessao:grok:delegated", {
                 "sessao_id": "grok:delegated", "surface": "grok",
@@ -184,6 +185,7 @@ class TopicThreadsProjectDirection(unittest.TestCase):
             eventlog.set_direction(
                 "topic-7d:topic-thread-direction",
                 "Ratified direction already owns this thread",
+                title="Topics -> Threads -> Direction",
                 log=log,
             )
 

--- a/tools/briefing.py
+++ b/tools/briefing.py
@@ -152,7 +152,11 @@ def _render_direction_items(items):
     lines = []
     for kind in KIND_ORDER + [k for k in by_kind if k not in KIND_ORDER]:
         for it in by_kind.get(kind, []):
-            lines.append(f"- **[{kind}]** {it.get('body', '')}")
+            # The handle leads, the body follows (#632). No title (a legacy steer) → body only,
+            # exactly as before.
+            gen = " _(derived)_" if it.get("title_generated") else ""
+            handle = f"**{it['title']}**{gen} — " if it.get("title") else ""
+            lines.append(f"- **[{kind}]** {handle}{it.get('body', '')}")
     return "\n".join(lines) if lines else "_none_"
 
 

--- a/tools/direction_backfill.py
+++ b/tools/direction_backfill.py
@@ -1,0 +1,151 @@
+"""direction_backfill — give the Directions already in the graph a HANDLE (#632, part 4).
+
+The fleet read of 2026-08-16 found 788 `:Direction` nodes in `roberto` and 577 in `petertosh`,
+each carrying only a `body`. The write path now REQUIRES a title (eventlog.propose /
+eventlog.set_direction), but that binds new writes only: the nodes already out there stay
+unreadable until something names them. This is that something.
+
+The rule, and its honesty clause: the title is DERIVED from the first sentence of the body
+(`eventlog.derive_direction_title`) and every node it touches is stamped `title_generated = true`.
+A derived handle is a legible placeholder for a steer nobody named — never a claim that somebody
+named it. The grill can find every one of them with
+
+    MATCH (d:Direction {group_id: $g}) WHERE d.title_generated RETURN d.title, d.body
+
+and replace them with authored ones. `title_generated` is what keeps the backfill from laundering
+machine guesses into curated memory.
+
+DRY-RUN IS THE DEFAULT (BRIEF rule 3). `plan()` reads and returns what WOULD change; `apply()`
+writes, and only when a caller asks for it explicitly. Nothing here deletes or merges a node: a
+title is ADDED where there is none. A node that already has a title is never touched, so the tool
+is idempotent and safe to re-run.
+
+    tools/edge-python -m direction_backfill                 # dry-run, the plan
+    tools/edge-python -m direction_backfill --apply         # write the derived titles
+    tools/edge-python -m direction_backfill --group other   # a specific group (default: this host)
+
+Out of scope, deliberately: DEDUPING the 788. The nodes are MERGE'd by body, so two rewordings of
+one steer are two nodes, and collapsing them is a destructive migration that needs a human ruling
+on which body survives. This tool makes the pile READABLE first — that is the input that ruling
+needs, and it is the part that is safe to run unattended.
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import communities  # noqa: E402
+import eventlog  # noqa: E402
+
+# Read every Direction in the group that has no usable handle yet. `coalesce(d.title,'') = ''`
+# catches both the absent property and a blank one; a node whose title was already authored (or
+# already backfilled) is out of the result set, which is what makes a re-run a no-op.
+# The node is addressed by (group_id, body) — the same key the projection MERGEs on, so it is
+# unique by construction and needs no internal node id (id() is deprecated, elementId() is not
+# available on every Neo4j the fleet runs; the property key works on both).
+UNTITLED_QUERY = (
+    "MATCH (d:Direction {group_id:$g}) WHERE coalesce(d.title,'') = '' "
+    "RETURN d.body AS node_id, d.id AS direction_id, d.body AS body "
+    "ORDER BY coalesce(d.id,''), d.body")
+COUNT_QUERY = (
+    "MATCH (d:Direction {group_id:$g}) "
+    "RETURN count(d) AS total, "
+    "count(CASE WHEN coalesce(d.title,'') <> '' THEN 1 END) AS titled, "
+    "count(CASE WHEN d.title_generated THEN 1 END) AS derived, "
+    "count(CASE WHEN coalesce(d.expires_at,'') <> '' THEN 1 END) AS with_expiry")
+# The write. `title_generated` rides with the title in the SAME SET so the two can never come
+# apart — a title in the graph without its provenance mark would read as authored.
+BACKFILL_QUERY = (
+    "MATCH (d:Direction {group_id:$g, body:$node_id}) WHERE coalesce(d.title,'') = '' "
+    "SET d.title = $title, d.title_generated = true "
+    "RETURN d.body AS node_id")
+
+
+def _group(group=None):
+    if group:
+        return group
+    import _identity
+    return _identity.require_group()  # fail-loud: never guess another tenant's group (ADR-0015)
+
+
+def survey(group=None, driver=None):
+    """Read-only census of the group's Directions: how many there are, how many carry a handle,
+    how many of those handles are derived, how many declare an end. This is the number #632 is
+    about — run it before and after."""
+    g = _group(group)
+    drv = driver or communities._driver()
+    if drv is None:
+        raise RuntimeError("no Neo4j driver — cannot survey (check EDGE_NEO4J_* / secrets)")
+    with drv.session() as s:
+        row = dict(s.run(COUNT_QUERY, g=g).single())
+    row["group"] = g
+    return row
+
+
+def plan(group=None, driver=None):
+    """DRY-RUN: what a backfill WOULD write, as a list of {node_id, direction_id, body, title}.
+    Reads only. A node whose body yields no derivable title (empty/whitespace) is reported with
+    `title=None` and would be SKIPPED — the tool never invents a handle out of nothing."""
+    g = _group(group)
+    drv = driver or communities._driver()
+    if drv is None:
+        raise RuntimeError("no Neo4j driver — cannot plan (check EDGE_NEO4J_* / secrets)")
+    with drv.session() as s:
+        rows = [dict(r) for r in s.run(UNTITLED_QUERY, g=g)]
+    for r in rows:
+        r["title"] = eventlog.derive_direction_title(r.get("body"))
+    return rows
+
+
+def apply(group=None, driver=None, rows=None):
+    """WRITE the derived titles, each stamped `title_generated = true`. Additive only — no node is
+    deleted, merged or reworded, and the guard in BACKFILL_QUERY re-checks emptiness at write time
+    so a concurrent authored title is never overwritten. Returns the number of nodes titled."""
+    g = _group(group)
+    drv = driver or communities._driver()
+    if drv is None:
+        raise RuntimeError("no Neo4j driver — cannot apply (check EDGE_NEO4J_* / secrets)")
+    rows = plan(group=g, driver=drv) if rows is None else rows
+    written = 0
+    with drv.session() as s:
+        for r in rows:
+            if not r.get("title"):
+                continue  # nothing derivable — leave it, an empty handle is worse than none
+            if s.run(BACKFILL_QUERY, g=g, node_id=r["node_id"], title=r["title"]).single():
+                written += 1
+    return written
+
+
+def main(argv=None, driver=None, echo=print):
+    """The CLI. `driver`/`echo` are injection seams so the whole dry-run/apply decision is testable
+    against a fake graph — the one decision in this file that must never be wrong is "did a bare
+    run write anything?", and that is not a question to answer by reading the source."""
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--group", default=None, help="group_id (default: this host's identity)")
+    ap.add_argument("--apply", action="store_true",
+                    help="WRITE the derived titles (default is a dry-run plan)")
+    ap.add_argument("--limit", type=int, default=20, help="rows to print in the plan")
+    args = ap.parse_args(argv)
+
+    census = survey(group=args.group, driver=driver)
+    echo(f"group {census['group']}: {census['total']} Direction(s), {census['titled']} with a "
+         f"handle ({census['derived']} derived), {census['with_expiry']} with a declared end")
+    rows = plan(group=args.group, driver=driver)
+    derivable = [r for r in rows if r.get("title")]
+    echo(f"{len(rows)} without a handle; {len(derivable)} have a derivable one")
+    for r in rows[:args.limit]:
+        mark = r["title"] or "<NO DERIVABLE TITLE — skipped>"
+        echo(f"  {r.get('direction_id') or '(no id)'}: {mark}")
+    if len(rows) > args.limit:
+        echo(f"  ... {len(rows) - args.limit} more")
+    if not args.apply:
+        echo("\nDRY-RUN — nothing written. Re-run with --apply to write these titles "
+             "(each marked title_generated=true).")
+        return 0
+    written = apply(group=args.group, driver=driver, rows=rows)
+    echo(f"\napplied: {written} node(s) titled (title_generated=true)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/eventlog.py
+++ b/tools/eventlog.py
@@ -133,15 +133,118 @@ DIRECTION_TYPES = [
     "session.topics.generation",
 ]
 KIND_ORDER = ["phase", "priority", "constraint", "thread"]
+# A Direction's HANDLE (#632). The fleet read of 2026-08-16 found 788 body-only :Direction nodes in
+# one group and 577 in another: "what is this agent working on?" had no answer short of opening
+# eight hundred paragraphs, and consolidate had no short name to merge on, so every beat appended
+# one more. 80 chars is the handle budget — long enough to name a steer, short enough that a list of
+# forty still reads as a list.
+DIRECTION_TITLE_MAX = 80
 
 
-def fold_direction(events):
+def require_direction_title(title, what):
+    """Reject a Direction with no usable HANDLE (#632) — the write FAILS, body-only is not ok.
+    A handle is a single line of <= DIRECTION_TITLE_MAX chars; a paragraph or a multi-line blob is
+    the body wearing the title's name. Returns the stripped title."""
+    if not isinstance(title, str) or not title.strip():
+        raise ValueError(
+            f"cannot append {what} without a title — a Direction with no short handle is "
+            "unreadable at volume (#632); pass title='<= 80 chars naming the steer'")
+    t = title.strip()
+    if len(t) > DIRECTION_TITLE_MAX:
+        raise ValueError(f"{what} title is {len(t)} chars, max {DIRECTION_TITLE_MAX} — a handle, "
+                         "not a paragraph; the long form belongs in `body`")
+    if "\n" in t or "\r" in t:
+        raise ValueError(f"{what} title must be a single line — the long form belongs in `body`")
+    return t
+
+
+def derive_direction_title(body, max_len=DIRECTION_TITLE_MAX):
+    """Derive a handle from the FIRST SENTENCE of a body (#632 part 4). Returns None when there is
+    nothing to derive from.
+
+    This is the BACKFILL rule, and every title it produces MUST be marked as generated
+    (`title_generated`) wherever it lands: a derived handle is a legible placeholder for a steer
+    nobody named, never a claim that somebody named it. Read paths may show it; the grill should
+    still be able to tell the two apart and replace it."""
+    if not isinstance(body, str) or not body.strip():
+        return None
+    text = " ".join(body.split())
+    # Cut at the EARLIEST clause boundary, not the first one in this list: a body whose full stop
+    # lands three lines in but whose em-dash lands at word ten yields a far better handle from the
+    # dash. (Measured on this host's own Direction: ". " gave a truncated 80-char stub, " — " gave
+    # "ed audita e conserta o caminho que só existe uma vez por instalação" whole.)
+    cuts = [i for i in (text.find(stop) for stop in (". ", "? ", "! ", "; ", " — ", " - "))
+            if i > 0]
+    if cuts:
+        text = text[:min(cuts)].strip()
+    text = text.rstrip(".?!;:, ")
+    if not text:
+        return None
+    if len(text) <= max_len:
+        return text
+    cut = text[:max_len - 1]
+    if " " in cut:
+        cut = cut[:cut.rindex(" ")]
+    return cut.rstrip(".?!;:, ") + "…"
+
+
+def _validated_expires_at(value, what):
+    """Normalize a declared END for a Direction (#632 part 2), or raise. `None` = no declared end.
+
+    The live counterexample this exists for: group `ed` holds one Direction, the well-written one,
+    which names its own deadline INSIDE the body ("PRAZO EXPLICITO: esta Direction expira no
+    nascimento de ed"). The deadline passed the same day the agent.yaml was emitted and nothing in
+    the system could tell, because a deadline in prose is not a field. This is the field.
+
+    Accepts an ISO-8601 date ('2026-08-16') or datetime. A DATE-ONLY value names the LAST DAY the
+    steer holds, so it normalizes to that day's end — "expires 2026-08-16" is still live during
+    2026-08-16. A naive datetime is read as UTC (the log stamps UTC)."""
+    if value is None:
+        return None
+    parsed = _parse_expiry(value)
+    if parsed is None:
+        raise ValueError(f"{what} expires_at must be an ISO-8601 date or datetime "
+                         f"(e.g. '2026-08-16'), got {value!r}")
+    return parsed.isoformat()
+
+
+def _parse_expiry(value):
+    """Parse an expiry to an aware UTC datetime, or None when unusable. FAIL-DARK on read (a
+    corrupt expiry on a historical event means 'no declared end', never a crashed briefing); the
+    WRITE path turns the same None into a loud ValueError via `_validated_expires_at`."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if len(raw) == 10:  # date-only → the last day the steer holds, inclusive
+        dt = dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _is_expired(item, now):
+    """True when the item declared an end and `now` is past it. No declared end → never expires
+    (persist-until-dropped stays the default: nothing is lost by omission)."""
+    end = _parse_expiry(item.get("expires_at"))
+    return end is not None and now is not None and now > end
+
+
+def fold_direction(events, now=None):
     """Pure fold of direction.* events → addressable items in two tiers (ADR-0007).
 
     Per-id, in seq order: `direction.proposed` opens/updates a `proposed` item; `direction.set`
     opens/updates a `set` item and **outranks** proposed for the same id (curado > hipótese, a
     correção sempre ganha); `direction.dropped` removes the id (persist-until-dropped — nothing is
     lost by omission). Returns {"set": [...], "proposed": [...]} in insertion order.
+
+    `now` (an aware datetime, #632) is the clock the EXPIRY is read against: an item whose declared
+    `expires_at` is past `now` has left the live fold and appears in NEITHER tier — that is what
+    makes the ANCHORS rebuild and recall go quiet on a steer whose window closed, with no beat
+    present to retire it by hand. It is not lost: `expired_directions` lists it, so the successor
+    is an open hole in the map and not silence. `now=None` disables expiry entirely (the fold stays
+    a pure function of the events it was handed).
 
     Fail-dark over a corrupt log (Slice 4 [high]): `id`/`supersedes` are used AS dict keys, so a
     JSON-valid event with a non-string (unhashable, e.g. list) key field would TypeError this fold —
@@ -195,6 +298,8 @@ def fold_direction(events):
             if items.get(iid, {}).get("tier") == "set":
                 continue  # set outranks proposed
             items[iid] = {"id": iid, "body": p.get("body", ""), "kind": p.get("kind", "thread"),
+                          "title": _key(p.get("title")), "expires_at": p.get("expires_at"),
+                          "title_generated": bool(p.get("title_generated")),
                           "from_artefato": p.get("from_artefato"), "relates_to": relates_to,
                           "tier": "proposed"}
         elif t == "direction.set":
@@ -209,20 +314,51 @@ def fold_direction(events):
                                       # stored but never honored, leaving the old steer active.
             items[iid] = {"id": iid, "body": p.get("body", p.get("plan", "")),
                           "kind": p.get("kind", "thread"), "supersedes": sup,
+                          "title": _key(p.get("title")), "expires_at": p.get("expires_at"),
+                          "title_generated": bool(p.get("title_generated")),
                           "origin_comment_id": p.get("origin_comment_id"),
                           "tier": "set"}
         elif t == "direction.dropped":
             items.pop(_key(p.get("id")), None)
-    return {"set": [i for i in items.values() if i["tier"] == "set"],
-            "proposed": [i for i in items.values() if i["tier"] == "proposed"]}
+    live = [i for i in items.values() if not _is_expired(i, now)]
+    return {"set": [i for i in live if i["tier"] == "set"],
+            "proposed": [i for i in live if i["tier"] == "proposed"]}
 
 
-def direction_at(seq=None, ts=None, log=LOG):
+def fold_expired_directions(events, now):
+    """The other half of the expiry fold (#632): the items that WOULD be live but for a declared
+    end already past. Same fold, opposite filter — an expired steer must stay readable so the beat
+    can see what ran out and write the successor ("sucessora é buraco aberto no mapa, não silêncio")."""
+    all_items = fold_direction(events, now=None)
+    return [i for i in all_items["set"] + all_items["proposed"] if _is_expired(i, now)]
+
+
+def _expiry_now(now, ts):
+    """The clock the fold reads expiry against. An explicit `now` wins; a `ts` CURSOR is its own
+    clock (replaying to a past cursor must reconstruct that past — a steer alive then is alive in
+    the replay, or wall-clock leaks into a fold documented as pure); otherwise the live read uses
+    the wall clock, which is the only thing that can notice a deadline passing with nobody there."""
+    if now is not None:
+        return now
+    if ts is not None:
+        return _parse_expiry(ts)
+    return datetime.now(timezone.utc)
+
+
+def direction_at(seq=None, ts=None, log=LOG, now=None):
     """Fold direction.* events up to a cursor → {"set":[...], "proposed":[...]} (ADR-0007).
     Pure: replaying to a past cursor reconstructs that past, both tiers — strategic versioning.
-    Returns None when there are no direction events at all."""
+    A steer whose declared `expires_at` has passed is NOT in either tier (#632); `now`/`ts` pick
+    the clock (see `_expiry_now`). Returns None when there are no direction events at all."""
     evs = read(types=DIRECTION_TYPES, until_seq=seq, until_ts=ts, log=log)
-    return fold_direction(evs) if evs else None
+    return fold_direction(evs, now=_expiry_now(now, ts)) if evs else None
+
+
+def expired_directions(seq=None, ts=None, log=LOG, now=None):
+    """The steers whose declared window CLOSED, as of the same cursor `direction_at` uses — the
+    open holes in the map. Empty list when none (or when the item was dropped by hand first)."""
+    evs = read(types=DIRECTION_TYPES, until_seq=seq, until_ts=ts, log=log)
+    return fold_expired_directions(evs, _expiry_now(now, ts)) if evs else []
 
 
 def _require_body(body, what):
@@ -232,21 +368,36 @@ def _require_body(body, what):
         raise ValueError(f"cannot append {what} with an empty/whitespace body")
 
 
-def propose(id, body, kind="thread", from_artefato=None, relates_to=None, log=LOG):
+def propose(id, body, kind="thread", from_artefato=None, relates_to=None, log=LOG,
+            *, title=None, expires_at=None, title_generated=False):
     """Append a `direction.proposed` item (the non-curated tier — grill achados / artefato candidates).
-    Raises ValueError on an empty/whitespace body — no hollow direction lands."""
+    Raises ValueError on an empty/whitespace body — no hollow direction lands — and on a missing or
+    over-long `title` (#632): a steer with no short handle is unfindable at volume, so it does not
+    get written. `title` is KEYWORD-ONLY on purpose: an existing positional call fails LOUDLY on the
+    new contract instead of silently binding its body to the title slot. `expires_at` (optional) is
+    the declared end (see `_validated_expires_at`)."""
     _require_body(body, "direction.proposed")
     return append("direction.proposed", "direction",
                   {"id": id, "body": body, "kind": kind,
+                   "title": require_direction_title(title, "direction.proposed"),
+                   "title_generated": bool(title_generated),
+                   "expires_at": _validated_expires_at(expires_at, "direction.proposed"),
                    "from_artefato": from_artefato, "relates_to": relates_to}, log=log)
 
 
-def set_direction(id, body, kind="thread", supersedes=None, log=LOG):
+def set_direction(id, body, kind="thread", supersedes=None, log=LOG,
+                  *, title=None, expires_at=None):
     """Append a `direction.set` item (the curated tier — Voz only; promotes/supersedes a proposed id).
-    Raises ValueError on an empty/whitespace body — no hollow direction lands."""
+    Raises ValueError on an empty/whitespace body and on a missing/over-long `title` (#632, same
+    contract and the same keyword-only reasoning as `propose`).
+
+    The two lifecycle handles are peers: `supersedes` retires a steer BY NAME (honored by the fold),
+    `expires_at` retires it BY DATE with nobody present to do it."""
     _require_body(body, "direction.set")
     return append("direction.set", "direction",
-                  {"id": id, "body": body, "kind": kind, "supersedes": supersedes}, log=log)
+                  {"id": id, "body": body, "kind": kind, "supersedes": supersedes,
+                   "title": require_direction_title(title, "direction.set"),
+                   "expires_at": _validated_expires_at(expires_at, "direction.set")}, log=log)
 
 
 def drop(id, reason="", log=LOG):
@@ -4635,7 +4786,18 @@ def consolidate_artefato_proposals(log=LOG):
                 cand.get("text") if isinstance(cand, dict) else None) or ""
             if not (isinstance(body, str) and body.strip()):
                 continue
-            propose(iid, body, kind=cand.get("kind", "thread"),
+            # #632: this fan is the volume engine — every published artefato's candidate steers
+            # become `proposed` items, which is most of the 788. It is a PROJECTION of an already
+            # published payload, not a fresh authoring, so it cannot fail the way an authored write
+            # does: refusing here would strand the steers of artefatos already on disk. A candidate
+            # that carries its own title keeps it; otherwise the handle is DERIVED and marked
+            # generated, exactly as the backfill does.
+            title = cand.get("title") if isinstance(cand, dict) else None
+            generated = not (isinstance(title, str) and title.strip())
+            if generated:
+                title = derive_direction_title(body)
+            propose(iid, body, kind=cand.get("kind", "thread"), title=title,
+                    title_generated=generated,
                     from_artefato=slug, relates_to=cand.get("relates_to"), log=log)
             have.add(iid)
             n += 1
@@ -4650,7 +4812,12 @@ def _render_items(items):
     for kind in KIND_ORDER + [k for k in by_kind if k not in KIND_ORDER]:
         for it in by_kind.get(kind, []):
             prov = f" _(from {it['from_artefato']})_" if it.get("from_artefato") else ""
-            lines.append(f"- **[{kind}]** {it.get('body', '')} `#{it['id']}`{prov}")
+            # The HANDLE leads (#632): a reader scanning forty steers reads forty titles, not forty
+            # paragraphs. A legacy item with no title renders exactly as before — body only.
+            gen = " _(derived)_" if it.get("title_generated") else ""
+            handle = f"**{it['title']}**{gen} — " if it.get("title") else ""
+            ends = f" _(expires {it['expires_at']})_" if it.get("expires_at") else ""
+            lines.append(f"- **[{kind}]** {handle}{it.get('body', '')} `#{it['id']}`{prov}{ends}")
     return "\n".join(lines) if lines else "_none_"
 
 

--- a/tools/publisher.py
+++ b/tools/publisher.py
@@ -1173,9 +1173,11 @@ def _project_session_topic_index(s, g, index, log=eventlog.LOG):
         s.run(
             "MATCH (t:Topic {group_id:$g, topic_id:$tid}) "
             "MERGE (d:Direction {group_id:$g, body:$body}) "
-            "SET d.id=$id, d.kind=$kind "
+            "SET d.id=$id, d.kind=$kind, d.title=coalesce($title,d.title), "
+            "d.expires_at=coalesce($expires,d.expires_at) "
             "MERGE (t)-[r:PROPOSES]->(d) SET r.provenance_class='extracted'",
-            g=g, tid=topic_id, body=body, id=iid, kind=item.get("kind") or "thread")
+            g=g, tid=topic_id, body=body, id=iid, kind=item.get("kind") or "thread",
+            title=item.get("title"), expires=item.get("expires_at"))
     s.run(
         "MATCH (t:Topic {group_id:$g}) "
         "WHERE NOT (()-[:HAS_TOPIC]->(t)) AND NOT (()-[:ABOUT]->(t)) "
@@ -1432,7 +1434,26 @@ def _project_backbone(s, g, log):
     dirs = cortex.direction_at(log=log) or {}
     s.run("MATCH (o:Objective {group_id:$g})-[r:ANCHORS]->(:Direction) DELETE r", g=g)
     for it in dirs.get("set", []) + dirs.get("proposed", []):
-        s.run("MERGE (d:Direction {group_id:$g, body:$b})", g=g, b=it["body"])
+        # The node used to be keyed by body ALONE and carried nothing else — so the fold's `id`,
+        # the only stable name a Direction has, never reached the graph (this host's single
+        # Direction had keys ['body','group_id'] and no id at all). That is how a group ends up
+        # with 788 of them: reword the body, get a new node, forever, with nothing to reconcile
+        # against. MERGE stays on body for compatibility with the nodes already out there — the
+        # dedupe by id belongs to the migration (tools/direction_backfill.py), not to a silent
+        # rewrite here — but the handle, the id and the declared end now ride along. `coalesce`
+        # so a re-projection never WIPES a backfilled title with a null (#632).
+        # `title`/`expires_at`/`supersedes` are the three fields tools/group_health.py reads to
+        # answer "is this group navigable?" — it counts a Direction as handled only when
+        # coalesce(title,name) is set, and as having lifecycle only when expires_at or supersedes
+        # is. Projecting them here is what turns the fix into a measurable one (#632/#636).
+        s.run("MERGE (d:Direction {group_id:$g, body:$b}) "
+              "SET d.id=coalesce($id,d.id), d.kind=coalesce($k,d.kind), "
+              "d.title=coalesce($t,d.title), d.expires_at=coalesce($x,d.expires_at), "
+              "d.supersedes=coalesce($sup,d.supersedes), "
+              "d.title_generated=coalesce($tg,d.title_generated)",
+              g=g, b=it["body"], id=it.get("id"), k=it.get("kind"),
+              t=it.get("title"), x=it.get("expires_at"), sup=it.get("supersedes"),
+              tg=True if it.get("title_generated") else None)
         s.run("MATCH (o:Objective {group_id:$g}),(d:Direction {group_id:$g, body:$b}) "
               "MERGE (o)-[:ANCHORS]->(d)", g=g, b=it["body"])
     # Ticket A — the episteme spine rides the same canonical sync: :Hypothesis nodes fold from

--- a/tools/recall.py
+++ b/tools/recall.py
@@ -40,8 +40,11 @@ SPINE_QUERY = (
     "MATCH (gen:Genesis {group_id:$g}) "
     "OPTIONAL MATCH (gen)-[:GROUNDS]->(o:Objective {group_id:$g}) "
     "OPTIONAL MATCH (o)-[:ANCHORS]->(d:Direction {group_id:$g}) "
+    # The bets are listed by HANDLE, not by a truncated paragraph (#632 acceptance): d.title is the
+    # short name the write path now requires, and coalesce falls back to d.body for a legacy node
+    # the backfill has not reached — the brief keeps working over the old graph either way.
     "RETURN gen.codename AS codename, gen.voice AS voice, o.body AS objective, "
-    "collect(DISTINCT d.body) AS bets")
+    "collect(DISTINCT coalesce(d.title, d.body)) AS bets")
 ARTEFATOS_QUERY = (
     "MATCH (a:Artefato {group_id:$g})-[:SERVES]->(:Objective {group_id:$g}) "
     "WHERE a.projection_complete = true AND coalesce(a.kind,'published') <> 'asset' "

--- a/tools/topic_threads.py
+++ b/tools/topic_threads.py
@@ -514,7 +514,9 @@ def propose_recent_topic_directions(
             continue
         if state == "proposed" and body == direction.body:
             continue
-        eventlog.propose(direction.id, direction.body, kind="thread",
+        # The inferred topic already HAS a handle (TOPIC_SPECS['title']); it used to be dropped on
+        # the floor here, which is one of the ways body-only Directions piled up (#632).
+        eventlog.propose(direction.id, direction.body, kind="thread", title=direction.title,
                          relates_to=direction.relates_to, log=log)
         status[direction.id] = ("proposed", direction.body)
         written += 1
@@ -558,7 +560,9 @@ def sync_recent_topic_memory(
             continue
         if state == "proposed" and body == direction.body:
             continue
-        eventlog.propose(direction.id, direction.body, kind="thread",
+        # The inferred topic already HAS a handle (TOPIC_SPECS['title']); it used to be dropped on
+        # the floor here, which is one of the ways body-only Directions piled up (#632).
+        eventlog.propose(direction.id, direction.body, kind="thread", title=direction.title,
                          relates_to=direction.relates_to, log=log)
         status[direction.id] = ("proposed", direction.body)
         directions_written += 1


### PR DESCRIPTION
Closes #632.

### Duas causas, uma raiz
1. **Escrita**: `propose`/`set_direction` aceitavam body-only. Sem handle, `consolidate` não tem sobre o que fundir e cada beat anexa mais uma.
2. **Projeção — o achado não previsto na issue, e é o que fecha o critério**: o nó era `MERGE (d:Direction {group_id, body})` **sem SET nenhum**. Nem o `id` do fold chegava ao grafo. Confirmado no grafo real: a única Direction do `ed` tinha as chaves `['body','group_id']`.

**Chavear pelo body É o mecanismo dos 788**: reescreveu a frase, ganhou nó novo, para sempre, sem nada contra o que reconciliar.

### `supersedes` não é campo morto
`fold_direction` já aposenta o id superseded. Fixado em teste para a resposta não se perder — e isso encolheu a parte 2 para a metade do calendário, `expires_at`.

### Medido no grafo real, com o instrumento do #638
`dir=0/1 com handle`, 1 falha → depois do backfill, `dir=1/1`, **0 falhas**. O `[warn]` de lifecycle **permanece, corretamente**: o backfill não inventa `expires_at` a partir de prosa.

E isso confirma a correção que eu havia mandado ao agente: a Direction "bem-feita" do `ed` falhava nos **dois** critérios, não só no lifecycle. O prazo dela estava em prosa.

### Parte 3 — ABERTA, com motivo medido
O gate de volume como a issue o descreve mira na camada errada. Os 788 não são fold vivo: são resíduo de projeção (nós keyed por body que nada retira) e o leque de `consolidate_artefato_proposals`, que transforma cada `proposes` de cada artefato publicado num `proposed` — e artefatos são imortais. **Um gate na escrita bloquearia a fonte da verdade sem tocar nos 788.**

Desenho proposto para depois: o teto vira alarme de leitura (já é isso no `OPEN_DIRECTIONS_CEILING` do #638) e, acima dele, exigir `supersedes` **ou** `expires_at` na Direction nova — converte append em lifecycle sem travar o beat.

### Quatro mutações, cada uma matou testes
24 + 14 testes, vermelhos antes. Nota do merge: resolvi o conflito em `publisher.py` combinando este `SET` com o `ANCHORS` chaveado na espinha do #633 — os dois são necessários e não se opõem.