### PR TITLE
rito: restore Feynman-first authoring as at 3aeb049; keep the HTML reader probe

### DIFF
--- a/skills/_shared/pipeline.md
+++ b/skills/_shared/pipeline.md
@@ -7,13 +7,11 @@ emits the PROPOSTA; the pipeline is what runs once the PROPOSTA names the forma/
 is no per-skill pipeline: the PROPOSTA supplies the theme, a skill supplies the producing
 cognition, the pipeline supplies the spine.
 
-This is the modern, publish-only rewrite of the legacy `consolidate-state` +
+This is the modern, **de-YAML'd, publish-only rewrite** of the legacy `consolidate-state` +
 the `_shared/` trio (`report-template` / `state-protocol` / `workflow-conventions`). The legacy
-mandated report-sections. **The report form writes YAML blocks again**:
-choosing the block is choosing the move (comparison, derivation, gap). There is no
-mandatory H2 outline and no word floor. Maps/plans/terse forms still owe nothing.
-The pipeline publishes HTML by rendering those blocks (`render.spec_to_html`).
-The reader probe and final review judge that rendered page, not the YAML source.
+mandated report-sections and emitted YAML; this pipeline mandates none and publishes HTML
+directly. The reader probe and final review judge the rendered HTML page the mentee
+sees, not raw authoring source (if a leftover draft is still YAML, they never score the keys).
 
 ## The three phases
 

--- a/skills/beat/SKILL.md
+++ b/skills/beat/SKILL.md
@@ -116,17 +116,6 @@ recently is the gradient the proposta follows; the beat's own picks are explorat
 
 ## Ato 2 — the branches: um agente por artefato, rounds próprios
 
-**Ato-2 report draft is YAML movements, not free markdown.** When the
-PROPOSTA `forma` is report, the branch writes a YAML document (`intent`,
-`cites`, `lineage`, `blocks`). First block type is lineage. Must include a
-substantive comparison or derivation (both sides), and a gap-marker /
-gap-table with nonblank text. Cites are `{ref, snippet}`. No free markdown.
-No required H2 names. Do not pin `forma: report` here — the Pauta still
-chooses the forma. The blind probe and final review read the rendered HTML
-the mentee sees (`yaml_rite.page_bytes`), not the YAML source. yaml-rite
-still checks the YAML. Import `rito` from `PYTHONPATH`. Do **not**
-`sys.path.insert(0, 'tools')` from the phenotype cwd.
-
 For each artefato in the proposal, dispatch **one artefato-agent** (parallel subagent calls in
 the SAME turn — blocking; the lei do turno above rules here too):
 

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -118,14 +118,8 @@ rendered page) and seals a receipt for every stage. Your job is the COGNITION: t
 prompts. The runtime owns sequencing, sealing, rendering (the pinned neutral-markdown renderer,
 `render.RENDERER_ID`) and publication. A run that didn't publish didn't finish the rite.
 
-The stages you feed (authoring format is **YAML blocks**, not free markdown and not a mandatory
-H2 outline). A developed report is a YAML document: root fields (`intent`, `cites` /
-bibliography, `lineage`) plus `blocks:` (or `content.sections[].blocks`). **Choosing the
-block is choosing the move** — comparison, derivation, gap-marker / gap-table /
-gap-resolution. The first authored block is lineage (what the prior report brought and why
-this exists) — a close check, not an H2 name. A markdown fence with yaml is accepted. Do
-not write a section outline. Do not write free markdown and call it a report:
-`grounding1_dossier` (your gathered factual dossier — the gather-grounding
+The stages you feed (authoring format is **Markdown**, H1 first; tables/lists/blockquotes carry
+the visual idiom): `grounding1_dossier` (your gathered factual dossier — the gather-grounding
 slot above) → `first_authorial_draft` → `gap_critique` → `grounding2_targeted` →
 `provisional_rewrite` → `fact_audit` → `author_correction` → `treatment_cleanup` (deterministic
 copy when the leak scan is clean) → `final_html` (pinned render, runtime-owned) →
@@ -156,6 +150,7 @@ report closes an Experiment: the atomic curated conclusion — short curated pro
 that becomes the canonical reading; omit when no experiment closes).
 
     tools/edge-python <<'EOF'
+    import sys; sys.path.insert(0, 'tools')
     import rito, llm_routes
 
     slug = '<slug>'
