### PR TITLE
fix(tests): o dublê não respondia a consulta da espinha — main vermelho pelo meu merge

### DIFF
--- a/tests/test_direction_handle.py
+++ b/tests/test_direction_handle.py
@@ -266,6 +266,13 @@ class TheProjectionCarriesTheHandleToTheGraph(unittest.TestCase):
 
         def run(self, cypher, **kw):
             self.calls.append((cypher, kw))
+            # O dublê tem que RESPONDER as consultas que o código faz, não só registrá-las.
+            # `merge_spine_objective` (#633) faz `.single()["id"]` sobre o MERGE da espinha; um
+            # dublê que devolve vazio ali quebra com TypeError — e, pior, um que devolvesse algo
+            # genérico esconderia a dependência. Responder só ao que é pedido mantém o dublê
+            # honesto: se a projeção passar a exigir outra coluna, isto quebra em vez de mentir.
+            if cypher.startswith("MERGE (o:Objective") and "elementId(o) AS id" in cypher:
+                return TheProjectionCarriesTheHandleToTheGraph._Rec([{"id": "e-spine-1"}])
             return TheProjectionCarriesTheHandleToTheGraph._Rec()
 
     def _project(self, log):


### PR DESCRIPTION
**Erro meu.** Editei o dublê depois do commit e empurrei o #641 sem ele; o `main` foi para o ar com `test_direction_handle` quebrado (3 erros).

O defeito é instrutivo. O #633 acrescentou `merge_spine_objective`, que faz `.single()["id"]`. O dublê deste teste é anterior e devolvia `_Rec()` vazio para tudo → `None["id"]`.

E **o primeiro conserto que tentei estava errado**: gatilhei em `"elementId(o) AS id" in cypher`, mas `spine_objectives` pede a **mesma coluna** para *buscar*. Respondendo às duas igual, a busca achava um nó inexistente e o `KeyError` só mudava de linha.

O gatilho agora é a **cunhagem** (`MERGE (o:Objective`), não qualquer consulta que peça a coluna.

> Um dublê que responde **demais** é tão cego quanto um que responde de menos — nos dois casos ele deixa de refletir o que o código realmente pede.

`test_direction_handle` 24/24.