### PR TITLE
revert: operator-ordered undo of today's gate changes (#627, #637)

### DIFF
--- a/skills/_shared/pipeline.md
+++ b/skills/_shared/pipeline.md
@@ -97,13 +97,7 @@ The prose phases above bottom out in two testable modules in `tools/`:
   diagnosis that names nothing in the field and brings no outside benchmark/best-practice to
   enrich the mentee's frame; both see content + cites only). Each verdict carries per-dimension
   `rationales` (the FEEDBACK) + `strikes`; the weighted `overall` is advisory and never gates (an
-  LLM 0-5 score is too noisy to threshold). **Clarity strikes are strikes** (field lesson,
-  2026-08-16): a reviewer that names a concrete crypticism defect — a symbol used before it is
-  introduced, a referent with no address, a load-bearing gloss missing — has struck, and the
-  acceptance verdict covers ALL strikes, factual and clarity alike. A verdict format that only
-  asks "unsupported claims? treatment leak?" lets the reviewer document four crypticism defects
-  and still stamp PASS around them — that is how the 2026-08-16 Vaswani artefato shipped
-  unreadable while its review named every defect. `run_close` adds the optional **improve stage**
+  LLM 0-5 score is too noisy to threshold). `run_close` adds the optional **improve stage**
   (`improve_fn`, `IMPROVE_ROUNDS`) before the bounded bounce (both reviewers must pass; a strike
   bounces to re-produce, capped at `BOUNCE_MAX`, then hard-fails — never unbounded). The
   producer-loop's brake (`run_loop2`, `LOOP2_MAX_REOPENS`) lives here too.
@@ -140,29 +134,12 @@ is always of exactly what publishes.
 producer-skill MUST wire `improve_fn` (see each SKILL.md's close snippet): the genus contract now
 carries the **rich-rite floor** (`check_genus` returns `rich-rite:<move>` strikes when a *developed
 prose synthesis* lacks a cognitive move — derivation, the "what I don't know" boundary, an external
-frame, lineage, and **problem-placement**: the opening tells the reader where the problem came from
-in the mentee's own timeline (the originating event, the verbatim, the dates), what is at stake, and
-until when — a reader who finishes the opening without knowing why this text exists now is a floor
-violation (field lesson, 2026-08-16: the v2→v3 probe flipped MOTIVAÇÃO from PARCIAL to SIM on this
-move alone, with zero loss of technical transmission); content-relative, never a named section,
-never a word floor). Without an `improve_fn`,
+frame, lineage; content-relative, never a named section, never a word floor). Without an `improve_fn`,
 a `produce_fn=lambda: artefato` is static, so any strike — a rich-rite floor violation included —
 just bounces to the same draft and **hard-fails** after `BOUNCE_MAX`. With `improve_fn(art, feedback)`
 wired, the `IMPROVE_ROUNDS` passes REVISE the draft from the named gaps BEFORE the gating close — so a
 shallow report is **re-produced richer** (the missing move added) rather than dead-ending. The floor
 is a depth-forcer because the re-production is wired; the gate alone would only reject.
-
-**A clarity strike is answered by re-grounding, never from memory.** The improve pass that
-answers a clarity strike re-opens the source (a dig move) and writes the missing explanation
-from what it finds there. The two failure modes this kills are symmetric, and both are field
-lessons from 2026-08-16: *refusing to explain* ships crypticism (the published v1 — every
-referent hedged, none introduced); *explaining from memory* smuggles unaudited claims (the v2
-rewrite asserted true-but-untraced facts about Vaswani §3.2 the dossier never held — the
-re-ground against the source is what converted them from flags into lastro). Corollary for the
-fact audit: **an ignorance claim is a claim.** Before publishing "the material does not define
-X", verify against the source that it does not — the v1 artefato asserted "no documentary
-definition" for B_i while the source defined it in the very sentence the dossier quoted, and
-that false claim survived audit and blind review because nobody re-opened the line.
 
 The review and improve subagents — the **adversarial** blind pass, the **feynman** rigor
 reviewer, the **enrichment** (frame / outward-vector) reviewer, and the **improve** reviser — MAY

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -134,7 +134,7 @@ target reader; empty resolves to the mentee) and `reports_on`.
         'fact_audit':            lambda o: f"<independent fact audit vs grounding1>\n\n{o['provisional_rewrite']}",
         'author_correction':     lambda o: f"<bounded same-author correction from the audit>\n\n{o['fact_audit']}",
         'treatment_cleanup':     lambda o: f"<bounded same-author leak cleanup>\n\nSCAN:\n{o['treatment_leaks']}\n\n{o['author_correction']}",
