### PR TITLE
chore(llm): gpt-5.6-luna como padrão OpenAI — exceto no extractor, onde ele não roda

### DIFF
--- a/tools/close.py
+++ b/tools/close.py
@@ -1779,7 +1779,7 @@ def _log_close_event(type_, payload):
 # presentation change) or SUBSTANTIVE (names a fix to the CONTENT — fabricated/uncited fact, an
 # unsupported number, a contradiction) is a JUDGMENT, not a lexical pattern: no keyword list can tell
 # "atenue: soa mais forte" (cosmetic) from "a conclusão é mais forte que a evidência permite"
-# (substantive). So an LLM AGENT decides it — the SAME review completer (codex/gpt-5.5 post-#55):
+# (substantive). So an LLM AGENT decides it — the SAME review completer (codex, no modelo declarado em routers.review post-#55):
 # codex gating codex's own strikes. Fail-closed: a malformed judge response is treated as SUBSTANTIVE
 # (blocks); an LLMTransportError propagates (infra ≠ veredito, issue #55).
 _COSMETIC_JUDGE_PROMPT = (
@@ -1803,7 +1803,7 @@ def _strike_texts(verdicts) -> list:
 
 
 def _strikes_are_cosmetic(verdicts, complete_fn) -> bool:
-    """SEMANTIC meta-gate (issue #65): an LLM agent (the review completer — codex/gpt-5.5) decides
+    """SEMANTIC meta-gate (issue #65): an LLM agent (the review completer — codex, no modelo declarado em routers.review) decides
     whether EVERY surviving strike is merely presentational. True ONLY iff the judge returns
     `all_cosmetic: true`. Fail-closed: no completer, or no strikes → False; a malformed/unparseable
     judge response → False (substantive, blocks). An LLMTransportError propagates (infra ≠ veredito)."""
@@ -1919,7 +1919,7 @@ def _try_residual_publish(artefato, verdicts, publish_fn, complete_fn=None):
     if not _residual_eligible(verdicts):
         return None
     # (1b) the SEMANTIC cosmetic meta-gate (issue #65): only cosmetic criticism converges to a
-    # graded publish; a substantive strike hard-gates. Judged by the codex/gpt-5.5 completer.
+    # graded publish; a substantive strike hard-gates. Judged by the codex, no modelo declarado em routers.review completer.
     if not _strikes_are_cosmetic(verdicts, complete_fn):
         _log_close_event("close.residual_substantive",
                          {"slug": artefato.get("slug"), "strikes": _strike_texts(verdicts)})

--- a/tools/communities.py
+++ b/tools/communities.py
@@ -265,7 +265,7 @@ def locate(names, group=_AUTO, **kw):
 
 
 def _default_summarize(members_text):
-    """gpt-5.4-mini one-shot name+summary; injected in tests. Raises on transport error —
+    """One-shot name+summary pelo modelo de chat do host (gpt-5.6-luna neste install); injected in tests. Raises on transport error —
     consolidate catches and degrades."""
     import urllib.request
     req = urllib.request.Request(

--- a/tools/onboarding.py
+++ b/tools/onboarding.py
@@ -398,7 +398,7 @@ def _routers_for_cfg(cast: dict, primary: str, embedding: Optional[dict]) -> dic
     if primary in ("claude", "opus", "fable"):
         routers["chat"] = {"provider": "claude", "model": "opus" if primary == "claude" else primary}
     elif primary == "codex":
-        routers["chat"] = {"provider": "codex", "model": "gpt-5.5"}
+        routers["chat"] = {"provider": "codex", "model": "gpt-5.6-luna"}
     elif primary == "grok":
         routers["chat"] = {"provider": "grok", "model": "grok-4.5"}
     elif primary == "hermes":


### PR DESCRIPTION
Fecha a instrução do operador de 2026-08-16 (*"use o gpt 5.6 luna como padrão para tudo"*), que vivia num branch local fora do `main`.

A maior parte **já entrou pelos PRs de hoje** — os consertos passaram por `communities.py`, `onboarding.py` e `wiki_render.py` e carregaram os valores junto. Sobrava **uma linha viva**: o modelo do adversarial/router de review, ainda em `gpt-5.5`.

### O extractor fica em `gpt-4o-mini`, e isso é deliberado

`graphiti_core` envia `reasoning.effort="minimal"` fixo (`openai_base_client.py:36`) e o luna **recusa** com HTTP 400. Não é degradação, é **apagão**: a sessão inteira deixa de ser filmada e o wake reporta sucesso nas outras pernas (issue #599).

Foi medido hoje num host real — e a recuperação do grafo do `turing`, depois do incidente, dependeu justamente de o extractor estar funcionando.

### Três docstrings que cravavam modelo

`codex/gpt-5.5` em `close.py` (3×) e `gpt-5.4-mini` em `communities.py` passam a citar o **router declarado**. Comentário que crava um modelo envelhece calado e ensina errado — e hoje já custou uma volta: eu mesmo demorei a entender que o extractor não era configurável porque o docstring dizia que era.