@@ -165,13 +160,13 @@ that becomes the canonical reading; omit when no experiment closes).
         return llm_routes.completer_for(route, max_tokens=max_tokens)(prompt)
 
     prompts = {
-        'first_authorial_draft': lambda o: f"Write a YAML document, not free markdown. Root fields: intent (one prose string, not a mapping), cites (non-empty {{ref, snippet}}; every load-bearing phrase appears in a snippet), lineage, blocks. First block type is lineage. Then a substantive comparison-table or derivation (hyphenated type; BOTH sides of a comparison carry payload). Then a gap-marker or gap-table whose text is nonblank. The mentee reads the rendered HTML (`yaml_rite.page_bytes`), not these keys — write payloads that teach. yaml-rite still checks the YAML source. Choosing the block is choosing the move. No H2 outline, no word target, no free markdown. PEDAGOGUE's Feynman voice lives in the block payloads.\n\nDOSSIER:\n{o['grounding1_dossier']}",
+        'first_authorial_draft': lambda o: f"<the produce guidance, this theme; PEDAGOGUE's Feynman voice: build from the concrete, motivate WHY before formalism, one vivid handle per hard idea, address the reader, explain-don't-label; CALIBRATE: contextualize the genuinely-new, ASSUME the operator's known (edge + his domain — re-explaining the known is enfadonho); prose carries the argument, a table only for a genuine A-vs-B comparison; length EMERGENT, no length target>\n\nDOSSIER:\n{o['grounding1_dossier']}",
         'gap_critique':          lambda o: f"<PEDAGOGICAL critique: where does this fail to TEACH the genuinely-new? where is it cryptic / contextualization thin? name ONLY the gaps a reader can't cross — not every possible elaboration (the known needs no handle)>\n\n{o['first_authorial_draft']}",
         'grounding2_targeted':   lambda o: f"<REACH for NEW grounding (world/domain beyond grounding-1) to fill the pedagogical gaps the critique named; FETCH + cite each source with its snippet, NEVER invent a fact or a citation. If the critique names no uncrossable gap, return no new grounding>\n\nGROUNDING-1 (the anchor — do not duplicate what it already covers):\n{o['grounding1_dossier']}\n\nCRITIQUE:\n{o['gap_critique']}",
-        'provisional_rewrite':   lambda o: f"<same-author rewrite STILL AS YAML (intent as one prose string, cites as [{{ref, snippet}}], lineage, hyphenated block types; do not convert to markdown; do not turn intent into a mapping) in the Feynman voice. Payloads are what the mentee reads after render. Keep the calibration (assume the known), fold critique+the new grounding2 into block payloads>\n\n{o['grounding2_targeted']}",
+        'provisional_rewrite':   lambda o: f"<same-author rewrite in the Feynman voice, keeping the calibration (assume the known), folding critique+the new grounding2 into contextualizing prose>\n\n{o['grounding2_targeted']}",
         'fact_audit':            lambda o: f"<independent fact audit: every factual claim traces to grounding-1 OR a grounding-2 source with its cited snippet; flag any fact or citation with no source (fabrication guard — treat grounding-2 as candidate evidence, don't trust a citation at face value)>\n\nGROUNDING-1:\n{o['grounding1_dossier']}\n\nGROUNDING-2 (candidate evidence):\n{o['grounding2_targeted']}\n\n{o['provisional_rewrite']}",
-        'author_correction':     lambda o: f"<bounded same-author correction from the audit; emit YAML not markdown; intent stays a prose string; hyphenated block types>\n\n{o['fact_audit']}",
-        'treatment_cleanup':     lambda o: f"<bounded same-author leak cleanup; keep YAML document shape>\n\nSCAN:\n{o['treatment_leaks']}\n\n{o['author_correction']}",
+        'author_correction':     lambda o: f"<bounded same-author correction from the audit>\n\n{o['fact_audit']}",
+        'treatment_cleanup':     lambda o: f"<bounded same-author leak cleanup>\n\nSCAN:\n{o['treatment_leaks']}\n\n{o['author_correction']}",
         'final_review':          lambda o: f"<strict review of the READER-FACING page (rendered HTML if the sealed draft is YAML; markdown as-is); begin with the 3-line ACCEPTANCE header>\n\n{o.get('reader_facing') or o['treatment_cleanup']}",
     }
 
@@ -184,9 +179,7 @@ that becomes the canonical reading; omit when no experiment closes).
                                 'experiment_curation': None})
     EOF
 
-Import `rito` / `close` / `publisher` via package/`PYTHONPATH`. Never `sys.path.insert(0, 'tools')` from the phenotype cwd — that loads the live phenotype rito and skips the YAML gate.
-
-The publisher's rito seam recomputes the pinned render from the sealed draft (YAML → `render.spec_to_html`, markdown stays the pinned markdown renderer) and **refuses a
+The publisher's rito seam recomputes the pinned render from the sealed markdown and **refuses a
 hash mismatch** — the exact reviewed bytes, and only they, land at `blog/entries/<slug>.html`,
 bound to the `artefato.published` event + mandatory `intent.kernel` in one atomic act (C3). The
 first authorial draft stays sealed and addressable in the run dir for later blind reading.

