### PR TITLE
rito: YAML thought-movements for report-form; review the published HTML

### DIFF
--- a/skills/_shared/pipeline.md
+++ b/skills/_shared/pipeline.md
@@ -7,10 +7,13 @@ emits the PROPOSTA; the pipeline is what runs once the PROPOSTA names the forma/
 is no per-skill pipeline: the PROPOSTA supplies the theme, a skill supplies the producing
 cognition, the pipeline supplies the spine.
 
-This is the modern, **de-YAML'd, publish-only rewrite** of the legacy `consolidate-state` +
+This is the modern, publish-only rewrite of the legacy `consolidate-state` +
 the `_shared/` trio (`report-template` / `state-protocol` / `workflow-conventions`). The legacy
-mandated report-sections and emitted YAML; this pipeline mandates none and publishes HTML
-directly.
+mandated report-sections. **The report form writes YAML blocks again**:
+choosing the block is choosing the move (comparison, derivation, gap). There is no
+mandatory H2 outline and no word floor. Maps/plans/terse forms still owe nothing.
+The pipeline publishes HTML by rendering those blocks (`render.spec_to_html`).
+The reader probe and final review judge that rendered page, not the YAML source.
 
 ## The three phases
 

--- a/skills/beat/SKILL.md
+++ b/skills/beat/SKILL.md
@@ -116,6 +116,17 @@ recently is the gradient the proposta follows; the beat's own picks are explorat
 
 ## Ato 2 — the branches: um agente por artefato, rounds próprios
 
+**Ato-2 report draft is YAML movements, not free markdown.** When the
+PROPOSTA `forma` is report, the branch writes a YAML document (`intent`,
+`cites`, `lineage`, `blocks`). First block type is lineage. Must include a
+substantive comparison or derivation (both sides), and a gap-marker /
+gap-table with nonblank text. Cites are `{ref, snippet}`. No free markdown.
+No required H2 names. Do not pin `forma: report` here — the Pauta still
+chooses the forma. The blind probe and final review read the rendered HTML
+the mentee sees (`yaml_rite.page_bytes`), not the YAML source. yaml-rite
+still checks the YAML. Import `rito` from `PYTHONPATH`. Do **not**
+`sys.path.insert(0, 'tools')` from the phenotype cwd.
+
 For each artefato in the proposal, dispatch **one artefato-agent** (parallel subagent calls in
 the SAME turn — blocking; the lei do turno above rules here too):
 

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -118,8 +118,14 @@ rendered page) and seals a receipt for every stage. Your job is the COGNITION: t
 prompts. The runtime owns sequencing, sealing, rendering (the pinned neutral-markdown renderer,
 `render.RENDERER_ID`) and publication. A run that didn't publish didn't finish the rite.
 
-The stages you feed (authoring format is **Markdown**, H1 first; tables/lists/blockquotes carry
-the visual idiom): `grounding1_dossier` (your gathered factual dossier — the gather-grounding
+The stages you feed (authoring format is **YAML blocks**, not free markdown and not a mandatory
+H2 outline). A developed report is a YAML document: root fields (`intent`, `cites` /
+bibliography, `lineage`) plus `blocks:` (or `content.sections[].blocks`). **Choosing the
+block is choosing the move** — comparison, derivation, gap-marker / gap-table /
+gap-resolution. The first authored block is lineage (what the prior report brought and why
+this exists) — a close check, not an H2 name. A markdown fence with yaml is accepted. Do
+not write a section outline. Do not write free markdown and call it a report:
+`grounding1_dossier` (your gathered factual dossier — the gather-grounding
 slot above) → `first_authorial_draft` → `gap_critique` → `grounding2_targeted` →
 `provisional_rewrite` → `fact_audit` → `author_correction` → `treatment_cleanup` (deterministic
 copy when the leak scan is clean) → `final_html` (pinned render, runtime-owned) →
@@ -150,7 +156,6 @@ report closes an Experiment: the atomic curated conclusion — short curated pro
 that becomes the canonical reading; omit when no experiment closes).
 
     tools/edge-python <<'EOF'
-    import sys; sys.path.insert(0, 'tools')
     import rito, llm_routes
 
     slug = '<slug>'
@@ -160,14 +165,14 @@ that becomes the canonical reading; omit when no experiment closes).
         return llm_routes.completer_for(route, max_tokens=max_tokens)(prompt)
 
     prompts = {
-        'first_authorial_draft': lambda o: f"<the produce guidance, this theme; PEDAGOGUE's Feynman voice: build from the concrete, motivate WHY before formalism, one vivid handle per hard idea, address the reader, explain-don't-label; CALIBRATE: contextualize the genuinely-new, ASSUME the operator's known (edge + his domain — re-explaining the known is enfadonho); prose carries the argument, a table only for a genuine A-vs-B comparison; length EMERGENT, no length target>\n\nDOSSIER:\n{o['grounding1_dossier']}",
+        'first_authorial_draft': lambda o: f"Write a YAML document, not free markdown. Root fields: intent (one prose string, not a mapping), cites (non-empty {{ref, snippet}}; every load-bearing phrase appears in a snippet), lineage, blocks. First block type is lineage. Then a substantive comparison-table or derivation (hyphenated type; BOTH sides of a comparison carry payload). Then a gap-marker or gap-table whose text is nonblank. The mentee reads the rendered HTML (`yaml_rite.page_bytes`), not these keys — write payloads that teach. yaml-rite still checks the YAML source. Choosing the block is choosing the move. No H2 outline, no word target, no free markdown. PEDAGOGUE's Feynman voice lives in the block payloads.\n\nDOSSIER:\n{o['grounding1_dossier']}",
         'gap_critique':          lambda o: f"<PEDAGOGICAL critique: where does this fail to TEACH the genuinely-new? where is it cryptic / contextualization thin? name ONLY the gaps a reader can't cross — not every possible elaboration (the known needs no handle)>\n\n{o['first_authorial_draft']}",
         'grounding2_targeted':   lambda o: f"<REACH for NEW grounding (world/domain beyond grounding-1) to fill the pedagogical gaps the critique named; FETCH + cite each source with its snippet, NEVER invent a fact or a citation. If the critique names no uncrossable gap, return no new grounding>\n\nGROUNDING-1 (the anchor — do not duplicate what it already covers):\n{o['grounding1_dossier']}\n\nCRITIQUE:\n{o['gap_critique']}",
-        'provisional_rewrite':   lambda o: f"<same-author rewrite in the Feynman voice, keeping the calibration (assume the known), folding critique+the new grounding2 into contextualizing prose>\n\n{o['grounding2_targeted']}",
+        'provisional_rewrite':   lambda o: f"<same-author rewrite STILL AS YAML (intent as one prose string, cites as [{{ref, snippet}}], lineage, hyphenated block types; do not convert to markdown; do not turn intent into a mapping) in the Feynman voice. Payloads are what the mentee reads after render. Keep the calibration (assume the known), fold critique+the new grounding2 into block payloads>\n\n{o['grounding2_targeted']}",
         'fact_audit':            lambda o: f"<independent fact audit: every factual claim traces to grounding-1 OR a grounding-2 source with its cited snippet; flag any fact or citation with no source (fabrication guard — treat grounding-2 as candidate evidence, don't trust a citation at face value)>\n\nGROUNDING-1:\n{o['grounding1_dossier']}\n\nGROUNDING-2 (candidate evidence):\n{o['grounding2_targeted']}\n\n{o['provisional_rewrite']}",
-        'author_correction':     lambda o: f"<bounded same-author correction from the audit>\n\n{o['fact_audit']}",
-        'treatment_cleanup':     lambda o: f"<bounded same-author leak cleanup>\n\nSCAN:\n{o['treatment_leaks']}\n\n{o['author_correction']}",
-        'final_review':          lambda o: f"<strict review; begin with the 3-line ACCEPTANCE header>\n\n{o['treatment_cleanup']}",
+        'author_correction':     lambda o: f"<bounded same-author correction from the audit; emit YAML not markdown; intent stays a prose string; hyphenated block types>\n\n{o['fact_audit']}",
+        'treatment_cleanup':     lambda o: f"<bounded same-author leak cleanup; keep YAML document shape>\n\nSCAN:\n{o['treatment_leaks']}\n\n{o['author_correction']}",
+        'final_review':          lambda o: f"<strict review of the READER-FACING page (rendered HTML if the sealed draft is YAML; markdown as-is); begin with the 3-line ACCEPTANCE header>\n\n{o.get('reader_facing') or o['treatment_cleanup']}",
     }
 
     rito.run_rito(slug, run_dir=f'state/rito/{slug}',
@@ -179,7 +184,9 @@ that becomes the canonical reading; omit when no experiment closes).
                                 'experiment_curation': None})
     EOF
 
-The publisher's rito seam recomputes the pinned render from the sealed markdown and **refuses a
+Import `rito` / `close` / `publisher` via package/`PYTHONPATH`. Never `sys.path.insert(0, 'tools')` from the phenotype cwd — that loads the live phenotype rito and skips the YAML gate.
+
+The publisher's rito seam recomputes the pinned render from the sealed draft (YAML → `render.spec_to_html`, markdown stays the pinned markdown renderer) and **refuses a
 hash mismatch** — the exact reviewed bytes, and only they, land at `blog/entries/<slug>.html`,
 bound to the `artefato.published` event + mandatory `intent.kernel` in one atomic act (C3). The
 first authorial draft stays sealed and addressable in the run dir for later blind reading.

--- a/tests/test_rito_runtime.py
+++ b/tests/test_rito_runtime.py
@@ -32,6 +32,7 @@ import eventlog  # noqa: E402
 import publisher  # noqa: E402
 import render  # noqa: E402
 import rito  # noqa: E402