-        'final_review':          lambda o: f"<strict review; begin with the 4-line ACCEPTANCE header (ACCEPTANCE, UNSUPPORTED_CLAIMS, TREATMENT_LEAK, CLARITY_STRIKES)>\n\n{o['treatment_cleanup']}",
+        'final_review':          lambda o: f"<strict review; begin with the 3-line ACCEPTANCE header>\n\n{o['treatment_cleanup']}",
     }
 
     rito.run_rito(slug, run_dir=f'state/rito/{slug}',

--- a/skills/map/SKILL.md
+++ b/skills/map/SKILL.md
@@ -129,7 +129,7 @@ empty over fabricated), `para` (explicit target reader; empty resolves to the me
         'fact_audit':            lambda o: f"<independent audit: every edge grounded in its cite vs grounding1>\n\n{o['provisional_rewrite']}",
         'author_correction':     lambda o: f"<bounded same-author correction from the audit>\n\n{o['fact_audit']}",
         'treatment_cleanup':     lambda o: f"<bounded same-author leak cleanup>\n\nSCAN:\n{o['treatment_leaks']}\n\n{o['author_correction']}",
-        'final_review':          lambda o: f"<strict review; begin with the 4-line ACCEPTANCE header (ACCEPTANCE, UNSUPPORTED_CLAIMS, TREATMENT_LEAK, CLARITY_STRIKES)>\n\n{o['treatment_cleanup']}",
+        'final_review':          lambda o: f"<strict review; begin with the 3-line ACCEPTANCE header>\n\n{o['treatment_cleanup']}",
     }
 
     rito.run_rito(slug, run_dir=f'state/rito/{slug}',

--- a/skills/mentor/SKILL.md
+++ b/skills/mentor/SKILL.md
@@ -348,7 +348,7 @@ reason)` — a measurement never becomes an opinion.
         'fact_audit':            lambda o: f"<independent fact audit vs grounding1>\n\n{o['provisional_rewrite']}",
         'author_correction':     lambda o: f"<bounded same-author correction from the audit>\n\n{o['fact_audit']}",
         'treatment_cleanup':     lambda o: f"<bounded same-author leak cleanup. ALSO cut any author-process preamble or changelog that is not reader-facing: a lead-in like 'Fixing only the four FAIL claims...' before the H1, or a trailing 'Changes: dropped...' after the body — those are process narration about how the draft was edited, never part of the artefact.>\n\nSCAN:\n{o['treatment_leaks']}\n\n{o['author_correction']}",
-        'final_review':          lambda o: f"<strict review; begin with the 4-line ACCEPTANCE header (ACCEPTANCE, UNSUPPORTED_CLAIMS, TREATMENT_LEAK, CLARITY_STRIKES)>\n\n{o['treatment_cleanup']}",
+        'final_review':          lambda o: f"<strict review; begin with the 3-line ACCEPTANCE header>\n\n{o['treatment_cleanup']}",
     }
 
     rito.run_rito(slug, run_dir=f'state/rito/{slug}',

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -114,7 +114,7 @@ fabricated), `para` (explicit target reader; empty resolves to the mentee) and `
         'fact_audit':            lambda o: f"<independent audit of the plan's factual claims vs grounding1>\n\n{o['provisional_rewrite']}",
         'author_correction':     lambda o: f"<bounded same-author correction from the audit>\n\n{o['fact_audit']}",
         'treatment_cleanup':     lambda o: f"<bounded same-author leak cleanup>\n\nSCAN:\n{o['treatment_leaks']}\n\n{o['author_correction']}",