--- a/tests/test_rito_runtime.py
+++ b/tests/test_rito_runtime.py
@@ -161,7 +161,27 @@ blocks:
 
 # Canned cognitive outputs — scan-clean (no draft/grounding/prompt/harness vocabulary), so the
 # deterministic treatment gates pass and treatment_cleanup takes the deterministic-copy branch.
+# Default canned outputs are Markdown (3aeb049 producer). YAML_* fixtures
+# remain for the leftover-YAML HTML-probe tests (#647 / #585).
 CANNED = {
+    "first_authorial_draft": (
+        "# Relatorio exp-teste\n\nA pergunta viva: o buscador melhora com o indice?\n\n"
+        "- fato: 29 vitorias\n- inferencia: o indice ajuda\n\n"
+        "| arm | placar |\n|---|---|\n| raw | 8 |\n| indice | 29 |"),
+    "gap_critique": "# Lacunas\n\nFaltou o caso concreto da rodada 3.",
+    "grounding2_targeted": "# Memo dirigido\n\nEvidencia adicional sobre a rodada 3.",
+    "provisional_rewrite": (
+        "# Relatorio exp-teste\n\nVersao revisada: a rodada 3 mostra o mecanismo."),
+    "fact_audit": "# Fact audit\n\n## Verdict\nPASS\n\n## Claim ledger\ntudo sustentado.",
+    "author_correction": (
+        "# Relatorio exp-teste\n\nVersao final auditada. A rodada 3 mostra o mecanismo.\n\n"
+        "> o indice vence onde a estrutura importa."),
+    "final_review": (
+        "ACCEPTANCE: PASS\nUNSUPPORTED_CLAIMS: 0\nTREATMENT_LEAK: NO\n\n"
+        "Revisao qualitativa: util por si so."),
+}
+
+YAML_CANNED = {
     "first_authorial_draft": YAML_AUTHORIAL_DRAFT,
     "gap_critique": "# Lacunas\n\nFaltou o caso concreto da rodada 3.",
     "grounding2_targeted": "# Memo dirigido\n\nEvidencia adicional sobre a rodada 3.",
@@ -331,7 +351,7 @@ class FullRiteTest(unittest.TestCase):
             self.assertEqual(len(evs), 1)
             spec = evs[0]["payload"]["spec"]
             self.assertEqual(spec["format"], "edge-markdown/v1")
-            self.assertEqual(spec["renderer_id"], yaml_rite.YAML_RENDERER_ID)
+            self.assertEqual(spec["renderer_id"], render.RENDERER_ID)
             self.assertEqual(spec["rito_manifest_sha256"], rito.manifest_core_hash(manifest))
             page_sha = hashlib.sha256((blog / f"{SLUG}.html").read_bytes()).hexdigest()
             self.assertEqual(spec["page_sha256"], page_sha)
@@ -373,8 +393,10 @@ class FullRiteTest(unittest.TestCase):
 
     def test_treatment_cleanup_same_author_when_correction_leaks(self):
         canned = dict(CANNED)
-        canned["author_correction"] = YAML_LEAKY_CORRECTION
-        canned["treatment_cleanup"] = YAML_CLEAN_CLEANUP
+        canned["author_correction"] = ("# Relatorio exp-teste\n\nNeste rascunho eu explico o "
+                                       "mecanismo da rodada 3.")
+        canned["treatment_cleanup"] = ("# Relatorio exp-teste\n\nAqui eu explico o mecanismo "
+                                       "da rodada 3.")
         order = LLM_ORDER[:6] + ["treatment_cleanup"] + LLM_ORDER[6:]
         with tempfile.TemporaryDirectory() as tmp:
             manifest, run_dir, log, blog = _green_run(tmp, canned=canned, order=order)
@@ -711,24 +733,18 @@ class DetectorCliTest(unittest.TestCase):
             self.assertEqual(bad, 1)
 
 
-    def test_report_markdown_first_draft_is_stage_failure(self):
-        """A report-form first draft that is free markdown fails immediately."""
-        canned = dict(CANNED)
-        canned["first_authorial_draft"] = (
-            "# Relatorio\n\nParagrafo um sobre o indice.\n\n"
-            "Paragrafo dois sobre a rodada 3.\n"
-        )
+    def test_report_markdown_first_draft_completes(self):
+        """3aeb049: a report-form first draft is Markdown. YAML is not required."""
         with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(rito.StageFailure) as ctx:
-                _green_run(tmp, canned=canned)
-            self.assertIn("draft is not YAML", str(ctx.exception))
-            manifest = json.loads((Path(tmp) / "run" / "00_MANIFEST.json").read_text())
-            self.assertEqual(manifest["failed_stage"], "first_authorial_draft")
-            self.assertFalse((Path(tmp) / "run" / "03_GAP_CRITIQUE.md").exists())
+            manifest, run_dir, log, blog = _green_run(tmp)
+            self.assertEqual(manifest["status"], "completed")
+            sealed = (run_dir / "08_BLIND_SAFE_FINAL.md").read_text()
+            self.assertFalse(yaml_rite.is_yaml_draft(sealed))
+            self.assertTrue((blog / f"{SLUG}.html").is_file())
 
 
 class ReaderFacingProbeReviewTest(unittest.TestCase):
-    """#585: probe + final_review judge the published HTML, not YAML keys."""
+    """#585 / #647: leftover YAML is reviewed as published HTML, not keys."""
 
     def test_final_review_prompt_is_rendered_html(self):
         def prompts():
@@ -746,7 +762,7 @@ class ReaderFacingProbeReviewTest(unittest.TestCase):
                 SLUG, run_dir=run_dir,
                 grounding1_fn=lambda: "# Dossier factual\n\nFatos: 29-8-3 em 40 rodadas.",
                 prompts=prompts(),
-                complete_fn=_complete_fn(CANNED, LLM_ORDER),
+                complete_fn=_complete_fn(YAML_CANNED, LLM_ORDER),
                 intent=INTENT, skill="report", dispatch_id=did,
                 log=log, blog_dir=blog,
             )

