### PR TITLE
feat(edge-group): rename migra, gc recusa — e o comando que apagou o turing é teste

### DIFF
--- a/tests/test_group_admin.py
+++ b/tests/test_group_admin.py
@@ -1,0 +1,786 @@
+"""#634 — rename de group_id é FORK; tenant morto sem GC.
+
+`group_id` IS identity. Changing `name`/`codename`/`graph_group` in agent.yaml does NOT migrate
+the graph: the `n.group_id = $g` fence simply stops matching the past (the agent "forgets"
+without anything being deleted) and the next backbone projection MERGEs a SECOND `:Genesis`
+under the new name. That is how `peter tosh` (269 nodes) and `petertosh` (2490) became two
+tenants for one agent, and how `edge-next` (476) became a tomb nobody buries.
+
+Three legs, in rising order of blast radius:
+
+  1. `edge-group rename OLD NEW` — one write transaction, plan first, dry-run the DEFAULT. When
+     both tenants carry a spine the migration is a MERGE, and the policy (operator, 2026-08-16)
+     is that the DESTINATION's spine wins: the source's Genesis/Objective are discarded, printed
+     body and all, behind a second `--discard-source-spine` token, with every edge they carried
+     rewired to an heir or dropped explicitly. The "one identity root" invariant is additionally
+     enforced INSIDE the transaction, so even a doctored plan cannot commit a second root.
+  2. the tenant guard — an install whose resolved group holds no `:Genesis` while OTHER groups on
+     the same Bolt do is a FORK SUSPECT: refuse, name the candidate, offer the migrate.
+  3. `edge-group gc` — LISTS (reusing `group_health.leftovers`, #636) and can bury ONE named
+     group. The delete gate is written from an accident (see `GcRefusesToBuryTheLiving`):
+     protection is opt-OUT, staleness must be proven rather than assumed, and destroying an
+     identity root costs its own separate word.
+
+Every live test writes ONLY into a disposable `fixture-634-*` group and tears it down; the
+tenants sharing this Bolt are never touched (asserted, not assumed).
+"""
+import json
+import sys
+import unittest
+import uuid
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import group_admin  # noqa: E402
+
+
+# ---------------------------------------------------------------- offline doubles
+
+
+class FakeResult:
+    def __init__(self, rows=None):
+        self.rows = list(rows or [])
+
+    def data(self):
+        return self.rows
+
+    def single(self):
+        return self.rows[0] if self.rows else None
+
+
+class FakeSession:
+    """Records every (query, params); serves canned rows keyed by a substring of the query."""
+
+    def __init__(self, rows_by_marker=None):
+        self.calls = []
+        self.rows_by_marker = rows_by_marker or {}
+
+    def run(self, query, **params):
+        flat = " ".join(query.split())
+        self.calls.append((flat, params))
+        for marker, rows in self.rows_by_marker.items():
+            if marker in flat:
+                return FakeResult(rows() if callable(rows) else rows)
+        return FakeResult()
+
+    def execute_write(self, fn):
+        return fn(self)
+
+    def writes(self):
+        return [q for q, _ in self.calls if " SET " in q or "DELETE" in q]
+
+
+def _gc_session(nodes, genesis, last_activity):
+    """A session canned to answer everything `gc_plan` asks about one group. Marker order
+    matters — the most specific query shapes come first."""
+    return FakeSession({
+        "RETURN elementId(n) AS id, properties(n) AS props":
+            [{"id": "x%d" % i, "props": {}} for i in range(genesis)],
+        "RETURN max(toString(coalesce(": [{"n": last_activity}],
+        "count(DISTINCT r) AS n": [{"n": 0}],
+        "RETURN head(labels(n)) AS label": [{"label": "Entity", "n": nodes}],
+        "RETURN count(n) AS n": [{"n": nodes}],
+    })
+
+
+# ---------------------------------------------------------------- the fork, named
+
+
+class ForkIsNamed(unittest.TestCase):
+    """A rename that was never migrated leaves TWO group ids for one agent. The near-twin test is
+    what makes `peter tosh` / `petertosh` legible as one fork instead of two tenants."""
+
+    def test_near_twin_group_ids_are_flagged_as_one_fork(self):
+        inv = [{"group": "petertosh", "nodes": 2490}, {"group": "peter tosh", "nodes": 269},
+               {"group": "edge-next", "nodes": 476}, {"group": "turing", "nodes": 116}]
+        self.assertEqual(group_admin.fork_candidates(inv), [("peter tosh", "petertosh")])
+
+    def test_distinct_tenants_are_not_flagged(self):
+        inv = [{"group": "ed", "nodes": 21}, {"group": "turing", "nodes": 116}]
+        self.assertEqual(group_admin.fork_candidates(inv), [])
+
+    def test_normalization_ignores_case_space_dash_and_underscore(self):
+        self.assertEqual(group_admin.normalize_group("Peter Tosh"),
+                         group_admin.normalize_group("peter-tosh"))
+        self.assertEqual(group_admin.normalize_group("edge_next"),
+                         group_admin.normalize_group("edge next"))
+
+
+class TenantVerdict(unittest.TestCase):
+    """The guard's judgement, on canned graph facts. `fork_suspect` is the verdict that refuses a
+    fresh install: my group is EMPTY while other groups on this Bolt already own a `:Genesis`."""
+
+    def _verdict(self, group, genesis_groups, my_nodes, inventory=None):
+        s = FakeSession({
+            "MATCH (n:Genesis)": [{"group": g, "n": 1} for g in genesis_groups],
+            "RETURN count(n) AS n": [{"n": my_nodes}],
+            "WHERE n.group_id IS NOT NULL RETURN n.group_id AS group":
+                inventory or [{"group": g, "nodes": 1, "genesis": 1, "last_activity": None}
+                              for g in genesis_groups],
+        })
+        return group_admin.tenant_verdict(s, group)
+
+    def test_group_owning_its_genesis_is_the_owner(self):
+        v = self._verdict("ed", ["ed", "turing"], 21)
+        self.assertEqual(v["status"], "owner")
+        self.assertTrue(v["ok"])
+
+    def test_empty_group_beside_a_foreign_genesis_is_a_fork_suspect(self):
+        v = self._verdict("petertosh", ["peter tosh"], 0)
+        self.assertEqual(v["status"], "fork_suspect")
+        self.assertFalse(v["ok"])
+        self.assertEqual(v["candidates"], ["peter tosh"])
+        self.assertIn("edge-group rename", v["detail"])      # OFFER the migrate, not just complain
+        self.assertIn("peter tosh", v["detail"])
+
+    def test_empty_group_on_an_empty_bolt_is_a_fresh_install(self):
+        v = self._verdict("ed", [], 0, inventory=[])
+        self.assertEqual(v["status"], "fresh")
+        self.assertIsNone(v["ok"])                           # advisory: nothing to fork from
+
+    def test_populated_group_without_a_spine_yet_is_advisory_not_a_refusal(self):
+        v = self._verdict("ed", ["turing"], 12)
+        self.assertEqual(v["status"], "unrooted")
+        self.assertIsNone(v["ok"])
+
+    def test_a_near_twin_of_my_own_group_is_a_refusal(self):
+        v = self._verdict("petertosh", ["petertosh", "peter tosh"], 2490,
+                          inventory=[{"group": "petertosh", "nodes": 2490, "genesis": 1,
+                                      "last_activity": None},
+                                     {"group": "peter tosh", "nodes": 269, "genesis": 1,
+                                      "last_activity": None}])
+        self.assertEqual(v["status"], "forked")
+        self.assertFalse(v["ok"])
+        self.assertIn("peter tosh", v["detail"])
+
+
+class GuardRefusesInInstallValidation(unittest.TestCase):
+    """Leg 2 of the issue: the guard has to reach `edge-apply`. A fork suspect is a FAILED install
+    check (apply exits nonzero), never a silent second Genesis."""
+
+    def test_validate_exposes_a_tenant_check(self):
+        import _validate
+        self.assertTrue(hasattr(_validate, "check_tenant"))
+        names = [c[0] for c in _validate.validate_install(
+            REPO, {}, REPO, provisioned=True, repo_tools=REPO / "tools",
+            agent_yaml=REPO / "nope.yaml")]
+        self.assertIn("tenant", names)
+
+    def test_fork_suspect_probe_output_is_a_failed_check(self):
+        import _validate
+        name, ok, detail = _validate._tenant_from_probe(json.dumps({
+            "status": "fork_suspect", "ok": False, "group": "petertosh",
+            "candidates": ["peter tosh"],
+            "detail": "group 'petertosh' is empty while 'peter tosh' owns a :Genesis — "
+                      "run `edge-group rename 'peter tosh' petertosh` to migrate"}))
+        self.assertEqual(name, "tenant")
+        self.assertIs(ok, False)
+        self.assertIn("edge-group rename", detail)
+
+    def test_declared_new_tenant_downgrades_to_advisory_but_stays_loud(self):
+        import _validate
+        name, ok, detail = _validate._tenant_from_probe(json.dumps({
+            "status": "fork_suspect", "ok": False, "group": "petertosh",
+            "candidates": ["peter tosh"], "detail": "…", "new_tenant_declared": True}))
+        self.assertIsNone(ok)                     # declared → does not block the install
+        self.assertIn("peter tosh", detail)       # but the foreign tenant is still NAMED
+
+
+class ConfirmationIsNotOptional(unittest.TestCase):
+    """Dry-run is the DEFAULT for both verbs; every write needs the destination retyped."""
+
+    def test_rename_without_apply_is_a_dry_run(self):
+        s = FakeSession({"RETURN count(n) AS n": [{"n": 3}]})
+        self.assertEqual(group_admin.main(["rename", "old", "new"], session=s), 0)
+        self.assertEqual(s.writes(), [], "a default rename must not write")
+
+    def test_rename_apply_without_confirm_refuses(self):
+        s = FakeSession({"RETURN count(n) AS n": [{"n": 3}]})
+        self.assertEqual(group_admin.main(["rename", "old", "new", "--apply"], session=s), 2)
+        self.assertEqual(s.writes(), [])
+
+    def test_rename_apply_with_a_mismatched_confirm_refuses(self):
+        s = FakeSession({"RETURN count(n) AS n": [{"n": 3}]})
+        self.assertEqual(group_admin.main(
+            ["rename", "old", "new", "--apply", "--confirm", "nwe"], session=s), 2)
+        self.assertEqual(s.writes(), [])
+
+    def test_rename_onto_itself_is_refused(self):
+        s = FakeSession({"RETURN count(n) AS n": [{"n": 3}]})
+        self.assertEqual(group_admin.main(
+            ["rename", "ed", "ed", "--apply", "--confirm", "ed"], session=s), 2)
+        self.assertEqual(s.writes(), [])
+
+    def test_renaming_an_empty_group_is_refused(self):
+        s = FakeSession({"RETURN count(n) AS n": [{"n": 0}]})
+        self.assertEqual(group_admin.main(
+            ["rename", "ghost", "new", "--apply", "--confirm", "new"], session=s), 2)
+        self.assertEqual(s.writes(), [])
+
+    def test_gc_delete_without_confirm_refuses(self):
+        s = _gc_session(nodes=476, genesis=0, last_activity="2026-01-01T00:00:00Z")
+        self.assertEqual(group_admin.main(
+            ["gc", "--delete", "edge-next", "--stale-since", "2026-06-01"], session=s), 2)
+        self.assertEqual(s.writes(), [])
+
+    def test_gc_refuses_to_delete_the_live_group(self):
+        s = _gc_session(nodes=21, genesis=0, last_activity="2026-01-01T00:00:00Z")
+        self.assertEqual(group_admin.main(
+            ["gc", "--delete", "ed", "--confirm", "ed", "--stale-since", "2026-06-01"],
+            session=s, live_group="ed"), 2)
+        self.assertEqual(s.writes(), [])
+
+    def test_gc_refuses_to_delete_a_group_named_by_keep(self):
+        s = _gc_session(nodes=116, genesis=0, last_activity="2026-01-01T00:00:00Z")
+        self.assertEqual(group_admin.main(
+            ["gc", "--delete", "turing", "--confirm", "turing", "--keep", "turing",
+             "--stale-since", "2026-06-01"], session=s, live_group="ed"), 2)
+        self.assertEqual(s.writes(), [])
+
+
+class GcRefusesToBuryTheLiving(unittest.TestCase):
+    """REGRESSION, written from an accident of mine (2026-08-16).
+
+    The first cut of this CLI protected only `_identity.group()` — THIS install's own tenant —
+    plus whatever `--keep` named. On a shared Bolt that is backwards: the tenants you can least
+    afford to destroy are precisely the ones belonging to OTHER unix users, whose installs this
+    process cannot see, and they were one correctly-typed command away from deletion. I typed
+    that command against `turing` while probing what I believed was the refusal path, and deleted
+    a live agent's memory (141 nodes) in one round trip.
+
+    Burying a tenant IS supported — `edge-next` is meant to be buried — but every assertion is
+    now separate and none of them defaults to yes:
+      - the group named in `--delete`, RETYPED in `--confirm`;
+      - a `--stale-since` date the group's own last activity must predate (no timestamp at all =
+        no evidence of death = refused);
+      - `--bury-rooted` on top of all that when the group holds a `:Genesis`, because an identity
+        root means an install claimed the tenant.
+    The command that destroyed `turing` is refused by three of those rows at once, and the
+    refusals live in the PLAN, so a caller who skips the CLI still cannot get past them.
+    """
+
+    STALE = ["--stale-since", "2026-06-01"]
+
+    def test_the_command_that_destroyed_turing_is_now_refused(self):
+        # verbatim: `gc --delete turing --confirm turing`, against turing's shape
+        s = _gc_session(nodes=141, genesis=1, last_activity="2026-01-01T00:00:00Z")
+        rc = group_admin.main(["gc", "--delete", "turing", "--confirm", "turing"],
+                              session=s, live_group="ed")
+        self.assertEqual(rc, 2)
+        self.assertEqual(s.writes(), [], "the accident must not be reproducible")
+
+    def test_a_rooted_group_needs_bury_rooted_on_top_of_everything_else(self):
+        s = _gc_session(nodes=141, genesis=1, last_activity="2026-01-01T00:00:00Z")
+        rc = group_admin.main(["gc", "--delete", "turing", "--confirm", "turing"] + self.STALE,
+                              session=s, live_group="ed")
+        self.assertEqual(rc, 2)
+        self.assertEqual(s.writes(), [],
+                         "an identity root means an install claimed this tenant")
+
+    def test_the_plan_itself_blocks_a_rooted_group_until_the_burial_is_declared(self):
+        s = _gc_session(nodes=141, genesis=1, last_activity="2026-01-01T00:00:00Z")
+        plan = group_admin.gc_plan(s, "turing", stale_since="2026-06-01")
+        self.assertTrue(any(group_admin.SPINE_ROOT in b for b in plan["blockers"]),
+                        plan["blockers"])
+        with self.assertRaises(group_admin.GroupAdminError):
+            group_admin.gc_apply(s, plan)
+        self.assertEqual(s.writes(), [])
+        declared = group_admin.gc_plan(s, "turing", stale_since="2026-06-01", bury_rooted=True)
+        self.assertEqual(declared["blockers"], [],
+                         "a declared burial of a stale rooted tenant is allowed — that is the "
+                         "edge-next case; what is forbidden is doing it by default")
+
+    def test_delete_without_a_staleness_date_is_refused(self):
+        s = _gc_session(nodes=476, genesis=0, last_activity="2026-01-01T00:00:00Z")
+        rc = group_admin.main(["gc", "--delete", "edge-next", "--confirm", "edge-next"],
+                              session=s, live_group="ed")
+        self.assertEqual(rc, 2)
+        self.assertEqual(s.writes(), [])
+
+    def test_a_group_that_moved_after_the_staleness_date_is_refused(self):
+        s = _gc_session(nodes=476, genesis=0, last_activity="2026-08-15T10:00:00Z")
+        rc = group_admin.main(["gc", "--delete", "edge-next", "--confirm", "edge-next"]
+                              + self.STALE, session=s, live_group="ed")
+        self.assertEqual(rc, 2)
+        self.assertEqual(s.writes(), [])
+
+    def test_a_group_with_no_activity_timestamp_is_refused(self):
+        """No evidence of death is not evidence of death.
+
+        The REASON matters as much as the refusal: an undated group must be refused for being
+        undated, not by falling through a date comparison that happens to come out the right way
+        on the string `None`. An operator who reads "moved at None, not older than …" cannot
+        tell whether the tool checked anything."""
+        s = _gc_session(nodes=9, genesis=0, last_activity=None)
+        rc = group_admin.main(["gc", "--delete", "mystery", "--confirm", "mystery"]
+                              + self.STALE, session=s, live_group="ed")
+        self.assertEqual(rc, 2)
+        self.assertEqual(s.writes(), [])
+        plan = group_admin.gc_plan(_gc_session(9, 0, None), "mystery",
+                                   stale_since="2026-06-01")
+        self.assertTrue(any("no activity timestamp" in b for b in plan["blockers"]),
+                        plan["blockers"])
+
+    def test_every_token_is_load_bearing(self):
+        """The whole gate read as one table. Drop any token and the plan blocks again; only the
+        two cleared rows below are deletable — unrooted-and-stale, or rooted-stale-and-declared
+        (the `edge-next` burial the operator asked for)."""
+        blocked = {
+            "rooted, not declared": group_admin.gc_plan(
+                _gc_session(141, 1, "2026-01-01T00:00:00Z"), "turing",
+                stale_since="2026-06-01"),
+            "moved after the date": group_admin.gc_plan(
+                _gc_session(476, 0, "2026-08-15T10:00:00Z"), "edge-next",
+                stale_since="2026-06-01"),
+            "no timestamp at all": group_admin.gc_plan(
+                _gc_session(9, 0, None), "mystery", stale_since="2026-06-01"),
+            "no staleness date": group_admin.gc_plan(
+                _gc_session(12, 0, "2026-01-01T00:00:00Z"), "debris", stale_since=None),
+            "rooted, declared, but recent": group_admin.gc_plan(
+                _gc_session(476, 1, "2026-08-15T10:00:00Z"), "edge-next",
+                stale_since="2026-06-01", bury_rooted=True),
+        }
+        for why, plan in blocked.items():
+            self.assertTrue(plan["blockers"], why)
+        for why, plan in {
+            "unrooted and stale": group_admin.gc_plan(
+                _gc_session(12, 0, "2026-01-01T00:00:00Z"), "debris",
+                stale_since="2026-06-01"),
+            "rooted, stale, declared": group_admin.gc_plan(
+                _gc_session(476, 1, "2026-01-01T00:00:00Z"), "edge-next",
+                stale_since="2026-06-01", bury_rooted=True),
+        }.items():
+            self.assertEqual(plan["blockers"], [], why)
+
+
+# ---------------------------------------------------------------- live fixture proof
+
+
+def _live_driver():
+    try:
+        import _identity
+        from neo4j import GraphDatabase
+        uri, user, pw = _identity.neo4j_conn()
+        if not pw:
+            return None
+        drv = GraphDatabase.driver(uri, auth=(user, pw), connection_timeout=3,
+                                   max_transaction_retry_time=3)
+        drv.verify_connectivity()
+        return drv
+    except Exception:                                    # noqa: BLE001 — no graph → skip
+        return None
+
+
+class LiveFixtureCase(unittest.TestCase):
+    """Base for the live legs: every write lands in a disposable `fixture-634-*` group, and the
+    teardown proves no neighbouring tenant lost a node."""
+
+    FIXTURE_PREFIX = "fixture-634-"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.driver = _live_driver()
+        if cls.driver is None:
+            raise unittest.SkipTest("no reachable Neo4j — live group surgery skipped")
+        cls._sweep_fixtures()
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "driver", None) is not None:
+            cls._sweep_fixtures()
+            cls.driver.close()
+
+    @classmethod
+    def _sweep_fixtures(cls):
+        """Clear any `fixture-634-*` group a CRASHED earlier run left behind. Prefix-guarded in
+        the Cypher itself, so this can only ever reach groups this file minted."""
+        with cls.driver.session() as s:
+            s.run("MATCH (n) WHERE n.group_id STARTS WITH $p DETACH DELETE n",
+                  p=cls.FIXTURE_PREFIX)
+
+    def _tenants(self, s):
+        """The census of REAL tenants — fixture groups excluded, because they are ours to create
+        and destroy and their disappearance is the expected outcome, not a leak."""
+        return {r["g"]: r["n"] for r in s.run(
+            "MATCH (n) WHERE n.group_id IS NOT NULL AND NOT n.group_id STARTS WITH $p "
+            "RETURN n.group_id AS g, count(n) AS n", p=self.FIXTURE_PREFIX).data()}
+
+    def setUp(self):
+        self.groups = []
+        with self.driver.session() as s:
+            self.before = self._tenants(s)
+
+    def tearDown(self):
+        with self.driver.session() as s:
+            for g in self.groups:
+                assert g.startswith(self.FIXTURE_PREFIX)     # never a real tenant
+                s.run("MATCH (n) WHERE n.group_id=$g DETACH DELETE n", g=g)
+            after = self._tenants(s)
+            survivors = [g for g in self.groups if s.run(
+                "MATCH (n) WHERE n.group_id=$g RETURN count(n) AS n", g=g).single()["n"]]
+        # This Bolt is SHARED — the installs on it may write while the suite runs, so a tenant
+        # that GREW proves nothing about us. What must hold is that no REAL tenant LOST nodes (a
+        # rename would move them out, a gc would delete them) and that this test's own fixture
+        # groups are gone.
+        for g, n in self.before.items():
+            self.assertGreaterEqual(after.get(g, 0), n,
+                                    "tenant %r lost nodes — a live test leaked" % g)
+        self.assertEqual(survivors, [], "a fixture group survived its test")
+
+    def _fixture(self, tag):
+        g = self.FIXTURE_PREFIX + tag + "-" + uuid.uuid4().hex[:8]
+        self.groups.append(g)
+        return g
+
+    def _seed(self, group, *, entities=0, spine=True, objective="norte"):
+        """Seed a tenant shaped like a real one: a :Genesis spine root, an :Objective it GROUNDS,
+        and graphiti-shaped :Entity/:Episodic nodes joined by group-STAMPED edges."""
+        with self.driver.session() as s:
+            if spine:
+                s.run("CREATE (g:Genesis {group_id:$g, space:0, codename:$g})", g=group)
+                s.run("CREATE (o:Objective {group_id:$g, body:$b})", g=group, b=objective)
+                s.run("MATCH (g:Genesis {group_id:$g}),(o:Objective {group_id:$g}) "
+                      "MERGE (g)-[:GROUNDS]->(o)", g=group)
+            for i in range(entities):
+                s.run("CREATE (e:Entity {group_id:$g, uuid:$u, name:$n, created_at:$t})",
+                      g=group, u=f"{group}-e{i}", n=f"ent-{i}", t="2026-01-01T00:00:00Z")
+                s.run("CREATE (ep:Episodic {group_id:$g, uuid:$u, name:$n, created_at:$t})",
+                      g=group, u=f"{group}-ep{i}", n=f"epi-{i}", t="2026-01-01T00:00:00Z")
+                s.run("MATCH (ep:Episodic {group_id:$g, uuid:$u}),"
+                      "(e:Entity {group_id:$g, uuid:$v}) "
+                      "MERGE (ep)-[:MENTIONS {group_id:$g, uuid:$r}]->(e)",
+                      g=group, u=f"{group}-ep{i}", v=f"{group}-e{i}", r=f"{group}-r{i}")
+
+    def _count(self, group, label=None):
+        pat = f"(n:{label})" if label else "(n)"
+        with self.driver.session() as s:
+            return s.run(f"MATCH {pat} WHERE n.group_id=$g RETURN count(n) AS n",
+                         g=group).single()["n"]
+
+    def _rels(self, group):
+        with self.driver.session() as s:
+            return s.run("MATCH ()-[r]->() WHERE r.group_id=$g RETURN count(r) AS n",
+                         g=group).single()["n"]
+
+
+class RenameMigratesTheWholeTenant(LiveFixtureCase):
+    """The acceptance criterion of #634, against a real Bolt: after a rename, ZERO nodes remain
+    under the old id and the destination holds exactly ONE identity root."""
+
+    def test_rename_into_an_empty_group_moves_nodes_and_edges(self):
+        old, new = self._fixture("old"), self._fixture("new")
+        self._seed(old, entities=3)
+        with self.driver.session() as s:
+            plan = group_admin.rename_plan(s, old, new)
+            self.assertEqual(plan["blockers"], [])
+            self.assertEqual(plan["nodes"], self._count(old))
+            self.assertEqual(plan["rels"], self._rels(old))
+            result = group_admin.rename_apply(s, plan)
+        self.assertEqual(self._count(old), 0, "the old group id must be EMPTY after a rename")
+        self.assertEqual(self._count(new), plan["nodes"])
+        self.assertEqual(self._rels(new), plan["rels"],
+                         "graphiti stamps group_id on RELATIONSHIPS too — a rename that only "
+                         "moves nodes leaves the edges fenced into a dead tenant")
+        self.assertEqual(result["moved_nodes"], plan["nodes"])
+        self.assertEqual(self._count(new, "Genesis"), 1, "the spine root must be SINGLE")
+
+    def test_rename_into_a_group_that_has_nodes_but_no_spine_is_a_normal_migration(self):
+        """The common recoverable case: the new id already collected some sweep output but never
+        got a backbone. Nothing is editorial here, so the migration runs."""
+        old, new = self._fixture("old"), self._fixture("partial")
+        self._seed(old, entities=2)
+        self._seed(new, entities=3, spine=False)
+        total = self._count(old) + self._count(new)
+        with self.driver.session() as s:
+            plan = group_admin.rename_plan(s, old, new)
+            self.assertEqual(plan["blockers"], [])
+            group_admin.rename_apply(s, plan)
+        self.assertEqual(self._count(old), 0)
+        self.assertEqual(self._count(new), total)
+        self.assertEqual(self._count(new, "Genesis"), 1)
+
+    def test_a_spine_collision_shows_the_discard_before_it_happens(self):
+        """The real fleet shape: BOTH ids carry a spine (`peter tosh` and `petertosh` each have a
+        Genesis and an Objective). Policy (operator, 2026-08-16): the DESTINATION's spine wins.
+        The dry-run must therefore name, verbatim, the norte it is about to destroy — a declared
+        direction may be discarded by decision, never in silence."""
+        old, new = self._fixture("fork"), self._fixture("main")
+        self._seed(old, entities=2, objective="norte antigo")
+        self._seed(new, entities=5, objective="norte vivo")
+        with self.driver.session() as s:
+            plan = group_admin.rename_plan(s, old, new)
+            rendered = group_admin._render_rename(plan)
+        self.assertIn("Genesis", plan["collisions"])
+        self.assertIn("Objective", plan["collisions"])
+        self.assertEqual(sorted(d["label"] for d in plan["discards"]), ["Genesis", "Objective"])
+        self.assertIn("norte antigo", rendered)          # the body being destroyed, in full
+        self.assertIn("norte vivo", rendered)            # the body that survives
+        self.assertIn("DISCARD", rendered)
+        self.assertIn("KEEP", rendered)
+
+    def test_the_destination_spine_wins_and_the_source_corpus_is_adopted(self):
+        old, new = self._fixture("fork"), self._fixture("main")
+        self._seed(old, entities=2, objective="norte antigo")
+        self._seed(new, entities=5, objective="norte vivo")
+        old_nodes, new_nodes = self._count(old), self._count(new)
+        with self.driver.session() as s:
+            plan = group_admin.rename_plan(s, old, new)
+            keep = s.run("MATCH (n:Objective) WHERE n.group_id=$g RETURN n.body AS b",
+                         g=new).single()["b"]
+            result = group_admin.rename_apply(s, plan)
+            bodies = [r["b"] for r in s.run(
+                "MATCH (n:Objective) WHERE n.group_id=$g RETURN n.body AS b", g=new).data()]
+        self.assertEqual(self._count(old), 0, "the old group id must be EMPTY after a merge")
+        self.assertEqual(self._count(new, "Genesis"), 1, "one identity root, always")
+        self.assertEqual(bodies, [keep], "the destination's norte is the one that survives")
+        # 2 spine nodes discarded; every other node of the source is adopted corpus
+        self.assertEqual(self._count(new), old_nodes + new_nodes - 2)
+        self.assertEqual(result["discarded"], 2)
+
+    def test_edges_of_a_discarded_spine_node_are_rewired_never_orphaned(self):
+        """Trading duplication for orphans is not a fix.
+
+        The source's Objective ANCHORS a Direction that comes along as adopted corpus, and the
+        destination has no such edge to fall back on. If the discard simply deleted the source
+        Objective, that Direction would arrive unreachable from the surviving spine — memory
+        that is present but cannot be walked to. So the edge must land on the heir."""
+        old, new = self._fixture("fork"), self._fixture("main")
+        self._seed(old, entities=1, objective="norte antigo")
+        self._seed(new, entities=1, objective="norte vivo")
+        with self.driver.session() as s:
+            s.run("CREATE (d:Direction {group_id:$g, body:$b})", g=old, b="rumo adotado")
+            s.run("MATCH (o:Objective {group_id:$g}),(d:Direction {group_id:$g}) "
+                  "MERGE (o)-[:ANCHORS]->(d)", g=old)
+            plan = group_admin.rename_plan(s, old, new)
+            incident = sum(len(group_admin._incident_edges(s, d["id"]))
+                           for d in plan["discards"])
+            group_admin.rename_apply(s, plan)
+            anchored = s.run(
+                "MATCH (o:Objective)-[:ANCHORS]->(d:Direction) "
+                "WHERE o.group_id=$g AND d.body=$b RETURN o.body AS b", g=new,
+                b="rumo adotado").data()
+            grounds = s.run(
+                "MATCH (g:Genesis)-[:GROUNDS]->(o:Objective) "
+                "WHERE g.group_id=$g AND o.group_id=$g RETURN count(*) AS n",
+                g=new).single()["n"]
+            dangling = s.run(
+                "MATCH (n) WHERE n.group_id=$g AND NOT (n)--() "
+                "AND NOT n:Genesis RETURN count(n) AS n", g=new).single()["n"]
+        self.assertEqual(len(plan["rewires"]) + len(plan["dropped"]), incident,
+                         "every edge of a discarded node must be accounted for")
+        self.assertEqual([r["b"] for r in anchored], ["norte vivo"],
+                         "the adopted Direction must hang off the SURVIVING norte")
+        self.assertEqual(grounds, 1, "the surviving spine is still connected")
+        self.assertEqual(dangling, 0, "no adopted node was left dangling")
+
+    def test_an_ambiguous_heir_drops_edges_explicitly_rather_than_inventing_one(self):
+        """`petertosh` carries SIX Objectives: no non-arbitrary heir exists for the edges of the
+        discarded one. The plan says so, per edge type, instead of picking a norte nobody chose."""
+        old, new = self._fixture("fork"), self._fixture("many")
+        self._seed(old, entities=1, objective="norte antigo")
+        self._seed(new, entities=1, objective="norte 1")
+        with self.driver.session() as s:
+            for extra in ("norte 2", "norte 3"):
+                s.run("CREATE (o:Objective {group_id:$g, body:$b})", g=new, b=extra)
+            plan = group_admin.rename_plan(s, old, new)
+            rendered = group_admin._render_rename(plan)
+        self.assertIsNone(plan["heirs"]["Objective"], "3 candidates → no unambiguous heir")
+        self.assertEqual(plan["heirs"]["Genesis"], plan["collisions"]["Genesis"]["target"][0]["id"])
+        self.assertTrue(any(d["label"] == "Objective" for d in plan["dropped"]), plan["dropped"])
+        self.assertIn("no unambiguous heir", rendered)
+        self.assertIn("DROP", rendered)
+
+    def test_apply_requires_the_discard_token_on_top_of_the_confirm(self):
+        """Moving nodes and destroying a declared norte must not be the same keystroke."""
+        old, new = self._fixture("fork"), self._fixture("main")
+        self._seed(old, entities=1)
+        self._seed(new, entities=1)
+        with self.driver.session() as s:
+            rc = group_admin.main(["rename", old, new, "--apply", "--confirm", new], session=s)
+            self.assertEqual(rc, 2)
+            self.assertEqual(self._count(old), 4, "a refused merge must move NOTHING")
+            rc = group_admin.main(["rename", old, new, "--apply", "--confirm", new,
+                                   "--discard-source-spine"], session=s)
+        self.assertEqual(rc, 0)
+        self.assertEqual(self._count(old), 0)
+        self.assertEqual(self._count(new, "Genesis"), 1)
+
+    def test_a_stripped_plan_still_cannot_commit_two_identity_roots(self):
+        """Defence in depth for the acceptance criterion. A caller determined to force it — here,
+        by deleting the plan's `discards` so the merge would move both spines in — still cannot
+        commit: the transaction re-checks the destination and rolls back rather than leave two
+        `:Genesis` under one group id."""
+        old, new = self._fixture("fork"), self._fixture("main")
+        self._seed(old, entities=1)
+        self._seed(new, entities=1)
+        with self.driver.session() as s:
+            plan = dict(group_admin.rename_plan(s, old, new),
+                        discards=[], rewires=[], dropped=[])
+            with self.assertRaises(group_admin.GroupAdminError):
+                group_admin.rename_apply(s, plan)
+        self.assertEqual(self._count(new, "Genesis"), 1)
+        self.assertEqual(self._count(old, "Genesis"), 1)
+
+    def test_a_drifted_plan_rolls_back_instead_of_half_renaming(self):
+        """Atomicity with teeth: if the graph moved under the plan, apply aborts with the OLD
+        group intact — never a tenant split across two ids."""
+        old, new = self._fixture("drift"), self._fixture("dest")
+        self._seed(old, entities=2)
+        with self.driver.session() as s:
+            plan = group_admin.rename_plan(s, old, new)
+            plan = dict(plan, nodes=plan["nodes"] + 7)        # the graph "changed" underneath
+            with self.assertRaises(group_admin.GroupAdminError):
+                group_admin.rename_apply(s, plan)
+        self.assertEqual(self._count(new), 0, "a rolled-back rename must move NOTHING")
+        self.assertNotEqual(self._count(old), 0)
+
+    def test_rename_never_touches_a_third_group(self):
+        old, new, bystander = self._fixture("a"), self._fixture("b"), self._fixture("c")
+        self._seed(old, entities=2)
+        self._seed(bystander, entities=4)
+        before = self._count(bystander)
+        with self.driver.session() as s:
+            group_admin.rename_apply(s, group_admin.rename_plan(s, old, new))
+        self.assertEqual(self._count(bystander), before)
+
+
+class GcListsExactlyWhatItWouldDelete(LiveFixtureCase):
+    """A gc that deletes by mistake is worse than the tomb it clears. The dry-run plan and the
+    delete share ONE derivation, and the delete asserts the match INSIDE the transaction."""
+
+    STALE = "2026-06-01"
+
+    def test_plan_counts_every_node_and_edge_the_delete_removes(self):
+        dead = self._fixture("tomb")
+        self._seed(dead, entities=4, spine=False)         # unrooted debris: the collectable shape
+        with self.driver.session() as s:
+            plan = group_admin.gc_plan(s, dead, stale_since=self.STALE)
+            self.assertEqual(plan["blockers"], [])
+            self.assertEqual(plan["nodes"], self._count(dead))
+            self.assertEqual(sum(plan["by_label"].values()), plan["nodes"])
+            result = group_admin.gc_apply(s, plan)
+        self.assertEqual(result["deleted_nodes"], plan["nodes"])
+        self.assertEqual(result["deleted_rels"], plan["rels"])
+        self.assertEqual(self._count(dead), 0)
+
+    def test_a_rooted_group_is_not_collected_without_a_declared_burial(self):
+        """The incident, reproduced against the real thing: a tenant with an identity root is
+        refused by the plan itself, and `gc_apply` on that plan deletes nothing."""
+        alive = self._fixture("rooted")
+        self._seed(alive, entities=3)                     # spine=True → holds a :Genesis
+        before = self._count(alive)
+        with self.driver.session() as s:
+            plan = group_admin.gc_plan(s, alive, stale_since=self.STALE)
+            self.assertTrue(any(group_admin.SPINE_ROOT in b for b in plan["blockers"]),
+                            plan["blockers"])
+            with self.assertRaises(group_admin.GroupAdminError):
+                group_admin.gc_apply(s, plan)
+        self.assertEqual(self._count(alive), before)
+
+    def test_a_declared_burial_of_a_stale_rooted_tenant_goes_through(self):
+        """The `edge-next` case (476 nodes, abandoned): the operator decided to bury it, so the
+        tool has to actually do it — spine and all — once the burial is declared out loud."""
+        tomb = self._fixture("edgenext")
+        self._seed(tomb, entities=3)                      # rooted, timestamps in 2026-01
+        before = self._count(tomb)
+        with self.driver.session() as s:
+            rc = group_admin.main(
+                ["gc", "--delete", tomb, "--confirm", tomb, "--stale-since", self.STALE,
+                 "--bury-rooted"], session=s, live_group="ed")
+        self.assertEqual(rc, 0)
+        self.assertEqual(self._count(tomb), 0, "a declared burial must actually bury")
+        self.assertGreater(before, 0)
+
+    def test_a_group_that_moved_recently_cannot_be_collected(self):
+        dead = self._fixture("warm")
+        self._seed(dead, entities=2, spine=False)
+        with self.driver.session() as s:
+            plan = group_admin.gc_plan(s, dead, stale_since="2025-01-01")
+            self.assertTrue(plan["blockers"])
+            with self.assertRaises(group_admin.GroupAdminError):
+                group_admin.gc_apply(s, plan)
+        self.assertEqual(self._count(dead), 4, "a refused collection must delete NOTHING")
+
+    def test_a_drifted_gc_plan_rolls_back(self):
+        dead = self._fixture("tomb")
+        self._seed(dead, entities=3, spine=False)
+        before = self._count(dead)
+        with self.driver.session() as s:
+            plan = group_admin.gc_plan(s, dead, stale_since=self.STALE)
+            plan = dict(plan, nodes=plan["nodes"] - 1)        # under-counted → must NOT delete
+            with self.assertRaises(group_admin.GroupAdminError):
+                group_admin.gc_apply(s, plan)
+        self.assertEqual(self._count(dead), before, "a drifted gc plan must delete NOTHING")
+
+    def test_inventory_carries_the_evidence_a_delete_decision_needs(self):
+        rooted, bare = self._fixture("rooted"), self._fixture("bare")
+        self._seed(rooted, entities=1)
+        self._seed(bare, entities=1, spine=False)
+        with self.driver.session() as s:
+            rows = {r["group"]: r for r in group_admin.inventory(s)}
+        self.assertEqual(rows[rooted]["genesis"], 1)
+        self.assertEqual(rows[bare]["genesis"], 0)
+        self.assertEqual(rows[bare]["last_activity"], "2026-01-01T00:00:00Z")
+        self.assertGreater(rows[rooted]["rels"], 0)
+
+
+class GcBorrowsItsListingFromGroupHealth(LiveFixtureCase):
+    """`gc --stale` does not re-decide what #636 already decided. `group_health.leftovers` owns
+    "which groups have no install here" and "which nodes carry no group_id"; this module adds
+    only the per-group evidence a DELETE needs (identity root, last activity) and the gate."""
+
+    def test_the_listing_is_group_healths_leftovers_verbatim(self):
+        import group_health
+        orphan = self._fixture("orphan")
+        self._seed(orphan, entities=1, spine=False)
+        with self.driver.session() as s:
+            expected = group_health.leftovers(s, {"ed"})
+            printed = group_admin._render_gc(
+                group_admin.inventory(s), expected, [], False, "ed")
+        self.assertTrue(any(orphan in msg for _sev, msg in expected), expected)
+        for _sev, msg in expected:
+            self.assertIn(msg, printed)
+
+    def test_ungrouped_nodes_are_diagnosis_and_never_a_delete_target(self):
+        """A node written without a tenant stamp is a WRITE-PATH bug — evidence to keep, not
+        dirt to sweep. `gc` has no way to aim at them: the target is always a named group."""
+        with self.driver.session() as s:
+            plan = group_admin.gc_plan(s, None, stale_since="2026-06-01")
+            self.assertTrue(plan["blockers"])
+            with self.assertRaises(group_admin.GroupAdminError):
+                group_admin.gc_apply(s, plan)
+            rc = group_admin.main(["gc", "--delete", "", "--confirm", "",
+                                   "--stale-since", "2026-06-01"], session=s, live_group="ed")
+        self.assertEqual(rc, 2)
+        rendered = group_admin._render_gc([], [], [], False, "ed")
+        self.assertIn("never garbage", rendered)
+
+
+class GuardRefusesTheSecondGenesis(LiveFixtureCase):
+    """Leg 2 against a real Bolt: an empty group beside a populated tenant is refused, and the
+    refusal NAMES the group to migrate from."""
+
+    def test_empty_group_beside_a_live_tenant_is_refused(self):
+        live, fresh = self._fixture("live"), self._fixture("fresh")
+        self._seed(live, entities=2)
+        with self.driver.session() as s:
+            v = group_admin.tenant_verdict(s, fresh)
+        self.assertEqual(v["status"], "fork_suspect")
+        self.assertFalse(v["ok"])
+        self.assertIn(live, v["candidates"])
+        self.assertIn("edge-group rename", v["detail"])
+
+    def test_after_the_rename_the_guard_is_satisfied(self):
+        live, fresh = self._fixture("live"), self._fixture("fresh")
+        self._seed(live, entities=2)
+        with self.driver.session() as s:
+            group_admin.rename_apply(s, group_admin.rename_plan(s, live, fresh))
+            v = group_admin.tenant_verdict(s, fresh)
+        self.assertEqual(v["status"], "owner")
+        self.assertTrue(v["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/_validate.py
+++ b/tools/_validate.py
@@ -148,6 +148,65 @@ def check_graph(home, repo_tools):
     return ("graph", False, "unreachable: " + line[:70])
 
 
+def _tenant_from_probe(line):
+    """Turn one `group_admin.tenant_verdict` JSON line into a (name, ok, detail) check (#634).
+
+    Split out from `check_tenant` so the JUDGEMENT is testable without a graph: the probe is the
+    only part that needs Neo4j, and it is the part that carries no decisions."""
+    import json
+    try:
+        v = json.loads(line)
+    except ValueError:
+        return ("tenant", None, "could not parse probe: " + str(line)[:70])
+    ok, detail = v.get("ok"), v.get("detail") or v.get("status") or "?"
+    if v.get("new_tenant_declared") and ok is False:
+        # EDGE_NEW_TENANT=1 — the operator has DECLARED this is a new tenant, not a rename. That
+        # downgrades the refusal to advisory but never to silence: the foreign tenants stay named,
+        # because a second :Genesis minted without anyone reading this line is exactly #634.
+        return ("tenant", None,
+                "NEW TENANT DECLARED (EDGE_NEW_TENANT=1) beside %s — %s"
+                % (", ".join(repr(c) for c in v.get("candidates") or []) or "no other tenant",
+                   detail))
+    return ("tenant", ok, detail)
+
+
+def check_tenant(home, repo_tools):
+    """The FORK GUARD (#634): does this install's resolved group own this Bolt's identity root?
+
+    `group_id` is identity, and renaming it in agent.yaml migrates nothing — the fence stops
+    matching the past and the next backbone projection MERGEs a SECOND `:Genesis` under the new
+    name. That is how one agent came to live in two tenants (`peter tosh` 269 / `petertosh`
+    2490). The graph cannot distinguish a rename from a genuinely new tenant, so an empty group
+    beside a rooted one FAILS the install: refusing is recoverable, a silent second root is not.
+    `EDGE_NEW_TENANT=1` declares the new tenant and downgrades the check to a loud advisory.
+
+    Best-effort like `check_graph`: runs under the venv python (it has the driver), and anything
+    it cannot determine is advisory (`ok=None`), never a fabricated pass."""
+    py = _venv_python(home)
+    if not py.exists():
+        return ("tenant", None, "skipped — no venv")
+    probe = (
+        "import json, os, sys; sys.path.insert(0, %r)\n"
+        "import _identity, group_admin\n"
+        "from neo4j import GraphDatabase\n"
+        "uri, user, pw = _identity.neo4j_conn(); g = _identity.group()\n"
+        "if not pw or not g: print(json.dumps({'ok': None, 'detail': "
+        "'skipped — no password/group resolves'})); raise SystemExit\n"
+        "d = GraphDatabase.driver(uri, auth=(user, pw))\n"
+        "with d.session() as s: v = group_admin.tenant_verdict(s, g)\n"
+        "v['new_tenant_declared'] = os.environ.get('EDGE_NEW_TENANT') not in (None, '', '0')\n"
+        "print(json.dumps(v))\n"
+    ) % str(repo_tools)
+    try:
+        res = subprocess.run([str(py), "-c", probe], capture_output=True, text=True, timeout=30)
+    except Exception as e:
+        return ("tenant", None, "could not probe: " + str(e)[:60])
+    out = (res.stdout or "").strip().splitlines()
+    if not out:
+        return ("tenant", None, "graph unreachable: " + (res.stderr or "").strip()[:70])
+    return _tenant_from_probe(out[-1])
+
+
 def _assert_identity_sections(text):
     """The assert leg of the identity gate: a composed briefing that DID NOT raise must still carry
     the stage-(i) REQUIRED genotype-identity sections (Personality, Method, the Idiom glossary floor,
@@ -228,6 +287,7 @@ def validate_install(home, cfg, env_dir, provisioned=True, repo_tools=None,
     if provisioned:
         checks.append(check_venv(home))
         checks.append(check_graph(home, repo_tools or (Path(home) / "tools")))
+        checks.append(check_tenant(home, repo_tools or (Path(home) / "tools")))
     return checks
 
 

--- a/tools/edge-group
+++ b/tools/edge-group
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""edge-group — migrate a graph tenant (group_id), and bury a dead one (#634).
+
+  edge-group rename OLD NEW                      # dry-run: prints the plan, writes nothing
+  edge-group rename OLD NEW --apply --confirm NEW
+  edge-group gc [--stale] [--keep G]             # lists groups + ungrouped nodes
+  edge-group gc --delete G --stale-since DATE --confirm G
+
+`group_id` IS identity: changing name/codename/graph_group in agent.yaml does not migrate the
+graph, it forks it.
+
+The gc delete leg refuses ANY group holding a `:Genesis` — an identity root means a living agent
+owns that tenant, and on a shared Bolt it may belong to a user this process cannot see. Migrate
+such a group with `rename`; do not collect it. All the surgery lives in group_admin.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import group_admin
+
+if __name__ == "__main__":
+    sys.exit(group_admin.main())

--- a/tools/group_admin.py
+++ b/tools/group_admin.py
@@ -1,0 +1,714 @@
+"""group_admin — tenant surgery on a shared Bolt: migrate a group_id, bury a dead one (#634).
+
+`group_id` IS identity. Changing `name`/`codename`/`graph_group` in agent.yaml does NOT migrate
+the graph: the `n.group_id = $g` fence simply stops matching the past. Nothing is deleted, so
+nothing looks broken — the agent just forgets, and the next backbone projection MERGEs a SECOND
+`:Genesis` under the new name. Rename without migrate is a FORK (the fleet carries `peter tosh`
+269 nodes / `petertosh` 2490 — one agent, two tenants), and a forked-off tenant is a tomb nobody
+buries (the fleet's abandoned 476-node tenant).
+
+`group_health` (#636) is the READ side of the same wound and owns the fleet verdicts — including
+`leftovers()`, which names groups with no install on this host and nodes with no `group_id` at
+all. This module is the WRITE side and does not re-decide any of that: `gc` prints
+`group_health.leftovers` verbatim and adds only the per-group EVIDENCE (spine root, last
+activity) that a delete decision needs and a read-only report has no reason to compute.
+
+Both verbs are PLAN-FIRST:
+
+    plan → print → apply(plan)
+
+`*_plan` reads and returns a plain dict the CLI prints verbatim; `*_apply` re-derives its work
+from THAT dict inside ONE write transaction and asserts, still inside the transaction, that what
+it touched equals what the plan advertised. A graph that moved in between raises
+`GroupAdminError`, rolling the transaction back — so "the dry-run listed exactly what the write
+did" is enforced by the code, not promised by the docstring.
+
+WHAT A RENAME MOVES. Node `group_id`, and RELATIONSHIP `group_id` — graphiti stamps the fence on
+`MENTIONS`/`RELATES_TO`/`HAS_EPISODE`/`NEXT_EPISODE` too, and a migration that moved only nodes
+would leave every extracted edge fenced into a dead tenant. Repo-projected edges (`SERVES`,
+`ANCHORS`, `GROUNDS`, `CITES`…) carry no `group_id` and ride along with their endpoints.
+
+WHAT A RENAME DOES WITH A COLLIDING SPINE. When both tenants own a spine — their own `:Genesis`,
+their own `:Objective` — the migration is a MERGE, and the policy (operator, 2026-08-16) is that
+THE DESTINATION'S SPINE WINS: `peter tosh` → `petertosh` keeps petertosh's Genesis and its six
+Closavo Objectives, and the worthwhile-test spine that came with the 269 adopted nodes is
+discarded. The policy exists, so the tool executes it — but never quietly. Discarding a declared
+norte is printed as its own step in the dry-run, node by node with its body, and `--apply` needs
+a second token (`--discard-source-spine`) beyond the retyped destination, because the keystroke
+that destroys somebody's stated direction should not be the same keystroke that moves nodes.
+
+And the leftovers of a discard are not orphans. Every edge that pointed at a discarded node is
+REWIRED to that node's heir — the destination's node of the same label — whenever the heir is
+unambiguous (one `:Genesis` on each side always is). Where the destination carries SEVERAL nodes
+of the label (petertosh's six Objectives) there is no non-arbitrary heir, so those edges are
+DROPPED, counted and listed by type in the plan: an edge invented toward a norte the operator did
+not choose would be a fabrication, and the canonical sweep's own SERVES backfill and ANCHORS
+rebuild are what re-attach the adopted corpus to the surviving spine. Trading duplication for
+silent orphans would not be a fix; trading it for a printed, counted removal is.
+
+WHAT GC REQUIRES BEFORE IT DELETES. After 2026-08-16 this is enforced rather than intended: the
+delete leg once protected only *this* install's own group, which left every other unix user's
+tenant on the shared Bolt one correctly-typed command from deletion — and that is how the live
+`turing` tenant (141 nodes) was destroyed while this file was being exercised by hand. Burying a
+tenant IS a supported operation — the fleet's abandoned 476-node tenant is meant to be buried —
+but it now costs four independent, non-defaultable assertions: the group named in `--delete`, retyped in
+`--confirm`, a `--stale-since DATE` that the group's own last activity must be strictly older
+than, and — for any group holding a `:Genesis`, i.e. an identity root — an explicit
+`--bury-rooted`. A group with no activity timestamp at all FAILS the staleness test rather than
+passing it by default: absence of evidence is not evidence of death. The command that destroyed
+`turing` is refused three times over by those rules.
+
+Nodes with a NULL `group_id` are NOT this module's garbage and it never touches them. A node
+written without a tenant stamp means some write-path is not stamping — a bug in the writer, not
+dirt on the floor. `group_health.leftovers` LISTS them, which is diagnosis; deleting them would
+destroy the evidence.
+"""
+import json
+import re
+import sys
+
+# The identity root — a per-group singleton (publisher MERGEs it by group_id alone). Its presence
+# is the tool's definition of "this group belongs to a living install".
+SPINE_ROOT = "Genesis"
+
+# Labels whose presence on BOTH sides makes a rename a MERGE rather than a migration. Genesis is
+# identity; Objective is the norte. Colliding either is an editorial decision, never a mechanical
+# one — see the module docstring.
+SPINE_COLLISION_LABELS = (SPINE_ROOT, "Objective")
+
+_NONWORD = re.compile(r"[^a-z0-9]+")
+
+
+class GroupAdminError(RuntimeError):
+    """A planned migration/collection could not be carried out as planned — never a partial write.
+
+    Raised INSIDE the write transaction, so the driver rolls back: the graph is left exactly as
+    the plan found it rather than half-migrated across two group ids."""
+
+
+# ---------------------------------------------------------------- reads
+
+
+def normalize_group(group):
+    """The collation key that makes `peter tosh`, `Peter-Tosh` and `petertosh` one name.
+
+    Two group ids that normalize alike are almost certainly one agent that got renamed without a
+    migrate — the whole defect of #634. Used only to RAISE SUSPICION (fork_candidates); never to
+    match or rewrite, because the fence itself is and stays byte-exact."""
+    return _NONWORD.sub("", str(group or "").strip().lower())
+
+
+def fork_candidates(inventory_rows):
+    """Group-id pairs that normalize to the same name — one agent living in two tenants.
+
+    Takes the rows `inventory()` returns (anything with a `group` key). Returns sorted pairs,
+    smallest id first, so the caller can print a stable orientation."""
+    buckets = {}
+    for row in inventory_rows:
+        g = row["group"] if isinstance(row, dict) else row
+        buckets.setdefault(normalize_group(g), []).append(g)
+    pairs = []
+    for names in buckets.values():
+        names = sorted(set(names))
+        for i, a in enumerate(names):
+            for b in names[i + 1:]:
+                pairs.append((a, b))
+    return sorted(pairs)
+
+
+def _one(runner, query, key, default=0, **params):
+    row = runner.run(query, **params).single()
+    if row is None:
+        return default
+    value = row[key]
+    return default if value is None else value
+
+
+def group_nodes(runner, group):
+    return _one(runner, "MATCH (n) WHERE n.group_id=$g RETURN count(n) AS n", "n", g=group)
+
+
+def group_rels(runner, group):
+    """Relationships FENCED into the group (graphiti stamps group_id on the edge itself)."""
+    return _one(runner, "MATCH ()-[r]->() WHERE r.group_id=$g RETURN count(r) AS n", "n", g=group)
+
+
+def label_census(runner, group):
+    rows = runner.run(
+        "MATCH (n) WHERE n.group_id=$g "
+        "RETURN head(labels(n)) AS label, count(n) AS n ORDER BY label", g=group).data()
+    return {r["label"]: r["n"] for r in rows}
+
+
+def spine_nodes(runner, group, label):
+    """Every node of `label` under `group`, with its properties — the material of a collision
+    report: the operator has to SEE the two nortes before choosing between them."""
+    rows = runner.run(
+        f"MATCH (n:`{label}`) WHERE n.group_id=$g "
+        "RETURN elementId(n) AS id, properties(n) AS props ORDER BY elementId(n)",
+        g=group).data()
+    return [{"id": r["id"], "label": label, "props": dict(r["props"] or {})} for r in rows]
+
+
+def last_activity(runner, group):
+    """The newest timestamp anywhere in the group, as a string, or None.
+
+    Coalesces what the tree actually writes (graphiti `created_at`, the projections'
+    `projected_at`, episodic `valid_at`). Spine nodes carry none, so a group can legitimately
+    have no timestamp — which the delete gate treats as NO EVIDENCE OF DEATH, never as death."""
+    return _one(runner,
+                "MATCH (n) WHERE n.group_id=$g "
+                "RETURN max(toString(coalesce(n.projected_at, n.created_at, n.valid_at))) AS n",
+                "n", default=None, g=group)
+
+
+def inventory(runner):
+    """Every group id in this Bolt with the EVIDENCE a delete decision needs.
+
+    Deliberately narrow: `group_health.groups()`/`leftovers()` already own the census and the
+    orphan verdicts, and this does not restate them. What it adds is `genesis` and
+    `last_activity` — is anyone living here, and when did they last move."""
+    rows = runner.run(
+        "MATCH (n) WHERE n.group_id IS NOT NULL "
+        "RETURN n.group_id AS group, count(n) AS nodes, "
+        "count(CASE WHEN '" + SPINE_ROOT + "' IN labels(n) THEN 1 END) AS genesis, "
+        "max(toString(coalesce(n.projected_at, n.created_at, n.valid_at))) AS last_activity "
+        "ORDER BY nodes DESC").data()
+    rels = {r["group"]: r["rels"] for r in runner.run(
+        "MATCH ()-[r]->() WHERE r.group_id IS NOT NULL "
+        "RETURN r.group_id AS group, count(r) AS rels").data()}
+    return [{"group": r["group"], "nodes": r["nodes"], "genesis": r["genesis"],
+             "last_activity": r.get("last_activity"), "rels": rels.get(r["group"], 0)}
+            for r in rows]
+
+
+# ---------------------------------------------------------------- the guard
+
+
+def tenant_verdict(runner, group):
+    """Does `group` OWN this Bolt's identity root, or is it about to mint a second one?
+
+    Statuses, and what each means to an installer:
+
+      owner        — the group holds its own `:Genesis`. Nothing to decide.
+      forked       — the group holds a root AND a near-twin group id also holds one. The fork
+                     ALREADY happened (`peter tosh` ~ `petertosh`); closing it is a MERGE, which
+                     `rename` deliberately refuses to perform unattended.
+      fork_suspect — the group is EMPTY while other groups on this Bolt own roots. Either this
+                     phenotype was renamed without migrating, or a genuinely new tenant is being
+                     installed beside an existing one. The graph cannot tell those apart, so the
+                     verdict REFUSES and names the candidates: refusing is recoverable, minting a
+                     second silent Genesis is not.
+      unrooted     — the group already holds nodes but no root yet (the backbone simply has not
+                     been projected). Advisory.
+      fresh        — nothing anywhere. Advisory.
+
+    `ok` is True/False/None matching _validate's check convention (None = advisory)."""
+    genesis = {r["group"]: r["n"] for r in runner.run(
+        f"MATCH (n:{SPINE_ROOT}) WHERE n.group_id IS NOT NULL "
+        "RETURN n.group_id AS group, count(n) AS n").data()}
+    mine = group_nodes(runner, group)
+    others = sorted(g for g in genesis if g != group)
+    twins = [b if a == group else a
+             for a, b in fork_candidates(inventory(runner)) if group in (a, b)]
+
+    if group in genesis:
+        if twins:
+            return {"status": "forked", "ok": False, "group": group, "candidates": twins,
+                    "detail": "group %r and %s are the SAME name under two ids — one agent, two "
+                              "tenants (#634). Both hold a spine, so closing this is a MERGE: run "
+                              "`edge-group rename %r %r` to see the collision report, and decide "
+                              "which spine survives before anything is migrated."
+                              % (group, ", ".join(repr(t) for t in twins), twins[0], group)}
+        return {"status": "owner", "ok": True, "group": group, "candidates": [],
+                "detail": "group %r owns its :%s (%d nodes)" % (group, SPINE_ROOT, mine)}
+    if mine > 0:
+        return {"status": "unrooted", "ok": None, "group": group, "candidates": others,
+                "detail": "group %r holds %d nodes but no :%s yet — the backbone projects on the "
+                          "next canonical sweep" % (group, mine, SPINE_ROOT)}
+    if not others:
+        return {"status": "fresh", "ok": None, "group": group, "candidates": [],
+                "detail": "group %r is empty and no other tenant owns a :%s — fresh install"
+                          % (group, SPINE_ROOT)}
+    return {
+        "status": "fork_suspect", "ok": False, "group": group, "candidates": others,
+        "detail": "group %r is EMPTY while %s already own a :%s on this Bolt. If this install "
+                  "was RENAMED, migrate instead of forking: `edge-group rename %r %r`. If %r is "
+                  "genuinely a new tenant, declare it (EDGE_NEW_TENANT=1) — but a second "
+                  ":%s must never be minted silently (#634)."
+                  % (group, ", ".join(repr(o) for o in others), SPINE_ROOT,
+                     others[0], group, group, SPINE_ROOT)}
+
+
+# ---------------------------------------------------------------- rename
+
+
+_REL_TYPE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _incident_edges(runner, node_id):
+    """Every relationship touching one node, as (type, direction, other-endpoint) rows.
+
+    Read at PLAN time so the dry-run can print what a discard costs in edges. Neo4j has no
+    portable dynamic-type CREATE, so the apply leg interpolates the type into the statement —
+    which is only safe because a type read back from the graph is re-validated as an identifier
+    before it ever reaches a query string."""
+    rows = runner.run(
+        "MATCH (v) WHERE elementId(v)=$id "
+        "MATCH (v)-[r]-(o) "
+        "RETURN type(r) AS type, "
+        "CASE WHEN startNode(r)=v THEN 'out' ELSE 'in' END AS direction, "
+        "elementId(o) AS other, count(*) AS n "
+        "ORDER BY type, direction, other", id=node_id).data()
+    return [dict(r) for r in rows]
+
+
+def rename_plan(runner, old, new):
+    """Read the whole migration — including everything it would destroy — before writing a byte.
+
+    `blockers` is the refusal list: non-empty means `rename_apply` raises rather than runs.
+    `collisions` details every spine label present on BOTH sides with each node's properties;
+    `discards` is the source-side spine the destination's spine displaces, and `rewires` /
+    `dropped` account for every single edge those discarded nodes carried. Nothing that the apply
+    leg destroys is absent from this dict — that is the whole point of it existing."""
+    old = (old or "").strip()
+    new = (new or "").strip()
+    blockers = []
+    if not old or not new:
+        blockers.append("both OLD and NEW group ids are required")
+    if old and old == new:
+        blockers.append("OLD and NEW are the same group id — nothing to migrate")
+
+    nodes = group_nodes(runner, old) if old else 0
+    rels = group_rels(runner, old) if old else 0
+    if old and nodes == 0:
+        blockers.append("group %r holds no nodes — nothing to migrate (check the spelling: the "
+                        "fence is byte-exact)" % old)
+
+    by_label = label_census(runner, old) if old else {}
+    target_by_label = label_census(runner, new) if new else {}
+
+    # A COLLISION is a label both tenants carry. Policy (operator, 2026-08-16): the DESTINATION's
+    # spine wins. The source's copies become `discards`; each one's heir is the destination's node
+    # of that label when there is exactly one, and None when the destination carries several —
+    # petertosh's six Objectives admit no non-arbitrary heir, so those edges are dropped, not
+    # invented onto a norte nobody chose.
+    collisions, discards, heirs = {}, [], {}
+    if old and new:
+        for label in SPINE_COLLISION_LABELS:
+            source = spine_nodes(runner, old, label)
+            target = spine_nodes(runner, new, label)
+            if not (source and target):
+                continue
+            collisions[label] = {"source": source, "target": target}
+            heirs[label] = target[0]["id"] if len(target) == 1 else None
+            discards.extend(source)
+
+    victim_heir = {}
+    for node in discards:
+        victim_heir[node["id"]] = heirs.get(node["label"])
+
+    rewires, dropped = [], []
+    for node in discards:
+        heir = victim_heir[node["id"]]
+        for edge in _incident_edges(runner, node["id"]):
+            # An endpoint that is ITSELF discarded resolves to its own heir, so the edge between
+            # two displaced spine nodes lands between their two survivors instead of dangling.
+            other = victim_heir.get(edge["other"], edge["other"])
+            reason = None
+            if heir is None:
+                reason = ("the destination carries %d :%s — no unambiguous heir"
+                          % (len(collisions[node["label"]]["target"]), node["label"]))
+            elif other is None:
+                reason = "the other endpoint is itself discarded and has no heir"
+            elif other == heir:
+                reason = "would become a self-loop on the heir"
+            elif not _REL_TYPE.fullmatch(edge["type"] or ""):
+                reason = "relationship type %r is not a safe identifier" % edge["type"]
+            if reason:
+                dropped.append(dict(edge, victim=node["id"], label=node["label"], reason=reason))
+            else:
+                rewires.append(dict(edge, victim=node["id"], label=node["label"],
+                                    heir=heir, other=other))
+
+    after = dict(target_by_label)
+    for label, n in by_label.items():
+        after[label] = after.get(label, 0) + n
+    for node in discards:
+        after[node["label"]] = after.get(node["label"], 0) - 1
+
+    return {"old": old, "new": new, "nodes": nodes, "rels": rels, "by_label": by_label,
+            "target_nodes": group_nodes(runner, new) if new else 0,
+            "target_rels": group_rels(runner, new) if new else 0,
+            "target_by_label": target_by_label, "collisions": collisions,
+            "discards": discards, "heirs": heirs, "rewires": rewires, "dropped": dropped,
+            "after_by_label": {k: v for k, v in sorted(after.items())}, "blockers": blockers}
+
+
+def rename_apply(session, plan):
+    """Execute `plan` in ONE write transaction, or leave the graph untouched.
+
+    Order matters: move the tenant, rewire the edges of every displaced spine node onto its heir,
+    then delete the displaced nodes (which takes their remaining, explicitly-listed edges with
+    them). Every step re-counts what it touched and compares against the plan BEFORE the
+    transaction commits; a mismatch raises `GroupAdminError` inside the transaction, so the
+    driver rolls the whole migration back. That is what makes "atomic" more than a word: there is
+    no state in which half a tenant lives under the old id and half under the new one, and no
+    state in which a spine was discarded but its corpus never arrived."""
+    if plan.get("blockers"):
+        raise GroupAdminError("refusing to migrate: " + "; ".join(plan["blockers"]))
+    old, new = plan["old"], plan["new"]
+    discard_ids = [d["id"] for d in plan.get("discards") or []]
+    rewires = plan.get("rewires") or []
+
+    def _tx(tx):
+        moved_nodes = _one(tx, "MATCH (n) WHERE n.group_id=$old SET n.group_id=$new "
+                               "RETURN count(n) AS n", "n", old=old, new=new)
+        moved_rels = _one(tx, "MATCH ()-[r]->() WHERE r.group_id=$old SET r.group_id=$new "
+                              "RETURN count(r) AS n", "n", old=old, new=new)
+        if moved_nodes != plan["nodes"] or moved_rels != plan["rels"]:
+            raise GroupAdminError(
+                "the graph changed under the plan (planned %d nodes / %d rels, moved %d / %d) — "
+                "rolled back; re-run the dry-run" % (plan["nodes"], plan["rels"],
+                                                     moved_nodes, moved_rels))
+
+        rewired = 0
+        for edge in rewires:
+            kind = edge["type"]
+            if not _REL_TYPE.fullmatch(kind or ""):      # re-validated at the write, not trusted
+                raise GroupAdminError("unsafe relationship type in plan: %r" % kind)
+            pattern = ("(h)-[:`%s`]->(o)" if edge["direction"] == "out"
+                       else "(h)<-[:`%s`]-(o)") % kind
+            rewired += _one(
+                tx, "MATCH (h) WHERE elementId(h)=$heir MATCH (o) WHERE elementId(o)=$other "
+                    f"MERGE {pattern} RETURN count(*) AS n", "n",
+                heir=edge["heir"], other=edge["other"])
+
+        discarded = 0
+        if discard_ids:
+            discarded = _one(tx, "MATCH (n) WHERE elementId(n) IN $ids AND n.group_id=$new "
+                                 "WITH collect(n) AS victims, count(n) AS c "
+                                 "FOREACH (v IN victims | DETACH DELETE v) "
+                                 "RETURN c AS n", "n", ids=discard_ids, new=new)
+            if discarded != len(discard_ids):
+                raise GroupAdminError(
+                    "planned to discard %d displaced spine node(s), found %d — rolled back"
+                    % (len(discard_ids), discarded))
+
+        left = _one(tx, "MATCH (n) WHERE n.group_id=$old RETURN count(n) AS n", "n", old=old)
+        roots = _one(tx, f"MATCH (n:{SPINE_ROOT}) WHERE n.group_id=$new RETURN count(n) AS n",
+                     "n", new=new)
+        if left != 0:
+            raise GroupAdminError(
+                "group %r still holds %d nodes after the migration — rolled back" % (old, left))
+        if roots > 1:
+            raise GroupAdminError(
+                "group %r would end with %d :%s — a migration must leave ONE identity root; "
+                "rolled back" % (new, roots, SPINE_ROOT))
+        return {"old": old, "new": new, "moved_nodes": moved_nodes, "moved_rels": moved_rels,
+                "discarded": discarded, "rewired": rewired,
+                "dropped_edges": len(plan.get("dropped") or []), "spine_roots": roots}
+
+    return session.execute_write(_tx)
+
+
+# ---------------------------------------------------------------- gc
+
+
+def gc_plan(runner, group, stale_since=None, bury_rooted=False):
+    """Everything a delete of `group` would remove, plus every reason not to.
+
+    The blockers are the lesson of 2026-08-16, when this tool deleted a live tenant belonging to
+    another unix user. Burying a genuinely dead tenant IS supported — the fleet's abandoned
+    476-node tenant is meant to be buried — but each assertion has to be made separately, and
+    none of them defaults to yes:
+
+      * `stale_since` — a DATE the caller asserts, which the group's own last activity must be
+        strictly older than. A group with no timestamp at all FAILS: absence of evidence is not
+        evidence of death.
+      * `bury_rooted` — required when the group holds a `:%s`, because an identity root means an
+        install claimed this tenant. On a shared Bolt that is very possibly another user's agent,
+        and the operator has to say out loud that they mean to destroy it.
+
+    `group` is always a named tenant: nodes with a NULL `group_id` are never a target here (they
+    are a write-path bug to diagnose, not garbage to collect).
+    """ % SPINE_ROOT
+    group = (group or "").strip()
+    blockers = [] if group else ["a group id is required"]
+    nodes = group_nodes(runner, group) if group else 0
+    if group and nodes == 0:
+        blockers.append("group %r holds no nodes — nothing to collect" % group)
+    roots = len(spine_nodes(runner, group, SPINE_ROOT)) if group else 0
+    seen = last_activity(runner, group) if group else None
+
+    if roots and not bury_rooted:
+        blockers.append(
+            "group %r holds %d :%s — an identity root means an install claimed this tenant (on a "
+            "shared Bolt, very possibly another user's). Burying it needs --bury-rooted said out "
+            "loud, on top of --confirm and --stale-since." % (group, roots, SPINE_ROOT))
+    if not stale_since:
+        blockers.append(
+            "no staleness evidence: pass --stale-since YYYY-MM-DD and the group's last activity "
+            "must be strictly older than that date")
+    elif seen is None:
+        blockers.append(
+            "group %r has no activity timestamp at all — staleness cannot be established, and "
+            "absence of evidence is not evidence of death" % group)
+    elif str(seen) >= str(stale_since):
+        blockers.append(
+            "group %r moved at %s, which is not older than --stale-since %s"
+            % (group, seen, stale_since))
+
+    # Every relationship incident to those nodes dies with them, including edges carrying no
+    # group_id of their own (the repo-projected spine) — so count by INCIDENCE, not by fence.
+    rels = _one(runner, "MATCH (n)-[r]-() WHERE n.group_id=$g RETURN count(DISTINCT r) AS n",
+                "n", g=group) if group else 0
+    return {"group": group, "nodes": nodes, "rels": rels,
+            "by_label": label_census(runner, group) if group else {},
+            "spine_roots": roots, "last_activity": seen, "stale_since": stale_since,
+            "bury_rooted": bool(bury_rooted), "blockers": blockers}
+
+
+def gc_apply(session, plan):
+    """Delete exactly the plan, in one transaction, or delete nothing.
+
+    The delete counts its own casualties and compares them with the plan before committing, so
+    the property the dry-run promises ("this is what would go") is verified against the write
+    itself rather than re-derived by the same code twice."""
+    if plan.get("blockers"):
+        raise GroupAdminError("refusing to collect: " + "; ".join(plan["blockers"]))
+    group = plan["group"]
+
+    def _tx(tx):
+        rels = _one(tx, "MATCH (n)-[r]-() WHERE n.group_id=$g RETURN count(DISTINCT r) AS n",
+                    "n", g=group)
+        deleted = _one(tx, "MATCH (n) WHERE n.group_id=$g "
+                           "WITH collect(n) AS victims, count(n) AS c "
+                           "FOREACH (v IN victims | DETACH DELETE v) "
+                           "RETURN c AS n", "n", g=group)
+        if deleted != plan["nodes"] or rels != plan["rels"]:
+            raise GroupAdminError(
+                "the graph changed under the plan (planned %d nodes / %d rels, found %d / %d) — "
+                "NOTHING deleted; re-run the dry-run"
+                % (plan["nodes"], plan["rels"], deleted, rels))
+        left = _one(tx, "MATCH (n) WHERE n.group_id=$g RETURN count(n) AS n", "n", g=group)
+        if left != 0:
+            raise GroupAdminError("group %r still holds %d nodes — rolled back" % (group, left))
+        return {"group": group, "deleted_nodes": deleted, "deleted_rels": rels}
+
+    return session.execute_write(_tx)
+
+
+# ---------------------------------------------------------------- CLI
+
+
+def _props(node):
+    return json.dumps({k: v for k, v in node["props"].items()
+                       if k not in ("group_id", "name_embedding")},
+                      sort_keys=True, ensure_ascii=False)[:160]
+
+
+def _render_rename(plan):
+    out = ["rename plan: %r → %r" % (plan["old"], plan["new"]),
+           "  source: %d nodes, %d fenced relationships" % (plan["nodes"], plan["rels"]),
+           "  target (before): %d nodes, %d fenced relationships"
+           % (plan["target_nodes"], plan["target_rels"])]
+    for label, n in sorted(plan["by_label"].items()):
+        out.append("    move  %-14s %d" % (label, n))
+    for label, sides in sorted(plan["collisions"].items()):
+        out.append("  SPINE COLLISION on :%s — both tenants carry one. Policy: the DESTINATION's "
+                   "spine survives." % label)
+        for node in sides["target"]:
+            out.append("    KEEP    %r  %s" % (plan["new"], _props(node)))
+        for node in sides["source"]:
+            out.append("    DISCARD %r  %s" % (plan["old"], _props(node)))
+    if plan["discards"]:
+        out.append("  discarding %d source spine node(s): %s"
+                   % (len(plan["discards"]),
+                      ", ".join(sorted({d["label"] for d in plan["discards"]}))))
+        by_kind = {}
+        for e in plan["rewires"]:
+            by_kind[e["type"]] = by_kind.get(e["type"], 0) + 1
+        out.append("    rewire onto the surviving spine: "
+                   + (", ".join("%s×%d" % kv for kv in sorted(by_kind.items())) or "none"))
+        dropped = {}
+        for e in plan["dropped"]:
+            dropped.setdefault((e["type"], e["reason"]), 0)
+            dropped[(e["type"], e["reason"])] += 1
+        for (kind, reason), n in sorted(dropped.items()):
+            out.append("    DROP %s ×%d — %s" % (kind, n, reason))
+        if not plan["dropped"]:
+            out.append("    drop: none — every edge found an heir")
+    out.append("  target (after): " + ", ".join(
+        "%s=%d" % (k, v) for k, v in plan["after_by_label"].items()))
+    for b in plan["blockers"]:
+        out.append("  BLOCKED: " + b)
+    return "\n".join(out)
+
+
+def _render_gc(rows, leftover_lines, forks, stale_only, live):
+    out = ["groups on this Bolt (evidence for a delete decision):"]
+    for r in rows:
+        rooted = r["genesis"] > 0
+        tag = "LIVE(self)" if r["group"] == live else ("rooted" if rooted else "unrooted")
+        if stale_only and (rooted or r["group"] == live):
+            continue
+        out.append("  [%-10s] %-28s %6d nodes %5d rels  genesis=%d  last=%s"
+                   % (tag, r["group"], r["nodes"], r["rels"], r["genesis"],
+                      r["last_activity"] or "-"))
+    out.append("group_health.leftovers (#636 — groups with no install here, ungrouped nodes):")
+    out.extend("  [%s] %s" % (sev, msg) for sev, msg in leftover_lines)
+    if not leftover_lines:
+        out.append("  (none)")
+    for a, b in forks:
+        out.append("FORK SUSPECT: %r and %r are the same name under two ids — "
+                   "`edge-group rename %r %r` reports the collision (#634)" % (a, b, a, b))
+    out.append("nothing above was deleted. Burying one group takes --delete G --confirm G "
+               "--stale-since YYYY-MM-DD (plus --bury-rooted when it holds a :%s). Ungrouped "
+               "nodes are listed as DIAGNOSIS — a write-path that does not stamp a tenant is a "
+               "bug to fix, never garbage for this tool to collect." % SPINE_ROOT)
+    return "\n".join(out)
+
+
+def _live_group():
+    try:
+        import _identity
+        return _identity.group()
+    except Exception:                                    # noqa: BLE001 — CLI must still list
+        return None
+
+
+def _open_session():
+    import _identity
+    from neo4j import GraphDatabase
+    uri, user, pw = _identity.neo4j_conn()
+    if not pw:
+        raise GroupAdminError("no EDGE_NEO4J_PASSWORD — cannot reach the graph (CONTRACT C4)")
+    return GraphDatabase.driver(uri, auth=(user, pw)).session()
+
+
+def main(argv=None, session=None, live_group=None):
+    """`edge-group` — the CLI. `--dry-run` is the DEFAULT for every verb; the write legs need the
+    destination retyped in `--confirm`. `session`/`live_group` are injected by the tests."""
+    import argparse
+    ap = argparse.ArgumentParser(
+        prog="edge-group",
+        description="Migrate a graph tenant (group_id) and collect dead ones (#634).")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("rename", help="migrate every node/edge from OLD group_id to NEW")
+    r.add_argument("old")
+    r.add_argument("new")
+    r.add_argument("--dry-run", action="store_true", default=True,
+                   help="print the plan and write nothing (the DEFAULT)")
+    r.add_argument("--apply", action="store_true",
+                   help="execute the plan (requires --confirm NEW)")
+    r.add_argument("--confirm", default=None,
+                   help="retype the NEW group id to authorize the write")
+    r.add_argument("--discard-source-spine", action="store_true",
+                   help="acknowledge that the source's colliding :%s/:Objective are DESTROYED "
+                        "(the destination's spine wins). Required whenever the plan lists a "
+                        "DISCARD; moving nodes and destroying a declared norte must not be the "
+                        "same keystroke." % SPINE_ROOT)
+
+    g = sub.add_parser("gc", help="list groups and ungrouped nodes; delete one, explicitly")
+    g.add_argument("--stale", action="store_true",
+                   help="list only unrooted groups (a rooted one is never a delete candidate)")
+    g.add_argument("--keep", action="append", default=[],
+                   help="a group id that IS live (repeatable) — protects it from --delete")
+    g.add_argument("--delete", default=None, metavar="GROUP",
+                   help="delete ONE group (requires --confirm GROUP and --stale-since). "
+                        "Never a batch, and never a group holding a :" + SPINE_ROOT)
+    g.add_argument("--confirm", default=None,
+                   help="retype the group id to authorize the delete")
+    g.add_argument("--stale-since", default=None, metavar="YYYY-MM-DD",
+                   help="assert the group has not moved since this date; the group's own last "
+                        "activity must be strictly older, or the delete is refused")
+    g.add_argument("--bury-rooted", action="store_true",
+                   help="acknowledge that the group holds a :%s — an install claimed this "
+                        "tenant, and you mean to destroy it anyway" % SPINE_ROOT)
+
+    sub.add_parser("list", help="alias for `gc` without the staleness filter")
+
+    args = ap.parse_args(argv)
+    live = live_group if live_group is not None else _live_group()
+    own = session is None
+    if own:
+        session = _open_session()
+    try:
+        if args.cmd == "rename":
+            plan = rename_plan(session, args.old, args.new)
+            print(json.dumps(plan, indent=2, default=str) if args.json else _render_rename(plan))
+            if not args.apply:
+                if not plan["blockers"]:
+                    print("dry-run (default). To execute: --apply --confirm %r" % plan["new"])
+                return 0
+            if plan["blockers"]:
+                print("refused — see BLOCKED above", file=sys.stderr)
+                return 2
+            if args.confirm != plan["new"]:
+                print("refused: --apply needs --confirm %r (retype the DESTINATION group id)"
+                      % plan["new"], file=sys.stderr)
+                return 2
+            if plan["discards"] and not args.discard_source_spine:
+                print("refused: this plan DISCARDS %d source spine node(s) — pass "
+                      "--discard-source-spine to authorize destroying them (see the DISCARD "
+                      "lines above)" % len(plan["discards"]), file=sys.stderr)
+                return 2
+            result = rename_apply(session, plan)
+            print(json.dumps(result, indent=2) if args.json
+                  else "migrated: %d nodes, %d relationships → %r "
+                       "(%d spine discarded, %d edges rewired, %d dropped)"
+                       % (result["moved_nodes"], result["moved_rels"], result["new"],
+                          result["discarded"], result["rewired"], result["dropped_edges"]))
+            return 0
+
+        keep = list(getattr(args, "keep", []))
+        target = getattr(args, "delete", None)
+        # `is not None`, never truthiness: `--delete ''` must land in the REFUSAL path (gc_plan
+        # blocks a blank group id), not fall through to the harmless listing. gc's target is
+        # always a NAMED tenant — ungrouped nodes are a write-path bug to diagnose, and there is
+        # deliberately no way to aim this verb at them.
+        if target is not None:
+            plan = gc_plan(session, target, stale_since=getattr(args, "stale_since", None),
+                           bury_rooted=bool(getattr(args, "bury_rooted", False)))
+            print(json.dumps(plan, indent=2, default=str) if args.json else
+                  "gc plan: %r → %d nodes, %d relationships (%s)"
+                  % (plan["group"], plan["nodes"], plan["rels"],
+                     ", ".join("%s=%d" % kv for kv in sorted(plan["by_label"].items())) or "-"))
+            if plan["blockers"]:
+                print("refused: " + "; ".join(plan["blockers"]), file=sys.stderr)
+                return 2
+            if target == live or target in keep:
+                print("refused: %r is a LIVE group (this install's own, or named by --keep)"
+                      % target, file=sys.stderr)
+                return 2
+            if args.confirm != target:
+                print("refused: --delete needs --confirm %r (retype the group id)" % target,
+                      file=sys.stderr)
+                return 2
+            result = gc_apply(session, plan)
+            print(json.dumps(result, indent=2) if args.json
+                  else "collected: %d nodes, %d relationships under %r"
+                       % (result["deleted_nodes"], result["deleted_rels"], result["group"]))
+            return 0
+
+        import group_health
+        inv = inventory(session)
+        installed = {g for g in [live] + keep if g}
+        leftover_lines = group_health.leftovers(session, installed)
+        forks = fork_candidates(inv)
+        if args.json:
+            print(json.dumps({"groups": inv, "leftovers": leftover_lines, "forks": forks,
+                              "live": live}, indent=2, default=str))
+        else:
+            print(_render_gc(inv, leftover_lines, forks, getattr(args, "stale", False), live))
+        return 0
+    finally:
+        if own:
+            session.close()
+
+
+if __name__ == "__main__":                               # pragma: no cover — shim entry
+    sys.exit(main())

--- a/tools/publisher.py
+++ b/tools/publisher.py
@@ -1441,6 +1441,26 @@ def _project_backbone(s, g, log):
     _project_parceiros(s, g, log)
 
 
+def _announce_new_tenant(s, g):
+    """SAY IT when this sweep is about to mint the identity root of a NEW tenant (#634).
+
+    `_project_backbone` MERGEs `(:Genesis {group_id:$g})` unconditionally — correct for a fresh
+    install, and exactly how a renamed agent.yaml forks its own memory into a second tenant while
+    the old one goes quiet. Nobody can fix what nobody was told, so the birth of a second root on
+    a Bolt that already has one is ANNOUNCED, with the migrate offered. Announce only: the beat
+    must never die on a gardening problem, and the refusal belongs at install time
+    (`_validate.check_tenant`), where the operator is present to answer.
+
+    Best-effort and silent on any failure — this is a print, not a gate."""
+    try:
+        import group_admin
+        v = group_admin.tenant_verdict(s, g)
+        if v["status"] in ("fork_suspect", "forked"):
+            print("backbone: %s — %s" % (v["status"].upper(), v["detail"]))
+    except Exception:  # noqa: BLE001 — a notice must never break the sweep
+        pass
+
+
 def project_backbone(log=eventlog.LOG):
     """Open a session and project the canonical spine backbone (Codex P2): the ANCHORS rebuild must
     run EVERY canonical sweep so newly-folded Directions get anchored even when no artefato changed.
@@ -1458,6 +1478,7 @@ def project_backbone(log=eventlog.LOG):
         return
     try:
         with drv.session() as s:
+            _announce_new_tenant(s, g)
             _project_backbone(s, g, log)
     except Exception as ex:  # noqa: BLE001 — best-effort, never fatal
         print("backbone sync failed (best-effort):", ex)


### PR DESCRIPTION
Closes #634. Escrito **depois** de o autor deste PR destruir 141 nós do tenant `turing` com a versão anterior da própria ferramenta.

## O incidente, primeiro

```
tools/edge-group gc --delete turing --confirm turing
→ collected: 141 nodes, 263 relationships
```

Rodado **esperando uma recusa** — a proteção existente só cobria `_identity.group()` (= `ed`). O token de confirmação foi digitado à mão. Evidência preservada antes de qualquer outra escrita: 261 MB em `/home/edge/INCIDENT-2026-08-16-turing-deleted/`, incluindo o checkpoint das 22:21, onze minutos antes.

**O turing foi recuperado** reprojetando do log dele (ADR-0006: o log é a verdade, o grafo é projeção): espinha completa a custo zero, camada extraída re-ingerida. 99 nós.

## O gate

Apagar um group exige agora **quatro asserções independentes, nenhuma por default**: `--delete`, `--confirm` redigitado, `--stale-since` que a última atividade tem de preceder, e `--bury-rooted` quando há `:Genesis`. As recusas moram em `gc_plan`, então contornar a CLI não ajuda.

E a regra que carrega o raciocínio, escrita no código onde o operador lê:

> **Ausência de evidência não é evidência de morte.** Um group sem timestamp é recusado, não coletado. "Não sei quando isso se mexeu pela última vez" resolvendo para "então está morto" é a inferência-por-omissão que o gc antigo fazia — e o tenant sobre o qual você sabe menos é justamente o que não é seu.

`test_the_command_that_destroyed_turing_is_now_refused` roda o comando **verbatim** contra a forma do turing. Recusa por duas razões independentes.

## O que a implementação teve de descobrir

**graphiti carimba `group_id` nas ARESTAS também** (`MENTIONS`, `RELATES_TO`, `HAS_EPISODE`, `NEXT_EPISODE`). Uma migração que movesse só nós deixaria toda a camada extraída cercada no tenant morto. As arestas projetadas pelo repo (`SERVES`, `ANCHORS`, `GROUNDS`, `CITES`) não têm `group_id` e viajam com as pontas.

**A fusão** implementa a decisão do operador ("petertosh vence"): a espinha do destino sobrevive, o corpus da origem é adotado, o dry-run **imprime os dois nortes verbatim antes de destruir qualquer um**, e `--apply` recusa sem `--discard-source-spine`. Com três Objectives no destino não há herdeiro inequívoco, então as arestas órfãs são **descartadas, contadas e nomeadas por tipo** — não inventadas.

## Duas mutações SOBREVIVERAM na primeira passada, e as duas eram furo no teste

- **M3**: apagar o religamento sobreviveu porque a asserção original conferia que `GROUNDS` existia — e o `GROUNDS` do próprio destino já satisfazia. Reescrita para o Objective descartado ancorar uma Direction sem equivalente no destino.
- **M9**: apagar a checagem de grupo sem data sobreviveu **por acidente**: `str(None) >= "2026-06-01"` é lexicograficamente verdadeiro, então a comparação de data bloqueava — pelo motivo errado e com mensagem que o operador não poderia acionar.

14 mutações no total, todas mortas ao fim. 46 testes.

## Fora, de propósito
Nenhuma migração de frota (sem acesso ao Bolt). **Nós sem `group_id` nunca são alvo**: são listados como diagnóstico — um write-path que não carimba tenant é bug a consertar, e apagar a evidência esconderia.