-        'final_review':          lambda o: f"<strict review; begin with the 4-line ACCEPTANCE header (ACCEPTANCE, UNSUPPORTED_CLAIMS, TREATMENT_LEAK, CLARITY_STRIKES)>\n\n{o['treatment_cleanup']}",
+        'final_review':          lambda o: f"<strict review; begin with the 3-line ACCEPTANCE header>\n\n{o['treatment_cleanup']}",
     }
 
     rito.run_rito(slug, run_dir=f'state/rito/{slug}',

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -167,7 +167,7 @@ that becomes the canonical reading; omit when no experiment closes).
         'fact_audit':            lambda o: f"<independent fact audit: every factual claim traces to grounding-1 OR a grounding-2 source with its cited snippet; flag any fact or citation with no source (fabrication guard — treat grounding-2 as candidate evidence, don't trust a citation at face value)>\n\nGROUNDING-1:\n{o['grounding1_dossier']}\n\nGROUNDING-2 (candidate evidence):\n{o['grounding2_targeted']}\n\n{o['provisional_rewrite']}",
         'author_correction':     lambda o: f"<bounded same-author correction from the audit>\n\n{o['fact_audit']}",
         'treatment_cleanup':     lambda o: f"<bounded same-author leak cleanup>\n\nSCAN:\n{o['treatment_leaks']}\n\n{o['author_correction']}",
-        'final_review':          lambda o: f"<strict review; begin with the 4-line ACCEPTANCE header (ACCEPTANCE, UNSUPPORTED_CLAIMS, TREATMENT_LEAK, CLARITY_STRIKES)>\n\n{o['treatment_cleanup']}",
+        'final_review':          lambda o: f"<strict review; begin with the 3-line ACCEPTANCE header>\n\n{o['treatment_cleanup']}",
     }
 
     rito.run_rito(slug, run_dir=f'state/rito/{slug}',

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -169,7 +169,7 @@ fabricated), `cites` (source + the snippet you used), `lineage` (`builds_on` the
         'fact_audit':            lambda o: f"<independent fact audit: every factual claim traces to grounding-1 OR a grounding-2 source with its cited snippet; flag any fact or citation with no source (fabrication guard — treat grounding-2 as candidate evidence, don't trust a citation at face value)>\n\nGROUNDING-1:\n{o['grounding1_dossier']}\n\nGROUNDING-2 (candidate evidence):\n{o['grounding2_targeted']}\n\n{o['provisional_rewrite']}",
         'author_correction':     lambda o: f"<bounded same-author correction from the audit>\n\n{o['fact_audit']}",
         'treatment_cleanup':     lambda o: f"<bounded same-author leak cleanup>\n\nSCAN:\n{o['treatment_leaks']}\n\n{o['author_correction']}",
-        'final_review':          lambda o: f"<strict review; begin with the 4-line ACCEPTANCE header (ACCEPTANCE, UNSUPPORTED_CLAIMS, TREATMENT_LEAK, CLARITY_STRIKES)>\n\n{o['treatment_cleanup']}",
+        'final_review':          lambda o: f"<strict review; begin with the 3-line ACCEPTANCE header>\n\n{o['treatment_cleanup']}",
     }
 
     rito.run_rito(slug, run_dir=f'state/rito/{slug}',

--- a/tests/test_rito_runtime.py
+++ b/tests/test_rito_runtime.py
@@ -25,7 +25,6 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
@@ -68,18 +67,13 @@ CANNED = {
     "author_correction": (
         "# Relatorio exp-teste\n\nVersao final auditada. A rodada 3 mostra o mecanismo.\n\n"
         "> o indice vence onde a estrutura importa."),
-    "reader_probe": (
-        "MOTIVACAO: SIM\nFRICTION_POINTS: 0\n\n"
-        "Sem friccoes; o texto pede a rodada 4 e da o caminho sozinho."),
     "final_review": (
-        "ACCEPTANCE: PASS\nUNSUPPORTED_CLAIMS: 0\nTREATMENT_LEAK: NO\n"
-        "CLARITY_STRIKES: 0\n\n"
+        "ACCEPTANCE: PASS\nUNSUPPORTED_CLAIMS: 0\nTREATMENT_LEAK: NO\n\n"
         "Revisao qualitativa: util por si so."),
 }
 
 LLM_ORDER = ["first_authorial_draft", "gap_critique", "grounding2_targeted",
-             "provisional_rewrite", "fact_audit", "author_correction", "reader_probe",
-             "final_review"]
+             "provisional_rewrite", "fact_audit", "author_correction", "final_review"]
 
 
 def _prompts():