--- a/tests/test_yaml_rite.py
+++ b/tests/test_yaml_rite.py
@@ -87,40 +87,19 @@ def _empty_comparison_yaml_art():
 
 
 class YamlRiteGate(unittest.TestCase):
-    def test_short_yaml_with_moves_passes_no_h2_no_word_floor(self):
-        violations = yaml_rite.check_yaml_rite(_short_yaml_art())
-        self.assertEqual(violations, [], violations)
-        # also through check_genus: no yaml-rite:* 
-        genus = [v for v in close.check_genus(_short_yaml_art()) if v.startswith("yaml-rite")]
-        self.assertEqual(genus, [], genus)
+    """The YAML/H2/word-floor form gate is rolled back to 3aeb049.
 
-    def test_jurix_thin_free_html_fails(self):
-        v = yaml_rite.check_yaml_rite(_jurix_thin_html_art())
-        self.assertIn("yaml-rite:typed-blocks", v, v)
-        self.assertIn("yaml-rite:comparison-or-derivation", v, v)
-        self.assertIn("yaml-rite:cites", v, v)
+    check_yaml_rite is a no-op. Leftover YAML still *renders* (YamlParseAndRender)
+    and the reader probe still sees HTML (ReaderFacingText).
+    """
 
-    def test_empty_comparison_yaml_fails(self):
-        v = yaml_rite.check_yaml_rite(_empty_comparison_yaml_art())
-        self.assertIn("yaml-rite:comparison-or-derivation", v, v)
-
-    def test_empty_comparison_chrome_fails_normalize(self):
-        self.assertIsNone(blocks.normalize_block({"type": "comparison", "title": "JURIX"}))
-        self.assertIsNone(blocks.normalize_block({
-            "type": "comparison",
-            "before": {"title": "A"},
-            "after": {"title": "B"},
-        }))
-
-    def test_title_only_derivation_fails_normalize(self):
-        self.assertIsNone(blocks.normalize_block({"type": "derivation", "title": "Derivation"}))
-
-    def test_substantive_comparison_survives_normalize(self):
-        self.assertIsNotNone(blocks.normalize_block(_comparison()))
-
-    def test_markdown_without_skill_still_owes_and_fails_typed_blocks(self):
-        """The last-beat bug: omitting skill used to skip the gate and publish markdown."""
-        art = {
+    def test_form_gate_never_blocks(self):
+        samples = [
+            _short_yaml_art(),
+            _jurix_thin_html_art(),
+            _empty_comparison_yaml_art(),
+        ]
+        md = {
             "intent": "open: venue unnamed; bet: mention JURIX",
             "cites": [],
             "lineage": [],
@@ -130,18 +109,41 @@ class YamlRiteGate(unittest.TestCase):
                 "JURIX remains the object of this note.\n"
             )},
         }
-        self.assertNotIn("skill", art)
-        self.assertTrue(yaml_rite.owes_yaml_rite(art))
-        v = yaml_rite.check_yaml_rite(art)
-        self.assertIn("yaml-rite:typed-blocks", v, v)
+        samples.append(md)
+        empty_skill = _jurix_thin_html_art()
+        empty_skill["skill"] = ""
+        samples.append(empty_skill)
+        for art in samples:
+            self.assertEqual(yaml_rite.check_yaml_rite(art), [], art)
 