+import yaml_rite  # noqa: E402
 
 SLUG = "exp-teste-rito"
 INTENT = "provar que o rito inteiro roda, do dossier a publicacao"
@@ -52,21 +53,121 @@ def _approved_generator_present():
     except OSError:
         return False
 
+YAML_AUTHORIAL_DRAFT = """intent: "open: o buscador sem indice; bet: o indice muda o placar"
+cites:
+  - ref: exp072
+    kind: atividade
+    snippet: "29 vitorias com o indice"
+lineage:
+  - type: builds_on
+    slug: prior-recall-report
+blocks:
+  - type: lineage
+    text: "O relato anterior nomeou o buraco do indice; este deriva o placar."
+  - type: comparison
+    before:
+      title: raw
+      bullets: ["8", "sem estrutura"]
+    after:
+      title: indice
+      bullets: ["29", "a rodada 3 mostra o mecanismo"]
+  - type: gap-marker
+    text: "unknown: whether the next round repeats the lift"
+"""
+YAML_PROVISIONAL = """intent: "open: o buscador sem indice; bet: o indice muda o placar"
+cites:
+  - ref: exp072
+    kind: atividade
+    snippet: "29 vitorias com o indice"
+lineage:
+  - type: builds_on
+    slug: prior-recall-report
+blocks:
+  - type: lineage
+    text: "O relato anterior nomeou o buraco do indice; este deriva o placar."
+  - type: comparison
+    before:
+      title: raw
+      bullets: ["8", "sem estrutura"]
+    after:
+      title: indice
+      bullets: ["29", "versao revisada: a rodada 3 mostra o mecanismo"]
+  - type: gap-marker
+    text: "unknown: whether the next round repeats the lift"
+"""
+YAML_AUTHOR_CORRECTION = """intent: "open: o buscador sem indice; bet: o indice muda o placar"
+cites:
+  - ref: exp072
+    kind: atividade
+    snippet: "29 vitorias com o indice"
+lineage:
+  - type: builds_on
+    slug: prior-recall-report
+blocks:
+  - type: lineage
+    text: "O relato anterior nomeou o buraco do indice; este deriva o placar."
+  - type: comparison
+    before:
+      title: raw
+      bullets: ["8", "sem estrutura"]
+    after:
+      title: indice
+      bullets: ["29", "versao final auditada. A rodada 3 mostra o mecanismo."]
+  - type: gap-marker
+    text: "unknown: whether the next round repeats the lift"
+"""
+YAML_LEAKY_CORRECTION = """intent: "open: o buscador sem indice; bet: o indice muda o placar"
+cites:
+  - ref: exp072
+    kind: atividade
+    snippet: "29 vitorias com o indice"
+lineage:
+  - type: builds_on
+    slug: prior-recall-report
+blocks:
+  - type: lineage
+    text: "Neste rascunho eu explico o mecanismo da rodada 3."
+  - type: comparison
+    before:
+      title: raw
+      bullets: ["8", "sem estrutura"]
+    after:
+      title: indice
+      bullets: ["29", "a rodada 3 mostra o mecanismo"]
+  - type: gap-marker
+    text: "unknown: whether the next round repeats the lift"
+"""
+YAML_CLEAN_CLEANUP = """intent: "open: o buscador sem indice; bet: o indice muda o placar"
+cites:
+  - ref: exp072
+    kind: atividade
+    snippet: "29 vitorias com o indice"
+lineage:
+  - type: builds_on
+    slug: prior-recall-report
+blocks:
+  - type: lineage
+    text: "Aqui eu explico o mecanismo da rodada 3."
+  - type: comparison
+    before:
+      title: raw
+      bullets: ["8", "sem estrutura"]
+    after:
+      title: indice
+      bullets: ["29", "a rodada 3 mostra o mecanismo"]
+  - type: gap-marker
+    text: "unknown: whether the next round repeats the lift"
+"""
+
 # Canned cognitive outputs — scan-clean (no draft/grounding/prompt/harness vocabulary), so the
 # deterministic treatment gates pass and treatment_cleanup takes the deterministic-copy branch.
 CANNED = {
-    "first_authorial_draft": (
-        "# Relatorio exp-teste\n\nA pergunta viva: o buscador melhora com o indice?\n\n"
-        "- fato: 29 vitorias\n- inferencia: o indice ajuda\n\n"
-        "| arm | placar |\n|---|---|\n| raw | 8 |\n| indice | 29 |"),
+    "first_authorial_draft": YAML_AUTHORIAL_DRAFT,
     "gap_critique": "# Lacunas\n\nFaltou o caso concreto da rodada 3.",
     "grounding2_targeted": "# Memo dirigido\n\nEvidencia adicional sobre a rodada 3.",
-    "provisional_rewrite": (
-        "# Relatorio exp-teste\n\nVersao revisada: a rodada 3 mostra o mecanismo."),
+    "provisional_rewrite": YAML_PROVISIONAL,
     "fact_audit": "# Fact audit\n\n## Verdict\nPASS\n\n## Claim ledger\ntudo sustentado.",
-    "author_correction": (
-        "# Relatorio exp-teste\n\nVersao final auditada. A rodada 3 mostra o mecanismo.\n\n"
-        "> o indice vence onde a estrutura importa."),
+    "author_correction": YAML_AUTHOR_CORRECTION,
     "final_review": (
         "ACCEPTANCE: PASS\nUNSUPPORTED_CLAIMS: 0\nTREATMENT_LEAK: NO\n\n"
         "Revisao qualitativa: util por si so."),
@@ -219,7 +320,7 @@ class FullRiteTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             _, run_dir, log, blog = _green_run(tmp)
             sealed_md = (run_dir / "08_BLIND_SAFE_FINAL.md").read_text()
-            expected = render.markdown_page_bytes(sealed_md)
+            expected = yaml_rite.page_bytes(sealed_md)
             self.assertEqual((blog / f"{SLUG}.html").read_bytes(), expected)
             self.assertEqual((run_dir / "09_FINAL.html").read_bytes(), expected)
 
@@ -230,7 +331,7 @@ class FullRiteTest(unittest.TestCase):
             self.assertEqual(len(evs), 1)
             spec = evs[0]["payload"]["spec"]
             self.assertEqual(spec["format"], "edge-markdown/v1")
-            self.assertEqual(spec["renderer_id"], render.RENDERER_ID)
+            self.assertEqual(spec["renderer_id"], yaml_rite.YAML_RENDERER_ID)
             self.assertEqual(spec["rito_manifest_sha256"], rito.manifest_core_hash(manifest))
             page_sha = hashlib.sha256((blog / f"{SLUG}.html").read_bytes()).hexdigest()
             self.assertEqual(spec["page_sha256"], page_sha)
@@ -272,10 +373,8 @@ class FullRiteTest(unittest.TestCase):
 
     def test_treatment_cleanup_same_author_when_correction_leaks(self):
         canned = dict(CANNED)
-        canned["author_correction"] = ("# Relatorio exp-teste\n\nNeste rascunho eu explico o "
-                                       "mecanismo da rodada 3.")
-        canned["treatment_cleanup"] = ("# Relatorio exp-teste\n\nAqui eu explico o mecanismo "
-                                       "da rodada 3.")
+        canned["author_correction"] = YAML_LEAKY_CORRECTION
+        canned["treatment_cleanup"] = YAML_CLEAN_CLEANUP
         order = LLM_ORDER[:6] + ["treatment_cleanup"] + LLM_ORDER[6:]
         with tempfile.TemporaryDirectory() as tmp:
             manifest, run_dir, log, blog = _green_run(tmp, canned=canned, order=order)
@@ -610,6 +709,63 @@ class DetectorCliTest(unittest.TestCase):
             bad = rito.main(["verify", str(run_dir), "--log", str(log),
                              "--blog-dir", str(blog)])
             self.assertEqual(bad, 1)
+
+
+    def test_report_markdown_first_draft_is_stage_failure(self):
+        """A report-form first draft that is free markdown fails immediately."""
+        canned = dict(CANNED)
+        canned["first_authorial_draft"] = (
+            "# Relatorio\n\nParagrafo um sobre o indice.\n\n"
+            "Paragrafo dois sobre a rodada 3.\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(rito.StageFailure) as ctx:
+                _green_run(tmp, canned=canned)
+            self.assertIn("draft is not YAML", str(ctx.exception))
+            manifest = json.loads((Path(tmp) / "run" / "00_MANIFEST.json").read_text())
+            self.assertEqual(manifest["failed_stage"], "first_authorial_draft")
+            self.assertFalse((Path(tmp) / "run" / "03_GAP_CRITIQUE.md").exists())
+
+
+class ReaderFacingProbeReviewTest(unittest.TestCase):
+    """#585: probe + final_review judge the published HTML, not YAML keys."""
+
+    def test_final_review_prompt_is_rendered_html(self):
+        def prompts():
+            base = _prompts()
+            base["final_review"] = (
+                lambda o: "<strict review>\n\n"
+                + (o.get("reader_facing") or o["treatment_cleanup"]))
+            return base
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            log, blog, run_dir = tmp / "log.jsonl", tmp / "blog", tmp / "run"
+            did = _stamp_wake(log)
+            rito.run_rito(
+                SLUG, run_dir=run_dir,
+                grounding1_fn=lambda: "# Dossier factual\n\nFatos: 29-8-3 em 40 rodadas.",
+                prompts=prompts(),
+                complete_fn=_complete_fn(CANNED, LLM_ORDER),
+                intent=INTENT, skill="report", dispatch_id=did,
+                log=log, blog_dir=blog,
+            )
+            review_prompt = (run_dir / "prompts" / "10_final_review.md").read_text()
+            sealed = (run_dir / "08_BLIND_SAFE_FINAL.md").read_text()
+            self.assertTrue(yaml_rite.is_yaml_draft(sealed))
+            self.assertIn("rodada 3", review_prompt)
+            self.assertIn("comparison-grid", review_prompt)
+            self.assertNotIn("type: lineage", review_prompt)
+            self.assertNotIn("type: comparison", review_prompt)
+            self.assertIn("type: lineage", sealed)
+
+    def test_yaml_source_is_not_the_probe_body(self):
+        """The probe facing text is HTML, never raw YAML keys."""
+        facing = yaml_rite.reader_facing_text(YAML_AUTHOR_CORRECTION)
+        self.assertIn("rodada 3", facing)
+        self.assertNotIn("type: comparison", facing)
+        self.assertTrue(facing.lstrip().startswith("<!doctype html>")
+                        or "<main>" in facing)
 
 
 if __name__ == "__main__":

--- a/tests/test_yaml_rite.py
+++ b/tests/test_yaml_rite.py
@@ -1,0 +1,402 @@
+"""exp/yaml-blocks — mechanical yaml-rite gate + YAML → HTML render.
+
+A developed report-form synthesis writes YAML blocks (choosing the block is
+choosing the move). The gate is content-relative: maps/plans/terse forms owe
+nothing; a short YAML with lineage + substantive comparison + gap + cites
+passes (no H2, no word floor). Empty chrome fails normalize_block.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import blocks  # noqa: E402
+import close  # noqa: E402
+import render  # noqa: E402
+import yaml_rite  # noqa: E402
+
+
+def _cite():
+    return {"ref": "arXiv:2507.02778", "kind": "mundo", "relevant": True,
+            "snippet": "an external benchmark the synthesis actually used"}
+
+
+def _lineage_block():
+    return {"type": "lineage",
+            "text": "The prior report named the read-budget hole; this one derives the watermark."}
+
+
+def _comparison():
+    return {
+        "type": "comparison",
+        "before": {"title": "session cursor",
+                   "bullets": ["one watermark for the whole process", "collides across sessions"]},
+        "after": {"title": "per-session watermark",
+                  "bullets": ["each session owns its cursor", "crash recovery is local"]},
+    }
+
+
+def _gap():
+    return {"type": "gap-marker",
+            "text": "unknown: whether the watermark survives a hard crash of the store"}
+
+
+def _short_yaml_art():
+    """The pass case: short YAML, no H2, no word floor, all required moves."""
+    return {
+        "skill": "report",
+        "intent": "open: budget unnamed; bet: name the per-session watermark",
+        "cites": [_cite()],
+        "lineage": [{"type": "builds_on", "slug": "prior-recall-report"}],
+        "format": "edge-yaml/v1",
+        "content": {"sections": [{"title": "", "blocks": [
+            _lineage_block(), _comparison(), _gap(),
+        ]}]},
+    }
+
+
+def _jurix_thin_html_art():
+    """Name-drop: the object is only a venue; no typed comparison/derivation payload."""
+    return {
+        "skill": "report",
+        "intent": "open: venue unnamed; bet: mention JURIX",
+        "cites": [],
+        "lineage": [],
+        "content": {"markdown": (
+            "JURIX is a conference on legal informatics.\n\n"
+            "The venue gathers papers on AI and law each year.\n\n"
+            "JURIX remains the object of this note.\n"
+        )},
+    }
+
+
+def _empty_comparison_yaml_art():
+    return {
+        "skill": "report",
+        "intent": "open: JURIX; bet: name-drop the venue",
+        "cites": [_cite()],
+        "lineage": [{"type": "builds_on", "slug": "prior"}],
+        "format": "edge-yaml/v1",
+        "content": {"sections": [{"title": "", "blocks": [
+            _lineage_block(),
+            {"type": "comparison", "title": "JURIX"},  # chrome only
+            _gap(),
+        ]}]},
+    }
+
+
+class YamlRiteGate(unittest.TestCase):
+    def test_short_yaml_with_moves_passes_no_h2_no_word_floor(self):
+        violations = yaml_rite.check_yaml_rite(_short_yaml_art())
+        self.assertEqual(violations, [], violations)
+        # also through check_genus: no yaml-rite:* 
+        genus = [v for v in close.check_genus(_short_yaml_art()) if v.startswith("yaml-rite")]
+        self.assertEqual(genus, [], genus)
+
+    def test_jurix_thin_free_html_fails(self):
+        v = yaml_rite.check_yaml_rite(_jurix_thin_html_art())
+        self.assertIn("yaml-rite:typed-blocks", v, v)
+        self.assertIn("yaml-rite:comparison-or-derivation", v, v)
+        self.assertIn("yaml-rite:cites", v, v)
+
+    def test_empty_comparison_yaml_fails(self):
+        v = yaml_rite.check_yaml_rite(_empty_comparison_yaml_art())
+        self.assertIn("yaml-rite:comparison-or-derivation", v, v)
+
+    def test_empty_comparison_chrome_fails_normalize(self):
+        self.assertIsNone(blocks.normalize_block({"type": "comparison", "title": "JURIX"}))
+        self.assertIsNone(blocks.normalize_block({
+            "type": "comparison",
+            "before": {"title": "A"},
+            "after": {"title": "B"},
+        }))
+
+    def test_title_only_derivation_fails_normalize(self):
+        self.assertIsNone(blocks.normalize_block({"type": "derivation", "title": "Derivation"}))
+
+    def test_substantive_comparison_survives_normalize(self):
+        self.assertIsNotNone(blocks.normalize_block(_comparison()))
+
+    def test_markdown_without_skill_still_owes_and_fails_typed_blocks(self):
+        """The last-beat bug: omitting skill used to skip the gate and publish markdown."""
+        art = {
+            "intent": "open: venue unnamed; bet: mention JURIX",
+            "cites": [],
+            "lineage": [],
+            "content": {"markdown": (
+                "JURIX is a conference on legal informatics.\n\n"
+                "The venue gathers papers on AI and law each year.\n\n"
+                "JURIX remains the object of this note.\n"
+            )},
+        }
+        self.assertNotIn("skill", art)
+        self.assertTrue(yaml_rite.owes_yaml_rite(art))
+        v = yaml_rite.check_yaml_rite(art)
+        self.assertIn("yaml-rite:typed-blocks", v, v)
+
+    def test_empty_skill_markdown_still_owes(self):
+        art = _jurix_thin_html_art()
+        art["skill"] = ""
+        self.assertTrue(yaml_rite.owes_yaml_rite(art))
+        self.assertIn("yaml-rite:typed-blocks", yaml_rite.check_yaml_rite(art))
+
+    def test_map_owes_nothing(self):
+        art = {
+            "slug": "rel-map",
+            "skill": "map",
+            "intent": "open: relations untraced; bet: trace them",
+            "cites": [],
+            "content": {"sections": [{"title": "Map", "blocks": [
+                {"type": "ascii-diagram", "content": "A --applies--> B"},
+                {"type": "table", "headers": ["From", "Type", "To"],
+                 "rows": [["A", "application", "B"], ["B", "rhyme", "C"], ["C", "parallel", "D"]]},
+            ]}]},
+        }
+        self.assertEqual(yaml_rite.check_yaml_rite(art), [])
+        rich = [v for v in close.check_genus(art) if v.startswith("yaml-rite")]
+        self.assertEqual(rich, [])
+
+    def test_terse_plan_owes_nothing(self):
+        art = {
+            "skill": "plan",
+            "intent": "open: next step unnamed; bet: name it",
+            "cites": [],
+            "content": {"sections": [{"title": "", "blocks": [
+                {"type": "next-steps-grid", "steps": [{"title": "ship the watermark"}]},
+            ]}]},
+        }
+        self.assertEqual(yaml_rite.check_yaml_rite(art), [])
+
+    def test_terse_report_below_threshold_owes_nothing(self):
+        art = {
+            "skill": "report",
+            "intent": "open: one observation; bet: park it",
+            "cites": [],
+            "content": {"sections": [{"title": "", "blocks": [
+                {"type": "paragraph", "text": "One terse observation, nothing more."},
+            ]}]},
+        }
+        self.assertEqual(yaml_rite.check_yaml_rite(art), [])
+
+    def test_first_block_must_be_lineage(self):
+        art = _short_yaml_art()
+        art["content"]["sections"][0]["blocks"] = [_comparison(), _lineage_block(), _gap()]
+        v = yaml_rite.check_yaml_rite(art)
+        self.assertIn("yaml-rite:lineage-first", v, v)
+
+    def test_missing_gap_fails(self):
+        art = _short_yaml_art()
+        art["content"]["sections"][0]["blocks"] = [_lineage_block(), _comparison()]
+        v = yaml_rite.check_yaml_rite(art)
+        self.assertIn("yaml-rite:gap", v, v)
+
+    def test_derivation_satisfies_comparison_or_derivation(self):
+        art = _short_yaml_art()
+        art["content"]["sections"][0]["blocks"] = [
+            _lineage_block(),
+            {"type": "derivation", "text": "A session is bounded, therefore the cursor is per-session."},
+            _gap(),
+        ]
+        v = yaml_rite.check_yaml_rite(art)
+        self.assertNotIn("yaml-rite:comparison-or-derivation", v, v)
+        self.assertEqual(v, [], v)
+
+    def test_one_sided_comparison_fails(self):
+        art = _short_yaml_art()
+        art["content"]["sections"][0]["blocks"] = [
+            _lineage_block(),
+            {"type": "comparison",
+             "before": {"title": "session cursor", "bullets": ["one watermark"]},
+             "after": {"title": "per-session watermark"}},
+            _gap(),
+        ]
+        v = yaml_rite.check_yaml_rite(art)
+        self.assertIn("yaml-rite:comparison-or-derivation", v, v)
+        self.assertIsNone(blocks.normalize_block(
+            art["content"]["sections"][0]["blocks"][1]))
+
+    def test_cite_without_snippet_fails(self):
+        art = _short_yaml_art()
+        art["cites"] = [{"ref": "arXiv:2507.02778", "kind": "mundo"}]
+        v = yaml_rite.check_yaml_rite(art)
+        self.assertIn("yaml-rite:cites", v, v)
+
+    def test_string_cite_fails(self):
+        art = _short_yaml_art()
+        art["cites"] = ["arXiv:2507.02778"]
+        v = yaml_rite.check_yaml_rite(art)
+        self.assertIn("yaml-rite:cites", v, v)
+
+    def test_empty_gap_marker_fails(self):
+        art = _short_yaml_art()
+        art["content"]["sections"][0]["blocks"] = [
+            _lineage_block(), _comparison(),
+            {"type": "gap-marker", "text": ""},
+        ]
+        v = yaml_rite.check_yaml_rite(art)
+        self.assertIn("yaml-rite:gap", v, v)
+        self.assertIsNone(blocks.normalize_block({"type": "gap-marker", "text": ""}))
+
+
+class YamlParseAndRender(unittest.TestCase):
+    SHORT_YAML = """\
+intent: "open: budget unnamed; bet: name the watermark"
+cites:
+  - ref: arXiv:2507.02778
+    kind: mundo
+    snippet: an external benchmark the synthesis actually used
+lineage:
+  - type: builds_on
+    slug: prior-recall-report
+blocks:
+  - type: lineage
+    text: The prior report named the read-budget hole; this one derives the watermark.
+  - type: comparison
+    before:
+      title: session cursor
+      bullets: ["one watermark for the whole process"]
+    after:
+      title: per-session watermark
+      bullets: ["each session owns its cursor"]
+  - type: gap-marker
+    text: "unknown: whether the watermark survives a hard crash"
+"""
+
+    def test_parse_root_blocks(self):
+        doc = yaml_rite.parse_authorial_draft(self.SHORT_YAML)
+        self.assertIsInstance(doc, dict)
+        self.assertEqual(len(doc["blocks"]), 3)
+        art = yaml_rite.artefato_from_draft(self.SHORT_YAML, skill="report")
+        self.assertEqual(yaml_rite.check_yaml_rite(art), [])
+
+    def test_parse_fenced_yaml(self):
+        fenced = "# notes\n\n```yaml\n" + self.SHORT_YAML + "```\n"
+        doc = yaml_rite.parse_authorial_draft(fenced)
+        self.assertIsInstance(doc, dict)
+        self.assertTrue(yaml_rite.is_yaml_draft(fenced))
+
+    def test_free_markdown_is_not_yaml(self):
+        md = "# Relatorio\n\nJURIX e uma conferencia.\n\nMais um paragrafo sobre o venue.\n"
+        self.assertIsNone(yaml_rite.parse_authorial_draft(md))
+        self.assertFalse(yaml_rite.is_yaml_draft(md))
+
+    def test_yaml_renders_via_spec_to_html(self):
+        page = yaml_rite.page_bytes(self.SHORT_YAML).decode("utf-8")
+        self.assertIn("comparison-grid", page)
+        self.assertIn("gap-marker", page)
+        self.assertIn("per-session watermark", page)
+        self.assertEqual(yaml_rite.renderer_id_for(self.SHORT_YAML), yaml_rite.YAML_RENDERER_ID)
+
+    def test_markdown_page_bytes_stay_pinned(self):
+        md = "# Titulo\n\nParagrafo com `code`.\n"
+        self.assertEqual(yaml_rite.page_bytes(md), render.markdown_page_bytes(md))
+        self.assertEqual(yaml_rite.renderer_id_for(md), render.RENDERER_ID)
+
+    def test_content_sections_shape(self):
+        text = """\
+intent: "open: x; bet: y"
+cites:
+  - ref: r
+    snippet: s
+lineage:
+  - type: builds_on
+    slug: prior
+content:
+  sections:
+    - title: ""
+      blocks:
+        - type: lineage
+          text: prior brought the hole
+        - type: comparison
+          before: {title: A, bullets: ["old"]}
+          after: {title: B, bullets: ["new"]}
+        - type: gap-marker
+          text: still open
+"""
+        art = yaml_rite.artefato_from_draft(text, skill="report")
+        self.assertEqual(yaml_rite.check_yaml_rite(art), [])
+
+
+class ExistingGenusNonReportStillPasses(unittest.TestCase):
+    """The yaml-rite must not falsely fail a diagram map or a terse plan."""
+
+    def test_diagram_form_map_genus_has_no_yaml_rite(self):
+        art = {
+            "slug": "rel-map",
+            "content": {"sections": [{"title": "Map", "blocks": [
+                {"type": "ascii-diagram", "content": "A --applies--> B\nB --rhymes--> C"},
+                {"type": "table", "headers": ["From", "Type", "To"],
+                 "rows": [["A", "application", "B"], ["B", "rhyme", "C"], ["C", "parallel", "D"]]},
+            ]}]},
+            "cites": [], "proposes": [], "distills": [],
+            "intent": "open: relations untraced; bet: trace them", "skill": "map",
+        }
+        self.assertEqual([v for v in close.check_genus(art) if v.startswith("yaml-rite")], [])
+
+    def test_wellformed_terse_still_empty(self):
+        # 1 paragraph, no report skill — the historic wellformed fixture shape
+        art = {
+            "slug": "recall-report",
+            "content": {"sections": [{"title": "What I found", "blocks": [
+                {"type": "paragraph", "text": "the read budget is unnamed"},
+            ]}]},
+            "cites": [{"ref": "github:abc123", "kind": "atividade", "relevant": True,
+                       "snippet": "switched the cursor to a per-session watermark"}],
+            "proposes": [{"body": "name the full-read budget", "kind": "constraint"}],
+            "distills": ["cluster:recall"],
+            "intent": "open: budget unnamed; bet: name it next beat",
+        }
+        self.assertEqual(close.check_genus(art), [])
+
+
+
+class ReaderFacingText(unittest.TestCase):
+    """Probe/review input is the mentee page, not YAML keys.
+
+    A SHORT_YAML that yaml-rite accepts must not look like jargon just for
+    being YAML. A genuinely cryptic *payload* still reaches the facing text
+    so a genuinely cryptic payload still reaches the facing text.
+    """
+
+    SHORT_YAML = YamlParseAndRender.SHORT_YAML
+
+    def test_yaml_becomes_published_html_not_source_keys(self):
+        art = yaml_rite.artefato_from_draft(self.SHORT_YAML, skill="report")
+        self.assertEqual(yaml_rite.check_yaml_rite(art), [])
+        facing = yaml_rite.reader_facing_text(self.SHORT_YAML)
+        self.assertIn("per-session watermark", facing)
+        self.assertIn("comparison-grid", facing)
+        self.assertIn("gap-marker", facing)
+        # authoring chrome the mentee never sees
+        self.assertNotIn("type: comparison", facing)
+        self.assertNotIn("type: lineage", facing)
+        self.assertNotIn("type: gap-marker", facing)
+        self.assertNotIn("\nblocks:\n", facing)
+        self.assertNotIn("kind: mundo", facing)
+
+    def test_markdown_stays_as_is(self):
+        md = "# Titulo\n\nParagrafo com `code`.\n"
+        self.assertEqual(yaml_rite.reader_facing_text(md), md)
+        self.assertIsNone(yaml_rite.parse_authorial_draft(md))
+
+    def test_cryptic_payload_survives_into_facing_text(self):
+        """A cryptic rendered page can still strike — we do not strip payload jargon."""
+        cryptic = self.SHORT_YAML.replace(
+            "per-session watermark", "grill.leveling event-type")
+        facing = yaml_rite.reader_facing_text(cryptic)
+        self.assertIn("grill.leveling", facing)
+        self.assertNotIn("type: comparison", facing)
+
+    def test_close_feynman_prompt_uses_rendered_html_for_yaml(self):
+        art = _short_yaml_art()
+        prompt = close._build_prompt(close._FEYNMAN_FOCUS, art)
+        self.assertIn("per-session watermark", prompt)
+        self.assertNotIn('"type": "comparison"', prompt)
+        # non-YAML artefato still gets the historic JSON view
+        empty = close._build_prompt(close._REGULAR_FOCUS,
+                                    {"slug": "x", "content": {}, "cites": []})
+        self.assertIn("metrics-grid", empty)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/blocks.py
+++ b/tools/blocks.py
@@ -72,17 +72,21 @@ def _diff_block_substantive(block: dict) -> bool:
     return any(isinstance(ln, dict) and _nonblank(ln.get("text")) for ln in lines)
 
 
+def _side_has_payload(side) -> bool:
+    if not isinstance(side, dict):
+        return False
+    return (
+        _nonblank(side.get("bullets")) or _nonblank(side.get("items"))
+        or _nonblank(side.get("text")) or _nonblank(side.get("content"))
+        or _nonblank(side.get("description")) or _nonblank(side.get("pre"))
+    )
+
+
 def _comparison_substantive(block: dict) -> bool:
-    """>= 1 side with non-empty bullets/items/text (titles alone never qualify)."""
-    sides = [block.get("before") or block.get("left"), block.get("after") or block.get("right")]
-    for side in sides:
-        if isinstance(side, dict) and (
-            _nonblank(side.get("bullets")) or _nonblank(side.get("items"))
-            or _nonblank(side.get("text")) or _nonblank(side.get("content"))
-            or _nonblank(side.get("description")) or _nonblank(side.get("pre"))
-        ):
-            return True
-    return False
+    """BOTH sides must carry payload (titles alone never qualify)."""
+    left = block.get("before") or block.get("left")
+    right = block.get("after") or block.get("right")
+    return _side_has_payload(left) and _side_has_payload(right)
 
 
 def _next_steps_substantive(block: dict) -> bool:
@@ -174,6 +178,10 @@ _PAYLOAD_PREDICATES = {
     "comparison-table": _comparison_table_substantive,
     "diff-block": _diff_block_substantive,
     "comparison": _comparison_substantive,
+    "gap-marker": lambda b: _nonblank(b.get("text")),
+    "derivation": lambda b: (_nonblank(b.get("text")) or _nonblank(b.get("bullets"))
+                            or _nonblank(b.get("steps")) or _nonblank(b.get("conclusion"))
+                            or _nonblank(b.get("code"))),
     "next-steps-grid": _next_steps_substantive,
     "concept-grid": _concept_grid_substantive,
     "flow-example": _flow_example_substantive,

--- a/tools/close.py
+++ b/tools/close.py
@@ -32,6 +32,7 @@ import render
 import visible  # Modulo 5 (Publicacao) visible-text adapter — reader-visible HTML/CSS/glyph machinery
 import producer_descriptor
 import blocks as block_validation
+import yaml_rite
 
 # ---------------------------------------------------------------------------
 # Genus contract constants — the pinned field shapes + the visual palette
@@ -150,6 +151,7 @@ def check_genus(artefato: dict, attest=None) -> list[str]:
     violations += _check_visual_coverage(artefato.get("content", {}))
     violations += _check_evidence_anchors(artefato.get("content", {}))
     violations += _check_rich_rite(artefato)
+    violations += yaml_rite.check_yaml_rite(artefato, skill=artefato.get("skill"))
     r0_violations = _check_storytelling_floor(artefato.get("content", {}))  # R0 (S2): explain, don't label
     r0_violations += _check_structured_visual_values(artefato.get("content", {}))  # R0-for-values (S7): no
     #   number hides ONLY in a structured visual — same family as R0, so it likewise suppresses the floor.
@@ -1245,10 +1247,18 @@ def _dimension_text() -> str:
 
 def _build_prompt(focus: str, artefato: dict) -> str:
     view = _published_view(artefato)
+    rendered = yaml_rite.reader_facing_from_artefato(artefato)
+    if rendered:
+        cites = view.get("cites") or []
+        body = rendered
+        if cites:
+            body = f"{rendered}\n\nCites:\n{json.dumps(cites, ensure_ascii=False)}"
+    else:
+        body = json.dumps(view, ensure_ascii=False)
     return (
         f"{_BLIND_PREAMBLE}\n\n{focus}\n\n"
         f"Dimensions:\n{_dimension_text()}\n\n"
-        f"Artefato (content + cites only):\n{json.dumps(view, ensure_ascii=False)}"
+        f"Artefato (content + cites only):\n{body}"
     )
 
 

--- a/tools/publisher.py
+++ b/tools/publisher.py
@@ -694,7 +694,8 @@ def _render_page(slug, spec, *, skill, date):
     pinned renderer's output — no legacy `_page` shell, no base.css — so a reprojection from
     the logged spec re-derives the EXACT bytes `publish_rito` wrote and sealed."""
     if isinstance(spec, dict) and spec.get("format") == "edge-markdown/v1":
-        page = render.markdown_spec_to_page(spec)
+        import yaml_rite
+        page = yaml_rite.page_text(spec.get("markdown") or "")
         return page, page
     body_html = render.spec_to_html(spec)
     css = BASE_CSS.read_text()
@@ -2230,18 +2231,21 @@ def publish_rito(slug, run_dir, *, intent, skill="report", dispatch_id=None,
 
     # THE PIN: recompute the approved renderer's bytes; refuse any mismatch with the sealed
     # final_html receipt (pinning the pipeline, not scoring the artifact).
-    page_bytes = render.markdown_page_bytes(markdown)
+    # YAML sealed drafts use yaml_rite.page_bytes / edge-yaml-spec/v1; markdown stays pinned.
+    import yaml_rite
+    page_bytes = yaml_rite.page_bytes(markdown)
     page_sha = hashlib.sha256(page_bytes).hexdigest()
     sealed_html_sha = (stages.get("final_html") or {}).get("output", {}).get("sha256")
+    renderer_id = yaml_rite.renderer_id_for(markdown)
     if page_sha != sealed_html_sha:
         raise ValueError(
             f"pinned renderer mismatch: recomputed page sha {page_sha} != sealed final_html "
-            f"receipt {sealed_html_sha} ({render.RENDERER_ID}) — refusing to publish")
+            f"receipt {sealed_html_sha} ({renderer_id}) — refusing to publish")
 
     out = _safe_target(slug, blog_dir)
     core = rito.manifest_core_hash(manifest)
     spec = {"format": "edge-markdown/v1", "markdown": markdown,
-            "renderer_id": render.RENDERER_ID, "rito_manifest_sha256": core,
+            "renderer_id": renderer_id, "rito_manifest_sha256": core,
             "page_sha256": page_sha}
 
     # IDEMPOTENT RESUME (codex [high]): the event is the commit point (ADR-0006), the page a
@@ -2292,7 +2296,7 @@ def publish_rito(slug, run_dir, *, intent, skill="report", dispatch_id=None,
             reports_on=reports_on)
     return {"event_seq": published_ev["seq"], "event_ts": published_ev["ts"],
             "page_path": str(out), "page_sha256": page_sha,
-            "rito_manifest_sha256": core, "renderer_id": render.RENDERER_ID}
+            "rito_manifest_sha256": core, "renderer_id": renderer_id}
 
 
 def promote_artefato_to_source(slug, reviewer, note="", log=eventlog.LOG):

--- a/tools/render.py
+++ b/tools/render.py
@@ -1208,6 +1208,10 @@ _BLOCK_TYPE_ALIASES = {
     # Comparison aliases
     "pros-cons": "comparison",
     "compare": "comparison",
+    # lineage / builds-on: a close-check marker, rendered as prose (no new renderer)
+    "lineage": "paragraph",
+    "builds-on": "paragraph",
+    "builds_on": "paragraph",
     # Callout aliases
     "note": "callout",
     "warning": "callout",

--- a/tools/rito.py
+++ b/tools/rito.py
@@ -41,6 +41,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import eventlog  # noqa: E402
 import render  # noqa: E402
+import yaml_rite  # noqa: E402
 
 SCHEMA = "edge.rito-manifest/v1"
 RITO_VERSION = "artefato-double-grounding/experiment-b"
@@ -98,9 +99,54 @@ FORBIDDEN = {
 
 DEFAULT_PUBLISH = object()  # sentinel: use publisher.publish_rito (imported lazily)
 
+# Injected into the first authorial draft prompt so the producer cannot "forget"
+# the YAML contract even if the skill body is paraphrased away.
+YAML_DRAFT_CONTRACT = (
+    "## YAML authoring contract (runtime-injected)\n"
+    "The draft body is a YAML document with root fields `intent`, `cites`, "
+    "`lineage`, `blocks`. First block type is lineage. Must include a "
+    "substantive comparison OR derivation (BOTH sides of a comparison carry "
+    "payload), and a gap-marker / gap-table whose text is nonblank. "
+    "`cites` items are {ref, snippet} — both required; a bare ref is chrome. "
+    "No free markdown. No required H2 names. No word target.\n"
+    "The mentee never sees YAML. The reader probe and final reviewer "
+    "read the RENDERED HTML (`yaml_rite.page_bytes` / `render.spec_to_html`) "
+    "— the same page the publisher emits. Write payloads that teach; do not "
+    "gloss YAML keys for the probe. yaml-rite still checks this YAML source. "
+    "`intent` is one prose string (not a mapping). Block types use hyphens.\n"
+)
+
+YAML_KEEP_CONTRACT = (
+    "Keep the body a YAML document (`intent` as a prose string, `cites` as "
+    "[{ref, snippet}], `lineage`, `blocks` with hyphenated types). Do not "
+    "convert to free markdown. Do not turn intent into a mapping. The probe "
+    "and final review read the rendered HTML the mentee sees, not these keys.\n"
+)
+
 
 class StageFailure(RuntimeError):
     pass
+
+
+def _resolved_skill(skill) -> str:
+    return skill or "report"
+
+
+def _skill_owes_yaml(skill) -> bool:
+    return _resolved_skill(skill) in yaml_rite.REPORT_FORM_SKILLS
+
+
+def _require_yaml_draft(text, skill, run, manifest, *, failed_stage: str) -> None:
+    """Fail-closed: a report-form draft that is not YAML does not continue to close."""
+    if not _skill_owes_yaml(skill):
+        return
+    if yaml_rite.parse_authorial_draft(text) is not None:
+        return
+    exc = StageFailure("draft is not YAML")
+    manifest.update({"status": "failed", "failed_stage": failed_stage,
+                     "finished_at": now()})
+    run.save(manifest)
+    raise exc
 
 
 # --- sealing primitives (run.py pattern) ---------------------------------------------------
@@ -392,8 +438,11 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
 
         # 2 — first authorial draft, then the deterministic treatment scan (fail the run,
         # never silently clean: the FIRST draft must be treatment-blind by construction)
+        draft_prompt = prompts["first_authorial_draft"](outputs)
+        if _skill_owes_yaml(skill):
+            draft_prompt = f"{draft_prompt.rstrip()}\n\n{YAML_DRAFT_CONTRACT}"
         draft = _llm_stage(run, manifest, "first_authorial_draft",
-                           prompts["first_authorial_draft"](outputs), complete_fn, outputs)
+                           draft_prompt, complete_fn, outputs)
         first_leaks = treatment_leaks(draft)
         stage = _stage_record(manifest, "first_authorial_draft")
         stage["treatment_scan"] = {"checked_at": now(), "passed": not first_leaks,
@@ -407,11 +456,18 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
             run.save(manifest)
             raise exc
         draft_sealed_sha = _stage_record(manifest, "first_authorial_draft")["output"]["sha256"]
+        _require_yaml_draft(draft, skill, run, manifest,
+                            failed_stage="first_authorial_draft")
 
         # 3–7 — critique, targeted grounding, rewrite, audit, correction
         for name in ("gap_critique", "grounding2_targeted", "provisional_rewrite",
                      "fact_audit", "author_correction"):
-            _llm_stage(run, manifest, name, prompts[name](outputs), complete_fn, outputs)
+            prompt = prompts[name](outputs)
+            if _skill_owes_yaml(skill) and name in {
+                "provisional_rewrite", "author_correction",
+            }:
+                prompt = f"{prompt.rstrip()}\n\n{YAML_KEEP_CONTRACT}"
+            _llm_stage(run, manifest, name, prompt, complete_fn, outputs)
 
         # 8 — treatment cleanup: deterministic byte-copy when the scan is clean, else the
         # SAME AUTHOR route rewrites (run.py's conditional stage, promoted as-is)
@@ -422,8 +478,11 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
             blind_safe = _completed_output(run, manifest, "treatment_cleanup")
         elif cleanup_leaks:
             outputs["treatment_leaks"] = json.dumps(cleanup_leaks, ensure_ascii=False)
+            cleanup_prompt = prompts["treatment_cleanup"](outputs)
+            if _skill_owes_yaml(skill):
+                cleanup_prompt = f"{cleanup_prompt.rstrip()}\n\n{YAML_KEEP_CONTRACT}"
             blind_safe = _llm_stage(run, manifest, "treatment_cleanup",
-                                    prompts["treatment_cleanup"](outputs), complete_fn, outputs)
+                                    cleanup_prompt, complete_fn, outputs)
             _stage_record(manifest, "treatment_cleanup")["execution"] = {"mode": "same_author"}
         else:
             _begin(run, manifest, "treatment_cleanup")
@@ -446,16 +505,40 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
             run.save(manifest)
             raise exc
 
-        # 9 — final_html: the PINNED render (renderer id sealed; one byte seam)
+        # yaml-rite gate: a developed report-form synthesis owes typed YAML blocks.
+        # Maps/plans/terse drafts owe nothing. Always pass the run's skill (default report).
+        _require_yaml_draft(blind_safe, skill, run, manifest,
+                            failed_stage="treatment_cleanup")
+        meta = publish_meta or {}
+        yaml_art = yaml_rite.artefato_from_draft(
+            blind_safe, intent=intent, skill=_resolved_skill(skill),
+            cites=meta.get("cites"), lineage=meta.get("lineage"))
+        yaml_violations = yaml_rite.check_yaml_rite(
+            yaml_art, skill=_resolved_skill(skill))
+        cleanup_stage["yaml_rite"] = {"checked_at": now(), "passed": not yaml_violations,
+                                      "violations": yaml_violations}
+        run.save(manifest)
+        if yaml_violations:
+            exc = StageFailure(f"yaml-rite rejected the draft: {yaml_violations}")
+            manifest.update({"status": "failed", "failed_stage": "yaml_rite",
+                             "finished_at": now()})
+            run.save(manifest)
+            raise exc
+
+        # #585: probe/review consume the mentee page, not the YAML source.
+        reader_facing = yaml_rite.reader_facing_text(blind_safe)
+        outputs["reader_facing"] = reader_facing
+
+        # 9 — final_html: YAML → spec_to_html; markdown stays the pinned renderer.
         if _completed_output(run, manifest, "final_html") is None:
             _begin(run, manifest, "final_html")
             try:
-                page_bytes = render.markdown_page_bytes(blind_safe)
+                page_bytes = yaml_rite.page_bytes(blind_safe)
                 out = run.output_for("final_html")
                 out.parent.mkdir(parents=True, exist_ok=True)
                 out.write_bytes(page_bytes)
                 _finish(run, manifest, "final_html")
-                _stage_record(manifest, "final_html")["renderer_id"] = render.RENDERER_ID
+                _stage_record(manifest, "final_html")["renderer_id"] = yaml_rite.renderer_id_for(blind_safe)
                 run.save(manifest)
             except BaseException as exc:
                 _fail(run, manifest, "final_html", exc)
@@ -466,7 +549,9 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
         # clareza pedagógica é critério de strike, com os contrapesos vinculantes
         # (fato é do fact-audit; enchimento ≠ crescimento) escritos na própria lente.
         import feynman_gate as _feynman_gate
-        final_review_prompt = (prompts["final_review"](outputs)
+        review_outputs = dict(outputs)
+        review_outputs["treatment_cleanup"] = outputs.get("reader_facing", blind_safe)
+        final_review_prompt = (prompts["final_review"](review_outputs)
                                + "\n\n" + _feynman_gate.LENS_BLOCK)
         if theme_review_contract:
             final_review_prompt = f"{final_review_prompt}\n\n{theme_review_contract}"
@@ -631,11 +716,14 @@ def verify_rito(run_dir, *, log, blog_dir) -> dict[str, Any]:
     expected_page = None
     sealed_md = None
     stage_renderer = (by_name.get("final_html") or {}).get("renderer_id")
-    if stage_renderer != render.RENDERER_ID and "renderer-id-mismatch" not in failures:
+    _verify_rid = render.RENDERER_ID
+    if md_path.is_file():
+        _verify_rid = yaml_rite.renderer_id_for(md_path.read_text(encoding="utf-8"))
+    if stage_renderer != _verify_rid and "renderer-id-mismatch" not in failures:
         failures.append("renderer-id-mismatch")
     if md_path.is_file():
         sealed_md = md_path.read_text(encoding="utf-8")
-        expected_page = render.markdown_page_bytes(sealed_md)
+        expected_page = yaml_rite.page_bytes(sealed_md)
         sealed = (by_name.get("final_html") or {}).get("output") or {}
         if sealed.get("sha256") != sha_bytes(expected_page):
             failures.append("form-renderer-mismatch")
@@ -660,7 +748,7 @@ def verify_rito(run_dir, *, log, blog_dir) -> dict[str, Any]:
         spec = (ev.get("payload") or {}).get("spec") or {}
         if (isinstance(spec, dict)
                 and spec.get("format") == "edge-markdown/v1"
-                and spec.get("renderer_id") == render.RENDERER_ID
+                and spec.get("renderer_id") == yaml_rite.renderer_id_for(sealed_md or "")
                 and spec.get("rito_manifest_sha256") == core
                 and expected_page is not None
                 and spec.get("page_sha256") == sha_bytes(expected_page)
@@ -681,7 +769,7 @@ def verify_rito(run_dir, *, log, blog_dir) -> dict[str, Any]:
     if not (isinstance(receipt, dict)
             and any(ev.get("seq") == receipt.get("event_seq") for ev in bound)
             and receipt.get("rito_manifest_sha256") == core
-            and receipt.get("renderer_id") == render.RENDERER_ID
+            and receipt.get("renderer_id") == yaml_rite.renderer_id_for(sealed_md or "")
             and expected_page is not None
             and receipt.get("page_sha256") == sha_bytes(expected_page)):
         failures.append("publication-receipt-unbound")

--- a/tools/yaml_rite.py
+++ b/tools/yaml_rite.py
@@ -1,0 +1,512 @@
+"""YAML-block authoring + the mechanical yaml-rite gate (exp/yaml-blocks).
+
+Old edge: the author wrote YAML choosing block types; choosing the block WAS
+choosing how to think. This experiment brings that back for the report form.
+
+This module is the smallest seam:
+
+  - parse an authorial draft (a YAML document, or a markdown fence with yaml)
+    into the existing structured spec `render.spec_to_html` already knows;
+  - `check_yaml_rite(artefato)` is the mechanical close gate (not an LLM count,
+    not a word floor, not named H2s);
+  - `page_bytes(text)` is the one render seam rito / publisher / verify share:
+    YAML → spec_to_html wrapped in a page; free markdown stays the pinned
+    markdown renderer (byte-identical for existing rito tests).
+
+Substance is `blocks.normalize_block` — empty chrome (a comparison with only a
+title, a derivation with only a heading) does not count.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import html
+import yaml
+
+import blocks as block_validation
+import render
+from lineage import normalize_lineage
+
+# Report-form skills that owe the yaml-rite when the piece is a developed synthesis.
+# Maps / plans / prototypes / anything else owe nothing (content-relative).
+REPORT_FORM_SKILLS = frozenset({"report", "report-deep"})
+
+# Same structural trigger idea as close.RICH_RITE_PROSE_THRESHOLD — a count of
+# authored units, NEVER a word floor.
+YAML_RITE_PROSE_THRESHOLD = 3
+
+COMPARISON_TYPES = frozenset({"comparison", "comparison-table", "compare", "pros-cons"})
+DERIVATION_TYPES = frozenset({"derivation"})
+GAP_TYPES = frozenset({"gap-marker", "gap-table", "gap-resolution"})
+LINEAGE_TYPES = frozenset({"lineage", "builds-on", "builds_on"})
+COGNITIVE_TYPES = COMPARISON_TYPES | DERIVATION_TYPES | GAP_TYPES
+
+# The page-bytes renderer id when the sealed draft is YAML. Markdown drafts keep
+# render.RENDERER_ID so existing rito pins stay byte-identical.
+YAML_RENDERER_ID = "edge-yaml-spec/v1"
+
+_FENCE_RE = re.compile(r"```(?:yaml|yml)\s*\n(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def is_yaml_draft(text: str) -> bool:
+    """True iff `text` is a YAML authorial draft (whole document or a yaml fence)."""
+    return parse_authorial_draft(text) is not None
+
+
+def parse_authorial_draft(text: str):
+    """Parse a producer draft into a YAML mapping, or None if it is free markdown/HTML.
+
+    Accepts:
+      - a YAML document whose root is a mapping with `blocks` / `content` / typical
+        report root fields;
+      - a markdown document carrying a ```yaml ... ``` fence with that mapping.
+    Never raises. A free-markdown report (H1 + paragraphs) returns None.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return None
+    candidates = []
+    for m in _FENCE_RE.finditer(text):
+        candidates.append(m.group(1))
+    candidates.append(text)
+    for raw in candidates:
+        try:
+            doc = yaml.safe_load(raw)
+        except Exception:  # noqa: BLE001 — parse is fail-closed
+            continue
+        if _is_yaml_mapping(doc):
+            return doc
+    return None
+
+
+def _is_yaml_mapping(doc) -> bool:
+    if not isinstance(doc, dict):
+        return False
+    if doc.get("format") in {"edge-yaml/v1", "yaml", "edge-yaml"}:
+        return True
+    if isinstance(doc.get("blocks"), list):
+        return True
+    content = doc.get("content")
+    if isinstance(content, dict) and (
+        isinstance(content.get("blocks"), list)
+        or isinstance(content.get("sections"), list)
+    ):
+        return True
+    # frontmatter-ish report: intent/cites/lineage plus something block-shaped
+    if any(k in doc for k in ("intent", "cites", "lineage", "bibliography")) and (
+        "blocks" in doc or "content" in doc or "sections" in doc
+    ):
+        return True
+    return False
+
+
+def draft_to_spec(doc: dict) -> dict:
+    """Normalize a parsed YAML document to the spec `render.spec_to_html` reads.
+
+    Two authoring shapes, one spec:
+      - root `blocks:` (optionally with `title` / `bibliography` / `executive_summary`)
+      - existing `content.sections[].blocks` (passed through)
+    """
+    if not isinstance(doc, dict):
+        return {}
+    if isinstance(doc.get("content"), dict):
+        spec = dict(doc["content"])
+    else:
+        spec = {}
+        for key in ("executive_summary", "executive_summary_title", "metrics",
+                    "sections", "additional_sections", "bibliography", "title"):
+            if key in doc:
+                spec[key] = doc[key]
+        if isinstance(doc.get("blocks"), list) and "sections" not in spec:
+            spec["sections"] = [{"title": doc.get("title") or "", "blocks": doc["blocks"]}]
+        elif isinstance(doc.get("sections"), list) and "sections" not in spec:
+            spec["sections"] = doc["sections"]
+    if "bibliography" not in spec and doc.get("bibliography"):
+        spec["bibliography"] = doc["bibliography"]
+    if "title" not in spec and doc.get("title"):
+        spec["title"] = doc["title"]
+    return spec
+
+
+def artefato_from_draft(text: str, *, intent=None, skill="report",
+                        cites=None, lineage=None, bibliography=None) -> dict:
+    """Build the artefato dict the yaml-rite gate reads from a sealed draft + rito meta."""
+    doc = parse_authorial_draft(text)
+    if doc is None:
+        return {
+            "skill": skill or "report",
+            "intent": intent or "",
+            "cites": list(cites or []),
+            "lineage": list(lineage or []),
+            "content": {"markdown": text or ""},
+        }
+    spec = draft_to_spec(doc)
+    art_cites = doc.get("cites") if isinstance(doc.get("cites"), list) else None
+    art_lineage = doc.get("lineage") if doc.get("lineage") is not None else None
+    art_intent = doc.get("intent") if doc.get("intent") else intent
+    if bibliography is None:
+        bibliography = doc.get("bibliography") or spec.get("bibliography")
+    if bibliography and not spec.get("bibliography"):
+        spec["bibliography"] = bibliography
+    return {
+        "skill": skill or doc.get("skill") or "report",
+        "intent": art_intent or "",
+        "cites": art_cites if art_cites is not None else list(cites or []),
+        "lineage": art_lineage if art_lineage is not None else list(lineage or []),
+        "content": spec,
+        "format": "edge-yaml/v1",
+        "blocks": spec_blocks(spec),
+    }
+
+
+def spec_blocks(spec: dict) -> list:
+    """Every authored block in a spec, in document order (sections then additional)."""
+    out = []
+    if not isinstance(spec, dict):
+        return out
+    if isinstance(spec.get("blocks"), list):
+        out.extend(b for b in spec["blocks"] if isinstance(b, dict))
+    for key in ("sections", "additional_sections"):
+        for section in spec.get(key) or []:
+            if not isinstance(section, dict):
+                continue
+            for b in section.get("blocks") or []:
+                if isinstance(b, dict):
+                    out.append(b)
+    return out
+
+
+def authored_blocks(artefato: dict) -> list:
+    """Authored blocks from a finished artefato (YAML root or content.sections)."""
+    if not isinstance(artefato, dict):
+        return []
+    if isinstance(artefato.get("blocks"), list):
+        root = [b for b in artefato["blocks"] if isinstance(b, dict)]
+        if root:
+            return root
+    content = artefato.get("content") or {}
+    if isinstance(content, dict):
+        return spec_blocks(content)
+    return []
+
+
+def _raw_type(block: dict) -> str:
+    t = block.get("type") or "paragraph"
+    return t if isinstance(t, str) else "paragraph"
+
+
+def _canon_type(block: dict) -> str:
+    bt, _ = render.canonical_block(block)
+    return bt or _raw_type(block)
+
+
+def _is_lineage_block(block: dict) -> bool:
+    if not isinstance(block, dict):
+        return False
+    raw = _raw_type(block).lower().replace("_", "-")
+    if raw in LINEAGE_TYPES or raw.replace("-", "_") in {"builds_on"}:
+        return True
+    for key in ("role", "kind"):
+        v = block.get(key)
+        if isinstance(v, str) and v.lower().replace("_", "-") in LINEAGE_TYPES:
+            return True
+    if block.get("lineage") or block.get("builds_on") or block.get("builds-on"):
+        return True
+    return False
+
+
+def _cite_qualified(c) -> bool:
+    """A cite is the qualify movement: nonblank ref AND snippet. String refs fail."""
+    return (
+        isinstance(c, dict)
+        and isinstance(c.get("ref"), str) and c["ref"].strip()
+        and isinstance(c.get("snippet"), str) and c["snippet"].strip()
+    )
+
+
+def _has_cites(artefato: dict) -> bool:
+    cites = artefato.get("cites")
+    if isinstance(cites, list) and any(_cite_qualified(c) for c in cites):
+        return True
+    return False
+
+
+def _has_intent(artefato: dict) -> bool:
+    intent = artefato.get("intent")
+    return isinstance(intent, str) and bool(intent.strip())
+
+
+def _has_lineage(artefato: dict, blocks: list) -> bool:
+    if normalize_lineage(artefato.get("lineage")):
+        return True
+    if blocks and _is_lineage_block(blocks[0]):
+        return True
+    return any(_is_lineage_block(b) for b in blocks)
+
+
+def _has_substantive(blocks: list, types: frozenset) -> bool:
+    """True iff a block of one of `types` survives `normalize_block` (payload, not chrome)."""
+    for b in blocks:
+        raw = _raw_type(b)
+        canon = _canon_type(b)
+        if raw not in types and canon not in types:
+            continue
+        if block_validation.normalize_block(b) is not None:
+            return True
+    return False
+
+
+def _prose_count(artefato: dict) -> int:
+    content = artefato.get("content") or {}
+    if not isinstance(content, dict):
+        return 0
+    n = 0
+    summary = content.get("executive_summary") or []
+    n += sum(1 for s in summary if isinstance(s, str) and s.strip())
+    for b in authored_blocks(artefato):
+        if _canon_type(b) in {"paragraph", "callout"}:
+            n += 1
+    return n
+
+
+def _markdown_prose_units(artefato: dict) -> int:
+    """Structural count of prose units in a free-markdown body — not a word floor.
+
+    A heading is not a unit. A list/table row is not a unit. A non-empty paragraph
+    or blockquote is. Mirrors RICH_RITE_PROSE_THRESHOLD's 'enough authored material'.
+    """
+    content = artefato.get("content")
+    text = ""
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, dict):
+        text = content.get("markdown") or ""
+    if not isinstance(text, str) or not text.strip():
+        return 0
+    units = 0
+    for chunk in re.split(r"\n\s*\n", text):
+        line = chunk.strip()
+        if not line:
+            continue
+        first = line.splitlines()[0].strip()
+        if first.startswith("#"):
+            rest = "\n".join(ln for ln in line.splitlines()[1:] if ln.strip() and not ln.strip().startswith("#"))
+            if not rest:
+                continue
+            first = rest.splitlines()[0].strip()
+        if first.startswith("|") or first.startswith("- ") or first.startswith("* "):
+            continue
+        if first.startswith("```"):
+            continue
+        units += 1
+    return units
+
+
+def _is_yaml_shaped(artefato: dict) -> bool:
+    if not isinstance(artefato, dict):
+        return False
+    if artefato.get("format") in {"edge-yaml/v1", "yaml", "edge-yaml"}:
+        return True
+    if isinstance(artefato.get("blocks"), list):
+        return True
+    content = artefato.get("content")
+    if isinstance(content, dict) and content.get("format") in {"edge-yaml/v1", "yaml"}:
+        return True
+    return False
+
+
+def _has_typed_cognitive(artefato: dict) -> bool:
+    for b in authored_blocks(artefato):
+        raw = _raw_type(b)
+        canon = _canon_type(b)
+        if raw in COGNITIVE_TYPES or canon in COGNITIVE_TYPES or _is_lineage_block(b):
+            return True
+    return False
+
+
+def _normalized_skill(skill) -> str:
+    if isinstance(skill, str):
+        return skill.strip()
+    return ""
+
+
+def owes_yaml_rite(artefato: dict) -> bool:
+    """Content-relative trigger: a developed report-form synthesis owes the gate.
+
+    Maps/plans/prototypes (explicit skill) owe nothing. If skill is missing/empty,
+    treat as report when the body is a developed markdown draft OR yaml-shaped
+    (rito path — omitting skill used to skip the gate). A short YAML that already
+    carries typed cognitive blocks OWES — the blocks are the authored material;
+    there is no word floor.
+    """
+    if not isinstance(artefato, dict):
+        return False
+    skill = _normalized_skill(artefato.get("skill"))
+    if skill and skill not in REPORT_FORM_SKILLS:
+        return False
+    if _is_yaml_shaped(artefato) or _has_typed_cognitive(artefato):
+        return True
+    # Free-markdown / free-HTML body (rito draft, not the historic sections+paragraphs spec).
+    # Structured-spec paragraph reports stay on rich-rite; this gate is the YAML/markdown draft.
+    if _markdown_prose_units(artefato) >= YAML_RITE_PROSE_THRESHOLD:
+        return True
+    return False
+
+
+def check_yaml_rite(artefato: dict, skill=None) -> list[str]:
+    """Mechanical yaml-rite violations ([] iff the gate is not owed or all present).
+
+    A developed report-form synthesis MUST contain:
+      - non-empty cites / bibliography
+      - a substantive comparison OR derivation (`normalize_block` — empty chrome fails)
+      - a substantive gap block
+      - lineage declared (root `lineage` or a lineage / builds-on block)
+      - first authored block is lineage (close check, not an H2 name)
+    Free-markdown-only drafts (no typed cognitive blocks) fail as `yaml-rite:typed-blocks`.
+    `skill` (the run's skill, default report) is applied when the caller has it —
+    rito must pass it so a missing artefato skill cannot skip the gate.
+    """
+    if not isinstance(artefato, dict):
+        return []
+    if skill is not None:
+        artefato = dict(artefato)
+        artefato["skill"] = skill
+    if not owes_yaml_rite(artefato):
+        return []
+    violations: list[str] = []
+    blocks = authored_blocks(artefato)
+
+    if not _has_cites(artefato):
+        violations.append("yaml-rite:cites")
+    if not _has_intent(artefato):
+        violations.append("yaml-rite:intent")
+
+    typed = [
+        b for b in blocks
+        if _raw_type(b) in COGNITIVE_TYPES
+        or _canon_type(b) in COGNITIVE_TYPES
+        or _is_lineage_block(b)
+    ]
+    if not typed:
+        violations.append("yaml-rite:typed-blocks")
+
+    if not _has_substantive(blocks, COMPARISON_TYPES | DERIVATION_TYPES):
+        violations.append("yaml-rite:comparison-or-derivation")
+    if not _has_substantive(blocks, GAP_TYPES):
+        violations.append("yaml-rite:gap")
+    if not _has_lineage(artefato, blocks):
+        violations.append("yaml-rite:lineage")
+    if blocks and not _is_lineage_block(blocks[0]):
+        violations.append("yaml-rite:lineage-first")
+    return violations
+
+
+def spec_page_bytes(spec: dict) -> bytes:
+    """YAML spec → self-contained HTML page via existing `render.spec_to_html`."""
+    title = ""
+    if isinstance(spec, dict):
+        title = spec.get("title") or ""
+    if not title:
+        for b in spec_blocks(spec) if isinstance(spec, dict) else []:
+            if isinstance(b.get("text"), str) and b["text"].strip():
+                title = b["text"].strip().splitlines()[0][:80]
+                break
+    title = title or "artefato"
+    body = render.spec_to_html(spec if isinstance(spec, dict) else {})
+    page = _YAML_PAGE.format(title=html.escape(str(title)), body=body)
+    return (page.rstrip() + "\n").encode("utf-8")
+
+
+def renderer_id_for(text: str) -> str:
+    return YAML_RENDERER_ID if is_yaml_draft(text) else render.RENDERER_ID
+
+
+def page_bytes(text: str) -> bytes:
+    """The SINGLE byte seam for a sealed authorial draft: YAML or markdown.
+
+    Markdown path is `render.markdown_page_bytes` — existing rito tests stay
+    byte-identical. YAML path is spec_to_html wrapped in a self-contained page.
+    """
+    doc = parse_authorial_draft(text)
+    if doc is not None:
+        return spec_page_bytes(draft_to_spec(doc))
+    return render.markdown_page_bytes(text)
+
+
+def page_text(text: str) -> str:
+    return page_bytes(text).decode("utf-8")
+
+
+_STYLE_RE = re.compile(r"<style\b[^>]*>.*?</style>", re.DOTALL | re.IGNORECASE)
+
+
+def reader_facing_text(text: str) -> str:
+    """What the mentee reads — the probe / final_review / Feynman input.
+
+    YAML drafts become the same HTML `page_bytes` would publish (the CSS
+    block is dropped so a Feynman reader is not asked to judge stylesheets).
+    Markdown drafts stay as-is. yaml-rite still runs on the YAML source.
+    """
+    if not isinstance(text, str):
+        return "" if text is None else str(text)
+    if parse_authorial_draft(text) is None:
+        return text
+    page = page_text(text)
+    return _STYLE_RE.sub("", page).strip() + "\n"
+
+
+def reader_facing_from_artefato(artefato: dict):
+    """Rendered page for a YAML-shaped artefato, or None if not YAML-shaped.
+
+    Used by close._build_prompt so a Feynman reviewer judges the mentee's
+    page, not the spec keys.
+    """
+    if not isinstance(artefato, dict) or not _is_yaml_shaped(artefato):
+        return None
+    content = artefato.get("content")
+    if isinstance(content, dict) and (
+        spec_blocks(content) or content.get("sections") or content.get("blocks")
+    ):
+        page = spec_page_bytes(content).decode("utf-8")
+        return _STYLE_RE.sub("", page).strip() + "\n"
+    return None
+
+
+# Compact chrome so comparison / derivation / gap actually read as those moves.
+# Palette classes match tools/assets/base.css; this is a self-contained subset so
+# rito does not have to import publisher / BASE_CSS.
+_YAML_PAGE = """<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style>
+body{{font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.58;color:#17202a;background:#fbfbf8;margin:0}}
+main{{max-width:960px;margin:0 auto;padding:48px 24px 72px}}
+h1{{font-size:2rem;line-height:1.15;margin:0 0 24px;color:#111827}}
+h2,h3,.section-title{{font-size:1.25rem;margin:28px 0 10px;color:#111827}}
+p,li{{font-size:1rem}}
+.comparison-grid{{display:grid;grid-template-columns:repeat(2,1fr);gap:24px;margin:18px 0}}
+.card{{background:#fff;border:1px solid #e5e7eb;border-radius:8px;padding:16px}}
+.card-header{{display:flex;align-items:center;gap:8px;margin-bottom:8px}}
+.card-title{{font-weight:600}}
+.derivation{{background:#fff;border:1px solid #ddd6fe;border-left:4px solid #7c3aed;border-radius:8px;padding:20px;margin:16px 0}}
+.derivation-header{{display:flex;align-items:center;gap:10px;margin-bottom:12px}}
+.derivation-icon{{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;background:#7c3aed;color:#fff;border-radius:50%;font-weight:700}}
+.gap-marker{{background:#fffbeb;border:1px solid #fde68a;border-left:4px solid #d97706;border-radius:6px;padding:14px 18px;margin:12px 0}}
+.gap-marker-label{{display:inline-block;background:#d97706;color:#fff;font-size:11px;font-weight:700;padding:1px 8px;border-radius:3px;margin-right:8px}}
+.gap-table{{margin:12px 0}}
+.gap-resolution{{background:#fff;border:1px solid #e5e7eb;border-radius:8px;margin:16px 0;overflow:hidden}}
+.gap-resolution-header{{background:#fffbeb;border-bottom:1px solid #fde68a;padding:12px 20px;font-weight:600;color:#92400e}}
+.gap-resolution-answer{{background:#f0fdf4;padding:14px 20px;color:#14532d}}
+.bibliography{{margin:24px 0}}
+table{{border-collapse:collapse;width:100%;margin:18px 0;background:#fff}}
+th,td{{border:1px solid #d5d9df;padding:8px;vertical-align:top;text-align:left}}
+th{{background:#eef1f5}}
+</style>
+</head>
+<body><main>
+{body}
+</main></body></html>
+"""


### PR DESCRIPTION
Closes #542 and #585.

A developed report-form draft owes YAML thought-movements, not free markdown chrome: lineage first, a substantive comparison OR derivation (both sides), a nonblank gap, and cites as `{ref, snippet}`. No mandatory H2s, no glossary, no word floor, no `RICHNESS_STRIKES` header. Maps/plans/prototypes skip. Missing/empty skill still owes when the body is developed markdown or yaml-shaped. `StageFailure("draft is not YAML")` after the first authorial draft and after cleanup.

#585 is the same layer-3 bug as LaTeX, new format: when the sealed draft is YAML, `reader_facing_text` / `final_review` / `close._build_prompt` consume the same HTML the mentee sees (`spec_to_html` / `page_bytes`, CSS stripped). yaml-rite still gates the YAML source. Markdown drafts stay as-is. Publisher `renderer_id` follows the yaml renderer when the sealed draft is YAML; the rest of current main publisher (graph fence) is untouched.

Does not reintroduce `CLARITY_STRIKES` as a source-text tooth. Does not pin `forma: report` in beat/pauta. Imports via package/`PYTHONPATH` — never `sys.path.insert(0, 'tools')` from the phenotype cwd.

## Test plan
- [x] `test_yaml_rite` + `test_rito_runtime` + `test_genus` — 122 passed, 1 skipped
- [x] markdown-only report (even without skill key) fails closed
- [x] map does not owe
- [x] short YAML with both-sides + snippet + gap passes
- [x] one-sided comparison / cite-without-snippet / empty gap-marker fail
- [x] probe facing text for YAML is HTML, not `type: comparison` keys