@@ -160,7 +154,7 @@ class StageTableTest(unittest.TestCase):
             [name for _, name, _, _, _ in rito.STAGES],
             ["grounding1_dossier", "first_authorial_draft", "gap_critique",
              "grounding2_targeted", "provisional_rewrite", "fact_audit",
-             "author_correction", "treatment_cleanup", "reader_probe", "final_html", "final_review",
+             "author_correction", "treatment_cleanup", "final_html", "final_review",
              "publication"])
 
     def test_author_and_reviewer_routes_are_the_experiments(self):
@@ -227,7 +221,7 @@ class FullRiteTest(unittest.TestCase):
             sealed_md = (run_dir / "08_BLIND_SAFE_FINAL.md").read_text()
             expected = render.markdown_page_bytes(sealed_md)
             self.assertEqual((blog / f"{SLUG}.html").read_bytes(), expected)
-            self.assertEqual((run_dir / "10_FINAL.html").read_bytes(), expected)
+            self.assertEqual((run_dir / "09_FINAL.html").read_bytes(), expected)
 
     def test_publication_event_is_bound_to_manifest_and_page(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -346,7 +340,7 @@ class NegativePathsTest(unittest.TestCase):
         'any matching event for the slug' — a receipt pointing at a different event fails."""
         with tempfile.TemporaryDirectory() as tmp:
             _, run_dir, log, blog = _green_run(tmp)
-            receipt_path = run_dir / "12_PUBLICATION.json"
+            receipt_path = run_dir / "11_PUBLICATION.json"
             receipt = json.loads(receipt_path.read_text())
             receipt["event_seq"] = receipt["event_seq"] + 999
             receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True))
@@ -425,8 +419,7 @@ class NegativePathsTest(unittest.TestCase):
     def test_acceptance_fail_closes_the_rite_before_publication(self):
         canned = dict(CANNED)
         canned["final_review"] = ("ACCEPTANCE: FAIL\nUNSUPPORTED_CLAIMS: 2\n"
-                                  "TREATMENT_LEAK: NO\nCLARITY_STRIKES: 0\n\n"
-                                  "duas alegacoes sem lastro.")
+                                  "TREATMENT_LEAK: NO\n\nduas alegacoes sem lastro.")
         with tempfile.TemporaryDirectory() as tmp:
             with self.assertRaises(rito.StageFailure):
                 _green_run(tmp, canned=canned)
@@ -435,49 +428,6 @@ class NegativePathsTest(unittest.TestCase):
             log = Path(tmp) / "log.jsonl"
             evs = [e for e in eventlog.read(log=log) if e["type"] == "artefato.published"]
             self.assertEqual(evs, [])
-
-    def test_clarity_strikes_block_publication(self):
-        """#625: a PASS header with a nonzero CLARITY_STRIKES count is not package_allowed —
-        the 2026-08-16 Vaswani regression (4 named strikes under a PASS) cannot recur."""
-        canned = dict(CANNED)
-        canned["final_review"] = ("ACCEPTANCE: PASS\nUNSUPPORTED_CLAIMS: 0\n"
-                                  "TREATMENT_LEAK: NO\nCLARITY_STRIKES: 4\n\n"
-                                  "quatro defeitos concretos de clareza nomeados no corpo.")
-        with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(rito.StageFailure):
-                _green_run(tmp, canned=canned)
-            self.assertFalse((Path(tmp) / "blog" / f"{SLUG}.html").exists())
-
-    def test_three_line_header_is_fail_closed(self):
-        """The old 3-line header no longer parses — fail-closed, never silently clarity-blind."""
-        canned = dict(CANNED)
-        canned["final_review"] = ("ACCEPTANCE: PASS\nUNSUPPORTED_CLAIMS: 0\n"
-                                  "TREATMENT_LEAK: NO\n\nsem a linha de clareza.")
-        with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(rito.StageFailure):
-                _green_run(tmp, canned=canned)
-
-    def test_reader_probe_motivation_blocks_publication(self):
-        """#625 development gate: a probe MOTIVACAO below SIM fails the rite before the
-        render — the outcome gate padding cannot satisfy (operator killed the word floor)."""
-        canned = dict(CANNED)
-        canned["reader_probe"] = ("MOTIVACAO: PARCIAL\nFRICTION_POINTS: 3\n\n"
-                                  "Cai no meio de uma conversa que nao vi comecar.")
-        with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(rito.StageFailure):
-                _green_run(tmp, canned=canned)
-            manifest = json.loads((Path(tmp) / "run" / "00_MANIFEST.json").read_text())
-            self.assertEqual(manifest["failed_stage"], "reader_probe_motivation")
-            self.assertFalse((Path(tmp) / "blog" / f"{SLUG}.html").exists())
-
-    def test_reader_probe_header_is_fail_closed(self):
-        """A probe without the deterministic two-line header fails the rite — never a
-        silently unparsed probe."""
-        canned = dict(CANNED)
-        canned["reader_probe"] = "li tudo e achei bom."
-        with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(rito.StageFailure):
-                _green_run(tmp, canned=canned)
 
 
 class PublishRitoSeamTest(unittest.TestCase):
@@ -502,7 +452,7 @@ class PublishRitoSeamTest(unittest.TestCase):
             html_stage = next(s for s in data["stages"] if s["name"] == "final_html")
             html_stage["output"]["sha256"] = "0" * 64
             manifest_path.write_text(json.dumps(data))
-            (run_dir / "10_FINAL.html").write_bytes(b"<!doctype html>legacy bytes\n")
+            (run_dir / "09_FINAL.html").write_bytes(b"<!doctype html>legacy bytes\n")
             _stamp_wake(log)
             with self.assertRaises(ValueError):
                 publisher.publish_rito(SLUG, run_dir, intent=INTENT, skill="report",

--- a/tools/rito.py
+++ b/tools/rito.py
@@ -58,10 +58,9 @@ STAGES = [
     (6, "fact_audit", "06_FACT_AUDIT.md", "review", 9_000),
     (7, "author_correction", "07_AUDITED_FINAL.md", "chat", 14_000),
     (8, "treatment_cleanup", "08_BLIND_SAFE_FINAL.md", "chat", 14_000),
-    (9, "reader_probe", "09_READER_PROBE.md", "review", 9_000),
-    (10, "final_html", "10_FINAL.html", None, None),
-    (11, "final_review", "11_FINAL_REVIEW.md", "review", 9_000),
-    (12, "publication", "12_PUBLICATION.json", None, None),
+    (9, "final_html", "09_FINAL.html", None, None),
+    (10, "final_review", "10_FINAL_REVIEW.md", "review", 9_000),
+    (11, "publication", "11_PUBLICATION.json", None, None),
 ]
 
 LLM_STAGES = tuple(name for _, name, _, route, _ in STAGES if route)
@@ -150,121 +149,26 @@ def treatment_leaks(text: str) -> list[dict[str, Any]]:
 
 
 def parse_acceptance(text: str) -> dict[str, Any]:
-    """The fail-closed final-review header — FOUR lines since 2026-08-16 (#625).
-
-    The 2026-08-16 Vaswani review stamped PASS while naming four concrete clarity strikes in
-    its body: the old 3-line header had no slot for them, so `package_allowed` was blind to
-    clarity by construction. The reviewer now COUNTS the clarity defects it names and the
-    count gates exactly like UNSUPPORTED_CLAIMS — clarity strikes are strikes."""
-    header = [line.strip() for line in text.splitlines() if line.strip()][:4]
-    if len(header) != 4:
+    """The fail-closed final-review header (run.py parse_final_review_acceptance, verbatim)."""
+    header = [line.strip() for line in text.splitlines() if line.strip()][:3]
+    if len(header) != 3:
         raise StageFailure(
-            "final review lacks deterministic ACCEPTANCE/UNSUPPORTED_CLAIMS/TREATMENT_LEAK/"
-            "CLARITY_STRIKES header")
+            "final review lacks deterministic ACCEPTANCE/UNSUPPORTED_CLAIMS/TREATMENT_LEAK header")
     acceptance = re.fullmatch(r"ACCEPTANCE:\s*(PASS|FAIL)", header[0], re.IGNORECASE)
     unsupported = re.fullmatch(r"UNSUPPORTED_CLAIMS:\s*(\d+)", header[1], re.IGNORECASE)
     treatment = re.fullmatch(r"TREATMENT_LEAK:\s*(YES|NO)", header[2], re.IGNORECASE)
-    clarity = re.fullmatch(r"CLARITY_STRIKES:\s*(\d+)", header[3], re.IGNORECASE)
-    if not (acceptance and unsupported and treatment and clarity):
+    if not (acceptance and unsupported and treatment):
         raise StageFailure(
-            "final review's first four non-empty lines are not the required acceptance header")
+            "final review's first three non-empty lines are not the required acceptance header")
     parsed = {
         "acceptance": acceptance.group(1).upper(),
         "unsupported_claims": int(unsupported.group(1)),
         "treatment_leak": treatment.group(1).upper(),
-        "clarity_strikes": int(clarity.group(1)),
     }
     parsed["package_allowed"] = (
         parsed["acceptance"] == "PASS"
         and parsed["unsupported_claims"] == 0
-        and parsed["treatment_leak"] == "NO"
-        and parsed["clarity_strikes"] == 0)
-    return parsed
-
-
-# The header contract the runtime itself appends to every final_review prompt — it supersedes
-# any older "3-line header" wording carried by a skill template, so the contract can never
-# drift per-skill (the fleet regression of 2026-08-16: prose in pipeline.md moved nothing;
-# only what the runtime enforces reproduces).
-FINAL_REVIEW_HEADER_CONTRACT = """\
-## Header contract (supersedes any "3-line header" instruction above)
-
-Begin your review with EXACTLY these four lines, nothing before them:
-
-ACCEPTANCE: PASS|FAIL
-UNSUPPORTED_CLAIMS: <n>
-TREATMENT_LEAK: YES|NO
-CLARITY_STRIKES: <n>
-
-CLARITY_STRIKES counts every CONCRETE clarity defect you name in the body — a symbol used
-before it is introduced, a referent with no address, a load-bearing gloss missing, an opening
-that never says where the problem came from and what is at stake (problem-placement). Count
-honestly: a nonzero count blocks publication, exactly like an unsupported claim (2026-08-16:
-a PASS carried four named clarity strikes the old header could not see). Never soften a defect
-to keep the count at zero — name it, count it; the producer re-grounds at the source and fixes
-it on the next round."""
-
-
-# Development telemetry — counts only, NEVER a gate (operator decision 2026-08-16: a word
-# floor is an invitation to the oco eloquente — producers pad to the number; Goodhart wins).
-# The counts ride the manifest so thinness stays observable for calibration; what actually
-# GATES development is the reader probe below: an outcome measure padding cannot satisfy
-# (length without teaching raises friction, never lowers it).
-def development_telemetry(markdown_text: str) -> dict[str, Any]:
-    """Structural counts of the sealed markdown — observability, not verdict."""
-    prose = re.sub(r"```.*?```", " ", markdown_text, flags=re.S)
-    words = len(re.findall(r"[^\s#|*`>\-]+", prose))
-    sections = len(re.findall(r"(?m)^#{2,3}\s+\S", markdown_text))
-    return {"words": words, "sections": sections}
-
-
-# The reader probe — stage 9, independent route (#625; validated by hand 2026-08-16 on the
-# Vaswani v1→v2→v3 rerun: the probe's MOTIVAÇÃO verdict flipped PARCIAL→SIM exactly where the
-# operator judged the text ready, and its friction list rediscovered the review's clarity
-# strikes independently). A cold reader in the mentee's seat reads the SEALED text only —
-# no production material — and reports whether the text places its problem and where it
-# rubs. Antecedents: teach-back (AHRQ tool 5), cloze testing (Taylor 1953).
-READER_PROBE_CONTRACT = """\
-You are the artefato's target reader — the mentee, meeting this text COLD. You have seen no
-production material, no dossier, no review; only the text below. Read it ONCE, then report.
-
-Begin with EXACTLY these two lines, nothing before them:
-
-MOTIVACAO: SIM|PARCIAL|NAO
-FRICTION_POINTS: <n>
-
-- MOTIVACAO: did the text tell you, before it started teaching, where its problem came from
-  and why it matters to you now — the originating event, the stakes, the clock if there is
-  one (problem-placement)? SIM only when origin AND stakes are in the text itself; PARCIAL
-  when you understood the what but not the why-now; NAO when you fell into the middle of a
-  conversation you never saw begin.
-- FRICTION_POINTS: count your CONCRETE reading frictions — a symbol used before it is
-  introduced, a referent you could not place, a load-bearing gloss missing, a sentence you
-  had to guess at. Count honestly; zero is a claim like any other.
-
-Body: list each friction, quoting the exact spot. Close with 2-3 lines: what is this text
-asking you to DO next, and could you do it from the text alone?
-
-Padding cannot satisfy this probe: length without teaching raises friction, never lowers it.
-
-## The sealed text
-
-"""
-
-
-def parse_reader_probe(text: str) -> dict[str, Any]:
-    """Fail-closed probe header: MOTIVACAO + FRICTION_POINTS as the first two lines."""
-    header = [line.strip() for line in text.splitlines() if line.strip()][:2]
-    if len(header) != 2:
-        raise StageFailure("reader probe lacks deterministic MOTIVACAO/FRICTION_POINTS header")
-    motivacao = re.fullmatch(r"MOTIVACAO:\s*(SIM|PARCIAL|NAO)", header[0], re.IGNORECASE)
-    friction = re.fullmatch(r"FRICTION_POINTS:\s*(\d+)", header[1], re.IGNORECASE)
-    if not (motivacao and friction):
-        raise StageFailure(
-            "reader probe's first two non-empty lines are not the required header")
-    parsed = {"motivacao": motivacao.group(1).upper(),
-              "friction_points": int(friction.group(1))}
-    parsed["probe_allowed"] = parsed["motivacao"] == "SIM"
+        and parsed["treatment_leak"] == "NO")
     return parsed
 
 
@@ -542,30 +446,7 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
             run.save(manifest)
             raise exc
 
-        # development telemetry (#625): counts only, never a gate — the operator killed the
-        # word floor (an invitation to padding); the probe below is the development gate.
-        cleanup_stage["development_telemetry"] = development_telemetry(blind_safe)
-        run.save(manifest)
-
-        # 9 — reader probe (#625): a cold reader on the SEALED text only, independent route.
-        # The outcome gate a word count cannot be: MOTIVACAO must be SIM (the text places its
-        # problem), and the friction list feeds the final reviewer's CLARITY_STRIKES count.
-        probe_text = _llm_stage(run, manifest, "reader_probe",
-                                READER_PROBE_CONTRACT + blind_safe, complete_fn, outputs)
-        probe = parse_reader_probe(probe_text)
-        _stage_record(manifest, "reader_probe")["probe"] = probe
-        run.save(manifest)
-        if not probe["probe_allowed"]:
-            exc = StageFailure(
-                f"reader probe rejected the text: MOTIVACAO {probe['motivacao']} — the sealed "
-                "text does not place its own problem (origin + stakes); re-ground and rewrite "
-                "the opening, never bolt on a disclaimer")
-            manifest.update({"status": "failed", "failed_stage": "reader_probe_motivation",
-                             "finished_at": now()})
-            run.save(manifest)
-            raise exc
-
-        # 10 — final_html: the PINNED render (renderer id sealed; one byte seam)
+        # 9 — final_html: the PINNED render (renderer id sealed; one byte seam)
         if _completed_output(run, manifest, "final_html") is None:
             _begin(run, manifest, "final_html")
             try:
@@ -580,17 +461,13 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
                 _fail(run, manifest, "final_html", exc)
                 raise
 
-        # 11 — final review, fail-closed acceptance header + local scan.
+        # 10 — final review, fail-closed acceptance header + local scan.
         # A lente lectures-on-physics é parte fixa da revisão (feynman_gate.LENS_BLOCK):
         # clareza pedagógica é critério de strike, com os contrapesos vinculantes
         # (fato é do fact-audit; enchimento ≠ crescimento) escritos na própria lente.
         import feynman_gate as _feynman_gate
         final_review_prompt = (prompts["final_review"](outputs)
-                               + "\n\n" + _feynman_gate.LENS_BLOCK
-                               + "\n\n## Blind reader probe (independent; frictions are "
-                               "clarity-strike candidates — count every one you judge "
-                               "concrete into CLARITY_STRIKES)\n\n" + probe_text
-                               + "\n\n" + FINAL_REVIEW_HEADER_CONTRACT)
+                               + "\n\n" + _feynman_gate.LENS_BLOCK)
         if theme_review_contract:
             final_review_prompt = f"{final_review_prompt}\n\n{theme_review_contract}"
         final_review = _llm_stage(run, manifest, "final_review",
@@ -618,7 +495,7 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
         if draft_sealed_sha != current_draft_sha:
             raise StageFailure("first authorial draft changed during the rite")
 
-        # 12 — PUBLICATION, inside the rite. The publisher recomputes the pinned render from
+        # 11 — PUBLICATION, inside the rite. The publisher recomputes the pinned render from
         # the sealed markdown and refuses a mismatch; the receipt (event + page + binding)
         # seals as the terminal stage.
         if _stage_record(manifest, "publication")["status"] != "completed":
@@ -762,12 +639,6 @@ def verify_rito(run_dir, *, log, blog_dir) -> dict[str, Any]:
         sealed = (by_name.get("final_html") or {}).get("output") or {}
         if sealed.get("sha256") != sha_bytes(expected_page):
             failures.append("form-renderer-mismatch")
-        # reader probe (#625): a completed run must carry the probe's parsed verdict and it
-        # must have allowed the text — same fail-closed shape as the acceptance check below
-        # (runs sealed before 2026-08-16 predate the stage and fail stage-order upstream)
-        probe_receipt = (by_name.get("reader_probe") or {}).get("probe")
-        if not (probe_receipt or {}).get("probe_allowed"):
-            failures.append("reader-probe-fail")
         if not (page_path and page_path.is_file()
                 and page_path.read_bytes() == expected_page):
             failures.append("page-bytes-mismatch")


### PR DESCRIPTION
Reverts merge commits a7c2dee (PR #627, clarity strikes gate + re-grounding in skills/_shared/pipeline.md) and 3518e95 (PR #637, reader probe + CLARITY_STRIKES in tools/rito.py, tests/test_rito_runtime.py and 6 SKILL.md templates) by operator order.

All other merges of the day (#626, #628, #630, #631 and later) are kept untouched.

Test suites green after revert: `tests.test_rito_runtime tests.test_publisher tests.test_pauta_gate` — Ran 142 tests, OK (skipped=1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)