-    def test_empty_skill_markdown_still_owes(self):
-        art = _jurix_thin_html_art()
-        art["skill"] = ""
-        self.assertTrue(yaml_rite.owes_yaml_rite(art))
-        self.assertIn("yaml-rite:typed-blocks", yaml_rite.check_yaml_rite(art))
+    def test_genus_does_not_emit_yaml_rite_codes(self):
+        genus = [v for v in close.check_genus(_short_yaml_art()) if v.startswith("yaml-rite")]
+        self.assertEqual(genus, [], genus)
+        thin = [v for v in close.check_genus(_jurix_thin_html_art()) if v.startswith("yaml-rite")]
+        self.assertEqual(thin, [], thin)
 
-    def test_map_owes_nothing(self):
+    def test_empty_comparison_chrome_fails_normalize(self):
+        """3aeb049: titles alone never qualify as comparison payload."""
+        self.assertIsNone(blocks.normalize_block({"type": "comparison", "title": "JURIX"}))
+        self.assertIsNone(blocks.normalize_block({
+            "type": "comparison",
+            "before": {"title": "A"},
+            "after": {"title": "B"},
+        }))
+
+    def test_substantive_comparison_survives_normalize(self):
+        self.assertIsNotNone(blocks.normalize_block(_comparison()))
+
+    def test_one_sided_comparison_is_payload_enough(self):
+        """3aeb049: one side with bullets qualifies; both-sides was a #647 form contract."""
+        block = {
+            "type": "comparison",
+            "before": {"title": "session cursor", "bullets": ["one watermark"]},
+            "after": {"title": "per-session watermark"},
+        }
+        self.assertIsNotNone(blocks.normalize_block(block))
+
+    def test_map_and_plan_still_unblocked(self):
         art = {
             "slug": "rel-map",
             "skill": "map",
@@ -154,11 +156,7 @@ class YamlRiteGate(unittest.TestCase):
             ]}]},
         }
         self.assertEqual(yaml_rite.check_yaml_rite(art), [])
-        rich = [v for v in close.check_genus(art) if v.startswith("yaml-rite")]
-        self.assertEqual(rich, [])
-
-    def test_terse_plan_owes_nothing(self):
-        art = {
+        plan = {
             "skill": "plan",
             "intent": "open: next step unnamed; bet: name it",
             "cites": [],
@@ -166,77 +164,7 @@ class YamlRiteGate(unittest.TestCase):
                 {"type": "next-steps-grid", "steps": [{"title": "ship the watermark"}]},
             ]}]},
         }
-        self.assertEqual(yaml_rite.check_yaml_rite(art), [])
-
-    def test_terse_report_below_threshold_owes_nothing(self):
-        art = {
-            "skill": "report",
-            "intent": "open: one observation; bet: park it",
-            "cites": [],
-            "content": {"sections": [{"title": "", "blocks": [
-                {"type": "paragraph", "text": "One terse observation, nothing more."},
-            ]}]},
-        }
-        self.assertEqual(yaml_rite.check_yaml_rite(art), [])
-
-    def test_first_block_must_be_lineage(self):
-        art = _short_yaml_art()
-        art["content"]["sections"][0]["blocks"] = [_comparison(), _lineage_block(), _gap()]
-        v = yaml_rite.check_yaml_rite(art)
-        self.assertIn("yaml-rite:lineage-first", v, v)
-
-    def test_missing_gap_fails(self):
-        art = _short_yaml_art()
-        art["content"]["sections"][0]["blocks"] = [_lineage_block(), _comparison()]
-        v = yaml_rite.check_yaml_rite(art)
-        self.assertIn("yaml-rite:gap", v, v)
-
-    def test_derivation_satisfies_comparison_or_derivation(self):
-        art = _short_yaml_art()
-        art["content"]["sections"][0]["blocks"] = [
-            _lineage_block(),
-            {"type": "derivation", "text": "A session is bounded, therefore the cursor is per-session."},
-            _gap(),
-        ]
-        v = yaml_rite.check_yaml_rite(art)
-        self.assertNotIn("yaml-rite:comparison-or-derivation", v, v)
-        self.assertEqual(v, [], v)
-
-    def test_one_sided_comparison_fails(self):
-        art = _short_yaml_art()
-        art["content"]["sections"][0]["blocks"] = [
-            _lineage_block(),
-            {"type": "comparison",
-             "before": {"title": "session cursor", "bullets": ["one watermark"]},
-             "after": {"title": "per-session watermark"}},
-            _gap(),
-        ]
-        v = yaml_rite.check_yaml_rite(art)
-        self.assertIn("yaml-rite:comparison-or-derivation", v, v)
-        self.assertIsNone(blocks.normalize_block(
-            art["content"]["sections"][0]["blocks"][1]))
-
-    def test_cite_without_snippet_fails(self):
-        art = _short_yaml_art()
-        art["cites"] = [{"ref": "arXiv:2507.02778", "kind": "mundo"}]
-        v = yaml_rite.check_yaml_rite(art)
-        self.assertIn("yaml-rite:cites", v, v)
-
-    def test_string_cite_fails(self):
-        art = _short_yaml_art()
-        art["cites"] = ["arXiv:2507.02778"]
-        v = yaml_rite.check_yaml_rite(art)
-        self.assertIn("yaml-rite:cites", v, v)
-
-    def test_empty_gap_marker_fails(self):
-        art = _short_yaml_art()
-        art["content"]["sections"][0]["blocks"] = [
-            _lineage_block(), _comparison(),
-            {"type": "gap-marker", "text": ""},
-        ]
-        v = yaml_rite.check_yaml_rite(art)
-        self.assertIn("yaml-rite:gap", v, v)
-        self.assertIsNone(blocks.normalize_block({"type": "gap-marker", "text": ""}))
+        self.assertEqual(yaml_rite.check_yaml_rite(plan), [])
 
 
 class YamlParseAndRender(unittest.TestCase):

--- a/tools/blocks.py
+++ b/tools/blocks.py
@@ -72,21 +72,17 @@ def _diff_block_substantive(block: dict) -> bool:
     return any(isinstance(ln, dict) and _nonblank(ln.get("text")) for ln in lines)
 
 
-def _side_has_payload(side) -> bool:
-    if not isinstance(side, dict):
-        return False
-    return (
-        _nonblank(side.get("bullets")) or _nonblank(side.get("items"))
-        or _nonblank(side.get("text")) or _nonblank(side.get("content"))
-        or _nonblank(side.get("description")) or _nonblank(side.get("pre"))
-    )
-
-
 def _comparison_substantive(block: dict) -> bool:
-    """BOTH sides must carry payload (titles alone never qualify)."""
-    left = block.get("before") or block.get("left")
-    right = block.get("after") or block.get("right")
-    return _side_has_payload(left) and _side_has_payload(right)
+    """>= 1 side with non-empty bullets/items/text (titles alone never qualify)."""
+    sides = [block.get("before") or block.get("left"), block.get("after") or block.get("right")]
+    for side in sides:
+        if isinstance(side, dict) and (
+            _nonblank(side.get("bullets")) or _nonblank(side.get("items"))
+            or _nonblank(side.get("text")) or _nonblank(side.get("content"))
+            or _nonblank(side.get("description")) or _nonblank(side.get("pre"))
+        ):
+            return True
+    return False
 
 
 def _next_steps_substantive(block: dict) -> bool:
@@ -178,10 +174,6 @@ _PAYLOAD_PREDICATES = {
     "comparison-table": _comparison_table_substantive,
     "diff-block": _diff_block_substantive,
     "comparison": _comparison_substantive,
-    "gap-marker": lambda b: _nonblank(b.get("text")),
-    "derivation": lambda b: (_nonblank(b.get("text")) or _nonblank(b.get("bullets"))
-                            or _nonblank(b.get("steps")) or _nonblank(b.get("conclusion"))
-                            or _nonblank(b.get("code"))),
     "next-steps-grid": _next_steps_substantive,
     "concept-grid": _concept_grid_substantive,
     "flow-example": _flow_example_substantive,

--- a/tools/close.py
+++ b/tools/close.py
@@ -151,7 +151,6 @@ def check_genus(artefato: dict, attest=None) -> list[str]:
     violations += _check_visual_coverage(artefato.get("content", {}))
     violations += _check_evidence_anchors(artefato.get("content", {}))
     violations += _check_rich_rite(artefato)
-    violations += yaml_rite.check_yaml_rite(artefato, skill=artefato.get("skill"))
     r0_violations = _check_storytelling_floor(artefato.get("content", {}))  # R0 (S2): explain, don't label
     r0_violations += _check_structured_visual_values(artefato.get("content", {}))  # R0-for-values (S7): no
     #   number hides ONLY in a structured visual — same family as R0, so it likewise suppresses the floor.

--- a/tools/rito.py
+++ b/tools/rito.py
@@ -99,54 +99,9 @@ FORBIDDEN = {
 
 DEFAULT_PUBLISH = object()  # sentinel: use publisher.publish_rito (imported lazily)
 
-# Injected into the first authorial draft prompt so the producer cannot "forget"
-# the YAML contract even if the skill body is paraphrased away.
-YAML_DRAFT_CONTRACT = (
-    "## YAML authoring contract (runtime-injected)\n"
-    "The draft body is a YAML document with root fields `intent`, `cites`, "
-    "`lineage`, `blocks`. First block type is lineage. Must include a "
-    "substantive comparison OR derivation (BOTH sides of a comparison carry "
-    "payload), and a gap-marker / gap-table whose text is nonblank. "
-    "`cites` items are {ref, snippet} — both required; a bare ref is chrome. "
-    "No free markdown. No required H2 names. No word target.\n"
-    "The mentee never sees YAML. The reader probe and final reviewer "
-    "read the RENDERED HTML (`yaml_rite.page_bytes` / `render.spec_to_html`) "
-    "— the same page the publisher emits. Write payloads that teach; do not "
-    "gloss YAML keys for the probe. yaml-rite still checks this YAML source. "
-    "`intent` is one prose string (not a mapping). Block types use hyphens.\n"
-)
-
-YAML_KEEP_CONTRACT = (
-    "Keep the body a YAML document (`intent` as a prose string, `cites` as "
-    "[{ref, snippet}], `lineage`, `blocks` with hyphenated types). Do not "
-    "convert to free markdown. Do not turn intent into a mapping. The probe "
-    "and final review read the rendered HTML the mentee sees, not these keys.\n"
-)
-
 
 class StageFailure(RuntimeError):
     pass
-
-
-def _resolved_skill(skill) -> str:
-    return skill or "report"
-
-
-def _skill_owes_yaml(skill) -> bool:
-    return _resolved_skill(skill) in yaml_rite.REPORT_FORM_SKILLS
-
-
-def _require_yaml_draft(text, skill, run, manifest, *, failed_stage: str) -> None:
-    """Fail-closed: a report-form draft that is not YAML does not continue to close."""
-    if not _skill_owes_yaml(skill):
-        return
-    if yaml_rite.parse_authorial_draft(text) is not None:
-        return
-    exc = StageFailure("draft is not YAML")
-    manifest.update({"status": "failed", "failed_stage": failed_stage,
-                     "finished_at": now()})
-    run.save(manifest)
-    raise exc
 
 
 # --- sealing primitives (run.py pattern) ---------------------------------------------------
@@ -438,11 +393,8 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
 
         # 2 — first authorial draft, then the deterministic treatment scan (fail the run,
         # never silently clean: the FIRST draft must be treatment-blind by construction)
-        draft_prompt = prompts["first_authorial_draft"](outputs)
-        if _skill_owes_yaml(skill):
-            draft_prompt = f"{draft_prompt.rstrip()}\n\n{YAML_DRAFT_CONTRACT}"
         draft = _llm_stage(run, manifest, "first_authorial_draft",
-                           draft_prompt, complete_fn, outputs)
+                           prompts["first_authorial_draft"](outputs), complete_fn, outputs)
         first_leaks = treatment_leaks(draft)
         stage = _stage_record(manifest, "first_authorial_draft")
         stage["treatment_scan"] = {"checked_at": now(), "passed": not first_leaks,
@@ -456,18 +408,11 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
             run.save(manifest)
             raise exc
         draft_sealed_sha = _stage_record(manifest, "first_authorial_draft")["output"]["sha256"]
-        _require_yaml_draft(draft, skill, run, manifest,
-                            failed_stage="first_authorial_draft")
 
         # 3–7 — critique, targeted grounding, rewrite, audit, correction
         for name in ("gap_critique", "grounding2_targeted", "provisional_rewrite",
                      "fact_audit", "author_correction"):
-            prompt = prompts[name](outputs)
-            if _skill_owes_yaml(skill) and name in {
-                "provisional_rewrite", "author_correction",
-            }:
-                prompt = f"{prompt.rstrip()}\n\n{YAML_KEEP_CONTRACT}"
-            _llm_stage(run, manifest, name, prompt, complete_fn, outputs)
+            _llm_stage(run, manifest, name, prompts[name](outputs), complete_fn, outputs)
 
         # 8 — treatment cleanup: deterministic byte-copy when the scan is clean, else the
         # SAME AUTHOR route rewrites (run.py's conditional stage, promoted as-is)
@@ -478,11 +423,8 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
             blind_safe = _completed_output(run, manifest, "treatment_cleanup")
         elif cleanup_leaks:
             outputs["treatment_leaks"] = json.dumps(cleanup_leaks, ensure_ascii=False)
-            cleanup_prompt = prompts["treatment_cleanup"](outputs)
-            if _skill_owes_yaml(skill):
-                cleanup_prompt = f"{cleanup_prompt.rstrip()}\n\n{YAML_KEEP_CONTRACT}"
             blind_safe = _llm_stage(run, manifest, "treatment_cleanup",
-                                    cleanup_prompt, complete_fn, outputs)
+                                    prompts["treatment_cleanup"](outputs), complete_fn, outputs)
             _stage_record(manifest, "treatment_cleanup")["execution"] = {"mode": "same_author"}
         else:
             _begin(run, manifest, "treatment_cleanup")
@@ -505,27 +447,8 @@ def run_rito(slug, *, run_dir, grounding1_fn, prompts, complete_fn, intent, skil
             run.save(manifest)
             raise exc
 
-        # yaml-rite gate: a developed report-form synthesis owes typed YAML blocks.
-        # Maps/plans/terse drafts owe nothing. Always pass the run's skill (default report).
-        _require_yaml_draft(blind_safe, skill, run, manifest,
-                            failed_stage="treatment_cleanup")
-        meta = publish_meta or {}
-        yaml_art = yaml_rite.artefato_from_draft(
-            blind_safe, intent=intent, skill=_resolved_skill(skill),
-            cites=meta.get("cites"), lineage=meta.get("lineage"))
-        yaml_violations = yaml_rite.check_yaml_rite(
-            yaml_art, skill=_resolved_skill(skill))
-        cleanup_stage["yaml_rite"] = {"checked_at": now(), "passed": not yaml_violations,
-                                      "violations": yaml_violations}
-        run.save(manifest)
-        if yaml_violations:
-            exc = StageFailure(f"yaml-rite rejected the draft: {yaml_violations}")
-            manifest.update({"status": "failed", "failed_stage": "yaml_rite",
-                             "finished_at": now()})
-            run.save(manifest)
-            raise exc
-
-        # #585: probe/review consume the mentee page, not the YAML source.
+        # #585 / #647: probe/review consume the mentee page, not raw YAML keys.
+        # Markdown drafts stay the pinned renderer; leftover YAML still renders to HTML.
         reader_facing = yaml_rite.reader_facing_text(blind_safe)
         outputs["reader_facing"] = reader_facing
 

--- a/tools/yaml_rite.py
+++ b/tools/yaml_rite.py
@@ -354,51 +354,12 @@ def owes_yaml_rite(artefato: dict) -> bool:
 
 
 def check_yaml_rite(artefato: dict, skill=None) -> list[str]:
-    """Mechanical yaml-rite violations ([] iff the gate is not owed or all present).
+    """Form gate rolled back to 3aeb049 — no YAML/H2/word-floor contract.
 
-    A developed report-form synthesis MUST contain:
-      - non-empty cites / bibliography
-      - a substantive comparison OR derivation (`normalize_block` — empty chrome fails)
-      - a substantive gap block
-      - lineage declared (root `lineage` or a lineage / builds-on block)
-      - first authored block is lineage (close check, not an H2 name)
-    Free-markdown-only drafts (no typed cognitive blocks) fail as `yaml-rite:typed-blocks`.
-    `skill` (the run's skill, default report) is applied when the caller has it —
-    rito must pass it so a missing artefato skill cannot skip the gate.
+    This module remains the #647/#585 render/probe seam: leftover YAML
+    still becomes the published HTML so the reader probe never scores keys.
     """
-    if not isinstance(artefato, dict):
-        return []
-    if skill is not None:
-        artefato = dict(artefato)
-        artefato["skill"] = skill
-    if not owes_yaml_rite(artefato):
-        return []
-    violations: list[str] = []
-    blocks = authored_blocks(artefato)
-
-    if not _has_cites(artefato):
-        violations.append("yaml-rite:cites")
-    if not _has_intent(artefato):
-        violations.append("yaml-rite:intent")
-
-    typed = [
-        b for b in blocks
-        if _raw_type(b) in COGNITIVE_TYPES
-        or _canon_type(b) in COGNITIVE_TYPES
-        or _is_lineage_block(b)
-    ]
-    if not typed:
-        violations.append("yaml-rite:typed-blocks")
-
-    if not _has_substantive(blocks, COMPARISON_TYPES | DERIVATION_TYPES):
-        violations.append("yaml-rite:comparison-or-derivation")
-    if not _has_substantive(blocks, GAP_TYPES):
-        violations.append("yaml-rite:gap")
-    if not _has_lineage(artefato, blocks):
-        violations.append("yaml-rite:lineage")
-    if blocks and not _is_lineage_block(blocks[0]):
-        violations.append("yaml-rite:lineage-first")
-    return violations
+    return []
 
 
 def spec_page_bytes(spec: dict) -> bytes:


### PR DESCRIPTION
## Summary

- Rollback the **whole rito** (report skill, beat/pipeline instructions, runtime prompt injection, close form gate, yaml-rite publish gate, comparison both-sides contract) to match commit `3aeb049` (merge #584). Not a hybrid that only moves a Feynman sentence.
- The producer's first instruction is again Feynman-first Markdown, not "Write a YAML document…". No word-floor, no mandatory H2/section outline.
- **Kept from #647 / #585:** the reader probe, final review, and close judge the **rendered HTML page**, not raw YAML keys. Leftover YAML still renders through `yaml_rite.page_bytes` so a good publish is not killed by scoring source chrome. Markdown stays the pinned renderer.

Refs #542. Related: #625, #637 (clarity/reader-probe history; this PR does not re-open those gates).

## Test plan

- [x] `tests.test_rito_runtime` + `tests.test_yaml_rite` + `tests.test_rito_feynman_lens` (56 tests)
- [x] `tests.test_publisher` + `tests.test_old_edge_rite` + `tests.test_close_cosmetic_gate` (117 tests)
- [ ] Do not merge until Lucas says so